### PR TITLE
diri: release 0.5.0

### DIFF
--- a/diri/Cargo.lock
+++ b/diri/Cargo.lock
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "diri-app"
-version = "0.4.7"
+version = "0.5.0"
 dependencies = [
  "block2 0.6.2",
  "diri-client",

--- a/diri/crates/diri-app/Cargo.toml
+++ b/diri/crates/diri-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diri-app"
-version = "0.4.7"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
Version bump plus lockfile, so `release.sh 0.5.0` has a reviewed source commit to build from.

A minor rather than a patch: this replaces the remote session transport wholesale.

Everything since `v0.4.7` ships here:

- **tmux-free Rust PTY Holder remote transport** (#27, supersedes #19) — `ssh -T` as a pure byte transport, one Holder per session, verified and atomically activated Helper bootstrap, detach/reconnect with authoritative terminal snapshots. Latency gates pass with ~5x headroom.
- **The 20-Agent catalog restored** — the refactor had silently shrunk it to 7, and a missing manifest spawns a bare login shell rather than erroring.
- **A migration for tmux-era remote sessions** — they stay resumable and the panes diri created are retired, rather than being abandoned on the host. Verified end to end: a migrated Forge session resumes onto the new transport with its conversation intact.
- Fixes for four things that only surfaced testing against a real install: upgrading from 0.4.7 stranded the app, signing the Helper after hashing it invalidated the catalog and disabled remote entirely, a 100ms redraw ticker cost 290 MB and ~3% idle CPU, and environment capture could never work through a bash login shell (so, every Linux host).

**Release prerequisites changed.** Cutting this needs `zig`, `cargo-zigbuild`, and both `*-unknown-linux-musl` targets — `package.sh` builds one remote Helper per supported platform and fails rather than shipping a partial catalog. Documented in PACKAGING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)