### PR TITLE
diri: release 0.4.8

### DIFF
--- a/diri/Cargo.lock
+++ b/diri/Cargo.lock
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "diri-app"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "block2 0.6.2",
  "diri-client",

--- a/diri/crates/diri-app/Cargo.toml
+++ b/diri/crates/diri-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diri-app"
-version = "0.4.7"
+version = "0.4.8"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
Version bump plus lockfile, so `release.sh 0.4.8` has a reviewed source commit to build from.

Everything since `v0.4.7` ships in this release:

- **tmux-free Rust PTY Holder remote transport** (#27, supersedes #19) — `ssh -T` as a pure byte transport, one Holder per session, verified+atomic Helper bootstrap, detach/reconnect with authoritative snapshots.
- **The 20-Agent catalog restored** — the refactor had silently shrunk it to 7, and a missing manifest spawns a bare login shell rather than erroring.
- **A migration for tmux-era remote sessions** — they stay resumable and their orphaned panes are retired, instead of being abandoned on the host.
- Fixes for four things that only turned up testing against a real install: an upgrade from 0.4.7 stranding the app, the Helper catalog being invalidated by signing after hashing, a 100ms redraw ticker costing 290 MB and ~3% idle CPU, and environment capture that could never work through a bash login shell.

**Release prerequisites changed.** Cutting this needs `zig`, `cargo-zigbuild`, and both `*-unknown-linux-musl` targets — `package.sh` builds a remote Helper per supported platform and fails rather than shipping a partial catalog. Documented in PACKAGING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)