### PR TITLE
diri: release 0.4.7

### DIFF
--- a/diri/Cargo.lock
+++ b/diri/Cargo.lock
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "diri-app"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "block2 0.6.2",
  "diri-client",

--- a/diri/crates/diri-app/Cargo.toml
+++ b/diri/crates/diri-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diri-app"
-version = "0.4.6"
+version = "0.4.7"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/diri/crates/diri-engine/src/control.rs
+++ b/diri/crates/diri-engine/src/control.rs
@@ -1351,10 +1351,19 @@ impl ControlServer {
             .into_iter()
             .find(|record| record.id.0 == p.session_id.0)
             .ok_or_else(|| ControlError::not_found(p.session_id.0.clone()))?;
+        let exited = matches!(record.status, diri_proto::SessionStatus::Exited(_));
         if registry.get(&p.session_id.0).is_some() {
-            // Already live: resuming is a no-op, not an error.
-            return serde_json::to_value(&record)
-                .map_err(|error| ControlError::internal(error.to_string()));
+            if !exited {
+                // Already live: resuming is a no-op, not an error.
+                return serde_json::to_value(&record)
+                    .map_err(|error| ControlError::internal(error.to_string()));
+            }
+            // An agent that died on its own leaves its session behind: only an
+            // explicit kill takes one out of the registry, so presence alone
+            // does not mean alive. Evicting the corpse — which also releases
+            // the holder still owning this id — is what keeps resume from
+            // silently handing back the dead record it was asked to revive.
+            let _ = registry.terminate(&p.session_id.0, std::time::Duration::from_millis(500));
         }
         if let Some(host_id) = record.host.clone() {
             // Remote revive: the same tmux name reattaches the live remote
@@ -2177,6 +2186,104 @@ mod tests {
         assert!(
             command.contains("; exec "),
             "the shell must survive: {command}"
+        );
+    }
+
+    /// An agent that dies on its own — a dropped ssh, a crash — leaves its
+    /// session in the registry, because only an explicit kill takes one out.
+    /// Resume used to read that presence as "already live", call itself a
+    /// no-op and hand the corpse straight back, which left a dead session
+    /// with no way at all to restart it.
+    #[test]
+    fn resume_relaunches_a_session_whose_agent_died_on_its_own() {
+        let temp = tempfile::tempdir().expect("temp");
+        // A manifest that resumes by flag, onto a binary that outlives the
+        // call: `sh -c 'read line'` blocks on the PTY instead of exiting.
+        let manifests = temp.path().join("manifests");
+        std::fs::create_dir_all(&manifests).expect("manifests dir");
+        std::fs::write(
+            manifests.join("probe.json"),
+            json!({
+                "schemaVersion": 2,
+                "id": "probe",
+                "version": "test",
+                "statusModel": "full",
+                "agent": {
+                    "binary": "/bin/sh",
+                    "spawnArgs": ["-c", "read line"],
+                    "resume": { "style": "flag", "token": "--resume" },
+                },
+                "rules": [],
+            })
+            .to_string(),
+        )
+        .expect("write manifest");
+        let (probe, _) = ManifestEngine::load_dir(&manifests).expect("load");
+        let probe = Arc::new(probe);
+
+        let registry = Arc::new(Mutex::new(Registry::new(
+            Arc::clone(&probe),
+            temp.path().join("state.json"),
+        )));
+        {
+            let mut guard = registry.lock().expect("registry");
+            let mut record = test_record("s_dead");
+            record.kind = diri_proto::AgentKind::new("probe");
+            record.agent_session_id = Some("conv-1".into());
+            // `true` exits the moment it is spawned, standing in for the agent
+            // that went away while the daemon kept its session.
+            guard
+                .spawn(
+                    crate::session::SessionSpec {
+                        id: "s_dead".into(),
+                        pty: crate::pty::PtySpec::new(vec!["/usr/bin/true".into()], "/tmp"),
+                        manifest_id: "probe".into(),
+                        authority: crate::session::authority_for("probe", &probe),
+                        logs_dir: temp.path().join("logs"),
+                        holder: None,
+                        defer_launch: false,
+                    },
+                    record,
+                )
+                .expect("spawn");
+        }
+        for _ in 0..100 {
+            let exited = registry
+                .lock()
+                .expect("registry")
+                .record("s_dead")
+                .is_some_and(|record| {
+                    matches!(record.status, diri_proto::SessionStatus::Exited(_))
+                });
+            if exited {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        assert!(
+            registry.lock().expect("registry").get("s_dead").is_some(),
+            "the premise: a dead agent's session stays in the registry"
+        );
+
+        let server = ControlServer::new(Arc::clone(&registry), temp.path().join("daemon.sock"));
+        let result = ok_of(call(
+            &server,
+            "session.resume",
+            Some(json!({ "sessionID": "s_dead" })),
+        ));
+
+        assert!(
+            result["status"].get("exited").is_none(),
+            "resume handed back the corpse instead of relaunching: {}",
+            result["status"]
+        );
+        assert!(
+            registry
+                .lock()
+                .expect("registry")
+                .get("s_dead")
+                .is_some_and(|session| !session.view().exited),
+            "the resumed session must be a live one"
         );
     }
 

--- a/diri/crates/diri-engine/src/registry.rs
+++ b/diri/crates/diri-engine/src/registry.rs
@@ -285,11 +285,7 @@ impl Registry {
     pub fn records(&self) -> Vec<SessionRecord> {
         let mut records: Vec<SessionRecord> = self.records.values().cloned().collect();
         for record in &mut records {
-            if let Some(session) = self.sessions.get(&record.id.0) {
-                let view = session.view();
-                record.status = view.status;
-                record.needs_input = view.needs_input;
-            }
+            self.fold_live(record);
         }
         records.sort_by(|a, b| a.id.0.cmp(&b.id.0));
         records
@@ -298,12 +294,46 @@ impl Registry {
     /// One record with live status folded in, without cloning the whole table.
     pub fn record(&self, id: &str) -> Option<SessionRecord> {
         let mut record = self.records.get(id)?.clone();
-        if let Some(session) = self.sessions.get(id) {
+        self.fold_live(&mut record);
+        Some(record)
+    }
+
+    /// Folds what only the live session knows into a stored record: its real
+    /// status, and the resumability that follows from it.
+    fn fold_live(&self, record: &mut SessionRecord) {
+        if let Some(session) = self.sessions.get(&record.id.0) {
             let view = session.view();
             record.status = view.status;
             record.needs_input = view.needs_input;
         }
-        Some(record)
+        // `Live` only records that the agent named its conversation while it
+        // was running. Once the session is gone the question every Resume
+        // affordance asks is a different one — can that conversation be
+        // re-entered — so answer it here rather than leaving a stale `Live`
+        // that reads as "not resumable" to each of them.
+        if matches!(record.status, SessionStatus::Exited(_))
+            && record.resumability == diri_proto::Resumability::Live
+        {
+            record.resumability = if self.can_reenter(record) {
+                diri_proto::Resumability::Resumable
+            } else {
+                diri_proto::Resumability::NotResumable
+            };
+        }
+    }
+
+    /// Whether this record's agent can be relaunched back into its own
+    /// conversation — a known conversation id plus a manifest that declares
+    /// how to resume one.
+    fn can_reenter(&self, record: &SessionRecord) -> bool {
+        let Some(agent_session_id) = record.agent_session_id.as_deref() else {
+            return false;
+        };
+        self.engine
+            .manifest(record.kind.id())
+            .and_then(|manifest| manifest.agent.as_ref())
+            .and_then(|agent| agent.resume_args(Some(agent_session_id)))
+            .is_some()
     }
 
     /// Diffs live sessions' state versions against `published` (updating it in
@@ -765,6 +795,75 @@ mod tests {
         let mut reloaded = Registry::new(engine(), &state_file);
         assert_eq!(reloaded.load().expect("load"), 1);
         assert_eq!(reloaded.records()[0].id.0, "s_1");
+    }
+
+    /// An exited record whose agent had named its conversation is the case
+    /// every Resume affordance gates on, and each of them checks for
+    /// `Resumable` — a record left on `Live` reads to all of them as "cannot
+    /// be resumed" and the button is never drawn.
+    #[test]
+    fn a_conversation_that_outlived_its_session_reports_resumable() {
+        let temp = tempfile::tempdir().expect("temp");
+        let mut registry = Registry::new(engine(), temp.path().join("state.json"));
+
+        let mut dead = record("s_dead");
+        dead.kind = AgentKind::CLAUDE_CODE;
+        dead.agent_session_id = Some("conv-1".into());
+        dead.resumability = Resumability::Live;
+        dead.status = SessionStatus::Exited(diri_proto::ExitInfo {
+            reason: diri_proto::ExitReason::Exited,
+            code: Some(255),
+            signal: None,
+        });
+        registry.records.insert("s_dead".into(), dead);
+
+        assert_eq!(
+            registry.record("s_dead").expect("record").resumability,
+            Resumability::Resumable
+        );
+    }
+
+    /// Without a conversation id there is nothing to re-enter, and offering
+    /// Resume would only produce an agent that fails to launch.
+    #[test]
+    fn an_exited_session_with_no_conversation_id_is_not_resumable() {
+        let temp = tempfile::tempdir().expect("temp");
+        let mut registry = Registry::new(engine(), temp.path().join("state.json"));
+
+        let mut dead = record("s_dead");
+        dead.kind = AgentKind::CLAUDE_CODE;
+        dead.resumability = Resumability::Live;
+        dead.status = SessionStatus::Exited(diri_proto::ExitInfo {
+            reason: diri_proto::ExitReason::Exited,
+            code: Some(0),
+            signal: None,
+        });
+        registry.records.insert("s_dead".into(), dead);
+
+        assert_eq!(
+            registry.record("s_dead").expect("record").resumability,
+            Resumability::NotResumable
+        );
+    }
+
+    /// A running session keeps saying `Live`: resumability only becomes a
+    /// question once the agent is gone.
+    #[test]
+    fn a_running_session_keeps_reporting_live() {
+        let temp = tempfile::tempdir().expect("temp");
+        let mut registry = Registry::new(engine(), temp.path().join("state.json"));
+
+        let mut running = record("s_live");
+        running.kind = AgentKind::CLAUDE_CODE;
+        running.agent_session_id = Some("conv-1".into());
+        running.resumability = Resumability::Live;
+        running.status = SessionStatus::Idle;
+        registry.records.insert("s_live".into(), running);
+
+        assert_eq!(
+            registry.record("s_live").expect("record").resumability,
+            Resumability::Live
+        );
     }
 
     /// Interop against the state file the Swift daemon actually maintains.


### PR DESCRIPTION
Version bump to 0.4.7 plus the resume-after-agent-death engine fix. Everything since the v0.4.6 tag ships in this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)