### PR TITLE
Give cached overlay roots a definite size

### DIFF
--- a/diri/crates/diri-app/src/navigation.rs
+++ b/diri/crates/diri-app/src/navigation.rs
@@ -1048,7 +1048,11 @@ impl Render for NavigationOverlay {
             .on_action(cx.listener(Self::toggle_command_palette))
             .on_action(cx.listener(Self::toggle_quick_open))
             .on_key_down(cx.listener(Self::on_key_down))
-            .absolute();
+            .absolute()
+            // Cached entity roots are laid out independently, so insets alone
+            // leave this absolute root without a definite size and its height
+            // collapses to its in-flow content, which is nothing.
+            .size_full();
         if let Some(overlay) = overlay {
             root.inset_0().child(overlay)
         } else {

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -2461,12 +2461,19 @@ impl Render for UtilitySurfaces {
             .on_action(cx.listener(|this, _: &MoveDown, _, cx| this.move_history(1, cx)))
             .on_action(cx.listener(|this, _: &Activate, _, cx| this.activate_history(cx)))
             .absolute()
+            // Cached entity roots are laid out independently, so insets alone
+            // leave this absolute root without a definite size: its height
+            // collapses to its in-flow content, which is nothing. The backdrop
+            // then paints no dim at all and the dialog centers on the window's
+            // top edge, putting its tab list and close control off-window.
+            .size_full()
             .text_color(COLORS.primary);
         if let Some(overlay) = overlay {
             root.inset_0().child(
                 div()
                     .absolute()
                     .inset_0()
+                    .debug_selector(|| "surface-backdrop".into())
                     // The modal backdrop dismisses the topmost surface while
                     // still protecting terminal selection and scrollback.
                     .occlude()
@@ -3001,8 +3008,27 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use gpui::{
-        Entity, Modifiers, MouseDownEvent, ScrollDelta, ScrollWheelEvent, TestAppContext, point,
+        Entity, Modifiers, MouseDownEvent, ScrollDelta, ScrollWheelEvent, StyleRefinement,
+        TestAppContext, point, size,
     };
+
+    /// RootView paints the utility surfaces through a cached wrapper. A cached
+    /// entity root is laid out independently of its content, so mount the
+    /// surfaces the way the app does -- not bare -- and a root that cannot size
+    /// itself fails here instead of on screen.
+    struct CachedOverlayHarness {
+        surfaces: Entity<UtilitySurfaces>,
+    }
+
+    impl Render for CachedOverlayHarness {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div().size_full().child(
+                self.surfaces
+                    .clone()
+                    .cached(StyleRefinement::default().absolute().inset_0()),
+            )
+        }
+    }
 
     struct SettingsModalHarness {
         surfaces: Entity<UtilitySurfaces>,
@@ -3129,6 +3155,49 @@ mod tests {
             Surface::Settings
         );
         assert_eq!(background_events.load(Ordering::Relaxed), 0);
+    }
+
+    #[gpui::test]
+    fn settings_dialog_centers_in_the_window_through_the_cached_wrapper(cx: &mut TestAppContext) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        let tokio = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime"),
+        );
+        let updates = crate::updates::inert();
+        let (_, cx) = cx.add_window_view(move |window, cx| {
+            let surfaces = cx.new(|cx| {
+                let mut surfaces = UtilitySurfaces::new(runtime, tokio, updates, window, cx);
+                surfaces.open_settings(cx);
+                surfaces
+            });
+            CachedOverlayHarness { surfaces }
+        });
+
+        let viewport = size(px(1200.0), px(800.0));
+        cx.simulate_resize(viewport);
+
+        // The backdrop must cover the window. A collapsed root leaves it
+        // 1200x0, which dims nothing and blocks nothing.
+        let backdrop = cx
+            .debug_bounds("surface-backdrop")
+            .expect("modal backdrop should render");
+        assert_eq!(backdrop.size, viewport);
+
+        let dialog = cx
+            .debug_bounds("settings-dialog")
+            .expect("settings dialog should render");
+        assert_eq!(dialog.size.width, px(SETTINGS_WIDTH));
+        assert_eq!(dialog.size.height, px(SETTINGS_HEIGHT));
+
+        // The dialog is taller than a collapsed root, so a zero-height root
+        // parks it half above the window instead of in the middle.
+        let center = dialog.center();
+        assert_eq!(center.x, viewport.width / 2.0);
+        assert_eq!(center.y, viewport.height / 2.0);
+        assert!(dialog.top() > px(0.0), "dialog hangs above the window top");
     }
 
     #[gpui::test]


### PR DESCRIPTION
Opening Settings puts the top of the dialog above the window. The tab list and the close button end up off-screen, and the modal backdrop doesn't dim anything behind it.

`UtilitySurfaces` builds its root as `absolute()` + `inset_0()`. `RootView` mounts it through `.cached()`, and a cached entity root is laid out on its own, so those insets have no containing block to resolve against. Width still comes from the available space, but height falls back to in-flow content — and every child is absolute, so it collapses to zero. The 420pt dialog then centers on a zero-height root.

Measured with `debug_bounds` on a 1200x800 window before the change:

```
backdrop = 1200 x 0
dialog   = origin (300, -210), 600 x 420
```

`session_surfaces.rs` already carries `.size_full()` on its root for exactly this, with a comment about the overview collapsing the same way. `UtilitySurfaces` and `NavigationOverlay` never got it. Navigation is affected too, just less visibly — the palette and Quick Open sit near the top of the window anyway.

The existing settings tests mount `UtilitySurfaces` bare instead of through the cached wrapper, which is why they stayed green while the app was broken. Added a harness that mounts it the way `RootView` does, plus a test that the backdrop covers the window and the dialog is centered in it. It fails on main with `center.y` 0 against 400.

Window layout only. Nothing the daemon owns changes, and existing sessions are untouched.

Tested with `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, all clean. Also ran the app with `DIRI_SETTINGS_PREVIEW=general` and checked the dialog by eye.
