### PR TITLE
Make Diri open-source ready

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cristicretu

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and workflow help
+    url: https://github.com/cristicretu/diri/discussions
+    about: Ask for setup help or talk through an idea before filing an issue.
+  - name: Security vulnerability
+    url: https://github.com/cristicretu/diri/security/advisories/new
+    about: Report vulnerabilities privately; do not post sensitive details publicly.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Why
+
+<!-- What problem does this solve? Link an issue when one exists. -->
+
+## What changed
+
+<!-- Keep this focused enough to review. -->
+
+## Verification
+
+<!-- Commands run and manual behavior checked. -->
+
+- [ ] `./scripts/check.sh` passes, or I explained why a check is not applicable.
+- [ ] Existing sessions still survive app and daemon restarts, or the migration is documented.
+- [ ] I considered security and privacy impact (processes, IPC, logs, updates, remote hosts).
+- [ ] User-visible behavior or setup changes are documented.
+- [ ] UI changes include a screenshot or short recording.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /diri
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      rust-dependencies:
+        patterns: ["*"]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: swift
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      swift-dependencies:
+        patterns: ["*"]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /sidecar
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      sidecar-dependencies:
+        patterns: ["*"]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      actions:
+        patterns: ["*"]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: rust-toolchain
+    directory: /diri
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,16 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   engine:
     name: Swift engine (daemon + CLI)
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
       - name: Validate shell scripts
         run: bash -n scripts/*.sh diri/scripts/*.sh
       - name: Test release publishing guards
@@ -59,10 +62,10 @@ jobs:
       run:
         working-directory: diri
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
       # rust-toolchain.toml pins 1.95.0 with clippy + rustfmt.
       - name: Cache cargo registry and target
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry
@@ -70,6 +73,8 @@ jobs:
             diri/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('diri/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
+      - name: Check dependency license policy
+        run: python3 ../scripts/check-licenses.py
       - name: Format
         run: cargo fmt --all -- --check
       - name: Clippy
@@ -84,9 +89,9 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
       - name: Cache cargo registry and target
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry
@@ -122,7 +127,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
       - name: Install sidecar and browser engines
         working-directory: sidecar
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "23 4 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: rust
+            build_mode: none
+            os: ubuntu-latest
+          - language: swift
+            build_mode: manual
+            os: macos-15
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build_mode }}
+      - name: Build Swift
+        if: matrix.language == 'swift'
+        run: swift build
+      - name: Analyze
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,19 @@
+name: Dependency review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: moderate
+          deny-licenses: AGPL-1.0-only, AGPL-1.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,19 @@
+# Code of Conduct
+
+We want Diri to be a welcoming, useful project for everyone who participates.
+Be respectful, assume good intent, give actionable feedback, and focus criticism
+on ideas and code rather than people. Harassment, discrimination, threats,
+doxxing, sexualized attention, and sustained disruption are not acceptable.
+
+Project maintainers may edit or remove contributions or interactions that break
+these expectations, and may temporarily or permanently restrict participation.
+Enforcement decisions should be proportionate, private where possible, and
+focused on protecting the community.
+
+Report conduct concerns privately to **crisemcr@gmail.com**. Include links or
+screenshots and any context needed to understand what happened. Reports will be
+handled as confidentially as practical; do not use a public issue for them.
+
+This policy applies in the repository, community spaces, and when someone is
+publicly representing the project. It is adapted from the principles of the
+[Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,19 +29,31 @@ changing what a session *does*, you are probably in `Sources/`.
 
 ## Build and test
 
+The one-command contributor check runs shell/release guards, the Swift suite,
+Rust formatting, Clippy, Rust tests, and the dependency-license policy:
+
+```sh
+./scripts/check.sh
+```
+
+Pass `--browser` to also install the sidecar dependencies and run Playwright's
+browser integration tests. The default stays self-contained after toolchains and
+dependencies have been fetched once.
+
+To run one half while iterating:
+
 ```sh
 swift build && swift test          # engine
-cd diri && cargo build && cargo test   # app
+(cd diri && cargo build && cargo test)   # app
 ```
 
 Before opening a pull request, run what CI runs:
 
 ```sh
 swift test
-cd diri
-cargo fmt --all -- --check
-cargo clippy --workspace --all-targets -- -D warnings
-cargo test --workspace
+(cd diri && cargo fmt --all -- --check)
+(cd diri && cargo clippy --workspace --all-targets -- -D warnings)
+(cd diri && cargo test --workspace)
 ```
 
 To try your change in the real app, `diri/scripts/package.sh` builds the bundle
@@ -75,3 +87,8 @@ without a manifest still runs as a plain terminal.
 Keep the change focused, explain why in the description, and say how you tested
 it. If it changes behavior the daemon owns, mention whether existing sessions
 survive it — that property matters more than almost anything else here.
+
+CI must be green before merge. Maintainers may ask for a design issue first when
+a change creates a new trust boundary, persistent format, or compatibility
+commitment. See [GOVERNANCE.md](GOVERNANCE.md) for how decisions are made and
+[SECURITY.md](SECURITY.md) for private vulnerability reports.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,19 @@
+# Governance
+
+Diri is a maintainer-led open-source project. Cristian Crețu (`@cristicretu`)
+is the current maintainer and has final responsibility for releases, security
+responses, repository administration, and the product direction.
+
+Most decisions happen in the open through issues and pull requests. Small,
+reversible changes can be decided in their PR. Broad or hard-to-reverse changes
+should start as an issue or Discussion describing the problem, alternatives,
+compatibility impact, and migration plan. The maintainer aims to explain a
+decision when tradeoffs are not obvious.
+
+Consistent contributors may be invited to triage issues or review areas they
+know well. Maintainer access is earned through sustained, constructive work,
+sound judgment around session safety and privacy, and reliable collaboration.
+There is no required contribution count.
+
+If the project gains multiple maintainers, this document should be updated with
+their scopes and a decision process that does not depend on one person.

--- a/LICENSES/GPL-3.0-or-later.txt
+++ b/LICENSES/GPL-3.0-or-later.txt
@@ -1,0 +1,200 @@
+GNU GENERAL PUBLIC LICENSE
+Version 3, 29 June 2007
+
+Copyright © 2007 Free Software Foundation, Inc. <https://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+Preamble
+
+The GNU General Public License is a free, copyleft license for software and other kinds of works.
+
+The licenses for most software and other practical works are designed to take away your freedom to share and change the works. By contrast, the GNU General Public License is intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users. We, the Free Software Foundation, use the GNU General Public License for most of our software; it applies also to any other work released this way by its authors. You can apply it to your programs, too.
+
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know you can do these things.
+
+To protect your rights, we need to prevent others from denying you these rights or asking you to surrender the rights. Therefore, you have certain responsibilities if you distribute copies of the software, or if you modify it: responsibilities to respect the freedom of others.
+
+For example, if you distribute copies of such a program, whether gratis or for a fee, you must pass on to the recipients the same freedoms that you received. You must make sure that they, too, receive or can get the source code. And you must show them these terms so they know their rights.
+
+Developers that use the GNU GPL protect your rights with two steps: (1) assert copyright on the software, and (2) offer you this License giving you legal permission to copy, distribute and/or modify it.
+
+For the developers' and authors' protection, the GPL clearly explains that there is no warranty for this free software. For both users' and authors' sake, the GPL requires that modified versions be marked as changed, so that their problems will not be attributed erroneously to authors of previous versions.
+
+Some devices are designed to deny users access to install or run modified versions of the software inside them, although the manufacturer can do so. This is fundamentally incompatible with the aim of protecting users' freedom to change the software. The systematic pattern of such abuse occurs in the area of products for individuals to use, which is precisely where it is most unacceptable. Therefore, we have designed this version of the GPL to prohibit the practice for those products. If such problems arise substantially in other domains, we stand ready to extend this provision to those domains in future versions of the GPL, as needed to protect the freedom of users.
+
+Finally, every program is threatened constantly by software patents. States should not allow patents to restrict development and use of software on general-purpose computers, but in those that do, we wish to avoid the special danger that patents applied to a free program could make it effectively proprietary. To prevent this, the GPL assures that patents cannot be used to render the program non-free.
+
+The precise terms and conditions for copying, distribution and modification follow.
+
+TERMS AND CONDITIONS
+
+0. Definitions.
+"This License" refers to version 3 of the GNU General Public License.
+
+"Copyright" also means copyright-like laws that apply to other kinds of works, such as semiconductor masks.
+
+"The Program" refers to any copyrightable work licensed under this License. Each licensee is addressed as "you". "Licensees" and "recipients" may be individuals or organizations.
+
+To "modify" a work means to copy from or adapt all or part of the work in a fashion requiring copyright permission, other than the making of an exact copy. The resulting work is called a "modified version" of the earlier work or a work "based on" the earlier work.
+
+A "covered work" means either the unmodified Program or a work based on the Program.
+
+To "propagate" a work means to do anything with it that, without permission, would make you directly or secondarily liable for infringement under applicable copyright law, except executing it on a computer or modifying a private copy. Propagation includes copying, distribution (with or without modification), making available to the public, and in some countries other activities as well.
+
+To "convey" a work means any kind of propagation that enables other parties to make or receive copies. Mere interaction with a user through a computer network, with no transfer of a copy, is not conveying.
+
+An interactive user interface displays "Appropriate Legal Notices" to the extent that it includes a convenient and prominently visible feature that (1) displays an appropriate copyright notice, and (2) tells the user that there is no warranty for the work (except to the extent that warranties are provided), that licensees may convey the work under this License, and how to view a copy of this License. If the interface presents a list of user commands or options, such as a menu, a prominent item in the list meets this criterion.
+
+1. Source Code.
+The "source code" for a work means the preferred form of the work for making modifications to it. "Object code" means any non-source form of a work.
+A "Standard Interface" means an interface that either is an official standard defined by a recognized standards body, or, in the case of interfaces specified for a particular programming language, one that is widely used among developers working in that language.
+
+The "System Libraries" of an executable work include anything, other than the work as a whole, that (a) is included in the normal form of packaging a Major Component, but which is not part of that Major Component, and (b) serves only to enable use of the work with that Major Component, or to implement a Standard Interface for which an implementation is available to the public in source code form. A "Major Component", in this context, means a major essential component (kernel, window system, and so on) of the specific operating system (if any) on which the executable work runs, or a compiler used to produce the work, or an object code interpreter used to run it.
+
+The "Corresponding Source" for a work in object code form means all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities. However, it does not include the work's System Libraries, or general-purpose tools or generally available free programs which are used unmodified in performing those activities but which are not part of the work. For example, Corresponding Source includes interface definition files associated with source files for the work, and the source code for shared libraries and dynamically linked subprograms that the work is specifically designed to require, such as by intimate data communication or control flow between those subprograms and other parts of the work.
+
+The Corresponding Source need not include anything that users can regenerate automatically from other parts of the Corresponding Source.
+
+The Corresponding Source for a work in source code form is that same work.
+
+2. Basic Permissions.
+All rights granted under this License are granted for the term of copyright on the Program, and are irrevocable provided the stated conditions are met. This License explicitly affirms your unlimited permission to run the unmodified Program. The output from running a covered work is covered by this License only if the output, given its content, constitutes a covered work. This License acknowledges your rights of fair use or other equivalent, as provided by copyright law.
+You may make, run and propagate covered works that you do not convey, without conditions so long as your license otherwise remains in force. You may convey covered works to others for the sole purpose of having them make modifications exclusively for you, or provide you with facilities for running those works, provided that you comply with the terms of this License in conveying all material for which you do not control copyright. Those thus making or running the covered works for you must do so exclusively on your behalf, under your direction and control, on terms that prohibit them from making any copies of your copyrighted material outside their relationship with you.
+
+Conveying under any other circumstances is permitted solely under the conditions stated below. Sublicensing is not allowed; section 10 makes it unnecessary.
+
+3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+No covered work shall be deemed part of an effective technological measure under any applicable law fulfilling obligations under article 11 of the WIPO copyright treaty adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention of such measures.
+When you convey a covered work, you waive any legal power to forbid circumvention of technological measures to the extent such circumvention is effected by exercising rights under this License with respect to the covered work, and you disclaim any intention to limit operation or modification of the work as a means of enforcing, against the work's users, your or third parties' legal rights to forbid circumvention of technological measures.
+
+4. Conveying Verbatim Copies.
+You may convey verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice; keep intact all notices stating that this License and any non-permissive terms added in accord with section 7 apply to the code; keep intact all notices of the absence of any warranty; and give all recipients a copy of this License along with the Program.
+You may charge any price or no price for each copy that you convey, and you may offer support or warranty protection for a fee.
+
+5. Conveying Modified Source Versions.
+You may convey a work based on the Program, or the modifications to produce it from the Program, in the form of source code under the terms of section 4, provided that you also meet all of these conditions:
+a) The work must carry prominent notices stating that you modified it, and giving a relevant date.
+b) The work must carry prominent notices stating that it is released under this License and any conditions added under section 7. This requirement modifies the requirement in section 4 to "keep intact all notices".
+c) You must license the entire work, as a whole, under this License to anyone who comes into possession of a copy. This License will therefore apply, along with any applicable section 7 additional terms, to the whole of the work, and all its parts, regardless of how they are packaged. This License gives no permission to license the work in any other way, but it does not invalidate such permission if you have separately received it.
+d) If the work has interactive user interfaces, each must display Appropriate Legal Notices; however, if the Program has interactive interfaces that do not display Appropriate Legal Notices, your work need not make them do so.
+A compilation of a covered work with other separate and independent works, which are not by their nature extensions of the covered work, and which are not combined with it such as to form a larger program, in or on a volume of a storage or distribution medium, is called an "aggregate" if the compilation and its resulting copyright are not used to limit the access or legal rights of the compilation's users beyond what the individual works permit. Inclusion of a covered work in an aggregate does not cause this License to apply to the other parts of the aggregate.
+
+6. Conveying Non-Source Forms.
+You may convey a covered work in object code form under the terms of sections 4 and 5, provided that you also convey the machine-readable Corresponding Source under the terms of this License, in one of these ways:
+a) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by the Corresponding Source fixed on a durable physical medium customarily used for software interchange.
+b) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by a written offer, valid for at least three years and valid for as long as you offer spare parts or customer support for that product model, to give anyone who possesses the object code either (1) a copy of the Corresponding Source for all the software in the product that is covered by this License, on a durable physical medium customarily used for software interchange, for a price no more than your reasonable cost of physically performing this conveying of source, or (2) access to copy the Corresponding Source from a network server at no charge.
+c) Convey individual copies of the object code with a copy of the written offer to provide the Corresponding Source. This alternative is allowed only occasionally and noncommercially, and only if you received the object code with such an offer, in accord with subsection 6b.
+d) Convey the object code by offering access from a designated place (gratis or for a charge), and offer equivalent access to the Corresponding Source in the same way through the same place at no further charge. You need not require recipients to copy the Corresponding Source along with the object code. If the place to copy the object code is a network server, the Corresponding Source may be on a different server (operated by you or a third party) that supports equivalent copying facilities, provided you maintain clear directions next to the object code saying where to find the Corresponding Source. Regardless of what server hosts the Corresponding Source, you remain obligated to ensure that it is available for as long as needed to satisfy these requirements.
+e) Convey the object code using peer-to-peer transmission, provided you inform other peers where the object code and Corresponding Source of the work are being offered to the general public at no charge under subsection 6d.
+A separable portion of the object code, whose source code is excluded from the Corresponding Source as a System Library, need not be included in conveying the object code work.
+
+A "User Product" is either (1) a "consumer product", which means any tangible personal property which is normally used for personal, family, or household purposes, or (2) anything designed or sold for incorporation into a dwelling. In determining whether a product is a consumer product, doubtful cases shall be resolved in favor of coverage. For a particular product received by a particular user, "normally used" refers to a typical or common use of that class of product, regardless of the status of the particular user or of the way in which the particular user actually uses, or expects or is expected to use, the product. A product is a consumer product regardless of whether the product has substantial commercial, industrial or non-consumer uses, unless such uses represent the only significant mode of use of the product.
+
+"Installation Information" for a User Product means any methods, procedures, authorization keys, or other information required to install and execute modified versions of a covered work in that User Product from a modified version of its Corresponding Source. The information must suffice to ensure that the continued functioning of the modified object code is in no case prevented or interfered with solely because modification has been made.
+
+If you convey an object code work under this section in, or with, or specifically for use in, a User Product, and the conveying occurs as part of a transaction in which the right of possession and use of the User Product is transferred to the recipient in perpetuity or for a fixed term (regardless of how the transaction is characterized), the Corresponding Source conveyed under this section must be accompanied by the Installation Information. But this requirement does not apply if neither you nor any third party retains the ability to install modified object code on the User Product (for example, the work has been installed in ROM).
+
+The requirement to provide Installation Information does not include a requirement to continue to provide support service, warranty, or updates for a work that has been modified or installed by the recipient, or for the User Product in which it has been modified or installed. Access to a network may be denied when the modification itself materially and adversely affects the operation of the network or violates the rules and protocols for communication across the network.
+
+Corresponding Source conveyed, and Installation Information provided, in accord with this section must be in a format that is publicly documented (and with an implementation available to the public in source code form), and must require no special password or key for unpacking, reading or copying.
+
+7. Additional Terms.
+"Additional permissions" are terms that supplement the terms of this License by making exceptions from one or more of its conditions. Additional permissions that are applicable to the entire Program shall be treated as though they were included in this License, to the extent that they are valid under applicable law. If additional permissions apply only to part of the Program, that part may be used separately under those permissions, but the entire Program remains governed by this License without regard to the additional permissions.
+When you convey a copy of a covered work, you may at your option remove any additional permissions from that copy, or from any part of it. (Additional permissions may be written to require their own removal in certain cases when you modify the work.) You may place additional permissions on material, added by you to a covered work, for which you have or can give appropriate copyright permission.
+
+Notwithstanding any other provision of this License, for material you add to a covered work, you may (if authorized by the copyright holders of that material) supplement the terms of this License with terms:
+
+a) Disclaiming warranty or limiting liability differently from the terms of sections 15 and 16 of this License; or
+b) Requiring preservation of specified reasonable legal notices or author attributions in that material or in the Appropriate Legal Notices displayed by works containing it; or
+c) Prohibiting misrepresentation of the origin of that material, or requiring that modified versions of such material be marked in reasonable ways as different from the original version; or
+d) Limiting the use for publicity purposes of names of licensors or authors of the material; or
+e) Declining to grant rights under trademark law for use of some trade names, trademarks, or service marks; or
+f) Requiring indemnification of licensors and authors of that material by anyone who conveys the material (or modified versions of it) with contractual assumptions of liability to the recipient, for any liability that these contractual assumptions directly impose on those licensors and authors.
+All other non-permissive additional terms are considered "further restrictions" within the meaning of section 10. If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term. If a license document contains a further restriction but permits relicensing or conveying under this License, you may add to a covered work material governed by the terms of that license document, provided that the further restriction does not survive such relicensing or conveying.
+
+If you add terms to a covered work in accord with this section, you must place, in the relevant source files, a statement of the additional terms that apply to those files, or a notice indicating where to find the applicable terms.
+
+Additional terms, permissive or non-permissive, may be stated in the form of a separately written license, or stated as exceptions; the above requirements apply either way.
+
+8. Termination.
+You may not propagate or modify a covered work except as expressly provided under this License. Any attempt otherwise to propagate or modify it is void, and will automatically terminate your rights under this License (including any patent licenses granted under the third paragraph of section 11).
+However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation.
+
+Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice.
+
+Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License. If your rights have been terminated and not permanently reinstated, you do not qualify to receive new licenses for the same material under section 10.
+
+9. Acceptance Not Required for Having Copies.
+You are not required to accept this License in order to receive or run a copy of the Program. Ancillary propagation of a covered work occurring solely as a consequence of using peer-to-peer transmission to receive a copy likewise does not require acceptance. However, nothing other than this License grants you permission to propagate or modify any covered work. These actions infringe copyright if you do not accept this License. Therefore, by modifying or propagating a covered work, you indicate your acceptance of this License to do so.
+10. Automatic Licensing of Downstream Recipients.
+Each time you convey a covered work, the recipient automatically receives a license from the original licensors, to run, modify and propagate that work, subject to this License. You are not responsible for enforcing compliance by third parties with this License.
+An "entity transaction" is a transaction transferring control of an organization, or substantially all assets of one, or subdividing an organization, or merging organizations. If propagation of a covered work results from an entity transaction, each party to that transaction who receives a copy of the work also receives whatever licenses to the work the party's predecessor in interest had or could give under the previous paragraph, plus a right to possession of the Corresponding Source of the work from the predecessor in interest, if the predecessor has it or can get it with reasonable efforts.
+
+You may not impose any further restrictions on the exercise of the rights granted or affirmed under this License. For example, you may not impose a license fee, royalty, or other charge for exercise of rights granted under this License, and you may not initiate litigation (including a cross-claim or counterclaim in a lawsuit) alleging that any patent claim is infringed by making, using, selling, offering for sale, or importing the Program or any portion of it.
+
+11. Patents.
+A "contributor" is a copyright holder who authorizes use under this License of the Program or a work on which the Program is based. The work thus licensed is called the contributor's "contributor version".
+A contributor's "essential patent claims" are all patent claims owned or controlled by the contributor, whether already acquired or hereafter acquired, that would be infringed by some manner, permitted by this License, of making, using, or selling its contributor version, but do not include claims that would be infringed only as a consequence of further modification of the contributor version. For purposes of this definition, "control" includes the right to grant patent sublicenses in a manner consistent with the requirements of this License.
+
+Each contributor grants you a non-exclusive, worldwide, royalty-free patent license under the contributor's essential patent claims, to make, use, sell, offer for sale, import and otherwise run, modify and propagate the contents of its contributor version.
+
+In the following three paragraphs, a "patent license" is any express agreement or commitment, however denominated, not to enforce a patent (such as an express permission to practice a patent or covenant not to sue for patent infringement). To "grant" such a patent license to a party means to make such an agreement or commitment not to enforce a patent against the party.
+
+If you convey a covered work, knowingly relying on a patent license, and the Corresponding Source of the work is not available for anyone to copy, free of charge and under the terms of this License, through a publicly available network server or other readily accessible means, then you must either (1) cause the Corresponding Source to be so available, or (2) arrange to deprive yourself of the benefit of the patent license for this particular work, or (3) arrange, in a manner consistent with the requirements of this License, to extend the patent license to downstream recipients. "Knowingly relying" means you have actual knowledge that, but for the patent license, your conveying the covered work in a country, or your recipient's use of the covered work in a country, would infringe one or more identifiable patents in that country that you have reason to believe are valid.
+
+If, pursuant to or in connection with a single transaction or arrangement, you convey, or propagate by procuring conveyance of, a covered work, and grant a patent license to some of the parties receiving the covered work authorizing them to use, propagate, modify or convey a specific copy of the covered work, then the patent license you grant is automatically extended to all recipients of the covered work and works based on it.
+
+A patent license is "discriminatory" if it does not include within the scope of its coverage, prohibits the exercise of, or is conditioned on the non-exercise of one or more of the rights that are specifically granted under this License. You may not convey a covered work if you are a party to an arrangement with a third party that is in the business of distributing software, under which you make payment to the third party based on the extent of your activity of conveying the work, and under which the third party grants, to any of the parties who would receive the covered work from you, a discriminatory patent license (a) in connection with copies of the covered work conveyed by you (or copies made from those copies), or (b) primarily for and in connection with specific products or compilations that contain the covered work, unless you entered into that arrangement, or that patent license was granted, prior to 28 March 2007.
+
+Nothing in this License shall be construed as excluding or limiting any implied license or other defenses to infringement that may otherwise be available to you under applicable patent law.
+
+12. No Surrender of Others' Freedom.
+If conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot convey a covered work so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not convey it at all. For example, if you agree to terms that obligate you to collect a royalty for further conveying from those to whom you convey the Program, the only way you could satisfy both those terms and this License would be to refrain entirely from conveying the Program.
+13. Use with the GNU Affero General Public License.
+Notwithstanding any other provision of this License, you have permission to link or combine any covered work with a work licensed under version 3 of the GNU Affero General Public License into a single combined work, and to convey the resulting work. The terms of this License will continue to apply to the part which is the covered work, but the special requirements of the GNU Affero General Public License, section 13, concerning interaction through a network will apply to the combination as such.
+14. Revised Versions of this License.
+The Free Software Foundation may publish revised and/or new versions of the GNU General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+Each version is given a distinguishing version number. If the Program specifies that a certain numbered version of the GNU General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of the GNU General Public License, you may choose any version ever published by the Free Software Foundation.
+
+If the Program specifies that a proxy can decide which future versions of the GNU General Public License can be used, that proxy's public statement of acceptance of a version permanently authorizes you to choose that version for the Program.
+
+Later license versions may give you additional or different permissions. However, no additional obligations are imposed on any author or copyright holder as a result of your choosing to follow a later version.
+
+15. Disclaimer of Warranty.
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+16. Limitation of Liability.
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+17. Interpretation of Sections 15 and 16.
+If the disclaimer of warranty and limitation of liability provided above cannot be given local legal effect according to their terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with the Program, unless a warranty or assumption of liability accompanies a copy of the Program in return for a fee.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+<one line to give the program's name and a brief idea of what it does.>
+Copyright (C) <year> <name of author>
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program does terminal interaction, make it output a short notice like this when it starts in an interactive mode:
+
+<program> Copyright (C) <year> <name of author>
+This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+This is free software, and you are welcome to redistribute it under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate parts of the General Public License. Of course, your program's commands might be different; for a GUI interface, you would use an "about box".
+
+You should also get your employer (if you work as a programmer) or school, if any, to sign a "copyright disclaimer" for the program, if necessary. For more information on this, and how to apply and follow the GNU GPL, see <https://www.gnu.org/licenses/>.
+
+The GNU General Public License does not permit incorporating your program into proprietary programs. If your program is a subroutine library, you may consider it more useful to permit linking proprietary applications with the library. If this is what you want to do, use the GNU Lesser General Public License instead of this License. But first, please read <https: //www.gnu.org/licenses/why-not-lgpl.html>.

--- a/LICENSES/README.md
+++ b/LICENSES/README.md
@@ -1,0 +1,15 @@
+# License texts
+
+Diri's original source is licensed under the repository's Apache-2.0
+`LICENSE`. Distributed builds also include third-party dependencies governed by
+their own terms.
+
+- `GPL-3.0-or-later.txt` is included for Zed packages conservatively treated
+  as GPL-3.0-or-later because their crate manifests do not carry independent
+  license metadata.
+- `SwiftTerm-MIT.txt` is SwiftTerm's MIT license notice.
+- Apache-2.0 dependencies are covered by the repository's Apache-2.0 text.
+
+`license-policy.json` records the reviewed exceptions and
+`scripts/check-licenses.py` fails CI when the dependency graph changes in a way
+that needs a new review.

--- a/LICENSES/SwiftTerm-MIT.txt
+++ b/LICENSES/SwiftTerm-MIT.txt
@@ -1,0 +1,23 @@
+Copyright (c) 2019-2022 Miguel de Icaza (https://github.com/migueldeicaza)
+Copyright (c) 2017-2019, The xterm.js authors (https://github.com/xtermjs/xterm.js)
+Copyright (c) 2014-2016, SourceLair Private Company (https://www.sourcelair.com)
+Copyright (c) 2012-2013, Christopher Jeffrey (https://github.com/chjj/)
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,20 @@
 Dirijor — third-party attributions
 ==================================
 
+GPUI (https://github.com/zed-industries/zed)
+--------------------------------------------
+The GPUI crates used by Diri are pinned to a specific Zed revision. Crates
+marked Apache-2.0 by upstream remain under that license. Zed describes its
+repository as primarily GPL-3.0-or-later with Apache-2.0 components where
+marked; the dependency inventory is checked by `scripts/check-licenses.sh`.
+
+Diri replaces GPUI's disabled, no-op `ztracing` profiling surface with a small
+independent Apache-2.0 compatibility implementation in `diri/vendor/` so the
+unused GPL logging/profiling implementation is not linked into release builds.
+
+The vendored `gpui_macos` renderer is an Apache-2.0 component from the same
+pinned revision, with the local changes described in `diri/Cargo.toml`.
+
 herdr (https://github.com/herdrdev/herdr)
 -----------------------------------------
 Licensed under the Apache License, Version 2.0.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,39 @@
+# Privacy
+
+Diri has no account system, advertising, analytics, or telemetry. The project
+does not run a service that receives your terminal contents or session history.
+
+## Data stored on your Mac
+
+Diri stores session state, terminal replay logs, host configuration, preferences,
+usage summaries, and search/index data under these locations:
+
+- `~/Library/Application Support/Dirijor`
+- `~/Library/Application Support/diri`
+- `~/Library/Caches/diri/updates`
+
+Terminal logs can contain prompts, command output, repository paths, and secrets
+printed by a process. Treat them as sensitive. Before attaching diagnostics to
+an issue, review and redact them. Archiving can intentionally preserve session
+metadata. Deleting the directories above removes all Diri-managed local data
+after Diri and its daemon are stopped.
+
+## Network activity
+
+Diri connects to GitHub Releases to check for and download updates. It may also
+make network connections when you explicitly use remote hosts, PR monitoring,
+browser automation, or a tool/agent that uses the network. Those tools and
+services have their own privacy practices. Diri does not proxy their traffic
+through a Diri-operated server.
+
+Remote-node credentials remain in the mechanisms you configure (for example,
+SSH configuration and your keychain); they are not sent to the Diri project.
+
+## Process access
+
+Diri is not sandboxed because its core function is to launch shells and coding
+agents, create worktrees, and communicate with local tools. Child processes run
+with your macOS user privileges and may inherit environment variables. Only run
+agents and MCP servers you trust, and review their permissions separately.
+
+For vulnerability reports, follow [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # diri
 
 [![CI](https://github.com/cristicretu/diri/actions/workflows/ci.yml/badge.svg)](https://github.com/cristicretu/diri/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+[![GitHub release](https://img.shields.io/github/v/release/cristicretu/diri)](https://github.com/cristicretu/diri/releases/latest)
 
 Native macOS orchestrator for coding agents. Run Claude Code, Codex, Cursor, Gemini and plain
 shells in parallel — across git worktrees or on remote hosts — each with a live status
@@ -24,6 +26,20 @@ taps. The cask lives in [cristicretu/homebrew-diri](https://github.com/cristicre
 rather than `homebrew-cask`, which requires a notability threshold diri does not meet yet.
 
 macOS 15 or newer.
+
+## 60-second tour
+
+1. Add a project directory and create a session for Claude Code, Codex, another
+   supported agent, or a plain shell.
+2. Start several sessions, ideally in separate git worktrees when they edit the
+   same repository.
+3. Watch the sidebar instead of every terminal: it shows which agents are
+   working, waiting for you, or done.
+4. Quit and reopen diri. The daemon keeps each PTY alive and replays the session
+   when you return.
+
+The [getting-started guide](docs/GETTING_STARTED.md) covers remote hosts, MCP
+orchestration, diagnostics, local data, and uninstalling.
 
 ## What it does
 
@@ -74,22 +90,41 @@ command-line tools. The first Rust build compiles GPUI from a pinned Zed revisio
 while.
 
 ```sh
-swift build && swift test          # engine
-cd diri && cargo build             # app
-cargo run -p diri-app
+swift build && swift test                  # engine
+(cd diri && cargo build)                   # app
+(cd diri && cargo run -p diri-app)         # run the app from source
 
-diri/scripts/package.sh            # full bundle
+diri/scripts/package.sh                    # full bundle
 diri/scripts/install-local.sh
+```
+
+Run the same core checks as CI with one command:
+
+```sh
+./scripts/check.sh
 ```
 
 [`diri/PACKAGING.md`](diri/PACKAGING.md) covers signing and notarization,
 [`diri/UPDATING.md`](diri/UPDATING.md) the updater and release flow,
 [`diri/NODE.md`](diri/NODE.md) running agents on a remote VPS node.
 
+The [documentation index](docs/README.md) links user and engineering guides.
+
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md). Bug reports, fixes, and new agent manifests all welcome.
+See [CONTRIBUTING.md](CONTRIBUTING.md). Bug reports, fixes, docs, and new agent
+manifests are all welcome. New contributors can start with
+[`good first issue`](https://github.com/cristicretu/diri/labels/good%20first%20issue)
+or [`help wanted`](https://github.com/cristicretu/diri/labels/help%20wanted).
+
+Questions belong in [Discussions](https://github.com/cristicretu/diri/discussions),
+reproducible bugs in [Issues](https://github.com/cristicretu/diri/issues), and
+vulnerabilities in [private security reports](SECURITY.md). See the
+[roadmap](ROADMAP.md), [support guide](SUPPORT.md), [privacy notice](PRIVACY.md),
+and [governance](GOVERNANCE.md) for project expectations.
 
 ## License
 
-Apache 2.0. See [LICENSE](LICENSE) and [NOTICE](NOTICE).
+Diri's original source is Apache 2.0. Builds also contain third-party software
+under its own licenses; see [LICENSE](LICENSE), [NOTICE](NOTICE), and the
+machine-checked dependency policy in [`license-policy.json`](license-policy.json).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,35 @@
+# Roadmap
+
+This is direction, not a promise or release calendar. Concrete work is tracked
+in [Issues](https://github.com/cristicretu/diri/issues).
+
+## Now
+
+- Keep `main` green and protected by required CI checks.
+- Make session persistence and daemon upgrades boring and recoverable.
+- Expand first-class agent manifests and status-detection coverage.
+- Improve contributor docs, security reporting, privacy disclosure, and release
+  supply-chain checks.
+
+## Next
+
+- Bring the Rust engine to feature parity with the shipped Swift daemon.
+- Improve remote-node setup, diagnostics, and least-privilege guidance.
+- Add deeper end-to-end tests for app updates and session recovery.
+- Move more release provenance into reproducible, attestable CI steps while
+  preserving Apple signing and notarization requirements.
+
+## Distribution
+
+- Continue publishing signed, notarized releases and the maintained Homebrew
+  tap.
+- Submit Diri to the official Homebrew cask repository once it is eligible.
+  Homebrew normally requires a repository to be at least 30 days old and applies
+  a higher notability threshold to owner submissions. Until then, the supported
+  command is `brew install --cask cristicretu/diri/diri`.
+
+## Not planned
+
+- A hosted Diri account or telemetry service.
+- Treating agent processes as a security sandbox. Diri orchestrates trusted
+  developer tools; it does not contain them.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security policy
+
+## Supported versions
+
+Security fixes are made for the latest Diri release. Because the app can launch
+processes with your user account's privileges, keeping Diri and the coding-agent
+CLIs it launches current is important.
+
+## Report a vulnerability
+
+Please use [GitHub's private vulnerability reporting](https://github.com/cristicretu/diri/security/advisories/new).
+Do not include an exploit, private terminal output, tokens, or personal paths in
+a public issue.
+
+Include the affected version and macOS version, a minimal reproduction, the
+impact you believe is possible, and any suggested mitigation. You should receive
+an acknowledgement within seven days. Timing for a fix or disclosure depends on
+severity and complexity; the maintainer will coordinate that with the reporter.
+
+For ordinary bugs, use the [bug report form](https://github.com/cristicretu/diri/issues/new?template=bug_report.yml).
+
+## Scope and trust model
+
+Diri intentionally runs local shells, coding agents, MCP tools, and optional
+remote-node commands. A tool doing something the user explicitly authorized is
+not itself a Diri vulnerability. Permission-boundary bypasses, unsafe update or
+IPC behavior, credential disclosure, session isolation failures, and unintended
+remote execution are in scope.
+
+See the [security model](docs/SECURITY-MODEL.md) for the boundaries Diri does
+and does not provide.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,17 @@
+# Support
+
+Use [GitHub Discussions](https://github.com/cristicretu/diri/discussions) for
+setup questions, workflows, and ideas that are not yet concrete bug reports.
+Use [Issues](https://github.com/cristicretu/diri/issues) for reproducible bugs
+and scoped feature requests.
+
+Before reporting a bug, check the latest release and run `dirijor doctor` when
+the CLI is available. Include the Diri version, macOS version and chip, the
+agent involved, reproduction steps, and the smallest useful log excerpt.
+
+Logs under `~/Library/Application Support/Dirijor` may contain prompt text,
+command output, repository paths, or secrets printed by a process. Redact them
+before posting publicly.
+
+Report security issues privately as described in [SECURITY.md](SECURITY.md),
+not through Discussions or a public issue.

--- a/diri/Cargo.lock
+++ b/diri/Cargo.lock
@@ -1452,7 +1452,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1628,7 +1628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3331,7 +3331,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3467,15 +3467,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4828,7 +4819,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5118,15 +5109,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5263,7 +5245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5321,7 +5303,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5605,7 +5587,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5655,15 +5637,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -5910,32 +5883,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
-dependencies = [
- "nu-ansi-term",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -5967,7 +5914,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6120,12 +6067,6 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
@@ -6555,7 +6496,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7383,17 +7324,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zlog"
-version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git?rev=dc2a339d5d043da448a3f7ddc7c0a85c63864aad#dc2a339d5d043da448a3f7ddc7c0a85c63864aad"
-dependencies = [
- "anyhow",
- "chrono",
- "collections",
- "log",
-]
-
-[[package]]
 name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7402,18 +7332,13 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git?rev=dc2a339d5d043da448a3f7ddc7c0a85c63864aad#dc2a339d5d043da448a3f7ddc7c0a85c63864aad"
 dependencies = [
- "tracing",
- "tracing-subscriber",
- "zlog",
  "ztracing_macro",
 ]
 
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed.git?rev=dc2a339d5d043da448a3f7ddc7c0a85c63864aad#dc2a339d5d043da448a3f7ddc7c0a85c63864aad"
 
 [[package]]
 name = "zune-core"

--- a/diri/Cargo.toml
+++ b/diri/Cargo.toml
@@ -59,3 +59,9 @@ unicode-segmentation = "1"
 # path/MSAA targets on every resize. Keep our renderer patch local and pinned to
 # the exact Zed revision used by `gpui`.
 gpui_macos = { path = "vendor/gpui_macos" }
+# GPUI's sum_tree currently imports Zed's GPL-licensed profiling shim even
+# though profiling is disabled and the attribute is a no-op in normal builds.
+# Keep the same tiny, no-op API in an Apache-licensed compatibility crate so an
+# unused profiler does not change the licensing of Diri's distributed binary.
+ztracing = { path = "vendor/ztracing" }
+ztracing_macro = { path = "vendor/ztracing_macro" }

--- a/diri/UPDATING.md
+++ b/diri/UPDATING.md
@@ -78,16 +78,21 @@ If the app sits somewhere the user cannot write, the writability check fails
 One-time setup is the Developer ID cert and notary profile described in
 [PACKAGING.md](PACKAGING.md). No Sparkle keys.
 
+First open and merge a normal pull request that updates the `diri-app` version
+and lockfile. Then check out the clean, current `main` branch and run:
+
 ```sh
 diri/scripts/release.sh 0.4.1
 ```
 
-Which bumps `crates/diri-app/Cargo.toml` (and commits the bump), runs clippy +
-tests, builds a universal binary, bundles the Swift daemon, signs it,
+The script refuses to release a version that does not match the manifest, a
+dirty checkout, or a commit other than the current `origin/main`. It runs
+clippy + tests, builds a universal binary, bundles the Swift daemon, signs it,
 **notarizes and staples the .app first**, then builds and notarizes the DMG
 from that stapled bundle, produces the update zip, rebuilds `appcast.json` from
-the currently published feed, and creates the GitHub Release with all three
-attached. It then updates, commits, **pushes, and reads back** the Homebrew cask;
+the currently published feed, generates `SHA256SUMS` and a reviewed dependency
+license inventory, and creates the GitHub Release at that exact source commit.
+It then updates, commits, **pushes, and reads back** the Homebrew cask;
 the release does not report success until the remote cask checksum matches the
 published DMG.
 
@@ -118,11 +123,9 @@ running from the replaced bundle, so a release that changes `dirijord` does not
 take effect until that daemon is restarted by other means. The app half updates
 immediately; the daemon half waits.
 
-It does not push the source. Finish with:
-
-```sh
-git push && git tag diri-v0.4.1 && git push origin diri-v0.4.1
-```
+The canonical release tag is `v<version>`. `gh release create` creates that tag
+at the verified `origin/main` commit; do not create a second `diri-v<version>`
+tag. Source is merged before release rather than pushed after binary publication.
 
 ### Why the .app is notarized before the DMG
 

--- a/diri/assets/Info.plist
+++ b/diri/assets/Info.plist
@@ -16,7 +16,5 @@
     <string>alert</string>
     <key>NSUserNotificationUsageDescription</key>
     <string>diri uses notifications to tell you when an agent needs input or finishes work.</string>
-    <key>NSCalendarsFullAccessUsageDescription</key>
-    <string>diri needs access to your calendars so tools you run can read and update events when you ask them to.</string>
 </dict>
 </plist>

--- a/diri/crates/diri-app/src/terminal_pane.rs
+++ b/diri/crates/diri-app/src/terminal_pane.rs
@@ -693,7 +693,8 @@ impl TerminalPane {
                 continue;
             }
             self.parked_grids.retain(|(parked, _)| parked != id);
-            self.parked_grids.push((id.clone(), resident.element.buffer()));
+            self.parked_grids
+                .push((id.clone(), resident.element.buffer()));
         }
         if self.parked_grids.len() > PARKED_GRID_CAP {
             let excess = self.parked_grids.len() - PARKED_GRID_CAP;

--- a/diri/crates/diri-engine/src/agent.rs
+++ b/diri/crates/diri-engine/src/agent.rs
@@ -191,7 +191,10 @@ impl AgentDescriptor {
                 .find(|(key, _)| key == "PATH")
                 .map(|(_, value)| value.clone())
                 .or_else(|| std::env::var("PATH").ok());
-            if let Some(resolved) = path.as_deref().and_then(|path| resolve_on_path(first, path)) {
+            if let Some(resolved) = path
+                .as_deref()
+                .and_then(|path| resolve_on_path(first, path))
+            {
                 *first = resolved;
             }
         }
@@ -336,8 +339,7 @@ mod tests {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755))
-                .expect("chmod");
+            std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).expect("chmod");
         }
         let gemini = descriptor("gemini");
         let inherited = [(
@@ -421,8 +423,15 @@ mod tests {
         let output = child.wait_with_output().expect("wait");
         let stdout = String::from_utf8_lossy(&output.stdout);
 
-        assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
-        assert!(stdout.contains("agent-finished"), "agent did not run: {stdout:?}");
+        assert!(
+            output.status.success(),
+            "stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            stdout.contains("agent-finished"),
+            "agent did not run: {stdout:?}"
+        );
         assert!(
             stdout.contains("shell-ready"),
             "the session did not accept shell input after agent exit: {stdout:?}"

--- a/diri/crates/diri-engine/src/artifacts.rs
+++ b/diri/crates/diri-engine/src/artifacts.rs
@@ -120,11 +120,13 @@ pub fn normalize(raw: &str) -> Option<String> {
         return None;
     }
     let lower = url.to_lowercase();
-    Some(if lower.starts_with("http://") || lower.starts_with("https://") {
-        url.to_string()
-    } else {
-        format!("https://{url}")
-    })
+    Some(
+        if lower.starts_with("http://") || lower.starts_with("https://") {
+            url.to_string()
+        } else {
+            format!("https://{url}")
+        },
+    )
 }
 
 #[cfg(test)]
@@ -161,12 +163,12 @@ mod tests {
 
     #[test]
     fn existing_artifacts_keep_their_first_seen_time() {
-        let first = scan(
-            "https://github.com/o/r/pull/1",
-            &[],
-            DateMillis(500.0),
+        let first = scan("https://github.com/o/r/pull/1", &[], DateMillis(500.0));
+        let merged = scan(
+            "https://github.com/o/r/pull/1 again",
+            &first,
+            DateMillis(900.0),
         );
-        let merged = scan("https://github.com/o/r/pull/1 again", &first, DateMillis(900.0));
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].first_seen_at, DateMillis(500.0));
     }
@@ -183,7 +185,11 @@ mod tests {
         }
         let result = scan("https://example.com/newest", &existing, DateMillis(9999.0));
         assert_eq!(result.len(), MAX_ARTIFACTS);
-        assert!(result.iter().any(|artifact| artifact.url.ends_with("newest")));
+        assert!(
+            result
+                .iter()
+                .any(|artifact| artifact.url.ends_with("newest"))
+        );
         assert!(
             !result.iter().any(|artifact| artifact.url.ends_with("/0")),
             "the oldest entry is the one dropped"

--- a/diri/crates/diri-engine/src/attach.rs
+++ b/diri/crates/diri-engine/src/attach.rs
@@ -69,7 +69,9 @@ impl AttachHub {
         // instantly from the emulator, and the live program resumes
         // underneath — the Swift attach() behavior.
         {
-            let Ok(mut guard) = registry.lock() else { return };
+            let Ok(mut guard) = registry.lock() else {
+                return;
+            };
             let _ = guard.wake_session(session_id);
         }
         // Seed before registering: the full snapshot must be the sink's first
@@ -144,12 +146,8 @@ impl AttachHub {
             }
             FrameType::Scroll => {
                 if let Some((direction, lines, col, row)) = frame.scroll_payload() {
-                    let _ = session.scroll(
-                        direction == 0,
-                        lines as usize,
-                        col as usize,
-                        row as usize,
-                    );
+                    let _ =
+                        session.scroll(direction == 0, lines as usize, col as usize, row as usize);
                 }
             }
             FrameType::Ping => {
@@ -216,7 +214,10 @@ impl AttachHub {
             let observed = {
                 let Ok(guard) = registry.lock() else { break };
                 guard.get(session_id).map(|session| {
-                    (session.grid_update_if_changed(&mut signature), session.modes())
+                    (
+                        session.grid_update_if_changed(&mut signature),
+                        session.modes(),
+                    )
                 })
             };
 
@@ -284,8 +285,8 @@ impl AttachHub {
 }
 
 fn write_frame(writer: &Arc<Mutex<UnixStream>>, frame: &Frame) -> std::io::Result<()> {
-    let bytes = FrameCodec::encode(frame)
-        .map_err(|error| std::io::Error::other(error.to_string()))?;
+    let bytes =
+        FrameCodec::encode(frame).map_err(|error| std::io::Error::other(error.to_string()))?;
     let mut stream = writer
         .lock()
         .map_err(|_| std::io::Error::other("writer poisoned"))?;

--- a/diri/crates/diri-engine/src/bin/dirijord-rs.rs
+++ b/diri/crates/diri-engine/src/bin/dirijord-rs.rs
@@ -91,7 +91,10 @@ fn main() {
 
     let (engine, failed) = load_manifests(&exe_dir, &app_support);
     if !failed.is_empty() {
-        eprintln!("dirijord-rs: {} manifest file(s) failed to parse: {failed:?}", failed.len());
+        eprintln!(
+            "dirijord-rs: {} manifest file(s) failed to parse: {failed:?}",
+            failed.len()
+        );
     }
     let engine = Arc::new(engine);
     if engine.ids().is_empty() {
@@ -169,10 +172,7 @@ fn main() {
         Arc::new(AtomicBool::new(false)),
     );
 
-    eprintln!(
-        "dirijord-rs: serving {}",
-        server.socket_path().display()
-    );
+    eprintln!("dirijord-rs: serving {}", server.socket_path().display());
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {

--- a/diri/crates/diri-engine/src/browser.rs
+++ b/diri/crates/diri-engine/src/browser.rs
@@ -121,7 +121,10 @@ impl BrowserPool {
                 inner.pending.remove(&id);
                 return Err("sidecar not running".into());
             };
-            if let Err(error) = stdin.write_all(line.as_bytes()).and_then(|()| stdin.flush()) {
+            if let Err(error) = stdin
+                .write_all(line.as_bytes())
+                .and_then(|()| stdin.flush())
+            {
                 inner.pending.remove(&id);
                 return Err(format!("sidecar write failed: {error}"));
             }
@@ -174,9 +177,7 @@ impl BrowserPool {
                         if let Some(sender) = inner.pending.remove(&id) {
                             let outcome = match message.get("error").and_then(Value::as_str) {
                                 Some(error) => Err(error.to_string()),
-                                None => {
-                                    Ok(message.get("result").cloned().unwrap_or(Value::Null))
-                                }
+                                None => Ok(message.get("result").cloned().unwrap_or(Value::Null)),
                             };
                             let _ = sender.send(outcome);
                         }

--- a/diri/crates/diri-engine/src/checkpoint.rs
+++ b/diri/crates/diri-engine/src/checkpoint.rs
@@ -62,7 +62,10 @@ impl ScreenCheckpoint {
     /// Swift's `PropertyListEncoder` emits.
     pub fn write_atomically(&self, path: &Path) -> std::io::Result<()> {
         let mut dict = plist::Dictionary::new();
-        dict.insert("version".into(), plist::Value::Integer(CURRENT_VERSION.into()));
+        dict.insert(
+            "version".into(),
+            plist::Value::Integer(CURRENT_VERSION.into()),
+        );
         dict.insert(
             "logOffset".into(),
             plist::Value::Integer(self.log_offset.into()),
@@ -116,10 +119,7 @@ mod tests {
                 cursor_row: 1,
                 cursor_visible: true,
                 is_full_snapshot: true,
-                changed_rows: vec![
-                    ChangedRow::new(0, cells.clone()),
-                    ChangedRow::new(1, cells),
-                ],
+                changed_rows: vec![ChangedRow::new(0, cells.clone()), ChangedRow::new(1, cells)],
             },
             marker_buffer: vec![0x1b, b']'],
             alt_screen: true,
@@ -223,10 +223,7 @@ mod tests {
         );
 
         std::fs::write(&path, b"not a plist at all").expect("write");
-        assert!(
-            ScreenCheckpoint::load(&path).is_none(),
-            "garbage is a miss"
-        );
+        assert!(ScreenCheckpoint::load(&path).is_none(), "garbage is a miss");
 
         let mut future = sample();
         future.write_atomically(&path).expect("write");

--- a/diri/crates/diri-engine/src/control.rs
+++ b/diri/crates/diri-engine/src/control.rs
@@ -64,9 +64,7 @@ impl ControlServer {
             attach: crate::attach::AttachHub::new(),
             pr_monitor_wake: crate::pr_monitor::PrMonitorWake::default(),
             injection: None,
-            governor: std::sync::Arc::new(Mutex::new(
-                crate::governor::GovernorConfig::default(),
-            )),
+            governor: std::sync::Arc::new(Mutex::new(crate::governor::GovernorConfig::default())),
             browser: std::sync::OnceLock::new(),
         }
     }
@@ -179,9 +177,7 @@ impl ControlServer {
             }
             if first {
                 first = false;
-                if let Ok(attach) =
-                    serde_json::from_slice::<diri_proto::AttachRequest>(&line)
-                {
+                if let Ok(attach) = serde_json::from_slice::<diri_proto::AttachRequest>(&line) {
                     // Attaching means this session is visible. Record that
                     // before waking the PR monitor so its immediate pass sees
                     // the session as foreground/recent even if registration
@@ -269,7 +265,9 @@ impl ControlServer {
     ) -> Result<JsonValue, ControlError> {
         let p: diri_proto::EventsSubscribeParams = decode(params).unwrap_or_default();
         if let Some(previous) = subscription.take() {
-            previous.stop.store(true, std::sync::atomic::Ordering::SeqCst);
+            previous
+                .stop
+                .store(true, std::sync::atomic::Ordering::SeqCst);
         }
         let stream = self.events.subscribe(
             p.since_seq,
@@ -287,9 +285,7 @@ impl ControlServer {
                 .name("diri-control-events".into())
                 .spawn(move || {
                     while !stop.load(std::sync::atomic::Ordering::SeqCst) {
-                        let Some(event) =
-                            stream.recv(std::time::Duration::from_millis(250))
-                        else {
+                        let Some(event) = stream.recv(std::time::Duration::from_millis(250)) else {
                             continue;
                         };
                         let frame = ControlMessage::Event {
@@ -346,8 +342,7 @@ impl ControlServer {
 
         let mut latest = {
             let registry = self.registry.lock().map_err(poisoned)?;
-            current(&registry)
-                .ok_or_else(|| ControlError::not_found(p.session_id.0.clone()))?
+            current(&registry).ok_or_else(|| ControlError::not_found(p.session_id.0.clone()))?
         };
         loop {
             if matches(&latest) {
@@ -356,8 +351,7 @@ impl ControlServer {
                     timed_out: false,
                 });
             }
-            let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now())
-            else {
+            let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now()) else {
                 return encode(&diri_proto::EventsWaitResult {
                     session: latest,
                     timed_out: true,
@@ -489,12 +483,9 @@ impl ControlServer {
         let mut worktree_path = None;
         let mut git_branch = None;
         if p.new_worktree.unwrap_or(false) {
-            let info = crate::git::create_worktree(
-                Path::new(&p.cwd),
-                p.worktree_branch.as_deref(),
-                None,
-            )
-            .map_err(io_control_error)?;
+            let info =
+                crate::git::create_worktree(Path::new(&p.cwd), p.worktree_branch.as_deref(), None)
+                    .map_err(io_control_error)?;
             git_branch.clone_from(&info.branch);
             cwd.clone_from(&info.path);
             worktree_path = Some(info.path);
@@ -572,10 +563,8 @@ impl ControlServer {
         // contains the complete command.
         if descriptor.binary.is_some() {
             if let Some(injection) = &self.injection {
-                pty.env.push((
-                    crate::inject::SESSION_ID_ENV.into(),
-                    id.clone(),
-                ));
+                pty.env
+                    .push((crate::inject::SESSION_ID_ENV.into(), id.clone()));
                 pty.env.push((
                     crate::inject::SOCKET_ENV.into(),
                     self.socket_path.to_string_lossy().into_owned(),
@@ -838,7 +827,10 @@ impl ControlServer {
             )
         };
         for record in &records {
-            let path = record.worktree_path.clone().unwrap_or_else(|| record.cwd.clone());
+            let path = record
+                .worktree_path
+                .clone()
+                .unwrap_or_else(|| record.cwd.clone());
             match session_by_path.get(&path) {
                 Some(existing) if running(existing) || !running(record) => {}
                 _ => {
@@ -853,9 +845,10 @@ impl ControlServer {
                 .current_dir(dir)
                 .output()
                 .ok()?;
-            output.status.success().then(|| {
-                String::from_utf8_lossy(&output.stdout).trim().to_string()
-            })
+            output
+                .status
+                .success()
+                .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
         };
 
         let mut entries = Vec::new();
@@ -894,12 +887,9 @@ impl ControlServer {
                 let is_main = worktree.path == root;
                 let dirty = run_git(&["status", "--porcelain"], &worktree.path)
                     .is_some_and(|output| !output.is_empty());
-                let merged = worktree
-                    .branch
-                    .as_ref()
-                    .is_some_and(|branch| {
-                        branch != &default_branch && merged_branches.contains(branch)
-                    });
+                let merged = worktree.branch.as_ref().is_some_and(|branch| {
+                    branch != &default_branch && merged_branches.contains(branch)
+                });
                 let age_days = std::fs::metadata(&worktree.path)
                     .ok()
                     .and_then(|meta| meta.created().or_else(|_| meta.modified()).ok())
@@ -917,7 +907,11 @@ impl ControlServer {
                     dirty,
                     merged,
                     age_days,
-                    stale_suggestion: !is_main && !session_alive && merged && !dirty && age_days > 7,
+                    stale_suggestion: !is_main
+                        && !session_alive
+                        && merged
+                        && !dirty
+                        && age_days > 7,
                 });
             }
         }
@@ -965,8 +959,8 @@ impl ControlServer {
             .map_err(|_| ControlError::internal("HOME is not set"))?;
 
         // Locate the target checkout by origin (shared with host.locate_repo).
-        let origin = crate::hosts::origin_of_cwd(&record.cwd, source_host.as_ref())
-            .ok_or_else(|| {
+        let origin =
+            crate::hosts::origin_of_cwd(&record.cwd, source_host.as_ref()).ok_or_else(|| {
                 ControlError::bad_request(format!(
                     "session cwd is not inside a git repository with an 'origin' remote: {}",
                     record.cwd
@@ -1091,7 +1085,11 @@ impl ControlServer {
     /// derived from a session's cwd + host).
     fn host_locate_repo(&self, params: Option<JsonValue>) -> Result<JsonValue, ControlError> {
         let p: diri_proto::HostLocateRepoParams = decode(params)?;
-        let target = p.host.as_deref().map(|id| self.resolve_host(id)).transpose()?;
+        let target = p
+            .host
+            .as_deref()
+            .map(|id| self.resolve_host(id))
+            .transpose()?;
 
         let mut origin = p.origin_url.clone();
         if origin.is_none()
@@ -1209,7 +1207,10 @@ impl ControlServer {
         })
     }
 
-    fn session_read_scrollback(&self, params: Option<JsonValue>) -> Result<JsonValue, ControlError> {
+    fn session_read_scrollback(
+        &self,
+        params: Option<JsonValue>,
+    ) -> Result<JsonValue, ControlError> {
         let p: diri_proto::SessionIdParams = decode(params)?;
         let registry = self.registry.lock().map_err(poisoned)?;
         let session = registry
@@ -1429,9 +1430,10 @@ impl ControlServer {
             .manifest(kind)
             .ok_or_else(|| ControlError::not_found(format!("no manifest for agent {kind}")))?;
         let descriptor = manifest.agent.clone().unwrap_or_default();
-        descriptor.binary.as_ref().ok_or_else(|| {
-            ControlError::bad_request(format!("agent {kind} declares no binary"))
-        })?;
+        descriptor
+            .binary
+            .as_ref()
+            .ok_or_else(|| ControlError::bad_request(format!("agent {kind} declares no binary")))?;
         let tail = descriptor.resume_args(agent_session_id).ok_or_else(|| {
             ControlError::bad_request(format!("agent {kind} does not support resume"))
         })?;
@@ -1539,8 +1541,8 @@ impl ControlServer {
                 .map(|record| record.cwd)
                 .ok_or_else(|| ControlError::not_found(p.session_id.0.clone()))?
         };
-        let result = crate::git::working_diff(Path::new(&cwd), p.base.as_ref())
-            .map_err(io_control_error)?;
+        let result =
+            crate::git::working_diff(Path::new(&cwd), p.base.as_ref()).map_err(io_control_error)?;
         encode(&result)
     }
 
@@ -1606,11 +1608,8 @@ impl ControlServer {
             .into_iter()
             .find(|record| record.id.0 == id)
         {
-            self.events.publish_encoded(
-                diri_proto::EventName::SESSION_UPDATED,
-                &record,
-                Some(id),
-            );
+            self.events
+                .publish_encoded(diri_proto::EventName::SESSION_UPDATED, &record, Some(id));
         }
     }
 
@@ -1730,10 +1729,7 @@ struct SubscriptionHandle {
 
 /// Serializes one message onto the shared write half. Responses and event
 /// frames interleave here; the mutex keeps each line whole.
-fn write_message(
-    writer: &Arc<Mutex<UnixStream>>,
-    message: &ControlMessage,
-) -> std::io::Result<()> {
+fn write_message(writer: &Arc<Mutex<UnixStream>>, message: &ControlMessage) -> std::io::Result<()> {
     let mut bytes = serde_json::to_vec(message)?;
     bytes.push(b'\n');
     let mut stream = writer
@@ -1762,9 +1758,7 @@ fn encode<T: serde::Serialize>(value: &T) -> Result<JsonValue, ControlError> {
 /// Resolves a binary on the daemon's PATH, as the readiness check needs.
 fn resolve_on_path(binary: &str) -> Option<String> {
     if binary.contains('/') {
-        return Path::new(binary)
-            .exists()
-            .then(|| binary.to_string());
+        return Path::new(binary).exists().then(|| binary.to_string());
     }
     let path = std::env::var("PATH").ok()?;
     for dir in path.split(':') {
@@ -1788,7 +1782,6 @@ fn resolve_on_path(binary: &str) -> Option<String> {
     }
     None
 }
-
 
 /// Resolves a spec's bare argv[0] to an absolute path against its own env
 /// PATH (daemon PATH as fallback). The process that execs it may be a
@@ -1898,9 +1891,9 @@ fn inject_initial_prompt(registry: &Arc<Mutex<Registry>>, session_id: &str, prom
         if view.exited {
             return;
         }
-        let Some(before) =
-            with_session(registry, session_id, |session| session.screen_lines().join("\n"))
-        else {
+        let Some(before) = with_session(registry, session_id, |session| {
+            session.screen_lines().join("\n")
+        }) else {
             return;
         };
         let sent = with_session(registry, session_id, |session| {
@@ -2181,7 +2174,10 @@ mod tests {
             command.contains("'claude' '--resume' 'uuid-1'"),
             "the complete resume command must run inside the shell: {command}"
         );
-        assert!(command.contains("; exec "), "the shell must survive: {command}");
+        assert!(
+            command.contains("; exec "),
+            "the shell must survive: {command}"
+        );
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/events.rs
+++ b/diri/crates/diri-engine/src/events.rs
@@ -448,7 +448,10 @@ mod tests {
         let bus = EventBus::new();
         let stream = bus.subscribe(
             None,
-            Filter::new(Some(vec!["s_1".into()]), Some(vec!["session.updated".into()])),
+            Filter::new(
+                Some(vec!["s_1".into()]),
+                Some(vec!["session.updated".into()]),
+            ),
         );
         bus.publish("session.updated", json!({}), Some("s_1"));
         bus.publish("session.updated", json!({}), Some("s_2")); // other session
@@ -464,8 +467,7 @@ mod tests {
             bus.publish("burst", json!({ "n": n }), None);
         }
         // Queue of 2: events 1..=3 were evicted; the newest two remain.
-        let survivors: Vec<Event> =
-            std::iter::from_fn(|| stream.try_recv()).collect();
+        let survivors: Vec<Event> = std::iter::from_fn(|| stream.try_recv()).collect();
         assert_eq!(survivors.len(), 2);
         assert_eq!(survivors[0].seq, 4);
         assert_eq!(survivors[1].seq, 5);

--- a/diri/crates/diri-engine/src/governor.rs
+++ b/diri/crates/diri-engine/src/governor.rs
@@ -119,8 +119,7 @@ fn sweep(
                     None,
                 );
             } else {
-                total_footprint =
-                    total_footprint.wrapping_add(record.memory_bytes.unwrap_or(0));
+                total_footprint = total_footprint.wrapping_add(record.memory_bytes.unwrap_or(0));
             }
             continue;
         }
@@ -161,7 +160,12 @@ fn sweep(
         // frozen out from under the user.
         if let Some(idle_since) = idle_since(record, attached) {
             if footprint > config.hard_memory_bytes {
-                let _ = hibernate(registry, events, &id, diri_proto::HibernationReason::MemoryPressure);
+                let _ = hibernate(
+                    registry,
+                    events,
+                    &id,
+                    diri_proto::HibernationReason::MemoryPressure,
+                );
                 continue;
             }
             idle_candidates.push((id, idle_since, footprint));
@@ -212,7 +216,9 @@ fn apply_sample(
     artifacts: Option<Vec<diri_proto::SessionArtifact>>,
 ) {
     let event = {
-        let Ok(mut guard) = registry.lock() else { return };
+        let Ok(mut guard) = registry.lock() else {
+            return;
+        };
         guard.apply_resource_sample(id, memory, ports, artifacts)
     };
     if let Some(event) = event {
@@ -235,10 +241,7 @@ fn hibernate(
         };
         guard.hibernate(id, reason)?;
         let _ = guard.persist();
-        guard
-            .records()
-            .into_iter()
-            .find(|record| record.id.0 == id)
+        guard.records().into_iter().find(|record| record.id.0 == id)
     };
     if let Some(record) = record {
         events.publish_encoded(diri_proto::EventName::SESSION_UPDATED, &record, Some(id));
@@ -392,13 +395,31 @@ pub fn listening_ports(pids: &[i32], timeout: Duration) -> Option<Vec<PortInfo>>
         .collect::<Vec<_>>()
         .join(",");
     let mut child = Command::new("/usr/sbin/lsof")
-        .args(["-a", "-iTCP", "-sTCP:LISTEN", "-p", &joined, "-Fpcn", "-n", "-P"])
+        .args([
+            "-a",
+            "-iTCP",
+            "-sTCP:LISTEN",
+            "-p",
+            &joined,
+            "-Fpcn",
+            "-n",
+            "-P",
+        ])
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
         .spawn()
         .or_else(|_| {
             Command::new("lsof")
-                .args(["-a", "-iTCP", "-sTCP:LISTEN", "-p", &joined, "-Fpcn", "-n", "-P"])
+                .args([
+                    "-a",
+                    "-iTCP",
+                    "-sTCP:LISTEN",
+                    "-p",
+                    &joined,
+                    "-Fpcn",
+                    "-n",
+                    "-P",
+                ])
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::null())
                 .spawn()

--- a/diri/crates/diri-engine/src/holder/client.rs
+++ b/diri/crates/diri-engine/src/holder/client.rs
@@ -9,8 +9,8 @@ use std::path::{Path, PathBuf};
 use base64::Engine as _;
 
 use super::protocol::{
-    HolderLaunchSpec, HolderManagerRequest, HolderManagerResponse, HolderOperation, HolderProcessSample,
-    HolderRequest, HolderResponse, HolderStat,
+    HolderLaunchSpec, HolderManagerRequest, HolderManagerResponse, HolderOperation,
+    HolderProcessSample, HolderRequest, HolderResponse, HolderStat,
 };
 use super::socket;
 use super::{HolderError, HolderResult};
@@ -114,12 +114,16 @@ impl HolderManagerClient {
         let response: HolderManagerResponse = socket::read_json_line(&mut stream)?;
         if !response.ok {
             return Err(HolderError::Rejected(
-                response.error.unwrap_or_else(|| "unknown manager error".into()),
+                response
+                    .error
+                    .unwrap_or_else(|| "unknown manager error".into()),
             ));
         }
         match response.manager_pid {
             Some(pid) if pid > 1 => Ok(pid),
-            _ => Err(HolderError::Transport("manager response omitted pid".into())),
+            _ => Err(HolderError::Transport(
+                "manager response omitted pid".into(),
+            )),
         }
     }
 }

--- a/diri/crates/diri-engine/src/holder/launcher.rs
+++ b/diri/crates/diri-engine/src/holder/launcher.rs
@@ -199,7 +199,11 @@ fn spawn_manager(executable_path: &Path, directory: &Path) -> HolderResult<()> {
 }
 
 fn read_pid_file(path: &Path) -> Option<i32> {
-    let pid = std::fs::read_to_string(path).ok()?.trim().parse::<i32>().ok()?;
+    let pid = std::fs::read_to_string(path)
+        .ok()?
+        .trim()
+        .parse::<i32>()
+        .ok()?;
     (pid > 1).then_some(pid)
 }
 

--- a/diri/crates/diri-engine/src/holder/manager.rs
+++ b/diri/crates/diri-engine/src/holder/manager.rs
@@ -15,7 +15,9 @@ use std::time::{Duration, Instant};
 
 use super::client::HolderClient;
 use super::paths::{HolderManagerPaths, HolderPaths, MANAGER_PROTOCOL_VERSION};
-use super::protocol::{HolderLaunchSpec, HolderManagerOperation, HolderManagerRequest, HolderManagerResponse};
+use super::protocol::{
+    HolderLaunchSpec, HolderManagerOperation, HolderManagerRequest, HolderManagerResponse,
+};
 use super::server::HolderServer;
 use super::socket;
 use super::{HolderError, HolderResult};
@@ -76,15 +78,13 @@ impl HolderManagerServer {
         loop {
             match socket::accept_raw(listen_fd, || state.shutting_down.load(Ordering::SeqCst)) {
                 Ok(Some(mut client)) => {
-                    let response =
-                        match socket::read_json_line::<HolderManagerRequest>(&mut client) {
-                            Ok(request) => self
-                                .handle(&state, &request)
-                                .unwrap_or_else(|error| {
-                                    HolderManagerResponse::failure(error.to_string())
-                                }),
-                            Err(error) => HolderManagerResponse::failure(error.to_string()),
-                        };
+                    let response = match socket::read_json_line::<HolderManagerRequest>(&mut client)
+                    {
+                        Ok(request) => self.handle(&state, &request).unwrap_or_else(|error| {
+                            HolderManagerResponse::failure(error.to_string())
+                        }),
+                        Err(error) => HolderManagerResponse::failure(error.to_string()),
+                    };
                     let _ = socket::write_json_line(&mut client, &response);
                 }
                 Ok(None) => break, // the watchdog closed the listener

--- a/diri/crates/diri-engine/src/holder/paths.rs
+++ b/diri/crates/diri-engine/src/holder/paths.rs
@@ -66,7 +66,8 @@ impl HolderManagerPaths {
     /// Whether a directory entry is a manager socket rather than a session's.
     /// Registry adoption scans use this to skip the manager endpoint.
     pub fn is_manager_socket(path: &Path) -> bool {
-        path.extension().is_some_and(|extension| extension == "sock")
+        path.extension()
+            .is_some_and(|extension| extension == "sock")
             && path
                 .file_stem()
                 .and_then(|stem| stem.to_str())

--- a/diri/crates/diri-engine/src/holder/protocol.rs
+++ b/diri/crates/diri-engine/src/holder/protocol.rs
@@ -378,9 +378,12 @@ mod tests {
 
     #[test]
     fn requests_spell_operations_the_swift_way() {
-        let kill = serde_json::to_string(&HolderRequest::op(HolderOperation::KillTree))
-            .expect("encode");
-        assert_eq!(kill, r#"{"op":"kill-tree"}"#, "hyphenated, optionals omitted");
+        let kill =
+            serde_json::to_string(&HolderRequest::op(HolderOperation::KillTree)).expect("encode");
+        assert_eq!(
+            kill, r#"{"op":"kill-tree"}"#,
+            "hyphenated, optionals omitted"
+        );
 
         let decoded: HolderRequest =
             serde_json::from_str(r#"{"op":"write","data":"aGk="}"#).expect("decode");
@@ -397,8 +400,7 @@ mod tests {
             serde_json::from_str(r#"{"ok":true,"managerPID":4242}"#).expect("decode");
         assert_eq!(response.manager_pid, Some(4242));
 
-        let encoded =
-            serde_json::to_string(&HolderManagerResponse::success(7)).expect("encode");
+        let encoded = serde_json::to_string(&HolderManagerResponse::success(7)).expect("encode");
         assert!(encoded.contains(r#""managerPID":7"#), "{encoded}");
     }
 

--- a/diri/crates/diri-engine/src/holder/server.rs
+++ b/diri/crates/diri-engine/src/holder/server.rs
@@ -285,11 +285,11 @@ fn handle(shared: &Shared, request: &HolderRequest) -> HolderResult<HolderRespon
                 .data
                 .as_deref()
                 .and_then(|encoded| {
-                    base64::engine::general_purpose::STANDARD.decode(encoded).ok()
+                    base64::engine::general_purpose::STANDARD
+                        .decode(encoded)
+                        .ok()
                 })
-                .ok_or_else(|| {
-                    HolderError::InvalidRequest("write requires base64 data".into())
-                })?;
+                .ok_or_else(|| HolderError::InvalidRequest("write requires base64 data".into()))?;
             write_pty(shared, &data)?;
             Ok(HolderResponse::success())
         }
@@ -310,9 +310,9 @@ fn handle(shared: &Shared, request: &HolderRequest) -> HolderResult<HolderRespon
         }
 
         HolderOperation::Signal => {
-            let signal = request.sig.ok_or_else(|| {
-                HolderError::InvalidRequest("signal requires a valid sig".into())
-            })?;
+            let signal = request
+                .sig
+                .ok_or_else(|| HolderError::InvalidRequest("signal requires a valid sig".into()))?;
             if signal <= 0 || signal >= MAX_SIGNAL {
                 return Err(HolderError::InvalidRequest(
                     "signal requires a valid sig".into(),
@@ -345,13 +345,8 @@ fn write_pty(shared: &Shared, data: &[u8]) -> HolderResult<()> {
     let mut written = 0;
     while written < data.len() {
         // SAFETY: plain write(2) on an owned fd with an in-bounds slice.
-        let count = unsafe {
-            libc::write(
-                fd,
-                data[written..].as_ptr().cast(),
-                data.len() - written,
-            )
-        };
+        let count =
+            unsafe { libc::write(fd, data[written..].as_ptr().cast(), data.len() - written) };
         if count > 0 {
             written += count as usize;
             continue;
@@ -384,10 +379,7 @@ fn current_stat(shared: &Shared) -> HolderStat {
     let pty = shared.pty.lock().expect("pty");
     // SAFETY: kill with signal 0 only checks existence.
     let child_alive = unsafe { libc::kill(shared.child_pid, 0) } == 0;
-    let master_fd = pty
-        .writer()
-        .map(|stream| stream.as_raw_fd())
-        .unwrap_or(-1);
+    let master_fd = pty.writer().map(|stream| stream.as_raw_fd()).unwrap_or(-1);
     // SAFETY: tcgetpgrp on the master; -1 fd yields an error, mapped to None.
     let foreground = unsafe { libc::tcgetpgrp(master_fd) };
     let size = pty.size().ok();

--- a/diri/crates/diri-engine/src/holder/socket.rs
+++ b/diri/crates/diri-engine/src/holder/socket.rs
@@ -68,7 +68,10 @@ pub fn write_json_line<T: Serialize>(stream: &mut impl Write, value: &T) -> Hold
 /// wakes an `accept(2)` blocked on an AF_UNIX listener via `shutdown` alone —
 /// the fd must also be closed, which means the accept loop cannot hold a safe
 /// owner of it. The Swift holder shipped this exact shape.
-pub fn accept_raw(listen_fd: i32, finished: impl Fn() -> bool) -> HolderResult<Option<std::os::unix::net::UnixStream>> {
+pub fn accept_raw(
+    listen_fd: i32,
+    finished: impl Fn() -> bool,
+) -> HolderResult<Option<std::os::unix::net::UnixStream>> {
     loop {
         // SAFETY: accept(2) on a listening fd; the addr out-params are unused.
         let client = unsafe { libc::accept(listen_fd, std::ptr::null_mut(), std::ptr::null_mut()) };

--- a/diri/crates/diri-engine/src/hosts.rs
+++ b/diri/crates/diri-engine/src/hosts.rs
@@ -30,7 +30,11 @@ pub struct ShellOutput {
 
 /// Runs `command` on the host (or locally when `host` is None) with a hard
 /// timeout; the process is killed at the deadline.
-pub fn run_shell(host: Option<&HostEntry>, command: &str, timeout: Duration) -> Option<ShellOutput> {
+pub fn run_shell(
+    host: Option<&HostEntry>,
+    command: &str,
+    timeout: Duration,
+) -> Option<ShellOutput> {
     let mut argv: Vec<String> = match host {
         Some(host) => {
             let mut argv = vec!["ssh".to_string()];
@@ -179,12 +183,7 @@ fn sync_tool(spec: &ToolSpec, host: &HostEntry) -> PrefsSyncToolReport {
         .chain(SSH_OPTIONS)
         .collect::<Vec<_>>()
         .join(" ");
-    let mut args: Vec<String> = vec![
-        "-a".into(),
-        "--timeout=60".into(),
-        "-e".into(),
-        transport,
-    ];
+    let mut args: Vec<String> = vec!["-a".into(), "--timeout=60".into(), "-e".into(), transport];
     args.extend(
         present
             .iter()
@@ -269,10 +268,7 @@ pub fn normalize_git_url(url: &str) -> String {
 /// The origin URL of the repository containing `cwd` on `host` (None host =
 /// local). None when cwd isn't in a git repo or the repo has no origin.
 pub fn origin_of_cwd(cwd: &str, host: Option<&HostEntry>) -> Option<String> {
-    let command = format!(
-        "cd {} && git remote get-url origin",
-        shell_quote_path(cwd)
-    );
+    let command = format!("cd {} && git remote get-url origin", shell_quote_path(cwd));
     let result = run_shell(host, &command, Duration::from_secs(20))?;
     if !result.ok {
         return None;
@@ -393,6 +389,11 @@ mod tests {
             empty.path(),
         );
         assert_eq!(result.tools.len(), 2);
-        assert!(result.tools.iter().all(|tool| tool.ok && tool.synced.is_empty()));
+        assert!(
+            result
+                .tools
+                .iter()
+                .all(|tool| tool.ok && tool.synced.is_empty())
+        );
     }
 }

--- a/diri/crates/diri-engine/src/inject.rs
+++ b/diri/crates/diri-engine/src/inject.rs
@@ -30,7 +30,10 @@ pub fn uuid_v4() -> String {
     bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
     bytes[8] = (bytes[8] & 0x3f) | 0x80; // RFC 4122 variant
     let h = |range: std::ops::Range<usize>| {
-        bytes[range].iter().map(|b| format!("{b:02x}")).collect::<String>()
+        bytes[range]
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<String>()
     };
     format!(
         "{}-{}-{}-{}-{}",

--- a/diri/crates/diri-engine/src/lib.rs
+++ b/diri/crates/diri-engine/src/lib.rs
@@ -31,8 +31,8 @@ pub mod governor;
 pub mod history;
 #[cfg(unix)]
 pub mod holder;
-pub mod hosts;
 pub mod hooks;
+pub mod hosts;
 pub mod inject;
 pub mod log;
 pub mod mcp;

--- a/diri/crates/diri-engine/src/mcp/host.rs
+++ b/diri/crates/diri-engine/src/mcp/host.rs
@@ -440,10 +440,9 @@ impl RegistryHost {
                     )
                 })?
             }
-            (None, None) => host
-                .default_cwd
-                .clone()
-                .ok_or("local cwd has no git origin and the host has no defaultCwd; pass remote_cwd")?,
+            (None, None) => host.default_cwd.clone().ok_or(
+                "local cwd has no git origin and the host has no defaultCwd; pass remote_cwd",
+            )?,
         };
 
         // Code handoff: the caller's exact tree state lands on the host
@@ -453,14 +452,9 @@ impl RegistryHost {
         let mut branch = None;
         let mut spawn_cwd = remote_root.clone();
         if sync_code && origin.is_some() {
-            let prepared = crate::migrate::prepare(
-                cwd,
-                None,
-                Some(&host),
-                &remote_root,
-                host.display_name(),
-            )
-            .map_err(|error| format!("code sync failed: {error}"))?;
+            let prepared =
+                crate::migrate::prepare(cwd, None, Some(&host), &remote_root, host.display_name())
+                    .map_err(|error| format!("code sync failed: {error}"))?;
             synced = true;
             branch = Some(prepared.branch.clone());
             spawn_cwd = prepared.target_repo_root;

--- a/diri/crates/diri-engine/src/migrate.rs
+++ b/diri/crates/diri-engine/src/migrate.rs
@@ -530,13 +530,19 @@ mod tests {
         std::fs::create_dir_all(&origin).unwrap();
         git(&origin, &["init", "-q", "--bare", "-b", "main"]);
         let source = temp.path().join("source");
-        git(temp.path(), &["clone", "-q", origin.to_str().unwrap(), "source"]);
+        git(
+            temp.path(),
+            &["clone", "-q", origin.to_str().unwrap(), "source"],
+        );
         std::fs::write(source.join("file.txt"), "v1\n").unwrap();
         git(&source, &["add", "."]);
         git(&source, &["commit", "-q", "-m", "root"]);
         git(&source, &["push", "-q", "-u", "origin", "main"]);
         let target = temp.path().join("target");
-        git(temp.path(), &["clone", "-q", origin.to_str().unwrap(), "target"]);
+        git(
+            temp.path(),
+            &["clone", "-q", origin.to_str().unwrap(), "target"],
+        );
 
         // Dirty the source; prepare must WIP-commit, push, and sync target.
         std::fs::write(source.join("file.txt"), "wip changes\n").unwrap();
@@ -589,13 +595,19 @@ mod tests {
         std::fs::create_dir_all(&origin).unwrap();
         git(&origin, &["init", "-q", "--bare", "-b", "main"]);
         let source = temp.path().join("source");
-        git(temp.path(), &["clone", "-q", origin.to_str().unwrap(), "source"]);
+        git(
+            temp.path(),
+            &["clone", "-q", origin.to_str().unwrap(), "source"],
+        );
         std::fs::write(source.join("f"), "x").unwrap();
         git(&source, &["add", "."]);
         git(&source, &["commit", "-q", "-m", "root"]);
         git(&source, &["push", "-q", "-u", "origin", "main"]);
         let target = temp.path().join("target");
-        git(temp.path(), &["clone", "-q", origin.to_str().unwrap(), "target"]);
+        git(
+            temp.path(),
+            &["clone", "-q", origin.to_str().unwrap(), "target"],
+        );
         std::fs::write(target.join("f"), "target work in progress").unwrap();
 
         let error = prepare(
@@ -606,9 +618,6 @@ mod tests {
             "local",
         )
         .expect_err("dirty target must refuse");
-        assert!(
-            error.to_string().contains("uncommitted changes"),
-            "{error}"
-        );
+        assert!(error.to_string().contains("uncommitted changes"), "{error}");
     }
 }

--- a/diri/crates/diri-engine/src/pr_monitor.rs
+++ b/diri/crates/diri-engine/src/pr_monitor.rs
@@ -413,12 +413,14 @@ pub fn fetch(url: &str, gh: &str, include_threads: bool) -> Option<PullRequestSt
     const FIELDS: &str = "number,title,author,body,baseRefName,headRefName,state,isDraft,\
         reviewDecision,mergeable,mergeStateStatus,additions,deletions,changedFiles,\
         comments,reviews,statusCheckRollup";
-    let data = run_gh(gh, &["pr", "view", url, "--json", FIELDS], Duration::from_secs(15))?;
+    let data = run_gh(
+        gh,
+        &["pr", "view", url, "--json", FIELDS],
+        Duration::from_secs(15),
+    )?;
     let mut status = parse(&data, url, now())?;
 
-    if include_threads
-        && let Some((owner, repo, number)) = pr_coordinates(url)
-    {
+    if include_threads && let Some((owner, repo, number)) = pr_coordinates(url) {
         let query = "query=query($owner:String!,$name:String!,$number:Int!){\
             repository(owner:$owner,name:$name){pullRequest(number:$number){\
             reviewThreads(first:100){totalCount nodes{isResolved}}}}}";
@@ -489,7 +491,11 @@ pub fn pr_coordinates(url: &str) -> Option<(String, String, i64)> {
         .collect::<String>()
         .parse()
         .ok()?;
-    Some((parts[pull - 2].to_string(), parts[pull - 1].to_string(), number))
+    Some((
+        parts[pull - 2].to_string(),
+        parts[pull - 1].to_string(),
+        number,
+    ))
 }
 
 /// Decodes the reviewThreads GraphQL response into (resolved, total).
@@ -565,9 +571,7 @@ pub fn parse(data: &[u8], url: &str, fetched_at: DateMillis) -> Option<PullReque
         } else {
             None
         },
-        created_at: entry[created_key]
-            .as_str()
-            .and_then(parse_github_date),
+        created_at: entry[created_key].as_str().and_then(parse_github_date),
         url: string(&entry["url"]),
     };
     let comments: Vec<PrDiscussionItem> = view["comments"]
@@ -632,9 +636,7 @@ fn parse_github_date(value: &str) -> Option<DateMillis> {
     if bytes.len() < 20 || bytes[4] != b'-' || bytes[7] != b'-' || bytes[10] != b'T' {
         return None;
     }
-    let number = |range: std::ops::Range<usize>| -> Option<i64> {
-        value.get(range)?.parse().ok()
-    };
+    let number = |range: std::ops::Range<usize>| -> Option<i64> { value.get(range)?.parse().ok() };
     let (year, month, day) = (number(0..4)?, number(5..7)?, number(8..10)?);
     let (hour, minute, second) = (number(11..13)?, number(14..16)?, number(17..19)?);
     // Days since epoch via the civil-days algorithm.
@@ -729,12 +731,7 @@ mod tests {
             },
         )]);
         assert_eq!(
-            next_refresh_delay(
-                &targets,
-                &refresh,
-                &HashSet::from([url]),
-                Instant::now(),
-            ),
+            next_refresh_delay(&targets, &refresh, &HashSet::from([url]), Instant::now(),),
             Duration::ZERO
         );
     }
@@ -792,7 +789,11 @@ mod tests {
         assert_eq!(status.author.as_deref(), Some("shawn"));
         assert_eq!(status.review_decision, None, "empty string means none");
         assert_eq!(
-            (status.checks_passed, status.checks_failed, status.checks_pending),
+            (
+                status.checks_passed,
+                status.checks_failed,
+                status.checks_pending
+            ),
             (1, 1, 1)
         );
         let checks = status.checks.expect("checks");
@@ -816,9 +817,6 @@ mod tests {
                 "nodes": [{"isResolved": true}, {"isResolved": false}, {"isResolved": true}]
             }}}}
         });
-        assert_eq!(
-            parse_threads(payload.to_string().as_bytes()),
-            Some((2, 5))
-        );
+        assert_eq!(parse_threads(payload.to_string().as_bytes()), Some((2, 5)));
     }
 }

--- a/diri/crates/diri-engine/src/registry.rs
+++ b/diri/crates/diri-engine/src/registry.rs
@@ -208,7 +208,8 @@ impl Registry {
             .flatten()
             .map(|entry| entry.path())
             .filter(|path| {
-                path.extension().is_some_and(|extension| extension == "sock")
+                path.extension()
+                    .is_some_and(|extension| extension == "sock")
                     && !HolderManagerPaths::is_manager_socket(path)
             })
             .filter_map(|path| {

--- a/diri/crates/diri-engine/src/screen.rs
+++ b/diri/crates/diri-engine/src/screen.rs
@@ -528,7 +528,6 @@ impl HeadlessScreen {
         hasher.finish()
     }
 
-
     /// Extracts `ESC ] 9 ; 4 ; state ; value` progress reports.
     ///
     /// Agents use this to say "I am working, 40% through"; the emulator has no
@@ -799,10 +798,7 @@ mod tests {
         assert!(!restored.is_alt_screen());
         assert_eq!(restored.cursor(), original.cursor());
         // Attribute fidelity, not just text: the restored grid's cells match.
-        assert_eq!(
-            restored.full_snapshot().changed_rows,
-            snapshot.changed_rows
-        );
+        assert_eq!(restored.full_snapshot().changed_rows, snapshot.changed_rows);
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -259,11 +259,7 @@ impl DeferredLaunch {
                 return Some(state.pending.unwrap_or(fallback));
             }
             let wait = state.deadline - now;
-            state = self
-                .cond
-                .wait_timeout(state, wait)
-                .expect("deferred")
-                .0;
+            state = self.cond.wait_timeout(state, wait).expect("deferred").0;
         }
     }
 
@@ -323,9 +319,7 @@ impl Session {
     /// spec carries a [`HolderConfig`], directly otherwise.
     pub fn spawn(spec: SessionSpec, engine: Arc<ManifestEngine>) -> std::io::Result<Self> {
         match spec.holder.clone() {
-            Some(holder) if spec.defer_launch => {
-                Self::spawn_held_deferred(spec, &holder, engine)
-            }
+            Some(holder) if spec.defer_launch => Self::spawn_held_deferred(spec, &holder, engine),
             Some(holder) => Self::spawn_held(spec, &holder, engine),
             None => Self::spawn_direct(spec, engine),
         }
@@ -335,9 +329,7 @@ impl Session {
         let pty = Pty::spawn(&spec.pty)?;
         let log = OutputLog::writer(&spec.logs_dir, &spec.id)?;
         let shared = new_shared(&spec, log);
-        shared
-            .child_pid
-            .store(pty.pid() as i32, Ordering::SeqCst);
+        shared.child_pid.store(pty.pid() as i32, Ordering::SeqCst);
 
         let reader = pty.reader()?;
         let pty = Arc::new(Mutex::new(pty));
@@ -391,8 +383,7 @@ impl Session {
             rows: spec.pty.rows.max(2),
             disk_capacity: crate::holder::protocol::DEFAULT_DISK_CAPACITY,
         };
-        HolderLauncher::launch(&holder.executable, &paths, &launch)
-            .map_err(holder_io_error)?;
+        HolderLauncher::launch(&holder.executable, &paths, &launch).map_err(holder_io_error)?;
 
         let client = HolderClient::new(paths.socket());
         let floor = wait_for_holder(&client, &spec.logs_dir, &spec.id, pre_spawn_tail)
@@ -429,8 +420,7 @@ impl Session {
             std::thread::Builder::new()
                 .name(format!("diri-session-{}", spec.id))
                 .spawn(move || {
-                    let Some((cols, rows)) =
-                        deferred.wait_for_launch_size((pty.cols, pty.rows))
+                    let Some((cols, rows)) = deferred.wait_for_launch_size((pty.cols, pty.rows))
                     else {
                         return; // cancelled before ever launching
                     };
@@ -466,8 +456,7 @@ impl Session {
                         mark_launch_failed(&shared);
                         return;
                     }
-                    let Ok(floor) = wait_for_holder(&client, &logs_dir, &id, pre_spawn_tail)
-                    else {
+                    let Ok(floor) = wait_for_holder(&client, &logs_dir, &id, pre_spawn_tail) else {
                         mark_launch_failed(&shared);
                         return;
                     };
@@ -568,9 +557,7 @@ impl Session {
             let manifest_id = spec.manifest_id.clone();
             std::thread::Builder::new()
                 .name(format!("diri-session-{}", spec.id))
-                .spawn(move || {
-                    pump_held(shared, engine, client, exit_marker_floor, manifest_id)
-                })?
+                .spawn(move || pump_held(shared, engine, client, exit_marker_floor, manifest_id))?
         };
 
         Ok(Self {
@@ -1377,7 +1364,9 @@ fn pump_held(
 
         // The floor is an incarnation boundary, so no marker straddles it:
         // markers wholly below are stripped but their statuses ignored.
-        let honored_from = exit_marker_floor.saturating_sub(start).min(chunk.len() as u64) as usize;
+        let honored_from = exit_marker_floor
+            .saturating_sub(start)
+            .min(chunk.len() as u64) as usize;
         let mut output = Vec::new();
         if honored_from > 0 {
             marker_buffer.extend_from_slice(&chunk[..honored_from]);
@@ -1568,8 +1557,7 @@ mod log_watch {
                 unsafe { libc::close(self.fd) };
                 self.fd = -1;
             }
-            let Ok(cpath) = std::ffi::CString::new(self.path.as_os_str().as_encoded_bytes())
-            else {
+            let Ok(cpath) = std::ffi::CString::new(self.path.as_os_str().as_encoded_bytes()) else {
                 return;
             };
             // SAFETY: O_EVTONLY opens for watching without inhibiting unmount.

--- a/diri/crates/diri-engine/tests/attach.rs
+++ b/diri/crates/diri-engine/tests/attach.rs
@@ -140,11 +140,12 @@ fn an_attach_is_seeded_then_streams_diffs_and_answers_input() {
     data.write_all(&attach_line).expect("attach");
 
     let mut frames = FrameReader::new(data.try_clone().expect("clone data"));
-    let seed = frames.until("the seed grid", |frame| {
-        frame.frame_type == FrameType::Grid
-    });
+    let seed = frames.until("the seed grid", |frame| frame.frame_type == FrameType::Grid);
     let update = seed.grid_payload().expect("decode").expect("grid");
-    assert!(update.is_full_snapshot, "a fresh sink gets the whole screen");
+    assert!(
+        update.is_full_snapshot,
+        "a fresh sink gets the whole screen"
+    );
     assert!(
         grid_text(&update).contains("seeded-screen"),
         "the seed carries what the child already painted"
@@ -156,8 +157,10 @@ fn an_attach_is_seeded_then_streams_diffs_and_answers_input() {
 
     // Typing through the data channel: cat echoes, and the echo comes back
     // as a grid DIFF (not a full snapshot).
-    data.write_all(&FrameCodec::encode(&Frame::input(b"typed-over-attach\n".to_vec())).expect("encode"))
-        .expect("send input");
+    data.write_all(
+        &FrameCodec::encode(&Frame::input(b"typed-over-attach\n".to_vec())).expect("encode"),
+    )
+    .expect("send input");
     let diff = frames.until("the echo diff", |frame| {
         frame.frame_type == FrameType::Grid
             && frame
@@ -175,9 +178,7 @@ fn an_attach_is_seeded_then_streams_diffs_and_answers_input() {
     // Ping answers pong on the same channel.
     data.write_all(&FrameCodec::encode(&Frame::ping()).expect("encode"))
         .expect("send ping");
-    frames.until("pong", |frame| {
-        frame.frame_type == FrameType::Pong
-    });
+    frames.until("pong", |frame| frame.frame_type == FrameType::Pong);
 
     // A resize through the data channel reshapes the PTY; the next grid
     // carries the new geometry.

--- a/diri/crates/diri-engine/tests/checkpoint.rs
+++ b/diri/crates/diri-engine/tests/checkpoint.rs
@@ -44,13 +44,10 @@ fn shell_spec(
 ) -> diri_engine::session::SessionSpec {
     diri_engine::session::SessionSpec {
         id: id.into(),
-        pty: diri_engine::PtySpec::new(
-            vec!["/bin/sh".into(), "-c".into(), script.into()],
-            "/tmp",
-        )
-        .env("PATH", "/usr/bin:/bin")
-        .env("TERM", "xterm-256color")
-        .size(80, 24),
+        pty: diri_engine::PtySpec::new(vec!["/bin/sh".into(), "-c".into(), script.into()], "/tmp")
+            .env("PATH", "/usr/bin:/bin")
+            .env("TERM", "xterm-256color")
+            .size(80, 24),
         manifest_id: "shell".into(),
         authority: diri_engine::Authority::ProcessOnly,
         logs_dir: logs.to_path_buf(),
@@ -171,10 +168,14 @@ fn the_held_pump_writes_a_checkpoint_once_output_settles() {
     });
     // The settle delay means the write happens after output went quiet, so
     // by load time the offset covers everything the child said.
-    wait_until("the checkpoint to cover the tail", Duration::from_secs(10), || {
-        ScreenCheckpoint::load(&path)
-            .is_some_and(|checkpoint| checkpoint.log_offset == log_tail(&logs, "s_ck"))
-    });
+    wait_until(
+        "the checkpoint to cover the tail",
+        Duration::from_secs(10),
+        || {
+            ScreenCheckpoint::load(&path)
+                .is_some_and(|checkpoint| checkpoint.log_offset == log_tail(&logs, "s_ck"))
+        },
+    );
     let checkpoint = ScreenCheckpoint::load(&path).expect("checkpoint");
     let text = checkpoint
         .grid
@@ -253,7 +254,11 @@ fn adoption_seeds_from_the_checkpoint_not_the_raw_tail() {
             .join("\n")
             .contains("PAINTED-FROM-CHECKPOINT")
     });
-    let screen = registry.get("s_ad").expect("adopted").screen_lines().join("\n");
+    let screen = registry
+        .get("s_ad")
+        .expect("adopted")
+        .screen_lines()
+        .join("\n");
     assert!(
         !screen.contains("hello-from-the-log"),
         "replay from the checkpoint offset must not re-feed old bytes: {screen:?}"
@@ -320,7 +325,11 @@ fn a_stale_checkpoint_falls_back_to_tail_replay() {
             .join("\n")
             .contains("the-log-is-truth")
     });
-    let screen = registry.get("s_fb").expect("adopted").screen_lines().join("\n");
+    let screen = registry
+        .get("s_fb")
+        .expect("adopted")
+        .screen_lines()
+        .join("\n");
     assert!(
         !screen.contains("GEOMETRY-MISMATCH"),
         "a refused checkpoint must not leak onto the screen: {screen:?}"

--- a/diri/crates/diri-engine/tests/control_socket.rs
+++ b/diri/crates/diri-engine/tests/control_socket.rs
@@ -174,10 +174,7 @@ fn spawning_a_shell_over_the_socket_produces_a_watched_session() {
     let id = match spawned {
         ControlMessage::Response {
             result: Ok(result), ..
-        } => result["id"]
-            .as_str()
-            .expect("a session id")
-            .to_string(),
+        } => result["id"].as_str().expect("a session id").to_string(),
         other => panic!("spawn failed: {other:?}"),
     };
     assert!(id.starts_with("s_"), "id follows the daemon format: {id}");
@@ -380,7 +377,10 @@ fn events_flow_to_a_subscribed_connection() {
             result: Ok(result), ..
         } => {
             assert_eq!(result["timedOut"], false, "{result}");
-            assert!(result["session"]["status"].get("exited").is_some(), "{result}");
+            assert!(
+                result["session"]["status"].get("exited").is_some(),
+                "{result}"
+            );
         }
         other => panic!("wait failed: {other:?}"),
     }

--- a/diri/crates/diri-engine/tests/deferred.rs
+++ b/diri/crates/diri-engine/tests/deferred.rs
@@ -31,13 +31,10 @@ fn holders_dir(tag: &str) -> PathBuf {
 fn deferred_spec(id: &str, script: &str, root: &Path) -> SessionSpec {
     SessionSpec {
         id: id.into(),
-        pty: PtySpec::new(
-            vec!["/bin/sh".into(), "-c".into(), script.into()],
-            "/tmp",
-        )
-        .env("PATH", "/usr/bin:/bin")
-        .env("TERM", "xterm-256color")
-        .size(80, 24),
+        pty: PtySpec::new(vec!["/bin/sh".into(), "-c".into(), script.into()], "/tmp")
+            .env("PATH", "/usr/bin:/bin")
+            .env("TERM", "xterm-256color")
+            .size(80, 24),
         manifest_id: "shell".into(),
         authority: Authority::ProcessOnly,
         logs_dir: root.join("logs"),
@@ -94,7 +91,9 @@ fn the_first_client_size_decides_the_launch_geometry() {
         "the child must never have existed at the estimated size"
     );
 
-    session.terminate(Duration::from_secs(2)).expect("terminate");
+    session
+        .terminate(Duration::from_secs(2))
+        .expect("terminate");
 }
 
 /// No client size at all (an MCP-spawned agent): the fallback window closes
@@ -114,7 +113,9 @@ fn without_a_client_size_the_fallback_launches_at_the_estimate() {
         log_text(&logs, "s_fall").contains("24 80")
     });
 
-    session.terminate(Duration::from_secs(2)).expect("terminate");
+    session
+        .terminate(Duration::from_secs(2))
+        .expect("terminate");
 }
 
 /// Keystrokes racing the exec are queued and flushed after it — the Swift
@@ -124,8 +125,8 @@ fn input_typed_before_the_exec_is_queued_and_flushed() {
     let root = holders_dir("input");
     let logs = root.join("logs");
 
-    let mut session = Session::spawn(deferred_spec("s_in", "exec cat", &root), engine())
-        .expect("spawn");
+    let mut session =
+        Session::spawn(deferred_spec("s_in", "exec cat", &root), engine()).expect("spawn");
     session
         .write_input(b"typed-before-exec\n")
         .expect("queued while unlaunched");
@@ -134,7 +135,9 @@ fn input_typed_before_the_exec_is_queued_and_flushed() {
         log_text(&logs, "s_in").contains("typed-before-exec")
     });
 
-    session.terminate(Duration::from_secs(2)).expect("terminate");
+    session
+        .terminate(Duration::from_secs(2))
+        .expect("terminate");
 }
 
 /// A kill during the deferral window means the child must never exist.
@@ -146,7 +149,9 @@ fn terminating_before_the_exec_prevents_the_launch() {
 
     let mut session =
         Session::spawn(deferred_spec("s_no", &script, &root), engine()).expect("spawn");
-    let exit = session.terminate(Duration::from_secs(2)).expect("terminate");
+    let exit = session
+        .terminate(Duration::from_secs(2))
+        .expect("terminate");
     assert!(matches!(exit, diri_engine::Exit::Signal(_)));
 
     // Well past the fallback window: the exec must not have happened.

--- a/diri/crates/diri-engine/tests/holder.rs
+++ b/diri/crates/diri-engine/tests/holder.rs
@@ -8,12 +8,12 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
+use diri_engine::OutputLog;
 use diri_engine::holder::protocol::DEFAULT_DISK_CAPACITY;
 use diri_engine::holder::{
     HolderClient, HolderExitMarker, HolderLaunchSpec, HolderLauncher, HolderManagerClient,
     HolderManagerPaths, HolderManagerServer, HolderPaths, HolderServer,
 };
-use diri_engine::OutputLog;
 
 fn spec(paths: &HolderPaths, logs: &Path, argv: &[&str]) -> HolderLaunchSpec {
     HolderLaunchSpec {
@@ -27,7 +27,10 @@ fn spec(paths: &HolderPaths, logs: &Path, argv: &[&str]) -> HolderLaunchSpec {
         argv: argv.iter().map(|word| word.to_string()).collect(),
         cwd: "/tmp".into(),
         environment: HashMap::from([
-            ("PATH".to_string(), std::env::var("PATH").unwrap_or_default()),
+            (
+                "PATH".to_string(),
+                std::env::var("PATH").unwrap_or_default(),
+            ),
             ("TERM".to_string(), "xterm-256color".to_string()),
         ]),
         cols: 80,
@@ -284,9 +287,7 @@ fn the_launcher_bootstraps_a_real_manager_process() {
     });
 
     fresh.kill_tree().expect("kill");
-    wait_until("session gone", Duration::from_secs(5), || {
-        !fresh.is_alive()
-    });
+    wait_until("session gone", Duration::from_secs(5), || !fresh.is_alive());
 
     // The detached manager idles out shortly after its last session ends.
     // Watch passively — a ping would re-arm the idle timer (by design: a

--- a/diri/crates/diri-engine/tests/holder_interop.rs
+++ b/diri/crates/diri-engine/tests/holder_interop.rs
@@ -25,7 +25,8 @@ use diri_engine::holder::{
 
 /// The Swift holder binary, if the outer package has been built.
 fn swift_holder() -> Option<PathBuf> {
-    let candidate = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../.build/debug/dirijord-holder");
+    let candidate =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../.build/debug/dirijord-holder");
     match candidate.canonicalize() {
         Ok(path) => Some(path),
         Err(_) => {
@@ -58,7 +59,10 @@ fn spec(paths: &HolderPaths, logs: &Path, argv: &[&str]) -> HolderLaunchSpec {
         argv: argv.iter().map(|word| word.to_string()).collect(),
         cwd: "/tmp".into(),
         environment: HashMap::from([
-            ("PATH".to_string(), std::env::var("PATH").unwrap_or_default()),
+            (
+                "PATH".to_string(),
+                std::env::var("PATH").unwrap_or_default(),
+            ),
             ("TERM".to_string(), "xterm-256color".to_string()),
         ]),
         cols: 100,
@@ -147,7 +151,10 @@ fn the_rust_client_drives_a_live_swift_holder() {
     let exit = exit.expect("swift wrote an exit marker rust can read");
     assert!(exit.signal.is_some(), "killed, so signaled: {exit:?}");
 
-    assert!(!paths.socket().exists(), "swift cleaned up its control files");
+    assert!(
+        !paths.socket().exists(),
+        "swift cleaned up its control files"
+    );
 }
 
 /// Rust launcher ⇄ Swift manager: the Rust daemon bootstraps the SWIFT

--- a/diri/crates/diri-engine/tests/holder_session.rs
+++ b/diri/crates/diri-engine/tests/holder_session.rs
@@ -43,13 +43,10 @@ fn holder_config(root: &Path) -> HolderConfig {
 fn shell_spec(id: &str, script: &str, logs: &Path, holder: Option<HolderConfig>) -> SessionSpec {
     SessionSpec {
         id: id.into(),
-        pty: PtySpec::new(
-            vec!["/bin/sh".into(), "-c".into(), script.into()],
-            "/tmp",
-        )
-        .env("PATH", "/usr/bin:/bin")
-        .env("TERM", "xterm-256color")
-        .size(80, 24),
+        pty: PtySpec::new(vec!["/bin/sh".into(), "-c".into(), script.into()], "/tmp")
+            .env("PATH", "/usr/bin:/bin")
+            .env("TERM", "xterm-256color")
+            .size(80, 24),
         manifest_id: "shell".into(),
         authority: Authority::ProcessOnly,
         logs_dir: logs.to_path_buf(),
@@ -76,9 +73,7 @@ fn log_contains(logs: &Path, id: &str, needle: &[u8]) -> bool {
     log.refresh_from_disk();
     let tail = log.tail_offset();
     let (_, bytes) = log.read(0, tail as usize);
-    bytes
-        .windows(needle.len())
-        .any(|window| window == needle)
+    bytes.windows(needle.len()).any(|window| window == needle)
 }
 
 #[test]

--- a/diri/crates/diri-engine/tests/inject_prompt.rs
+++ b/diri/crates/diri-engine/tests/inject_prompt.rs
@@ -65,10 +65,7 @@ impl Control {
 }
 
 fn start_server(temp: &Path) -> Arc<ControlServer> {
-    let registry = Arc::new(Mutex::new(Registry::new(
-        engine(),
-        temp.join("state.json"),
-    )));
+    let registry = Arc::new(Mutex::new(Registry::new(engine(), temp.join("state.json"))));
     let server = Arc::new(
         ControlServer::new(Arc::clone(&registry), temp.join("daemon.sock"))
             .with_logs_dir(temp.join("logs")),

--- a/diri/crates/diri-engine/tests/wake.rs
+++ b/diri/crates/diri-engine/tests/wake.rs
@@ -33,10 +33,7 @@ fn engine() -> Arc<ManifestEngine> {
 /// One daemon in miniature: control server on a private socket, holder-backed
 /// spawns — the exact shape `dirijord-rs` runs in production.
 fn start_server(temp: &Path) -> Arc<ControlServer> {
-    let registry = Arc::new(Mutex::new(Registry::new(
-        engine(),
-        temp.join("state.json"),
-    )));
+    let registry = Arc::new(Mutex::new(Registry::new(engine(), temp.join("state.json"))));
     let server = Arc::new(
         ControlServer::new(Arc::clone(&registry), temp.join("daemon.sock"))
             .with_logs_dir(temp.join("logs"))
@@ -111,12 +108,15 @@ fn spawn_cat(control: &mut Control) -> String {
         }),
     );
     let id = spawned["id"].as_str().expect("session id").to_string();
-    wait_until("the child painted its banner", Duration::from_secs(10), || {
-        control
-            .request("session.read_screen", json!({ "sessionID": id }))["text"]
-            .as_str()
-            .is_some_and(|text| text.contains("cat-ready"))
-    });
+    wait_until(
+        "the child painted its banner",
+        Duration::from_secs(10),
+        || {
+            control.request("session.read_screen", json!({ "sessionID": id }))["text"]
+                .as_str()
+                .is_some_and(|text| text.contains("cat-ready"))
+        },
+    );
     id
 }
 
@@ -130,7 +130,10 @@ fn ps_states(pids: &[i64]) -> Vec<(i64, String)> {
                 .args(["-o", "state=", "-p", &pid.to_string()])
                 .output()
                 .expect("ps");
-            (*pid, String::from_utf8_lossy(&output.stdout).trim().to_string())
+            (
+                *pid,
+                String::from_utf8_lossy(&output.stdout).trim().to_string(),
+            )
         })
         .collect()
 }
@@ -212,8 +215,7 @@ fn send_text_wakes_a_hibernated_tree_and_delivers_the_text() {
     });
     // …the text reaches the child (cat echoes it back to the screen)…
     wait_until("the echo to land", Duration::from_secs(10), || {
-        control
-            .request("session.read_screen", json!({ "sessionID": id }))["text"]
+        control.request("session.read_screen", json!({ "sessionID": id }))["text"]
             .as_str()
             .is_some_and(|text| text.contains("typed-into-a-frozen-session"))
     });
@@ -244,11 +246,15 @@ fn a_data_channel_attach_wakes_a_hibernated_tree() {
     data.write_all(&attach_line).expect("attach");
 
     // The attach itself is the wake trigger.
-    wait_until("the tree to resume on attach", Duration::from_secs(5), || {
-        ps_states(&pids)
-            .iter()
-            .all(|(_, state)| !state.is_empty() && !state.starts_with('T'))
-    });
+    wait_until(
+        "the tree to resume on attach",
+        Duration::from_secs(5),
+        || {
+            ps_states(&pids)
+                .iter()
+                .all(|(_, state)| !state.is_empty() && !state.starts_with('T'))
+        },
+    );
     assert!(
         hibernation_cleared(&mut control, &id),
         "an attach must clear the hibernation record"
@@ -292,7 +298,10 @@ fn a_data_channel_attach_wakes_a_hibernated_tree() {
             }
         }
     }
-    assert!(echoed, "input typed over the data channel never echoed back");
+    assert!(
+        echoed,
+        "input typed over the data channel never echoed back"
+    );
 
     control.request("session.kill", json!({ "sessionID": id }));
 }

--- a/diri/crates/diri-term/src/find.rs
+++ b/diri/crates/diri-term/src/find.rs
@@ -270,7 +270,14 @@ fn build_matches(query: &str, snapshot: &FindSnapshot, live: &GridBuffer) -> Vec
             if absolute_row >= snapshot.visible_start_row {
                 continue;
             }
-            append_matches(line, None, absolute_row, &needle, &mut scratch, &mut matches);
+            append_matches(
+                line,
+                None,
+                absolute_row,
+                &needle,
+                &mut scratch,
+                &mut matches,
+            );
             if matches.len() >= MATCH_CAP {
                 matches.truncate(MATCH_CAP);
                 return matches;

--- a/diri/crates/diri-updater/src/lib.rs
+++ b/diri/crates/diri-updater/src/lib.rs
@@ -300,8 +300,8 @@ mod tests {
     #[ignore = "requires network access and downloads a release"]
     fn the_published_release_downloads_and_verifies() {
         let http = Http::new();
-        let feed = Feed::parse(&http.fetch_text(DEFAULT_FEED_URL).expect("feed"))
-            .expect("feed parses");
+        let feed =
+            Feed::parse(&http.fetch_text(DEFAULT_FEED_URL).expect("feed")).expect("feed parses");
         let release = feed
             .releases
             .iter()

--- a/diri/crates/diri-updater/src/net.rs
+++ b/diri/crates/diri-updater/src/net.rs
@@ -223,52 +223,28 @@ mod tests {
 
     #[test]
     fn accepts_a_release_url_on_the_pinned_host() {
-        assert!(
-            validated_download_url(
-                "https://github.com/diri/diri-0.2.0.zip",
-                HOST
-            )
-            .is_ok()
-        );
+        assert!(validated_download_url("https://github.com/diri/diri-0.2.0.zip", HOST).is_ok());
     }
 
     #[test]
     fn rejects_other_hosts_and_schemes() {
         assert!(validated_download_url("https://evil.test/diri.zip", HOST).is_err());
-        assert!(
-            validated_download_url(
-                "http://github.com/diri.zip",
-                HOST
-            )
-            .is_err()
-        );
+        assert!(validated_download_url("http://github.com/diri.zip", HOST).is_err());
         assert!(validated_download_url("file:///tmp/diri.zip", HOST).is_err());
     }
 
     #[test]
     fn rejects_userinfo_that_would_fake_the_host() {
-        assert!(
-            validated_download_url(
-                "https://github.com@evil.test/diri.zip",
-                HOST
-            )
-            .is_err()
-        );
+        assert!(validated_download_url("https://github.com@evil.test/diri.zip", HOST).is_err());
     }
 
     #[test]
     fn rejects_urls_that_could_inject_curl_options() {
         assert!(
-            validated_download_url(
-                "https://github.com/a\"\nupload-file = \"/etc/passwd",
-                HOST
-            )
-            .is_err()
-        );
-        assert!(
-            validated_download_url("https://github.com/a\\b", HOST)
+            validated_download_url("https://github.com/a\"\nupload-file = \"/etc/passwd", HOST)
                 .is_err()
         );
+        assert!(validated_download_url("https://github.com/a\\b", HOST).is_err());
     }
 
     #[test]

--- a/diri/scripts/package.sh
+++ b/diri/scripts/package.sh
@@ -80,6 +80,20 @@ cargo packager \
     --binaries-dir "${universal_dir}" \
     --out-dir "${dist_dir}"
 
+# Ship the same reviewed dependency disclosure that CI validates. The JSON is
+# also attached to GitHub Releases so users can inspect it without mounting the
+# app bundle.
+third_party_inventory="${dist_dir}/THIRD-PARTY-LICENSES.json"
+echo "==> Generating third-party license inventory"
+python3 "${workspace_dir}/../scripts/check-licenses.py" --output "${third_party_inventory}"
+license_dir="${app_path}/Contents/Resources/licenses"
+mkdir -p "${license_dir}"
+cp "${workspace_dir}/../LICENSE" "${license_dir}/Apache-2.0.txt"
+cp "${workspace_dir}/../NOTICE" "${license_dir}/NOTICE.txt"
+cp "${workspace_dir}/../license-policy.json" "${license_dir}/license-policy.json"
+cp "${workspace_dir}/../LICENSES/"*.txt "${license_dir}/"
+cp "${third_party_inventory}" "${license_dir}/THIRD-PARTY-LICENSES.json"
+
 # --------------------------------------------------------------------------
 # Bundle the Swift daemon inside diri.app so diri is self-contained and can
 # replace the retired Dirijor.app. diri launches dirijord from here; dirijord

--- a/diri/scripts/publish-github-release.sh
+++ b/diri/scripts/publish-github-release.sh
@@ -14,6 +14,7 @@ artifacts=("$@")
 gh_repo="${GH_REPO:-cristicretu/diri}"
 gh_bin="${GH_BIN:-gh}"
 tag="v${version}"
+source_commit="${SOURCE_COMMIT:-}"
 
 if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo "error: version '${version}' is not X.Y.Z" >&2
@@ -65,7 +66,11 @@ if "${gh_bin}" release view "${tag}" --repo "${gh_repo}" >/dev/null 2>&1; then
     verify_published_artifacts
     echo "    ${tag} already exists with identical artifacts; leaving it immutable"
 else
-    "${gh_bin}" release create "${tag}" "${artifacts[@]}" \
+    create_args=(release create "${tag}" "${artifacts[@]}")
+    if [[ -n "${source_commit}" ]]; then
+        create_args+=(--target "${source_commit}")
+    fi
+    "${gh_bin}" "${create_args[@]}" \
         --repo "${gh_repo}" \
         --title "diri ${version}" \
         --notes-file "${notes_file}"

--- a/diri/scripts/release.sh
+++ b/diri/scripts/release.sh
@@ -12,12 +12,12 @@
 #   SKIP_GATES=1        skip cargo test/clippy (for re-running a failed publish)
 #   SKIP_PERF_GATE=1   skip packaged app memory/idle-CPU probe
 #
-# This publishes TWO artifacts per release, both notarized and stapled:
+# This publishes TWO application artifacts per release, both notarized and stapled:
 #   diri-<version>-universal.dmg  what people download by hand
 #   diri-<version>-universal.zip  what the in-app updater fetches
-# plus appcast.json, the feed the updater reads. All three are attached to a
-# GitHub Release, so `releases/latest/download/appcast.json` is a stable feed
-# URL. See diri/UPDATING.md for the trust model and one-time setup.
+# plus appcast.json, SHA256SUMS, and the reviewed dependency-license inventory.
+# All are attached to a GitHub Release, so the updater feed has a stable URL.
+# See diri/UPDATING.md for the trust model and one-time setup.
 set -euo pipefail
 
 if [ $# -lt 1 ]; then
@@ -46,6 +46,8 @@ GH_REPO="${GH_REPO:-cristicretu/diri}"
 TAP_DIR="${TAP_DIR:-$ROOT/../homebrew-diri}"
 TAG="v$VERSION"
 FEED="$DIST/appcast.json"
+CHECKSUMS="$DIST/SHA256SUMS"
+INVENTORY="$DIST/THIRD-PARTY-LICENSES.json"
 MINIMUM_SYSTEM="15.0"
 # Old builds stay downloadable but the repo should not grow without bound.
 KEEP_RELEASES=5
@@ -101,23 +103,47 @@ EOF
 fi
 
 # ----------------------------------------------------------------------------
-# 1. Version bump
+# 1. Source provenance
 # ----------------------------------------------------------------------------
 # The updater compares against CARGO_PKG_VERSION, so the manifest is the single
-# source of truth for what version this build claims to be.
+# source of truth for what version this build claims to be. Version bumps go
+# through a normal pull request; a release must build the exact remote main
+# commit rather than creating an unpushed release-only commit.
 CURRENT="$(sed -n 's/^version = "\(.*\)"/\1/p' "$MANIFEST" | head -1)"
 if [ "$CURRENT" != "$VERSION" ]; then
-    if [ -n "$(git -C "$ROOT" status --porcelain --untracked-files=no)" ]; then
-        echo "error: uncommitted changes; commit them before bumping to $VERSION" >&2
+    cat >&2 <<EOF
+error: diri-app is $CURRENT, not $VERSION
+
+Open and merge a version-bump pull request first, then run this script from the
+clean main checkout. Release artifacts must map to a reviewed source commit.
+EOF
+    exit 1
+fi
+if [ -n "$(git -C "$ROOT" status --porcelain --untracked-files=no)" ]; then
+    echo "error: tracked files are dirty; release from a clean main checkout" >&2
+    exit 1
+fi
+git -C "$ROOT" fetch --quiet origin main --tags
+SOURCE_COMMIT="$(git -C "$ROOT" rev-parse HEAD)"
+REMOTE_MAIN="$(git -C "$ROOT" rev-parse origin/main)"
+if [ "$SOURCE_COMMIT" != "$REMOTE_MAIN" ]; then
+    cat >&2 <<EOF
+error: release source is not the current origin/main
+  local:  $SOURCE_COMMIT
+  remote: $REMOTE_MAIN
+
+Merge the source and version bump first, then check out and pull main.
+EOF
+    exit 1
+fi
+if git -C "$ROOT" rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null; then
+    TAG_COMMIT="$(git -C "$ROOT" rev-list -n 1 "$TAG")"
+    if [ "$TAG_COMMIT" != "$SOURCE_COMMIT" ]; then
+        echo "error: $TAG points to $TAG_COMMIT, not release source $SOURCE_COMMIT" >&2
         exit 1
     fi
-    echo "==> Bumping diri-app $CURRENT -> $VERSION"
-    sed -i '' -E "1,/^version = /s/^version = \".*\"/version = \"$VERSION\"/" "$MANIFEST"
-    cargo update --workspace --offline >/dev/null 2>&1 || cargo update --workspace >/dev/null
-    git -C "$ROOT" add "$MANIFEST" "$WORKSPACE/Cargo.lock"
-    git -C "$ROOT" commit -m "diri: release $VERSION" >/dev/null
-    echo "    committed the bump"
 fi
+echo "    source commit : $SOURCE_COMMIT"
 
 # ----------------------------------------------------------------------------
 # 2. Gates
@@ -240,6 +266,22 @@ feed_path.write_text(json.dumps(feed, indent=2) + "\n")
 print(f"    {len(feed['releases'])} release(s) in the feed, newest {feed['releases'][0]['version']}")
 PYFEED
 
+if [ ! -f "$INVENTORY" ]; then
+    echo "error: packaging did not produce $INVENTORY" >&2
+    exit 1
+fi
+
+echo "==> Writing $CHECKSUMS"
+(
+    cd "$DIST"
+    shasum -a 256 \
+        "$(basename "$DMG")" \
+        "$(basename "$ZIP")" \
+        "$(basename "$FEED")" \
+        "$(basename "$INVENTORY")" > "$(basename "$CHECKSUMS")"
+    shasum -a 256 -c "$(basename "$CHECKSUMS")"
+)
+
 # ----------------------------------------------------------------------------
 # 5. Publish the GitHub Release
 # ----------------------------------------------------------------------------
@@ -260,9 +302,9 @@ NOTES
 fi
 
 echo "==> Publishing $TAG to $GH_REPO"
-GH_REPO="$GH_REPO" \
+GH_REPO="$GH_REPO" SOURCE_COMMIT="$SOURCE_COMMIT" \
     "$WORKSPACE/scripts/publish-github-release.sh" \
-    "$VERSION" "$NOTES_FILE" "$DMG" "$ZIP" "$FEED"
+    "$VERSION" "$NOTES_FILE" "$DMG" "$ZIP" "$FEED" "$CHECKSUMS" "$INVENTORY"
 
 # ----------------------------------------------------------------------------
 # 6. Bump the Homebrew cask
@@ -289,12 +331,13 @@ cat <<EOF
   Update zip : $ZIP
   DMG sha256 : $DMG_SHA256
   ZIP sha256 : $SHA256
+  Checksums   : $CHECKSUMS
+  Licenses    : $INVENTORY
+  Source      : $SOURCE_COMMIT
   Release    : https://github.com/$GH_REPO/releases/tag/$TAG
   Feed       : https://github.com/$GH_REPO/releases/latest/download/appcast.json
 
   Next steps:
-    1. Push the source and tag it:
-         git -C "$ROOT" push && git tag diri-v$VERSION && git push origin diri-v$VERSION
-    2. Confirm an old build updates itself (diri/UPDATING.md → "Verifying a release")
+    1. Confirm an old build updates itself (diri/UPDATING.md → "Verifying a release")
 ============================================================
 EOF

--- a/diri/scripts/test-publish-github-release.sh
+++ b/diri/scripts/test-publish-github-release.sh
@@ -22,15 +22,21 @@ notes="${fixture_root}/notes.md"
 dmg="${fixture_root}/diri-0.4.6-universal.dmg"
 zip="${fixture_root}/diri-0.4.6-universal.zip"
 feed="${fixture_root}/appcast.json"
+checksums="${fixture_root}/SHA256SUMS"
+inventory="${fixture_root}/THIRD-PARTY-LICENSES.json"
 mkdir -p "${state_dir}"
 printf 'notes\n' > "${notes}"
 printf 'dmg bytes\n' > "${dmg}"
 printf 'zip bytes\n' > "${zip}"
 printf '{"feed_version":1}\n' > "${feed}"
+printf 'checksums\n' > "${checksums}"
+printf '{"schema":1}\n' > "${inventory}"
 
 dmg_sha="$(shasum -a 256 "${dmg}" | awk '{print $1}')"
 zip_sha="$(shasum -a 256 "${zip}" | awk '{print $1}')"
 feed_sha="$(shasum -a 256 "${feed}" | awk '{print $1}')"
+checksums_sha="$(shasum -a 256 "${checksums}" | awk '{print $1}')"
+inventory_sha="$(shasum -a 256 "${inventory}" | awk '{print $1}')"
 
 printf '%s\n' \
     '#!/usr/bin/env bash' \
@@ -44,6 +50,8 @@ printf '%s\n' \
     '            *diri-0.4.6-universal.dmg*) printf "sha256:%s\n" "${TEST_DMG_SHA:?}" ;;' \
     '            *diri-0.4.6-universal.zip*) printf "sha256:%s\n" "${TEST_ZIP_SHA:?}" ;;' \
     '            *appcast.json*) printf "sha256:%s\n" "${TEST_FEED_SHA:?}" ;;' \
+    '            *SHA256SUMS*) printf "sha256:%s\n" "${TEST_CHECKSUMS_SHA:?}" ;;' \
+    '            *THIRD-PARTY-LICENSES.json*) printf "sha256:%s\n" "${TEST_INVENTORY_SHA:?}" ;;' \
     '            *) exit 1 ;;' \
     '        esac' \
     '    fi' \
@@ -62,9 +70,12 @@ run_publisher() {
     TEST_DMG_SHA="${dmg_sha}" \
     TEST_ZIP_SHA="${zip_sha}" \
     TEST_FEED_SHA="${feed_sha}" \
+    TEST_CHECKSUMS_SHA="${checksums_sha}" \
+    TEST_INVENTORY_SHA="${inventory_sha}" \
     GH_BIN="${fake_gh}" \
     GH_REPO="example/diri" \
-        "${publisher}" 0.4.6 "${notes}" "${dmg}" "${zip}" "${feed}"
+    SOURCE_COMMIT="0123456789abcdef0123456789abcdef01234567" \
+        "${publisher}" 0.4.6 "${notes}" "${dmg}" "${zip}" "${feed}" "${checksums}" "${inventory}"
 }
 
 # An exact rerun may recover a failed downstream tap push without modifying the
@@ -93,6 +104,8 @@ rm -f "${state_dir}/exists" "${state_dir}/calls.log"
 run_publisher
 grep -q 'release create' "${state_dir}/calls.log" \
     || fail "new release was not created"
+grep -q -- '--target 0123456789abcdef0123456789abcdef01234567' "${state_dir}/calls.log" \
+    || fail "new release was not pinned to the reviewed source commit"
 if grep -q -- '--clobber' "${state_dir}/calls.log"; then
     fail "publisher exposed a clobber path"
 fi

--- a/diri/vendor/ztracing/Cargo.toml
+++ b/diri/vendor/ztracing/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ztracing"
+version = "0.1.0"
+edition = "2024"
+publish = false
+license = "Apache-2.0"
+
+[features]
+default = []
+tracy = []
+
+[dependencies]
+ztracing_macro = { path = "../ztracing_macro" }

--- a/diri/vendor/ztracing/src/lib.rs
+++ b/diri/vendor/ztracing/src/lib.rs
@@ -1,0 +1,7 @@
+//! No-op compatibility surface for GPUI's optional profiling annotations.
+//!
+//! Diri does not enable Zed's `ztracing` cfg or Tracy integration. Keeping the
+//! attribute as a no-op preserves that release behavior without pulling the
+//! unrelated GPL-licensed logging/profiling implementation into the app.
+
+pub use ztracing_macro::instrument;

--- a/diri/vendor/ztracing_macro/Cargo.toml
+++ b/diri/vendor/ztracing_macro/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ztracing_macro"
+version = "0.1.0"
+edition = "2024"
+publish = false
+license = "Apache-2.0"
+
+[lib]
+proc-macro = true

--- a/diri/vendor/ztracing_macro/src/lib.rs
+++ b/diri/vendor/ztracing_macro/src/lib.rs
@@ -1,0 +1,9 @@
+//! No-op profiling attribute used by Diri's pinned GPUI dependency.
+
+#[proc_macro_attribute]
+pub fn instrument(
+    _attributes: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    item
+}

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,74 @@
+# Getting started
+
+## Install
+
+Diri requires macOS 15 or newer. Install the signed, notarized universal build:
+
+```sh
+brew install --cask cristicretu/diri/diri
+```
+
+Alternatively, download the latest DMG from [GitHub Releases](https://github.com/cristicretu/diri/releases/latest),
+open it, and drag Diri to Applications. The app checks the same release feed for
+updates; it never installs one until you click restart.
+
+## Your first session
+
+1. Open Diri and add a project directory.
+2. Create a session and choose Claude Code, Codex, another supported agent, or a
+   plain shell.
+3. Work in the embedded terminal. The sidebar summarizes whether each agent is
+   working, waiting for input, or done.
+4. Quit and reopen Diri. The background daemon owns the PTY, so the session and
+   its terminal history remain available.
+
+Claude Code and Codex have first-class status detection and resume support.
+Other agents may offer partial detection; every agent can still run as a normal
+terminal.
+
+## Parallel work with worktrees
+
+Create separate sessions with separate git worktrees when agents may edit the
+same repository. This keeps branches and working trees isolated while Diri
+gives you one place to monitor them. Treat each worktree as a normal checkout:
+commit or move changes before deleting it.
+
+## Agent orchestration
+
+Diri ships a CLI and MCP server. A running agent can create or inspect Diri
+sessions when you explicitly configure the MCP server. That capability is
+powerful: it can launch local processes with your user privileges. Only expose
+it to agents you trust and review requested actions.
+
+## Remote hosts
+
+Remote sessions use SSH and tmux; Diri does not run a hosted relay. Start with
+the [remote-node guide](../diri/NODE.md), use a dedicated non-admin account when
+possible, and avoid forwarding credentials the remote job does not need.
+
+## Diagnostics
+
+Run this when the CLI is available:
+
+```sh
+dirijor doctor
+```
+
+Daemon logs and session state live under
+`~/Library/Application Support/Dirijor`. Logs may contain terminal output,
+paths, or secrets printed by a process, so redact them before filing an issue.
+See [SUPPORT.md](../SUPPORT.md) for the details to include.
+
+## Local data and uninstalling
+
+After stopping Diri and its daemon, remove the app and these directories if you
+also want to remove its local state:
+
+```text
+~/Library/Application Support/Dirijor
+~/Library/Application Support/diri
+~/Library/Caches/diri/updates
+```
+
+Read [PRIVACY.md](../PRIVACY.md) and the [security model](SECURITY-MODEL.md)
+before using Diri with sensitive repositories or remote hosts.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+# Documentation
+
+- [Getting started](GETTING_STARTED.md) — installation, first session, worktrees,
+  remote hosts, diagnostics, and local data.
+- [Security model](SECURITY-MODEL.md) — trust boundaries and safe-use guidance.
+- [Remote nodes](../diri/NODE.md) — run sessions over SSH and tmux.
+- [Packaging](../diri/PACKAGING.md) — build, signing, and notarization.
+- [Updates and releases](../diri/UPDATING.md) — updater design and release flow.
+- [Rust engine port](../diri/PORT.md) — status of the cross-platform engine.
+- [Performance](../diri/PERF.md) — budgets and measurement workflow.
+
+Project policies live at the repository root: [contributing](../CONTRIBUTING.md),
+[support](../SUPPORT.md), [security](../SECURITY.md), [privacy](../PRIVACY.md),
+and [governance](../GOVERNANCE.md).

--- a/docs/SECURITY-MODEL.md
+++ b/docs/SECURITY-MODEL.md
@@ -1,0 +1,66 @@
+# Security model
+
+Diri is a local developer tool that deliberately launches other powerful local
+developer tools. It reduces orchestration mistakes; it is not a sandbox.
+
+## Trust boundaries
+
+### Desktop app and daemon
+
+The app talks to a background daemon over local Unix sockets. The daemon owns
+PTYs, terminal replay logs, worktrees, child processes, and persistent session
+state. Socket and state paths are scoped to the current user. Another process
+already running as that user should be treated as inside the same trust boundary.
+
+The PTY holder lets sessions survive daemon restarts. Compatibility changes to
+the holder protocol or on-disk registry must preserve existing sessions or ship
+an explicit migration.
+
+### Child tools
+
+Shells, coding agents, hooks, MCP servers, and browser automation run with the
+macOS user's privileges. They can read any files that user and macOS privacy
+controls allow, use inherited environment variables, access configured
+credentials, and make network requests. Diri does not inspect or approve each
+operation they perform.
+
+Use separate worktrees to avoid accidental edit collisions, not as a security
+boundary. For untrusted code, use a dedicated OS account, VM, or container and
+restrict credentials and network access there.
+
+### Remote nodes
+
+Remote sessions cross the SSH boundary and run under the configured remote
+account. Diri relies on SSH host verification, keys, and configuration; it does
+not provide a separate encrypted relay or authorization layer. Prefer a
+dedicated non-admin user and narrowly scoped credentials.
+
+### Updates
+
+The updater downloads a versioned ZIP from GitHub Releases, checks its SHA-256
+from the release feed, verifies the code signature, requires the running app's
+Team ID and bundle identifier, validates notarization, and refuses downgrades.
+Published release assets are treated as immutable. Details are in
+[UPDATING.md](../diri/UPDATING.md).
+
+## Sensitive data
+
+Terminal replay logs can contain prompts, output, paths, and secrets emitted by
+tools. PR monitoring, remote hosts, and third-party agents can send data to their
+own services. Diri itself has no account, analytics, or telemetry service; see
+[PRIVACY.md](../PRIVACY.md).
+
+## Security assumptions
+
+Diri assumes:
+
+- macOS and the current user account are not already compromised;
+- installed agents, MCP servers, hooks, and shell configuration are trusted;
+- GitHub, Apple code-signing/notarization, Homebrew, SSH, and dependency sources
+  provide the guarantees documented by those systems;
+- contributors and release operators protect their GitHub and Apple credentials.
+
+## Reporting
+
+Report boundary bypasses, unsafe IPC/update behavior, credential disclosure,
+and unintended code execution privately through [SECURITY.md](../SECURITY.md).

--- a/license-policy.json
+++ b/license-policy.json
@@ -1,0 +1,62 @@
+{
+  "schema": 1,
+  "project_license": "Apache-2.0",
+  "rust_missing_metadata": [
+    {
+      "name": "gpui_shared_string",
+      "version": "0.1.0",
+      "source_contains": "zed-industries/zed.git?rev=dc2a339d5d043da448a3f7ddc7c0a85c63864aad",
+      "conservative_license": "GPL-3.0-or-later",
+      "reason": "The crate does not declare a license; Zed says repository code is primarily GPL-3.0-or-later unless an Apache-2.0 component is marked."
+    },
+    {
+      "name": "gpui_util",
+      "version": "0.1.0",
+      "source_contains": "zed-industries/zed.git?rev=dc2a339d5d043da448a3f7ddc7c0a85c63864aad",
+      "conservative_license": "GPL-3.0-or-later",
+      "reason": "The crate does not declare a license; Zed says repository code is primarily GPL-3.0-or-later unless an Apache-2.0 component is marked."
+    }
+  ],
+  "manually_reviewed_non_rust": [
+    {
+      "name": "SwiftTerm",
+      "ecosystem": "SwiftPM",
+      "version": "1.13.0",
+      "license": "MIT",
+      "source": "https://github.com/migueldeicaza/SwiftTerm"
+    },
+    {
+      "name": "swift-argument-parser",
+      "ecosystem": "SwiftPM",
+      "version": "1.8.2",
+      "license": "Apache-2.0",
+      "source": "https://github.com/apple/swift-argument-parser"
+    },
+    {
+      "name": "playwright",
+      "ecosystem": "npm",
+      "version": "1.61.1",
+      "license": "Apache-2.0",
+      "source": "https://github.com/microsoft/playwright"
+    },
+    {
+      "name": "playwright-core",
+      "ecosystem": "npm",
+      "version": "1.61.1",
+      "license": "Apache-2.0",
+      "source": "https://github.com/microsoft/playwright"
+    },
+    {
+      "name": "fsevents",
+      "ecosystem": "npm",
+      "version": "2.3.2",
+      "license": "MIT",
+      "source": "https://github.com/fsevents/fsevents"
+    }
+  ],
+  "notes": [
+    "Diri's original code remains Apache-2.0; distributed builds are also subject to dependency licenses.",
+    "The GPL-marked zlog/ztracing packages are replaced by the Apache-2.0 no-op compatibility crates under diri/vendor.",
+    "This inventory is an engineering control, not legal advice. Re-review it when the pinned Zed revision changes."
+  ]
+}

--- a/scripts/check-licenses.py
+++ b/scripts/check-licenses.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Validate dependency license metadata and optionally write an inventory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import subprocess
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+POLICY_PATH = ROOT / "license-policy.json"
+RUST_WORKSPACE = ROOT / "diri"
+
+
+def cargo_metadata() -> dict:
+    result = subprocess.run(
+        ["cargo", "metadata", "--format-version", "1", "--locked"],
+        cwd=RUST_WORKSPACE,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode:
+        print(result.stderr, file=sys.stderr, end="")
+        raise SystemExit(result.returncode)
+    return json.loads(result.stdout)
+
+
+def is_unacceptable_expression(expression: str) -> bool:
+    upper = expression.upper()
+    if any(token in upper for token in ("AGPL", "SSPL", "BUSL", "COMMONS-CLAUSE")):
+        return True
+    if "GPL" not in upper:
+        return False
+    # SPDX OR expressions let the distributor choose a permissive branch.
+    permissive = ("APACHE-2.0", "MIT", "BSD-", "ISC", "ZLIB", "MPL-2.0")
+    return " OR " not in upper or not any(token in upper for token in permissive)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=pathlib.Path, help="write the reviewed inventory as JSON")
+    args = parser.parse_args()
+
+    policy = json.loads(POLICY_PATH.read_text())
+    metadata = cargo_metadata()
+    missing_policy = {
+        (entry["name"], entry["version"]): entry
+        for entry in policy["rust_missing_metadata"]
+    }
+    seen_exceptions: set[tuple[str, str]] = set()
+    failures: list[str] = []
+    inventory: list[dict[str, str]] = []
+
+    for package in sorted(metadata["packages"], key=lambda item: (item["name"], item["version"])):
+        if package["source"] is None:
+            continue
+        license_expression = package.get("license") or ""
+        key = (package["name"], package["version"])
+        if not license_expression:
+            exception = missing_policy.get(key)
+            source = package["source"] or ""
+            if exception is None or exception["source_contains"] not in source:
+                failures.append(
+                    f"{package['name']} {package['version']} has no license metadata ({source})"
+                )
+                effective_license = "UNKNOWN"
+            else:
+                seen_exceptions.add(key)
+                effective_license = exception["conservative_license"]
+        else:
+            effective_license = license_expression
+            if is_unacceptable_expression(license_expression):
+                failures.append(
+                    f"{package['name']} {package['version']} uses {license_expression}"
+                )
+
+        inventory.append(
+            {
+                "name": package["name"],
+                "version": package["version"],
+                "license": effective_license,
+                "source": package["source"],
+            }
+        )
+
+    stale = set(missing_policy) - seen_exceptions
+    for name, version in sorted(stale):
+        failures.append(
+            f"stale missing-license exception for {name} {version}; review and remove it"
+        )
+
+    rust_names = {package["name"] for package in metadata["packages"]}
+    if {"zlog"} & rust_names:
+        failures.append("GPL profiling package zlog re-entered the Rust dependency graph")
+
+    reviewed = {
+        (entry["ecosystem"].lower(), entry["name"].lower()): entry
+        for entry in policy["manually_reviewed_non_rust"]
+    }
+    found_non_rust: set[tuple[str, str]] = set()
+
+    swift_lock = json.loads((ROOT / "Package.resolved").read_text())
+    for pin in swift_lock["pins"]:
+        key = ("swiftpm", pin["identity"].lower())
+        found_non_rust.add(key)
+        entry = reviewed.get(key)
+        version = pin["state"].get("version", pin["state"]["revision"])
+        if entry is None:
+            failures.append(f"unreviewed SwiftPM dependency {pin['identity']} {version}")
+        elif entry["version"] != version:
+            failures.append(
+                f"SwiftPM dependency {pin['identity']} changed {entry['version']} -> {version}; review its license"
+            )
+
+    npm_lock = json.loads((ROOT / "sidecar" / "package-lock.json").read_text())
+    for package_path, package in npm_lock["packages"].items():
+        if "node_modules/" not in package_path:
+            continue
+        name = package_path.rsplit("node_modules/", 1)[1]
+        key = ("npm", name.lower())
+        found_non_rust.add(key)
+        entry = reviewed.get(key)
+        version = package.get("version", "UNKNOWN")
+        if entry is None:
+            failures.append(f"unreviewed npm dependency {name} {version}")
+        elif entry["version"] != version:
+            failures.append(
+                f"npm dependency {name} changed {entry['version']} -> {version}; review its license"
+            )
+        elif package.get("license") and entry["license"] != package["license"]:
+            failures.append(
+                f"npm dependency {name} declares {package['license']}, policy says {entry['license']}"
+            )
+
+    for ecosystem, name in sorted(set(reviewed) - found_non_rust):
+        failures.append(f"stale {ecosystem} license review entry for {name}")
+
+    if failures:
+        print("dependency license policy failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        report = {
+            "schema": 1,
+            "project_license": policy["project_license"],
+            "rust_dependencies": inventory,
+            "non_rust_dependencies": policy["manually_reviewed_non_rust"],
+            "notes": policy["notes"],
+        }
+        args.output.write_text(json.dumps(report, indent=2) + "\n")
+
+    print(
+        f"dependency license policy passed: {len(inventory)} Rust packages, "
+        f"{len(seen_exceptions)} conservative metadata exceptions"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+run_browser=0
+
+case "${1:-}" in
+    "") ;;
+    --browser) run_browser=1 ;;
+    -h|--help)
+        echo "usage: ./scripts/check.sh [--browser]"
+        exit 0
+        ;;
+    *)
+        echo "error: unknown option: $1" >&2
+        echo "usage: ./scripts/check.sh [--browser]" >&2
+        exit 2
+        ;;
+esac
+
+for tool in bash cargo python3 swift; do
+    if ! command -v "${tool}" >/dev/null 2>&1; then
+        echo "error: ${tool} is required; see CONTRIBUTING.md" >&2
+        exit 1
+    fi
+done
+
+# Keep compiler caches inside the checkout. This works in sandboxed development
+# environments and avoids depending on writable global Swift/Clang cache paths.
+export CLANG_MODULE_CACHE_PATH="${CLANG_MODULE_CACHE_PATH:-${root}/.build/clang-module-cache}"
+export SWIFTPM_MODULECACHE_OVERRIDE="${SWIFTPM_MODULECACHE_OVERRIDE:-${CLANG_MODULE_CACHE_PATH}}"
+mkdir -p "${CLANG_MODULE_CACHE_PATH}"
+
+echo "==> Shell and release publishing guards"
+bash -n "${root}"/scripts/*.sh "${root}"/diri/scripts/*.sh
+bash "${root}/diri/scripts/test-publish-github-release.sh"
+bash "${root}/diri/scripts/test-publish-homebrew-cask.sh"
+
+echo "==> Swift engine"
+swift test --package-path "${root}" --no-parallel
+
+echo "==> Rust app"
+(
+    cd "${root}/diri"
+    cargo fmt --all -- --check
+    cargo clippy --workspace --all-targets -- -D warnings
+    cargo test --workspace
+)
+
+echo "==> Dependency license policy"
+python3 "${root}/scripts/check-licenses.py"
+
+if [[ "${run_browser}" == "1" ]]; then
+    if ! command -v npm >/dev/null 2>&1; then
+        echo "error: npm is required for --browser" >&2
+        exit 1
+    fi
+    echo "==> Browser sidecar"
+    (
+        cd "${root}/sidecar"
+        npm ci
+        npm audit --omit=dev
+        npx playwright install chromium webkit firefox
+    )
+    DIRIJOR_RUN_BROWSER_TESTS=1 swift test --package-path "${root}" --filter BrowserPoolTests
+fi
+
+echo "All contributor checks passed."


### PR DESCRIPTION
## Summary

- restore the pinned rustfmt output so main is green again
- add contributor, conduct, governance, support, security, privacy, roadmap, and getting-started documentation
- add CODEOWNERS, PR/issue routing, Dependabot, dependency review, and Rust/Swift CodeQL
- pin every GitHub Action to an immutable commit
- remove the unused calendar permission disclosure and document the actual trust boundaries
- remove the unused GPL profiling chain, check all dependency license metadata, and bundle/publish the reviewed license inventory
- make releases source-commit-pinned, checksum every asset, keep assets immutable, and standardize on v<version> tags

## Local verification

- Swift suite: 274 tests passed
- Rust workspace: format, Clippy with warnings denied, and all tests passed
- release publishing regression tests passed
- dependency license policy passed for 706 Rust packages plus SwiftPM/npm reviews
- workflow YAML, JSON policy, shell syntax, and Info.plist validated

## Distribution note

The maintained tap remains the supported Homebrew route. The roadmap records the official cask submission because Homebrew currently time-gates this four-day-old repository and applies a 225-star owner-submission threshold.