### PR TITLE
Run the Swift CodeQL analysis weekly, not per pull request

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,32 +12,49 @@ permissions:
   contents: read
   security-events: write
 
+# Rust and Swift used to share one matrix. They are split because they belong on
+# different schedules, and a matrix cannot express that: `matrix` is not in
+# scope for a job-level `if`, so the condition has to sit on a job of its own.
 jobs:
-  analyze:
-    name: CodeQL (${{ matrix.language }})
-    runs-on: ${{ matrix.os }}
+  rust:
+    name: CodeQL (rust)
+    runs-on: ubuntu-latest
     timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - language: rust
-            build_mode: none
-            os: ubuntu-latest
-          - language: swift
-            build_mode: manual
-            os: macos-15
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
-          languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build_mode }}
+          languages: rust
+          build-mode: none
+      - name: Analyze
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        with:
+          category: /language:rust
+
+  swift:
+    name: CodeQL (swift)
+    # Swift has no `build-mode: none`, so this analysis pays for a full
+    # `swift build` on a macos runner and lands minutes after the rest of the
+    # gate has gone green -- long enough that it was routinely the last thing
+    # holding up a merge. Rust analyses without building at all and stays on
+    # pull requests; Swift runs on the weekly cron instead, which keeps the
+    # coverage without putting a package build in front of every merge. Drop
+    # `CodeQL (swift)` from the required checks on main to match, or PRs wait
+    # for a run that no longer happens.
+    if: github.event_name == 'schedule'
+    runs-on: macos-15
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        with:
+          languages: swift
+          build-mode: manual
       - name: Build Swift
-        if: matrix.language == 'swift'
         run: swift build
       - name: Analyze
         uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
-          category: /language:${{ matrix.language }}
+          category: /language:swift


### PR DESCRIPTION
Swift has no `build-mode: none`, so its CodeQL job builds the package itself on a macos runner. It lands minutes after the rest of the gate is green, which makes it the last thing standing between a reviewed PR and the merge button. Rust is analysed on ubuntu without building at all and costs nothing next to it.

Weekly is the right cadence for what it scans. The daemon and CLI change slowly, and a CodeQL finding does not need to land in the minutes before a merge rather than the following Monday. The `schedule` trigger already exists, so this is a condition, not new machinery.

The two languages shared a matrix, which cannot express the split: `matrix` is out of scope for a job-level `if`, so a condition written there sees a null language and runs everything anyway. They are separate jobs now, with the job names pinned to the old matrix-generated `CodeQL (rust)` / `CodeQL (swift)` so the required check on main keeps resolving to the same context.

**This needs a settings change to work.** `CodeQL (swift)` is currently a required check on main. It has to come off, or every PR waits forever on a run that no longer happens:

```sh
gh api -X PUT repos/cristicretu/diri/branches/main/protection --input protection.json
```

Verified by parsing the workflow: two jobs, names `CodeQL (rust)` and `CodeQL (swift)`, the swift one gated on `github.event_name == 'schedule'`. The weekly path itself only proves out on the cron, or on a manual re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)