### PR TITLE
release: give the Apple Helper signature a secure timestamp

### DIFF
--- a/diri/scripts/build-remote-helpers.sh
+++ b/diri/scripts/build-remote-helpers.sh
@@ -94,11 +94,15 @@ for target in "${targets[@]}"; do
     # the musl binaries are plain ELF and are measured as built.
     case "${target}" in
         *-apple-darwin)
+            # A secure timestamp is required for notarization: without it Apple
+            # rejects the whole archive with "The signature does not include a
+            # secure timestamp." Ad-hoc signatures cannot carry one, so they
+            # opt out explicitly — those builds are not notarized anyway.
             if [[ -n "${DIRI_SIGN_IDENTITY:-}" && "${DIRI_SIGN_IDENTITY}" != "-" ]]; then
-                codesign --force --options runtime --timestamp=none \
+                codesign --force --options runtime --timestamp \
                     --sign "${DIRI_SIGN_IDENTITY}" "${artifact}"
             else
-                codesign --force --sign - "${artifact}"
+                codesign --force --timestamp=none --sign - "${artifact}"
             fi
             ;;
     esac


### PR DESCRIPTION
Notarization rejected the 0.5.0 build:

```
diri.app/.../remote-helpers/artifacts/aarch64-apple-darwin/diri-remote
The signature does not include a secure timestamp.
```

Moving the Helper's codesign call into `build-remote-helpers.sh` (so it signs before its length and digest are recorded) carried `--timestamp=none` with it — the flag `package.sh` uses only for ad-hoc signatures. A real Developer ID needs `--timestamp`.

Found by running the release, not in review: everything up to notarization succeeded, including all three Helper builds and the catalog verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)