### PR TITLE
Remove personal email from conduct policy

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -10,9 +10,12 @@ these expectations, and may temporarily or permanently restrict participation.
 Enforcement decisions should be proportionate, private where possible, and
 focused on protecting the community.
 
-Report conduct concerns privately to **crisemcr@gmail.com**. Include links or
-screenshots and any context needed to understand what happened. Reports will be
-handled as confidentially as practical; do not use a public issue for them.
+Report conduct concerns through [GitHub's private reporting
+channel](https://github.com/cristicretu/diri/security/advisories/new), and note at
+the top that it is a conduct report rather than a software vulnerability. Include
+links or screenshots and any context needed to understand what happened. Reports
+will be handled as confidentially as practical; do not use a public issue for
+them.
 
 This policy applies in the repository, community spaces, and when someone is
 publicly representing the project. It is adapted from the principles of the


### PR DESCRIPTION
Removes the personal Gmail address from the public Code of Conduct and directs confidential conduct reports to GitHub private reporting instead.