### PR TITLE
diri: land the Command-N prompt, and let its composer follow the caret

### DIFF
--- a/diri/crates/diri-app/src/composer.rs
+++ b/diri/crates/diri-app/src/composer.rs
@@ -1,0 +1,432 @@
+//! The multi-line prompt field behind Command-N.
+//!
+//! [`QueryEditor`](crate::query_editor::QueryEditor) is a buffer: it knows
+//! where the caret is in BYTES and nothing about where that lands on screen.
+//! That is all a one-line search field needs, and the Command-N composer
+//! inherited it — which is why a prompt longer than the box scrolled out of
+//! sight with no way to follow it, why ↑/↓ did nothing, and why ⌘← jumped to
+//! the top of the whole prompt instead of the start of the line you were on.
+//!
+//! This adds the missing half: the buffer soft-wrapped into VISUAL lines at
+//! the field's real width, which is what makes "the line the caret is on"
+//! a thing that exists. From that follows caret-following scroll, vertical
+//! motion that keeps its column, and a box that grows with the prompt until
+//! it hits a ceiling and starts scrolling instead.
+//!
+//! Wrapping needs the text system, so it is recomputed during render (which
+//! has a `Window`) rather than on each keystroke, and cached against the text
+//! it was computed from.
+
+use std::ops::Range;
+
+use gpui::{AnyElement, Pixels, ScrollHandle, SharedString, Window, div, prelude::*, px};
+use unicode_segmentation::UnicodeSegmentation;
+
+use crate::query_editor::{LocalEdit, Motion, QueryEditor};
+
+/// One soft-wrapped display line: a byte range of the buffer, plus whether it
+/// ended because the text wrapped rather than because the user pressed Return.
+/// The distinction matters for the caret: at a soft break the caret belongs to
+/// the start of the FOLLOWING line (there is no position after the last
+/// character of a wrapped line — it is the same position), while at a hard
+/// break both ends are real places to be.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VisualLine {
+    pub range: Range<usize>,
+    pub soft_wrapped: bool,
+}
+
+/// A prompt buffer plus everything needed to draw and navigate it as a
+/// multi-line field.
+pub struct PromptComposer {
+    editor: QueryEditor,
+    scroll: ScrollHandle,
+    lines: Vec<VisualLine>,
+    /// The (text, width) the cached `lines` were computed from.
+    wrapped_from: Option<(String, Pixels)>,
+    /// Set by any edit; cleared once render has scrolled the caret into view.
+    reveal_caret: bool,
+    /// Column the caret returns to when vertical motion passes through a
+    /// short line, in graphemes. `None` outside a run of ↑/↓.
+    goal_column: Option<usize>,
+}
+
+impl Default for PromptComposer {
+    fn default() -> Self {
+        Self {
+            editor: QueryEditor::default(),
+            scroll: ScrollHandle::new(),
+            lines: Vec::new(),
+            wrapped_from: None,
+            reveal_caret: false,
+            goal_column: None,
+        }
+    }
+}
+
+impl PromptComposer {
+    pub fn text(&self) -> &str {
+        self.editor.text()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.editor.is_empty()
+    }
+
+    pub fn editor(&self) -> &QueryEditor {
+        &self.editor
+    }
+
+    pub fn clear(&mut self) {
+        self.editor.clear();
+        self.lines.clear();
+        self.wrapped_from = None;
+        self.goal_column = None;
+        self.reveal_caret = true;
+    }
+
+    /// How many visual lines the prompt currently occupies, as last wrapped.
+    /// One even when empty — the field is always at least a line tall.
+    pub fn line_count(&self) -> usize {
+        self.lines.len().max(1)
+    }
+
+    /// Applies an edit from the shared key map, keeping the caret in view.
+    /// Line-granular edits act on the caret's VISUAL line rather than the
+    /// whole buffer — `QueryEditor` reads `Motion::Line` as "everything",
+    /// which is right for a search field and wrong for a prompt — so ⌘⌫ on
+    /// the third line of a prompt deletes that line and not the prompt.
+    pub fn apply(&mut self, edit: LocalEdit) {
+        self.goal_column = None;
+        self.reveal_caret = true;
+        let line = self
+            .caret_line()
+            .map(|index| self.lines[index].range.clone());
+        match (edit, line) {
+            (LocalEdit::MoveLeft(Motion::Line, extend), Some(line)) => {
+                self.editor.move_to(line.start, extend);
+            }
+            (LocalEdit::MoveRight(Motion::Line, extend), Some(line)) => {
+                self.editor.move_to(line.end, extend);
+            }
+            (LocalEdit::DeleteBackward(Motion::Line), Some(line)) => {
+                self.editor.delete_to(line.start);
+            }
+            (LocalEdit::DeleteForward(Motion::Line), Some(line)) => {
+                self.editor.delete_to(line.end);
+            }
+            (edit, _) => {
+                self.editor.apply(edit);
+            }
+        }
+    }
+
+    /// ↑ / ↓. Kept off the shared key map on purpose: in the palette and
+    /// Quick Open those keys move the highlighted row, and only a field that
+    /// has visual lines can answer them at all.
+    pub fn move_up(&mut self, extend: bool) {
+        self.move_vertically(-1, extend);
+    }
+
+    pub fn move_down(&mut self, extend: bool) {
+        self.move_vertically(1, extend);
+    }
+
+    pub fn insert_multiline(&mut self, text: &str) {
+        self.editor.insert_multiline(text);
+        self.goal_column = None;
+        self.reveal_caret = true;
+    }
+
+    pub fn editor_mut(&mut self) -> &mut QueryEditor {
+        self.reveal_caret = true;
+        self.goal_column = None;
+        &mut self.editor
+    }
+
+    /// Index of the visual line the caret sits on. `None` before the first
+    /// wrap, when there is no layout to consult.
+    pub fn caret_line(&self) -> Option<usize> {
+        let cursor = self.editor.cursor();
+        if self.lines.is_empty() {
+            return None;
+        }
+        // The LAST line that starts at or before the caret: at a soft break
+        // this puts the caret at the head of the new line, where the next
+        // typed character will actually appear.
+        self.lines
+            .iter()
+            .rposition(|line| line.range.start <= cursor)
+            .or(Some(0))
+    }
+
+    fn move_vertically(&mut self, delta: isize, extend: bool) {
+        self.reveal_caret = true;
+        let Some(current) = self.caret_line() else {
+            return;
+        };
+        let line = self.lines[current].range.clone();
+        let caret = self.editor.cursor().clamp(line.start, line.end);
+        // The column is remembered across a run of ↑/↓ so passing through a
+        // short line does not permanently drag the caret left.
+        let column = self
+            .goal_column
+            .unwrap_or_else(|| grapheme_count(&self.editor.text()[line.start..caret]));
+        self.goal_column = Some(column);
+
+        let Some(target) = current
+            .checked_add_signed(delta)
+            .filter(|index| *index < self.lines.len())
+        else {
+            // Past the first or last line: park at the buffer's edge, the way
+            // every macOS text view does.
+            let offset = if delta < 0 {
+                0
+            } else {
+                self.editor.text().len()
+            };
+            self.editor.move_to(offset, extend);
+            self.goal_column = None;
+            return;
+        };
+        let target = self.lines[target].range.clone();
+        let offset = offset_at_column(self.editor.text(), &target, column);
+        self.editor.move_to(offset, extend);
+    }
+
+    /// Re-wraps if the text or width changed, then scrolls the caret into view
+    /// if an edit asked for it. Call once per render, before building the
+    /// element — [`Self::line_count`] is only meaningful afterwards.
+    pub fn layout(&mut self, width: Pixels, font: gpui::Font, font_size: Pixels, window: &Window) {
+        let text = self.editor.text();
+        if self
+            .wrapped_from
+            .as_ref()
+            .is_some_and(|(cached, cached_width)| cached == text && *cached_width == width)
+        {
+            self.reveal();
+            return;
+        }
+        self.lines = wrap(text, width, font, font_size, window);
+        self.wrapped_from = Some((text.to_owned(), width));
+        self.reveal();
+    }
+
+    fn reveal(&mut self) {
+        if !self.reveal_caret {
+            return;
+        }
+        if let Some(line) = self.caret_line() {
+            self.scroll.scroll_to_item(line);
+            self.reveal_caret = false;
+        }
+    }
+
+    /// The scroll container the rendered lines must be children of, so the
+    /// handle's `scroll_to_item` indices line up with visual lines.
+    pub fn scroll_handle(&self) -> &ScrollHandle {
+        &self.scroll
+    }
+
+    /// One element per visual line, ready to be dropped into the scroll
+    /// container. `caret` is drawn only when the field has focus.
+    pub fn render_lines(
+        &self,
+        line_height: Pixels,
+        caret: Option<&str>,
+        selection_style: gpui::HighlightStyle,
+    ) -> Vec<AnyElement> {
+        if self.lines.is_empty() {
+            return vec![div().h(line_height).into_any_element()];
+        }
+        let text = self.editor.text();
+        let cursor = self.editor.cursor();
+        let selection = self.editor.selection();
+        let caret_line = self.caret_line();
+
+        self.lines
+            .iter()
+            .enumerate()
+            .map(|(index, line)| {
+                let mut display = text[line.range.clone()].to_owned();
+                let mut highlights = selection
+                    .as_ref()
+                    .and_then(|range| intersect(range, &line.range))
+                    .map(|range| range.start - line.range.start..range.end - line.range.start);
+                // The caret is spliced into the string rather than positioned,
+                // matching the single-line fields; a real positioned caret
+                // would need per-line text layout on every frame.
+                if let (Some(caret), Some(caret_line)) = (caret, caret_line)
+                    && caret_line == index
+                    && selection.is_none()
+                {
+                    let at = cursor.saturating_sub(line.range.start).min(display.len());
+                    display.insert_str(at, caret);
+                    highlights = None;
+                }
+                let text: SharedString = display.into();
+                let line = div().h(line_height).child(match highlights {
+                    Some(range) => gpui::StyledText::new(text)
+                        .with_highlights([(range, selection_style)])
+                        .into_any_element(),
+                    None => text.into_any_element(),
+                });
+                line.into_any_element()
+            })
+            .collect()
+    }
+}
+
+/// Soft-wraps `text` at `width`, keeping hard line breaks as their own
+/// boundaries. Always yields at least one line so an empty prompt still has a
+/// caret row.
+fn wrap(
+    text: &str,
+    width: Pixels,
+    font: gpui::Font,
+    font_size: Pixels,
+    window: &Window,
+) -> Vec<VisualLine> {
+    let mut wrapper = window.text_system().line_wrapper(font, font_size);
+    let mut lines = Vec::new();
+    let mut paragraph_start = 0;
+    // `split` (not `lines`) so a trailing newline yields the empty line after
+    // it — the row the caret sits on when you have just pressed ⇧↵.
+    for paragraph in text.split('\n') {
+        let mut cut = paragraph_start;
+        for boundary in
+            wrapper.wrap_line(&[gpui::LineFragment::text(paragraph)], width.max(px(1.0)))
+        {
+            let at = paragraph_start + boundary.ix;
+            if at > cut {
+                lines.push(VisualLine {
+                    range: cut..at,
+                    soft_wrapped: true,
+                });
+                cut = at;
+            }
+        }
+        lines.push(VisualLine {
+            range: cut..paragraph_start + paragraph.len(),
+            soft_wrapped: false,
+        });
+        paragraph_start += paragraph.len() + 1; // the '\n' itself
+    }
+    if lines.is_empty() {
+        lines.push(VisualLine {
+            range: 0..0,
+            soft_wrapped: false,
+        });
+    }
+    lines
+}
+
+fn grapheme_count(text: &str) -> usize {
+    text.graphemes(true).count()
+}
+
+/// The byte offset `column` graphemes into `line`, clamped to its end.
+fn offset_at_column(text: &str, line: &Range<usize>, column: usize) -> usize {
+    text[line.clone()]
+        .grapheme_indices(true)
+        .nth(column)
+        .map_or(line.end, |(index, _)| line.start + index)
+}
+
+fn intersect(left: &Range<usize>, right: &Range<usize>) -> Option<Range<usize>> {
+    let start = left.start.max(right.start);
+    let end = left.end.min(right.end);
+    (start < end).then_some(start..end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Wrapping needs a window, so these exercise the parts that do not:
+    /// the line-relative arithmetic every caret operation rests on.
+    fn lines(spans: &[(usize, usize, bool)]) -> Vec<VisualLine> {
+        spans
+            .iter()
+            .map(|(start, end, soft)| VisualLine {
+                range: *start..*end,
+                soft_wrapped: *soft,
+            })
+            .collect()
+    }
+
+    fn composer(text: &str, spans: &[(usize, usize, bool)]) -> PromptComposer {
+        let mut composer = PromptComposer::default();
+        composer.editor.insert_multiline(text);
+        composer.lines = lines(spans);
+        composer
+    }
+
+    #[test]
+    fn the_caret_belongs_to_the_last_line_that_starts_before_it() {
+        // "abcdef" wrapped as "abc" / "def".
+        let mut composer = composer("abcdef", &[(0, 3, true), (3, 6, false)]);
+        assert_eq!(composer.caret_line(), Some(1)); // caret at 6, end of text
+        composer.editor.move_to(3, false);
+        // At a soft break the caret shows at the head of the wrapped line,
+        // where the next character typed will appear.
+        assert_eq!(composer.caret_line(), Some(1));
+        composer.editor.move_to(1, false);
+        assert_eq!(composer.caret_line(), Some(0));
+    }
+
+    #[test]
+    fn vertical_motion_keeps_its_column_across_a_short_line() {
+        // "abcdef" / "gh" / "ijklmn"
+        let mut composer = composer(
+            "abcdef\ngh\nijklmn",
+            &[(0, 6, false), (7, 9, false), (10, 16, false)],
+        );
+        composer.editor.move_to(5, false); // column 5 of "abcdef"
+        composer.move_down(false);
+        assert_eq!(composer.editor.cursor(), 9); // "gh" has no column 5
+        composer.move_down(false);
+        assert_eq!(composer.editor.cursor(), 15); // column 5 of "ijklmn"
+        composer.move_up(false);
+        assert_eq!(composer.editor.cursor(), 9);
+        composer.move_up(false);
+        assert_eq!(composer.editor.cursor(), 5); // back where it started
+    }
+
+    #[test]
+    fn line_granular_edits_stop_at_the_visual_line() {
+        let mut composer = composer("first\nsecond", &[(0, 5, false), (6, 12, false)]);
+        composer.editor.move_to(12, false);
+        composer.apply(LocalEdit::DeleteBackward(Motion::Line));
+        // Only the caret's own line is gone, not the whole prompt.
+        assert_eq!(composer.editor.text(), "first\n");
+    }
+
+    #[test]
+    fn line_granular_motion_stops_at_the_visual_line() {
+        let mut composer = composer("first\nsecond", &[(0, 5, false), (6, 12, false)]);
+        composer.editor.move_to(9, false);
+        composer.apply(LocalEdit::MoveLeft(Motion::Line, false));
+        assert_eq!(composer.editor.cursor(), 6); // start of "second", not 0
+        composer.apply(LocalEdit::MoveRight(Motion::Line, false));
+        assert_eq!(composer.editor.cursor(), 12);
+    }
+
+    #[test]
+    fn moving_past_the_last_line_parks_at_the_end_of_the_buffer() {
+        let mut composer = composer("ab\ncd", &[(0, 2, false), (3, 5, false)]);
+        composer.editor.move_to(4, false);
+        composer.move_down(false);
+        assert_eq!(composer.editor.cursor(), 5);
+        composer.move_up(false);
+        composer.move_up(false);
+        assert_eq!(composer.editor.cursor(), 0);
+    }
+
+    #[test]
+    fn a_selection_is_clipped_to_each_line_it_crosses() {
+        assert_eq!(intersect(&(2..9), &(0..5)), Some(2..5));
+        assert_eq!(intersect(&(2..9), &(5..12)), Some(5..9));
+        assert_eq!(intersect(&(2..9), &(12..14)), None);
+    }
+}

--- a/diri/crates/diri-app/src/launcher.rs
+++ b/diri/crates/diri-app/src/launcher.rs
@@ -8,25 +8,54 @@ use diri_ui::{
     AgentKind as UiAgentKind, AgentLogo, Fill, FloatingSurface, Palette, Radius, SemanticColors,
 };
 use gpui::{
-    AnyElement, App, Context, EventEmitter, FocusHandle, Focusable, FontWeight, KeyDownEvent,
-    MouseButton, PathPromptOptions, Render, Task, Window, div, prelude::*, px, rgba,
+    AnyElement, App, Context, EventEmitter, FocusHandle, Focusable, FontWeight, HighlightStyle,
+    KeyDownEvent, MouseButton, PathPromptOptions, Render, Task, Window, div, prelude::*, px, rgba,
 };
 
 use crate::AppServices;
+use crate::composer::PromptComposer;
 use crate::macos::sf_symbols::{SymbolWeight, sf_symbol, sf_symbol_weighted};
-use crate::navigation::query_label;
-use crate::query_editor::{self, ClipboardEdit, Edit, QueryEditor};
+use crate::navigation::CARET;
+use crate::query_editor::{self, ClipboardEdit, Edit};
 use crate::store::SpawnOptions;
 
 const PANEL_WIDTH: f32 = 540.0;
 const TITLE_HEIGHT: f32 = 36.0;
 const TITLE_GAP: f32 = 22.0;
-const COMPOSER_HEIGHT: f32 = 108.0;
-const COMPOSER_TEXT_HEIGHT: f32 = 64.0;
 const CONTROL_SIZE: f32 = 32.0;
 const CONTROL_RADIUS: f32 = 9.0;
 const SHELF_HEIGHT: f32 = 40.0;
 const PICKER_HEIGHT: f32 = 200.0;
+
+/// Composer metrics. The text area is sized from the wrapped line count
+/// rather than pinned at one height: a one-line prompt should not sit in a
+/// half-empty box, and a twenty-line one should not vanish out of the bottom
+/// of a fixed one — it grows to [`COMPOSER_MAX_LINES`] and then scrolls,
+/// following the caret.
+const COMPOSER_FONT_SIZE: f32 = 13.0;
+const COMPOSER_LINE_HEIGHT: f32 = 19.0;
+const COMPOSER_MIN_LINES: usize = 3;
+const COMPOSER_MAX_LINES: usize = 9;
+const COMPOSER_INSET: f32 = 8.0;
+const COMPOSER_PADDING: f32 = 16.0;
+const COMPOSER_PAD_TOP: f32 = 12.0;
+const COMPOSER_PAD_BOTTOM: f32 = 6.0;
+const COMPOSER_CONTROLS_HEIGHT: f32 = 44.0;
+
+/// The width text actually wraps at, derived from the panel so the two cannot
+/// drift apart: the panel, less the composer's margin, padding and border.
+const COMPOSER_TEXT_WIDTH: f32 = PANEL_WIDTH - 2.0 * COMPOSER_INSET - 2.0 * COMPOSER_PADDING - 2.0;
+
+const fn composer_text_height(lines: usize) -> f32 {
+    let visible = if lines < COMPOSER_MIN_LINES {
+        COMPOSER_MIN_LINES
+    } else if lines > COMPOSER_MAX_LINES {
+        COMPOSER_MAX_LINES
+    } else {
+        lines
+    };
+    visible as f32 * COMPOSER_LINE_HEIGHT + COMPOSER_PAD_TOP + COMPOSER_PAD_BOTTOM
+}
 
 #[derive(Clone)]
 struct HarnessChoice {
@@ -42,14 +71,22 @@ pub(crate) enum LauncherEvent {
 pub(crate) struct LauncherOverlay {
     services: Arc<AppServices>,
     focus: FocusHandle,
-    prompt: QueryEditor,
+    prompt: PromptComposer,
     selected_harness: AgentKind,
     selected_root: String,
-    harness_picker_open: bool,
-    project_picker_open: bool,
+    /// Which picker, if any, is open — and where its keyboard highlight sits,
+    /// so both are reachable without the mouse.
+    picker: Option<Picker>,
+    highlight: usize,
     open: bool,
     preview: bool,
     _store_changes: Task<()>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Picker {
+    Harness,
+    Project,
 }
 
 impl EventEmitter<LauncherEvent> for LauncherOverlay {}
@@ -75,11 +112,11 @@ impl LauncherOverlay {
         Self {
             services,
             focus,
-            prompt: QueryEditor::default(),
+            prompt: PromptComposer::default(),
             selected_harness,
             selected_root,
-            harness_picker_open: false,
-            project_picker_open: false,
+            picker: None,
+            highlight: 0,
             open: false,
             preview,
             _store_changes: store_changes,
@@ -91,12 +128,16 @@ impl LauncherOverlay {
     }
 
     pub(crate) fn open(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let (harness, root) = initial_target(&self.services);
-        self.selected_harness = harness;
-        self.selected_root = root;
-        self.prompt.clear();
-        self.harness_picker_open = false;
-        self.project_picker_open = false;
+        // A half-written prompt survives Escape. This used to clear on every
+        // open, so closing the launcher by reflex — or bouncing off it to
+        // check something — threw the prompt away with no way back. It is
+        // cleared on submit, and only there.
+        if self.prompt.is_empty() {
+            let (harness, root) = initial_target(&self.services);
+            self.selected_harness = harness;
+            self.selected_root = root;
+        }
+        self.picker = None;
         self.open = true;
         window.focus(&self.focus, cx);
         cx.notify();
@@ -111,8 +152,7 @@ impl LauncherOverlay {
             return;
         }
         self.open = false;
-        self.harness_picker_open = false;
-        self.project_picker_open = false;
+        self.picker = None;
         cx.emit(LauncherEvent::Closed);
         cx.notify();
     }
@@ -197,14 +237,29 @@ impl LauncherOverlay {
             .unwrap_or_else(|| "Choose project".to_owned())
     }
 
+    /// Why the prompt cannot be sent yet, as something to show the user.
+    /// `None` means it can. The submit button used to just sit there dimmed
+    /// with no explanation, which reads as "broken" rather than "not yet".
+    fn blocker(&self) -> Option<String> {
+        if self.selected_root.is_empty() {
+            return Some("Choose a project to start in".to_owned());
+        }
+        match self
+            .harness_choices()
+            .into_iter()
+            .find(|choice| choice.kind == self.selected_harness)
+        {
+            Some(choice) if choice.available => None,
+            Some(choice) => Some(format!("{} is not installed", choice.label)),
+            None => Some(format!(
+                "{} is not available on this machine",
+                self.selected_harness_label()
+            )),
+        }
+    }
+
     fn can_submit(&self) -> bool {
-        !self.preview
-            && !self.prompt.text().trim().is_empty()
-            && !self.selected_root.is_empty()
-            && self
-                .harness_choices()
-                .iter()
-                .any(|choice| choice.kind == self.selected_harness && choice.available)
+        !self.preview && !self.prompt.text().trim().is_empty() && self.blocker().is_none()
     }
 
     fn submit(&mut self, cx: &mut Context<Self>) -> bool {
@@ -225,6 +280,7 @@ impl LauncherOverlay {
                     ..SpawnOptions::default()
                 },
             );
+        self.prompt.clear();
         self.close(cx);
         true
     }
@@ -235,25 +291,131 @@ impl LauncherOverlay {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {
+        if self.picker.is_some() && self.handle_picker_key(event, cx) {
+            return true;
+        }
+        let shift = event.keystroke.modifiers.shift;
         match event.keystroke.key.as_str() {
-            "escape" if self.harness_picker_open || self.project_picker_open => {
-                self.harness_picker_open = false;
-                self.project_picker_open = false;
-                cx.notify();
-                true
-            }
             "escape" => {
                 self.close(cx);
                 true
             }
-            "enter" if event.keystroke.modifiers.shift => {
+            "enter" if shift => {
                 self.prompt.insert_multiline("\n");
                 cx.notify();
                 true
             }
             "enter" => self.submit(cx),
+            // Cycling the agent from the keyboard: the picker was mouse-only,
+            // which is a strange thing to require of a surface you reached
+            // with ⌘N and are about to leave with ↵.
+            "tab" => {
+                self.cycle_harness(if shift { -1 } else { 1 });
+                cx.notify();
+                true
+            }
+            "up" => {
+                self.prompt.move_up(shift);
+                cx.notify();
+                true
+            }
+            "down" => {
+                self.prompt.move_down(shift);
+                cx.notify();
+                true
+            }
             _ => self.edit_prompt(event, cx),
         }
+    }
+
+    /// Arrow keys drive the open picker instead of the prompt behind it.
+    fn handle_picker_key(&mut self, event: &KeyDownEvent, cx: &mut Context<Self>) -> bool {
+        let count = match self.picker {
+            Some(Picker::Harness) => self.harness_choices().len(),
+            Some(Picker::Project) => self.projects().len(),
+            None => return false,
+        };
+        match event.keystroke.key.as_str() {
+            "escape" => {
+                self.picker = None;
+                cx.notify();
+                true
+            }
+            "up" | "down" if count > 0 => {
+                self.highlight = if event.keystroke.key == "up" {
+                    self.highlight.saturating_sub(1)
+                } else {
+                    (self.highlight + 1).min(count - 1)
+                };
+                cx.notify();
+                true
+            }
+            "enter" => {
+                self.commit_highlight();
+                cx.notify();
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn commit_highlight(&mut self) {
+        match self.picker {
+            Some(Picker::Harness) => {
+                if let Some(choice) = self
+                    .harness_choices()
+                    .get(self.highlight)
+                    .filter(|choice| choice.available)
+                {
+                    self.selected_harness = choice.kind.clone();
+                }
+            }
+            Some(Picker::Project) => {
+                if let Some(project) = self.projects().get(self.highlight) {
+                    self.selected_root.clone_from(&project.root);
+                }
+            }
+            None => return,
+        }
+        self.picker = None;
+    }
+
+    fn toggle_picker(&mut self, picker: Picker) {
+        if self.picker == Some(picker) {
+            self.picker = None;
+            return;
+        }
+        self.highlight = match picker {
+            Picker::Harness => self
+                .harness_choices()
+                .iter()
+                .position(|choice| choice.kind == self.selected_harness),
+            Picker::Project => self
+                .projects()
+                .iter()
+                .position(|project| project.root == self.selected_root),
+        }
+        .unwrap_or(0);
+        self.picker = Some(picker);
+    }
+
+    /// Steps to the next installed agent, skipping any that cannot run.
+    fn cycle_harness(&mut self, delta: isize) {
+        let choices: Vec<_> = self
+            .harness_choices()
+            .into_iter()
+            .filter(|choice| choice.available)
+            .collect();
+        if choices.is_empty() {
+            return;
+        }
+        let current = choices
+            .iter()
+            .position(|choice| choice.kind == self.selected_harness)
+            .unwrap_or(0);
+        let count = choices.len() as isize;
+        let next = (current as isize + delta).rem_euclid(count) as usize;
+        self.selected_harness = choices[next].kind.clone();
     }
 
     fn edit_prompt(&mut self, event: &KeyDownEvent, cx: &mut Context<Self>) -> bool {
@@ -265,10 +427,10 @@ impl LauncherOverlay {
                 self.prompt.apply(local);
             }
             Edit::Clipboard(ClipboardEdit::Copy) => {
-                query_editor::copy_selection(&self.prompt, cx);
+                query_editor::copy_selection(self.prompt.editor(), cx);
             }
             Edit::Clipboard(ClipboardEdit::Cut) => {
-                query_editor::cut_selection(&mut self.prompt, cx);
+                query_editor::cut_selection(self.prompt.editor_mut(), cx);
             }
             Edit::Clipboard(ClipboardEdit::Paste) => {
                 if let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) {
@@ -281,7 +443,7 @@ impl LauncherOverlay {
     }
 
     fn choose_folder(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        self.project_picker_open = false;
+        self.picker = None;
         let paths = cx.prompt_for_paths(PathPromptOptions {
             files: false,
             directories: true,
@@ -313,6 +475,7 @@ impl LauncherOverlay {
         for (index, choice) in self.harness_choices().into_iter().enumerate() {
             let selected = choice.kind == self.selected_harness;
             let enabled = choice.available;
+            let highlighted = self.highlight == index;
             let kind = choice.kind.clone();
             let logo = ui_agent_kind(&choice.kind);
             list = list.child(
@@ -331,12 +494,15 @@ impl LauncherOverlay {
                     } else {
                         colors.tertiary
                     })
+                    .when(highlighted && enabled, |row| {
+                        row.bg(colors.primary.alpha(0.08))
+                    })
                     .when(enabled, |row| {
                         row.cursor_pointer()
                             .hover(move |row| row.bg(colors.primary.alpha(0.06)))
                             .on_click(cx.listener(move |this, _, _, cx| {
                                 this.selected_harness = kind.clone();
-                                this.harness_picker_open = false;
+                                this.picker = None;
                                 cx.notify();
                             }))
                     })
@@ -385,6 +551,7 @@ impl LauncherOverlay {
         }
         for (index, project) in projects.into_iter().enumerate() {
             let selected = project.root == self.selected_root;
+            let highlighted = self.highlight == index;
             let root = project.root.clone();
             list = list.child(
                 div()
@@ -398,10 +565,11 @@ impl LauncherOverlay {
                     .gap(px(9.0))
                     .rounded(px(8.0))
                     .cursor_pointer()
+                    .when(highlighted, |row| row.bg(colors.primary.alpha(0.08)))
                     .hover(move |row| row.bg(colors.primary.alpha(0.06)))
                     .on_click(cx.listener(move |this, _, _, cx| {
                         this.selected_root.clone_from(&root);
-                        this.project_picker_open = false;
+                        this.picker = None;
                         cx.notify();
                     }))
                     .child(sf_symbol("folder", 12.0, colors.secondary))
@@ -447,8 +615,14 @@ impl LauncherOverlay {
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let can_submit = self.can_submit();
-        let harness_open = self.harness_picker_open;
-        let project_open = self.project_picker_open;
+        let harness_open = self.picker == Some(Picker::Harness);
+        let project_open = self.picker == Some(Picker::Project);
+        let text_height = composer_text_height(self.prompt.line_count());
+        let composer_height = text_height + COMPOSER_CONTROLS_HEIGHT;
+        // The pickers hang off the bottom of the panel, which now moves with
+        // the composer.
+        let picker_top = TITLE_HEIGHT + TITLE_GAP + composer_height + SHELF_HEIGHT + 8.0;
+        let blocker = self.blocker();
         let harness_label = self.selected_harness_label();
         let project_label = self.selected_project_label();
         let logo = ui_agent_kind(&self.selected_harness);
@@ -463,16 +637,17 @@ impl LauncherOverlay {
             rgba(0xe8e7e4ff)
         };
 
+        // Wrapped lines are children of a scroll container so the composer's
+        // handle can scroll BY LINE to keep the caret on screen — the whole
+        // point of the rewrite. An empty prompt shows the placeholder in the
+        // same row the caret is on, so the two do not fight over the baseline.
         let prompt = if self.prompt.is_empty() {
             div()
+                .h(px(COMPOSER_LINE_HEIGHT))
                 .flex()
                 .items_center()
                 .when(focused, |line| {
-                    line.child(
-                        div()
-                            .text_color(colors.primary.alpha(0.92))
-                            .child(query_label(&self.prompt)),
-                    )
+                    line.child(div().text_color(colors.primary.alpha(0.92)).child(CARET))
                 })
                 .child(
                     div()
@@ -481,7 +656,22 @@ impl LauncherOverlay {
                 )
                 .into_any_element()
         } else {
-            query_label(&self.prompt)
+            div()
+                .id("launcher-prompt-lines")
+                .size_full()
+                .flex()
+                .flex_col()
+                .overflow_y_scroll()
+                .track_scroll(self.prompt.scroll_handle())
+                .children(self.prompt.render_lines(
+                    px(COMPOSER_LINE_HEIGHT),
+                    focused.then_some(CARET),
+                    HighlightStyle {
+                        background_color: Some(Palette::CLAY.alpha(0.35).into()),
+                        ..HighlightStyle::default()
+                    },
+                ))
+                .into_any_element()
         };
 
         let panel = div()
@@ -505,8 +695,8 @@ impl LauncherOverlay {
                 div()
                     .relative()
                     .mt(px(TITLE_GAP))
-                    .mx(px(8.0))
-                    .h(px(COMPOSER_HEIGHT))
+                    .mx(px(COMPOSER_INSET))
+                    .h(px(composer_height))
                     .rounded(px(Radius::PANEL))
                     .bg(composer_fill)
                     .border_1()
@@ -522,18 +712,18 @@ impl LauncherOverlay {
                     })
                     .child(
                         div()
-                            .h(px(COMPOSER_TEXT_HEIGHT))
-                            .px(px(16.0))
-                            .pt(px(12.0))
-                            .overflow_hidden()
-                            .text_size(px(13.0))
-                            .line_height(px(19.0))
+                            .h(px(text_height))
+                            .px(px(COMPOSER_PADDING))
+                            .pt(px(COMPOSER_PAD_TOP))
+                            .pb(px(COMPOSER_PAD_BOTTOM))
+                            .text_size(px(COMPOSER_FONT_SIZE))
+                            .line_height(px(COMPOSER_LINE_HEIGHT))
                             .text_color(colors.primary)
                             .child(prompt),
                     )
                     .child(
                         div()
-                            .h(px(COMPOSER_HEIGHT - COMPOSER_TEXT_HEIGHT))
+                            .h(px(COMPOSER_CONTROLS_HEIGHT))
                             .px(px(10.0))
                             .pb(px(8.0))
                             .flex()
@@ -566,7 +756,9 @@ impl LauncherOverlay {
                                         div()
                                             .text_size(px(10.0))
                                             .text_color(colors.tertiary)
-                                            .child("⇧↵  New line"),
+                                            .child(blocker.clone().unwrap_or_else(|| {
+                                                "⇧↵  New line   ⇥  Agent".to_owned()
+                                            })),
                                     ),
                             )
                             .child(
@@ -602,9 +794,7 @@ impl LauncherOverlay {
                                             .child(harness_label)
                                             .child(sf_symbol("chevron.down", 7.5, colors.tertiary))
                                             .on_click(cx.listener(|this, _, _, cx| {
-                                                this.harness_picker_open =
-                                                    !this.harness_picker_open;
-                                                this.project_picker_open = false;
+                                                this.toggle_picker(Picker::Harness);
                                                 cx.notify();
                                             })),
                                     )
@@ -685,8 +875,7 @@ impl LauncherOverlay {
                             )
                             .child(sf_symbol("chevron.down", 8.0, colors.tertiary))
                             .on_click(cx.listener(|this, _, _, cx| {
-                                this.project_picker_open = !this.project_picker_open;
-                                this.harness_picker_open = false;
+                                this.toggle_picker(Picker::Project);
                                 cx.notify();
                             })),
                     )
@@ -713,32 +902,32 @@ impl LauncherOverlay {
             )
             .when(harness_open, |panel| {
                 panel.child(
-                    div()
-                        .absolute()
-                        .right(px(8.0))
-                        .top(px(TITLE_HEIGHT
-                            + TITLE_GAP
-                            + COMPOSER_HEIGHT
-                            + SHELF_HEIGHT
-                            + 8.0))
+                    self.floating(picker_top, cx)
+                        .right(px(COMPOSER_INSET))
                         .child(self.render_harness_picker(colors, cx)),
                 )
             })
             .when(project_open, |panel| {
                 panel.child(
-                    div()
-                        .absolute()
-                        .left(px(8.0))
-                        .top(px(TITLE_HEIGHT
-                            + TITLE_GAP
-                            + COMPOSER_HEIGHT
-                            + SHELF_HEIGHT
-                            + 8.0))
+                    self.floating(picker_top, cx)
+                        .left(px(COMPOSER_INSET))
                         .child(self.render_project_picker(colors, cx)),
                 )
             });
 
         panel.into_any_element()
+    }
+
+    /// Wrapper for a picker popover. It swallows its own mouse-down so the
+    /// canvas behind it — which closes any open picker — does not tear the
+    /// list away between press and release, which would eat the click.
+    fn floating(&self, top: f32, cx: &mut Context<Self>) -> gpui::Div {
+        div().absolute().top(px(top)).on_mouse_down(
+            MouseButton::Left,
+            cx.listener(|_, _, _, cx| {
+                cx.stop_propagation();
+            }),
+        )
     }
 }
 
@@ -749,7 +938,7 @@ impl Focusable for LauncherOverlay {
 }
 
 impl Render for LauncherOverlay {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let root = div()
             .id("new-session-launcher")
             .key_context("DiriLauncher")
@@ -761,23 +950,39 @@ impl Render for LauncherOverlay {
             return root.size(px(0.0));
         }
 
+        // Soft-wrapping needs the text system, which only exists here. Doing
+        // it before the panel is built is what lets the composer size itself
+        // to the prompt and scroll the caret into view.
+        self.prompt.layout(
+            px(COMPOSER_TEXT_WIDTH),
+            gpui::font(crate::fonts::ui_family()),
+            px(COMPOSER_FONT_SIZE),
+            window,
+        );
+
         // The session workbench is intentionally always dark, independent of
         // macOS appearance. This is a destination in that workbench—not a
         // translucent window overlay—so paint the same fully opaque surface.
         let colors = SemanticColors::dark();
-        let focused = self.focus.is_focused(_window);
-        let focus = self.focus.clone();
+        let focused = self.focus.is_focused(window);
         root.size_full()
             .relative()
             .flex()
             .items_center()
             .justify_center()
             .bg(colors.background)
-            // The entire empty workbench behaves like the editor's canvas.
-            // This also recovers focus after a project/harness popover click.
-            .on_mouse_down(MouseButton::Left, move |_, window, cx| {
-                window.focus(&focus, cx);
-            })
+            // The entire empty workbench behaves like the editor's canvas: a
+            // click anywhere returns to the prompt and dismisses whichever
+            // picker was open, which previously stayed up until you found the
+            // button again or pressed Escape.
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, window, cx| {
+                    this.picker = None;
+                    window.focus(&this.focus, cx);
+                    cx.notify();
+                }),
+            )
             // Command-N is a high-frequency keyboard action; the destination
             // appears immediately rather than making the user wait on motion.
             .child(self.render_panel(colors, focused, cx))

--- a/diri/crates/diri-app/src/main.rs
+++ b/diri/crates/diri-app/src/main.rs
@@ -2,6 +2,7 @@ mod app_theme;
 mod clipboard_transfer;
 mod code_intelligence;
 mod code_viewer;
+mod composer;
 #[cfg(unix)]
 mod daemon_launch;
 mod dev_build;

--- a/diri/crates/diri-app/src/navigation.rs
+++ b/diri/crates/diri-app/src/navigation.rs
@@ -1113,7 +1113,7 @@ const fn row_child_index(row: usize, first_section: Option<usize>) -> usize {
 /// A static caret. Blinking would need an autonomous frame timer, which is
 /// exactly what PERF.md's idle-CPU budget forbids; the terminal cursor is
 /// static for the same reason.
-const CARET: &str = "▏";
+pub(crate) const CARET: &str = "▏";
 
 /// Draw a query field's contents: caret at the cursor, or the selection washed
 /// in the brand accent. Shared by the palette, Quick Open, and the find bar so

--- a/diri/crates/diri-app/src/query_editor.rs
+++ b/diri/crates/diri-app/src/query_editor.rs
@@ -202,6 +202,47 @@ impl QueryEditor {
         }
     }
 
+    /// Puts the caret at an arbitrary offset. Multi-line callers compute
+    /// offsets from a wrapped layout this type knows nothing about — vertical
+    /// motion, or a `Line` motion that should stop at a visual line rather
+    /// than at the ends of the buffer.
+    pub fn move_to(&mut self, offset: usize, extend: bool) {
+        self.cursor = self.floor_boundary(offset);
+        if !extend {
+            self.anchor = self.cursor;
+        }
+    }
+
+    /// Deletes between the caret and `offset` (or the selection, if there is
+    /// one), leaving the caret at the near edge.
+    pub fn delete_to(&mut self, offset: usize) -> bool {
+        if let Some(range) = self.selection() {
+            self.text.replace_range(range.clone(), "");
+            self.cursor = range.start;
+            self.anchor = self.cursor;
+            return true;
+        }
+        let offset = self.floor_boundary(offset);
+        if offset == self.cursor {
+            return false;
+        }
+        let range = offset.min(self.cursor)..offset.max(self.cursor);
+        self.text.replace_range(range.clone(), "");
+        self.cursor = range.start;
+        self.anchor = range.start;
+        true
+    }
+
+    /// Nearest character boundary at or before `offset`, so a caller working
+    /// in graphemes can never split a multibyte character.
+    fn floor_boundary(&self, offset: usize) -> usize {
+        let mut offset = offset.min(self.text.len());
+        while !self.text.is_char_boundary(offset) {
+            offset -= 1;
+        }
+        offset
+    }
+
     fn offset_before(&self, from: usize, motion: Motion) -> usize {
         match motion {
             Motion::Line => 0,

--- a/diri/crates/diri-engine/src/control.rs
+++ b/diri/crates/diri-engine/src/control.rs
@@ -16,7 +16,7 @@ use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use diri_proto::control::MAX_CONTROL_LINE_BYTES;
 use diri_proto::{ControlError, ControlMessage, JsonValue, Method, WIRE_VERSION};
@@ -2518,38 +2518,213 @@ fn is_claude_workspace_trust_screen(screen: &str) -> bool {
         && (normalized.contains("1.") || normalized.contains("1 "))
 }
 
-/// Types an initial prompt into a freshly spawned agent, gated on the TUI
-/// actually being ready and verified afterward. Ported from the Swift
-/// `AgentSession.injectInitialPrompt`: up to three attempts, each abandoned
-/// only when the screen shows no evidence at all that input landed — a
-/// changed screen means it did, and a second submit would duplicate it.
+/// Types an initial prompt into a freshly spawned agent.
+///
+/// The old shape of this — paste-and-Enter in one go, then call it settled
+/// the moment the screen changed at all — lost the prompt outright against
+/// Claude Code: its banner and tips repaint for seconds after bracketed-paste
+/// mode comes on, so the "screen changed" tell fired on a repaint while the
+/// composer had quietly discarded the keystrokes. The user typed a prompt,
+/// got a bare agent, and the prompt was gone.
+///
+/// So the Enter is no longer sent blind, and "it landed" is no longer
+/// inferred from the screen merely moving. Each attempt TYPES the prompt
+/// without submitting and watches for it to echo into the composer; if it
+/// does, the Enter follows a prompt we can see. If it does not — which also
+/// describes a line-mode reader that paints nothing before a newline — the
+/// Enter goes out anyway and the prompt itself must then appear on screen.
+/// Only when neither happens is the attempt treated as swallowed, and only
+/// then is anything retyped.
+///
+/// And it keeps trying. A first-run agent can sit on a trust dialog or a
+/// login for a minute before it has a composer at all (Codex asks whether it
+/// trusts the directory), which the old three-quick-tries shape treated as
+/// "prompt lost". The prompt is held rather than fired: a dialog does not
+/// echo what it is handed, so those attempts simply fail their check and come
+/// back a moment later, and the first attempt after the dialog closes is the
+/// one that lands. Nothing here consults the session's status — Codex reads
+/// as `Working` even at an idle composer, so the echo is the only tell worth
+/// trusting.
 fn inject_initial_prompt(registry: &Arc<Mutex<Registry>>, session_id: &str, prompt: &str) {
     if !wait_until_ready(registry, session_id) {
         return;
     }
-    let probe = verification_probe(prompt);
-    for _attempt in 0..3 {
-        let Some(view) = with_session(registry, session_id, |session| session.view()) else {
+    let give_up_at = Instant::now() + PROMPT_INJECTION_WINDOW;
+    loop {
+        let Some(before) = screen_text(registry, session_id) else {
             return;
         };
-        if view.exited {
+        // A word already on screen (a path in the banner, a word from the
+        // tips panel) proves nothing, so the probe is chosen against the
+        // pre-typing screen.
+        let probe = verification_probe(prompt, &before);
+        if with_session(registry, session_id, |session| session.paste_text(prompt)).is_none() {
             return;
         }
-        let Some(before) = with_session(registry, session_id, |session| {
-            session.screen_lines().join("\n")
-        }) else {
-            return;
-        };
-        let sent = with_session(registry, session_id, |session| {
-            session.send_text(prompt, true)
-        });
-        if sent.is_none() {
+        match wait_for_echo(registry, session_id, probe.as_deref(), &before, ECHO_WINDOW) {
+            EchoOutcome::Gone => return,
+            // The composer is holding our text: the Enter is safe.
+            EchoOutcome::Visible => {
+                submit_typed_prompt(registry, session_id, probe.as_deref());
+                return;
+            }
+            EchoOutcome::Missing => {}
+        }
+
+        // Nothing came back. Either the keystrokes were discarded, or this is
+        // a reader that paints nothing until it sees a newline (a line-mode
+        // shell with echo off). Submitting tells the two apart: the prompt
+        // shows up when it landed, and nothing shows up when it did not.
+        //
+        // This Enter is a keypress into something we cannot see, and some of
+        // those things are questions — Codex's "do you trust this directory?"
+        // reads Enter as yes. Nothing here can tell a line-mode reader from a
+        // dialog: both swallow a paste without repainting, and the difference
+        // is canonical vs raw mode, which lives in the holder's pty and not
+        // here. The old code sent this same blind Enter on every attempt, so
+        // the exposure is unchanged; narrowing it would need the holder to
+        // report termios.
+        if with_session(registry, session_id, |session| session.submit_input()).is_none() {
             return;
         }
-        if prompt_settled(registry, session_id, &probe, &before) {
+        match wait_for_echo(
+            registry,
+            session_id,
+            probe.as_deref(),
+            &before,
+            LANDED_WINDOW,
+        ) {
+            EchoOutcome::Gone | EchoOutcome::Visible => return,
+            EchoOutcome::Missing => {}
+        }
+
+        // Truly swallowed. Empty the composer before retyping so a late echo
+        // cannot concatenate with the retry.
+        if with_session(registry, session_id, |session| session.clear_input_line()).is_none() {
             return;
+        }
+        if !sleep_until(give_up_at, PROMPT_RETRY_DELAY) {
+            break;
         }
     }
+    eprintln!(
+        "dirijord: {session_id} never accepted its initial prompt within \
+         {}s — left untyped rather than submitted blind",
+        PROMPT_INJECTION_WINDOW.as_secs()
+    );
+}
+
+/// How long a prompt waits for a composer that will take it. Long enough to
+/// outlast a trust dialog or a first-run login, short enough that a session
+/// abandoned at a wall does not hold a thread forever.
+const PROMPT_INJECTION_WINDOW: Duration = Duration::from_secs(180);
+
+/// Quiet time between delivery attempts.
+const PROMPT_RETRY_DELAY: Duration = Duration::from_secs(2);
+
+/// Sleeps for `delay`, or reports false when that would pass `deadline`.
+fn sleep_until(deadline: Instant, delay: Duration) -> bool {
+    if Instant::now() + delay >= deadline {
+        return false;
+    }
+    std::thread::sleep(delay);
+    true
+}
+
+/// What the screen said about a prompt we just typed.
+enum EchoOutcome {
+    /// The prompt is visibly sitting in the composer: safe to submit.
+    Visible,
+    /// Nothing arrived; the composer can be cleared and the prompt retyped.
+    Missing,
+    /// The session exited or vanished — stop touching it.
+    Gone,
+}
+
+/// How long to watch for the prompt to echo back as it is typed, and how long
+/// to watch for it after submitting. The first is short because a TUI that
+/// renders its composer does so immediately; the second is longer because it
+/// covers a round trip through the agent.
+const ECHO_WINDOW: Duration = Duration::from_millis(1500);
+const LANDED_WINDOW: Duration = Duration::from_millis(2500);
+
+/// Polls for the typed prompt to appear on screen. With no usable probe —
+/// every word of the prompt was already on screen — any change from `before`
+/// is taken as the echo, which is the best signal available in that case.
+fn wait_for_echo(
+    registry: &Arc<Mutex<Registry>>,
+    session_id: &str,
+    probe: Option<&str>,
+    before: &str,
+    window: Duration,
+) -> EchoOutcome {
+    let polls = (window.as_millis() / 100).max(1);
+    for _ in 0..polls {
+        std::thread::sleep(Duration::from_millis(100));
+        let Some((exited, now)) = with_session(registry, session_id, |session| {
+            (session.view().exited, session.screen_lines().join("\n"))
+        }) else {
+            return EchoOutcome::Gone;
+        };
+        if exited {
+            return EchoOutcome::Gone;
+        }
+        let echoed = probe.map_or_else(|| now != before, |probe| now.contains(probe));
+        if echoed {
+            return EchoOutcome::Visible;
+        }
+    }
+    EchoOutcome::Missing
+}
+
+/// Presses Enter on a prompt already verified to be in the composer, and
+/// confirms the composer let go of it. A prompt still sitting there after the
+/// first Enter gets exactly one more — never a retype, which is what would
+/// double-send.
+fn submit_typed_prompt(registry: &Arc<Mutex<Registry>>, session_id: &str, probe: Option<&str>) {
+    for _ in 0..2 {
+        if with_session(registry, session_id, |session| session.submit_input()).is_none() {
+            return;
+        }
+        let Some(probe) = probe else {
+            return;
+        };
+        // Submitting moves the prompt out of the composer and into the
+        // transcript above it; either way the agent now owns it. Only a
+        // screen that never moved at all means the Enter was swallowed.
+        for _ in 0..20 {
+            std::thread::sleep(Duration::from_millis(100));
+            match screen_text(registry, session_id) {
+                None => return,
+                Some(now)
+                    if !now.contains(probe) || agent_started_working(registry, session_id) =>
+                {
+                    return;
+                }
+                Some(_) => {}
+            }
+        }
+    }
+}
+
+/// True once the session's own status reducer says the agent is doing
+/// something — the prompt was received even if its text is still echoed in
+/// the transcript above the composer.
+fn agent_started_working(registry: &Arc<Mutex<Registry>>, session_id: &str) -> bool {
+    with_session(registry, session_id, |session| {
+        matches!(
+            session.view().status,
+            diri_proto::SessionStatus::Working | diri_proto::SessionStatus::NeedsInput(_)
+        )
+    })
+    .unwrap_or(false)
+}
+
+fn screen_text(registry: &Arc<Mutex<Registry>>, session_id: &str) -> Option<String> {
+    with_session(registry, session_id, |session| {
+        (!session.view().exited).then(|| session.screen_lines().join("\n"))
+    })
+    .flatten()
 }
 
 /// Waits until the agent can actually receive typed input. First for the
@@ -2586,9 +2761,12 @@ fn wait_until_ready(registry: &Arc<Mutex<Registry>>, session_id: &str) -> bool {
             return false;
         }
         if paste {
-            // One more frame so the composer finishes painting.
-            std::thread::sleep(Duration::from_millis(80));
-            return true;
+            // Paste mode says the input line exists; it does NOT say the TUI
+            // has stopped repainting over it. Claude Code turns paste mode on
+            // while its banner and tips panel are still landing, and anything
+            // typed into that window is discarded. Wait for the screen to
+            // hold still before treating the composer as real.
+            return screen_settled(registry, session_id);
         }
         if !text.trim().is_empty() && text == last_text {
             stable_ticks += 1;
@@ -2604,46 +2782,59 @@ fn wait_until_ready(registry: &Arc<Mutex<Registry>>, session_id: &str) -> bool {
     true
 }
 
-/// Polls the screen (≤ ~2s) for evidence the prompt was received. True as
-/// soon as the probe is visible OR the screen diverged from `before` —
-/// either means input landed, and a retry would duplicate the prompt. Only
-/// an entirely unchanged screen returns false → safe to retype.
-fn prompt_settled(
-    registry: &Arc<Mutex<Registry>>,
-    session_id: &str,
-    probe: &str,
-    before: &str,
-) -> bool {
-    for _ in 0..20 {
-        std::thread::sleep(Duration::from_millis(100));
-        let Some((exited, now)) = with_session(registry, session_id, |session| {
+/// Waits (≤ ~5s) for the screen to stop changing, so the prompt is typed into
+/// a composer that has finished being drawn over. True unless the session
+/// exited or vanished; a TUI that simply never goes quiet (an animated
+/// spinner in the banner) still gets its prompt, verified by the echo.
+fn screen_settled(registry: &Arc<Mutex<Registry>>, session_id: &str) -> bool {
+    let mut last = String::new();
+    let mut stable_ticks = 0;
+    for _ in 0..50 {
+        let Some((exited, text)) = with_session(registry, session_id, |session| {
             (session.view().exited, session.screen_lines().join("\n"))
         }) else {
-            return true; // session gone: don't retype into it
+            return false;
         };
         if exited {
-            return true; // dead pty: don't retype into it
+            return false;
         }
-        if !probe.is_empty() && now.contains(probe) {
-            return true;
+        if text == last {
+            stable_ticks += 1;
+            if stable_ticks >= 3 {
+                return true;
+            }
+        } else {
+            stable_ticks = 0;
+            last = text;
         }
-        if now != before {
-            return true;
-        }
+        std::thread::sleep(Duration::from_millis(100));
     }
-    false
+    true
 }
 
-/// A distinctive slice of the prompt to look for on screen: the first
-/// non-empty line, trimmed and capped short enough to survive composer
-/// wrapping or a transcript truncating a long prompt when it echoes back.
-fn verification_probe(prompt: &str) -> String {
-    let first_line = prompt
-        .lines()
-        .find(|line| !line.trim().is_empty())
-        .unwrap_or(prompt);
-    first_line.trim().chars().take(24).collect()
+/// A fragment of the prompt whose presence on screen means the composer
+/// received it.
+///
+/// It has to be a WHOLE word, not a leading slice: composers soft-wrap, and
+/// wrapping happens at word boundaries, so any prefix of the prompt can be
+/// split across two screen lines while a single word survives intact. It also
+/// has to be absent from `before`, or a word the banner already displays
+/// would read as an echo the instant we looked. `None` when the prompt offers
+/// nothing that qualifies — a prompt made entirely of words already on
+/// screen, or of words too long to escape wrapping.
+fn verification_probe(prompt: &str, before: &str) -> Option<String> {
+    prompt
+        .split_whitespace()
+        .filter(|word| (MIN_PROBE_CHARS..=MAX_PROBE_CHARS).contains(&word.chars().count()))
+        .filter(|word| !before.contains(*word))
+        .max_by_key(|word| word.chars().count())
+        .map(str::to_owned)
 }
+
+/// Short words appear by coincidence; long ones are the ones a narrow
+/// composer breaks mid-word.
+const MIN_PROBE_CHARS: usize = 4;
+const MAX_PROBE_CHARS: usize = 20;
 
 #[cfg(test)]
 mod tests {

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -1265,15 +1265,40 @@ impl Session {
         if !submit {
             return self.write_input(text.as_bytes());
         }
+        self.paste_text(text)?;
+        std::thread::sleep(Duration::from_millis(30));
+        self.submit_input()
+    }
+
+    /// Types `text` into the composer WITHOUT submitting it, framed as a
+    /// bracketed paste when the child has that mode on. Separated from
+    /// [`Self::send_text`] so a caller that cannot see the composer — the
+    /// initial-prompt injector — can watch the text echo back before it
+    /// commits to an Enter it can never take back.
+    ///
+    /// Titling happens here rather than at submit, so a prompt the injector
+    /// types names its session the same way one the user types does. It is
+    /// idempotent, which matters because the injector may retype.
+    pub fn paste_text(&self, text: &str) -> std::io::Result<()> {
         self.capture_prompt_title(text);
         let framed = if self.bracketed_paste() {
             format!("\x1b[200~{text}\x1b[201~")
         } else {
-            text.to_string()
+            text.to_owned()
         };
-        self.write_input(framed.as_bytes())?;
-        std::thread::sleep(Duration::from_millis(30));
+        self.write_input(framed.as_bytes())
+    }
+
+    /// The Enter that submits whatever is in the composer.
+    pub fn submit_input(&self) -> std::io::Result<()> {
         self.write_input(b"\r")
+    }
+
+    /// Kill-line (⌃U): what every one of these TUIs uses to empty its
+    /// composer. Sent before a retyped prompt so a half-landed first attempt
+    /// cannot concatenate with the second.
+    pub fn clear_input_line(&self) -> std::io::Result<()> {
+        self.write_input(b"\x15")
     }
 
     /// Sends bytes to the child, as if typed.

--- a/diri/crates/diri-engine/tests/inject_prompt.rs
+++ b/diri/crates/diri-engine/tests/inject_prompt.rs
@@ -201,3 +201,48 @@ fn a_silently_swallowed_prompt_is_retried_until_it_lands() {
 
     control.request("session.kill", json!({ "sessionID": id }));
 }
+
+/// The Claude Code shape, and the one that used to lose prompts outright:
+/// bracketed paste comes on EARLY, while the banner is still repainting, and
+/// input typed into that window is discarded. A busy screen must not be
+/// mistaken for "the prompt arrived" — the prompt itself has to show up.
+#[test]
+fn a_prompt_swallowed_behind_a_repainting_banner_still_lands() {
+    let temp = tempfile::tempdir().expect("temp");
+    let server = start_server(temp.path());
+    let mut control = Control::connect(&server);
+
+    // Paste mode on immediately (the readiness tell), then ~7s of repainting
+    // while every line typed is discarded, then a real reader. The screen
+    // changes constantly throughout, so any "did the screen move?" check
+    // reports success on the very first attempt and the prompt is lost.
+    let id = spawn(
+        &mut control,
+        r#"printf '\033[?2004h'; stty -echo; end=$((SECONDS+7)); while [ $SECONDS -lt $end ]; do printf '.'; read -t 1 junk; done; exec cat"#,
+        "/bin/bash",
+        "prompt behind the banner",
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut text = String::new();
+    while Instant::now() < deadline {
+        text = screen(&mut control, &id);
+        if text.contains("prompt behind the banner") {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(
+        text.contains("prompt behind the banner"),
+        "a repainting banner was mistaken for a delivered prompt: {text:?}"
+    );
+    std::thread::sleep(Duration::from_millis(2500));
+    let text = screen(&mut control, &id);
+    assert_eq!(
+        occurrences(&text, "prompt behind the banner"),
+        1,
+        "retries must stop the moment one attempt lands: {text:?}"
+    );
+
+    control.request("session.kill", json!({ "sessionID": id }));
+}


### PR DESCRIPTION
Two ways a new-tab prompt was lost, and one reason the field it was typed into was hard to use.

## The prompt never arrived

Reproduced before changing anything, by spawning Claude Code over `daemon.sock` with an `initialPrompt` and watching it land at a bare composer.

The daemon pasted the prompt, pressed Enter blind, and then treated **any** screen change as proof it arrived. Claude Code turns bracketed-paste mode on while its banner and tips are still repainting — so that repaint satisfied the check while the composer quietly discarded the keystrokes. The user typed a prompt, got a bare agent, and the prompt was gone.

`inject_initial_prompt` now types **without** submitting, waits for the prompt to echo back into the composer, and only then presses Enter. A missing echo means the keystrokes were dropped, which is safe to retype precisely because nothing was submitted. It also holds the prompt for three minutes rather than three quick tries, so an agent parked behind a first-run trust dialog still gets it once the dialog is answered.

Verified end to end against a sandboxed daemon: Claude Code and Codex both received and answered the prompt across repeated runs, no duplicates.

### Known trade-off

One blind Enter per attempt remains when a paste produces no screen change at all. That is the only way a line-mode reader (`cat` with echo off) can ever receive a prompt, and it is what the two pre-existing tests encode. It also means Codex's "do you trust this directory?" dialog can be answered unattended — as it already could, since the old code sent that same Enter on every attempt, so the exposure is unchanged. Telling a line-mode reader from a dialog needs canonical-vs-raw mode, which lives in the holder's pty rather than the daemon. Called out in a comment at the site.

## The composer

It was the one-line search field from ⌘K, painted into a fixed clipped box: no scroll handle, no cursor tracking, and a `Motion::Line` that meant the whole buffer. Past the third line you could no longer see what you were typing.

New `composer.rs` soft-wraps the buffer into visual lines at the field's real width via GPUI's `LineWrapper` — which is what makes "the line the caret is on" exist. From that follow a box that grows to nine lines and then scrolls with the caret, arrow keys that work and hold their column across short lines, and line motions that stop at the line rather than the prompt.

Around it: a draft now survives Escape and is cleared only on submit (a second way prompts were being lost), a click on the canvas dismisses an open picker, the pickers answer the keyboard, Tab cycles agents, and a blocked submit button says why instead of sitting there dimmed.

## Testing

- `a_prompt_swallowed_behind_a_repainting_banner_still_lands` models the exact failure — paste mode on early, screen repainting, input discarded. It fails against the old code with the reported symptom and passes here.
- Six unit tests in `composer.rs` cover the line arithmetic: caret-to-line mapping at soft breaks, vertical motion holding its column, line-granular edits and motions, selection clipping.
- Full suite on this branch rebased onto current `main`: 509 passed, 0 failed. Clippy clean.

**Not visually verified.** The composer's logic is tested; its on-screen layout is not. Worth a look at ⌘N before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
