### PR TITLE
Make terminal input rendering latency-aware

### DIFF
--- a/diri/REMOTE_PORT.md
+++ b/diri/REMOTE_PORT.md
@@ -397,10 +397,12 @@ and sequence. Scrollback is bounded to 4 MiB and served on demand through
 `Scroll`. Raw output is bounded to 32 MiB.
 
 The PTY reader must never block on a client. The Holder uses bounded queues. It
-coalesces active output for no more than 16 ms. When no client is attached, it
-continues parsing terminal state but does not construct or serialize diffs. If
-an attached client falls behind, stale updates are discarded and the connection
-is reseeded from a complete snapshot after reconnect.
+coalesces background output for no more than 16 ms, while up to two grid
+publications after interactive input bypass that wait (one trailing publication
+may already be in flight before the actual response). When no client is
+attached, it continues parsing terminal state but does not construct or
+serialize diffs. If an attached client falls behind, stale updates are discarded
+and the connection is reseeded from a complete snapshot after reconnect.
 
 One owner/event loop handles PTY drain, terminal parsing, diff construction, and
 attach writes. The hot path does not put an `Arc<Mutex<Terminal>>` across tasks.
@@ -492,19 +494,19 @@ Release builds must satisfy the local Helper/UDS gates:
 ```text
 FullSnapshot p90          <= 100 ms
 input-to-PTY p95          <= 10 ms
-output-to-diff p90        <= 50 ms
+output-to-diff p90        <= 8 ms
 loopback interaction p50 <= 75 ms
 loopback interaction p90 <= 150 ms
 ```
 
-The 2026-08-09 local release sample measured:
+The 2026-08-11 local release sample measured:
 
 ```text
-FullSnapshot p90          1 us
-input-to-PTY p95          667 us
-output-to-diff p90        17.319 ms
-loopback interaction p50 179 us
-loopback interaction p90 401 us
+FullSnapshot p90          0 us
+input-to-PTY p95          138 us
+output-to-diff p90        13 us
+loopback interaction p50 76 us
+loopback interaction p90 99 us
 ```
 
 Measured values are printed in CI so regressions are visible rather than hidden

--- a/diri/crates/diri-app/src/terminal_pane.rs
+++ b/diri/crates/diri-app/src/terminal_pane.rs
@@ -57,9 +57,9 @@ const TOOLBAR_LINK_MAX_WIDTH: f32 = 176.0;
 const TOOLBAR_OVERFLOW_WIDTH: f32 = 50.0;
 const REATTACH_DELAY: Duration = Duration::from_millis(500);
 /// Burst ceiling for repaints (~60fps). The pacer paints the first frame of a
-/// burst immediately; this only caps sustained output, and background panes
-/// never invalidate the window, so idle budgets are unaffected. Matched to the
-/// daemon's `gridFlushInterval`.
+/// burst and the next response after interactive input immediately; this only
+/// caps sustained output, and background panes never invalidate the window, so
+/// idle budgets are unaffected. Matched to the daemon's `gridFlushInterval`.
 const ACTIVE_REPAINT_INTERVAL: Duration = Duration::from_millis(16);
 /// How often a live drag is allowed to push a new PTY geometry. Matched to the
 /// daemon's coalesced grid flush (also 16ms): resizing faster produces frames
@@ -392,10 +392,18 @@ enum AttachmentCommand {
 #[derive(Clone)]
 struct AttachmentControl {
     tx: mpsc::UnboundedSender<AttachmentCommand>,
+    pane_tx: mpsc::UnboundedSender<PaneEvent>,
 }
 
 impl AttachmentControl {
     fn input(&self, bytes: Vec<u8>) {
+        if bytes.is_empty() {
+            return;
+        }
+        // Queue the priority marker before the bytes leave for the daemon, so
+        // an echo that returns immediately cannot land behind the UI's
+        // background-output repaint timer.
+        let _ = self.pane_tx.send(PaneEvent::InteractiveInput);
         let _ = self.tx.send(AttachmentCommand::Input(bytes));
     }
 
@@ -418,6 +426,7 @@ impl AttachmentControl {
 }
 
 enum PaneEvent {
+    InteractiveInput,
     AttachmentState(SessionId, AttachmentState),
     Chunk(SessionId, TerminalChunk),
     FindSnapshot(SessionId, SearchRequest, FindSnapshot),
@@ -891,6 +900,7 @@ impl TerminalPane {
 
     fn handle_pane_event(&mut self, event: PaneEvent, window: &mut Window, cx: &mut Context<Self>) {
         match event {
+            PaneEvent::InteractiveInput => self.repaint_pacer.prioritize_interactive_damage(),
             PaneEvent::AttachmentState(id, state) => {
                 if let Some(resident) = self.residents.get_mut(&id) {
                     resident.attachment_state = state;
@@ -3001,7 +3011,10 @@ fn spawn_attachment(
     pane_tx: mpsc::UnboundedSender<PaneEvent>,
 ) -> AttachmentControl {
     let (command_tx, mut commands) = mpsc::unbounded_channel();
-    let control = AttachmentControl { tx: command_tx };
+    let control = AttachmentControl {
+        tx: command_tx,
+        pane_tx: pane_tx.clone(),
+    };
     runtime.spawn(async move {
         // The first resize must be the measured pane geometry: deferred agent
         // launch waits for it. Do not seed an arbitrary 80×24 size.

--- a/diri/crates/diri-engine/src/attach.rs
+++ b/diri/crates/diri-engine/src/attach.rs
@@ -24,8 +24,9 @@ use diri_proto::frames::{Frame, FrameCodec, FrameType};
 use crate::registry::Registry;
 use crate::session::{AttachmentSeed, GridSignature};
 
-/// Burst ceiling for grid emission, matching the client pacer and the Swift
-/// daemon's flush interval. The first frame after quiet goes immediately.
+/// Background-output ceiling for grid emission, matching the client pacer and
+/// the Swift daemon's flush interval. The first frame after quiet and the
+/// bounded response frames after interactive input go immediately.
 const GRID_FLUSH_INTERVAL: Duration = Duration::from_millis(16);
 
 /// One attached client's write half.
@@ -202,9 +203,10 @@ impl AttachHub {
         }
     }
 
-    /// The per-session broadcast loop. Grid writers wake it on change; bursts
-    /// coalesce to 16 ms, while a quiet attached terminal performs no Registry
-    /// or Screen polling. Ends within one bounded wait after the last sink.
+    /// The per-session broadcast loop. Grid writers wake it on change;
+    /// background bursts coalesce to 16 ms while interactive responses bypass
+    /// that wait. A quiet attached terminal performs no Registry or Screen
+    /// polling. Ends within one bounded wait after the last sink.
     fn pump(&self, registry: &Arc<Mutex<Registry>>, session_id: &str, seed: AttachmentSeed) {
         let mut signature = seed.signature;
         let mut last_modes = Some(seed.modes);
@@ -215,9 +217,11 @@ impl AttachHub {
             .unwrap_or_else(Instant::now);
         let stop = AtomicBool::new(false);
         loop {
-            let next_generation = wake.wait_for_change(wake_generation, Duration::from_secs(1));
-            let mut changed = next_generation != wake_generation;
-            wake_generation = next_generation;
+            let observed_generation = wake_generation;
+            let event = wake.wait_for_change(wake_generation, Duration::from_secs(1));
+            let mut changed = event.generation != wake_generation;
+            let mut interactive = event.interactive;
+            wake_generation = event.generation;
 
             // A restart can replace the Session (and therefore its wake
             // source) while sinks remain connected. The bounded wait above is
@@ -234,12 +238,17 @@ impl AttachHub {
                 signature = GridSignature::default();
                 last_modes = None;
                 changed = true;
+                interactive = true;
             }
 
-            if changed {
+            if changed && !interactive {
                 let elapsed = last_emission.elapsed();
                 if elapsed < GRID_FLUSH_INTERVAL {
-                    std::thread::sleep(GRID_FLUSH_INTERVAL - elapsed);
+                    let event = wake.wait_for_priority_or_timeout(
+                        observed_generation,
+                        GRID_FLUSH_INTERVAL - elapsed,
+                    );
+                    wake_generation = event.generation;
                 }
             }
             // The session may be briefly absent mid-restart adoption: keep
@@ -274,6 +283,11 @@ impl AttachHub {
             }
 
             if !frames.is_empty() {
+                // Two publications per input may bypass coalescing: one can
+                // be a trailing change already in flight, and the next is the
+                // actual terminal response. The bounded budget prevents a
+                // keystroke from unthrottling sustained output indefinitely.
+                wake.consume_interactive_priority();
                 last_emission = Instant::now();
                 let sinks: Vec<(u64, Arc<Mutex<UnixStream>>)> = {
                     let sessions = self.sessions.lock().expect("attach hub");

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -264,45 +264,95 @@ pub(crate) struct GridWake {
 }
 
 struct GridWakeInner {
-    generation: Mutex<u64>,
+    state: Mutex<GridWakeState>,
     changed: Condvar,
 }
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct GridWakeEvent {
+    pub generation: u64,
+    pub interactive: bool,
+}
+
+struct GridWakeState {
+    generation: u64,
+    interactive_budget: u8,
+}
+
+const INTERACTIVE_GRID_BUDGET: u8 = 2;
 
 impl GridWake {
     fn new() -> Self {
         Self {
             inner: Arc::new(GridWakeInner {
-                generation: Mutex::new(0),
+                state: Mutex::new(GridWakeState {
+                    generation: 0,
+                    interactive_budget: 0,
+                }),
                 changed: Condvar::new(),
             }),
         }
     }
 
     fn notify(&self) {
-        let mut generation = self.inner.generation.lock().expect("grid wake");
-        *generation = generation.wrapping_add(1);
+        let mut state = self.inner.state.lock().expect("grid wake");
+        state.generation = state.generation.saturating_add(1);
         self.inner.changed.notify_all();
     }
 
-    pub(crate) fn generation(&self) -> u64 {
-        *self.inner.generation.lock().expect("grid wake")
+    fn prioritize_interactive_changes(&self) {
+        let mut state = self.inner.state.lock().expect("grid wake");
+        state.interactive_budget = INTERACTIVE_GRID_BUDGET;
+        self.inner.changed.notify_all();
     }
 
-    pub(crate) fn wait_for_change(&self, observed: u64, timeout: Duration) -> u64 {
-        let generation = self.inner.generation.lock().expect("grid wake");
-        if *generation != observed {
-            return *generation;
+    pub(crate) fn consume_interactive_priority(&self) {
+        let mut state = self.inner.state.lock().expect("grid wake");
+        state.interactive_budget = state.interactive_budget.saturating_sub(1);
+    }
+
+    pub(crate) fn generation(&self) -> u64 {
+        self.inner.state.lock().expect("grid wake").generation
+    }
+
+    pub(crate) fn wait_for_change(&self, observed: u64, timeout: Duration) -> GridWakeEvent {
+        let state = self.inner.state.lock().expect("grid wake");
+        if state.generation != observed {
+            return grid_wake_event(&state, observed);
         }
-        let (generation, _) = self
+        let (state, _) = self
             .inner
             .changed
-            .wait_timeout_while(generation, timeout, |generation| *generation == observed)
+            .wait_timeout_while(state, timeout, |state| state.generation == observed)
             .expect("grid wake");
-        *generation
+        grid_wake_event(&state, observed)
+    }
+
+    pub(crate) fn wait_for_priority_or_timeout(
+        &self,
+        observed: u64,
+        timeout: Duration,
+    ) -> GridWakeEvent {
+        let state = self.inner.state.lock().expect("grid wake");
+        let (state, _) = self
+            .inner
+            .changed
+            .wait_timeout_while(state, timeout, |state| {
+                state.interactive_budget == 0 || state.generation == observed
+            })
+            .expect("grid wake");
+        grid_wake_event(&state, observed)
     }
 
     pub(crate) fn same_source(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.inner, &other.inner)
+    }
+}
+
+fn grid_wake_event(state: &GridWakeState, observed: u64) -> GridWakeEvent {
+    GridWakeEvent {
+        generation: state.generation,
+        interactive: state.interactive_budget > 0 && state.generation != observed,
     }
 }
 
@@ -1281,6 +1331,13 @@ impl Session {
         // Input means someone is interacting: keep the pump on its fast tick
         // so the echo renders promptly.
         self.shared.note_hot();
+        if !bytes.is_empty() {
+            // The next grid changes are likely a trailing echo already in
+            // flight and the TUI's response. Let the attachment pump interrupt
+            // its background coalescing wait instead of making typed input
+            // cross a 16 ms frame boundary before the host can render it.
+            self.shared.grid_wake.prioritize_interactive_changes();
+        }
         self.observe_prompt_input(bytes);
         // Typed before the deferred exec: queue for the launch flush, and
         // still count as a keystroke for the reducer.
@@ -2770,10 +2827,37 @@ mod grid_wake_tests {
 
         let changed = wake.wait_for_change(observed, Duration::from_secs(1));
         thread.join().expect("notifier");
-        assert!(changed > observed);
+        assert!(changed.generation > observed);
+        assert!(!changed.interactive);
         assert_eq!(
-            wake.wait_for_change(changed, Duration::from_millis(5)),
+            wake.wait_for_change(changed.generation, Duration::from_millis(5)),
             changed
         );
+    }
+
+    #[test]
+    fn interactive_priority_covers_two_grid_changes_then_expires() {
+        let wake = GridWake::new();
+        let observed = wake.generation();
+        wake.prioritize_interactive_changes();
+
+        let unchanged = wake.wait_for_priority_or_timeout(observed, Duration::from_millis(1));
+        assert_eq!(unchanged.generation, observed);
+        assert!(!unchanged.interactive);
+
+        wake.notify();
+        let changed = wake.wait_for_priority_or_timeout(observed, Duration::from_secs(1));
+        assert!(changed.generation > observed);
+        assert!(changed.interactive);
+
+        wake.consume_interactive_priority();
+        wake.notify();
+        let trailing = wake.wait_for_change(changed.generation, Duration::from_secs(1));
+        assert!(trailing.interactive);
+
+        wake.consume_interactive_priority();
+        wake.notify();
+        let background = wake.wait_for_change(trailing.generation, Duration::from_secs(1));
+        assert!(!background.interactive);
     }
 }

--- a/diri/crates/diri-engine/tests/attach.rs
+++ b/diri/crates/diri-engine/tests/attach.rs
@@ -168,24 +168,39 @@ fn an_attach_is_seeded_then_streams_diffs_and_answers_input() {
                 .is_some_and(|update| grid_text(&update).contains("warm-up-pump"))
     });
 
-    // Typing through the established data channel: cat echoes, and the echo
-    // comes back as a grid DIFF (not a full snapshot).
-    data.write_all(
-        &FrameCodec::encode(&Frame::input(b"typed-over-attach\n".to_vec())).expect("encode"),
-    )
-    .expect("send input");
-    let diff = frames.until("the echo diff", |frame| {
-        frame.frame_type == FrameType::Grid
-            && frame
-                .grid_payload()
-                .ok()
-                .flatten()
-                .is_some_and(|update| grid_text(&update).contains("typed-over-attach"))
-    });
-    let update = diff.grid_payload().expect("decode").expect("grid");
+    // Typing through the established data channel: cat echoes, and each echo
+    // comes back as a grid DIFF (not a full snapshot). Use the median so a
+    // single scheduler hiccup cannot fail the test, while a fixed 16 ms frame
+    // boundary on every keystroke still does.
+    let mut interactive_latencies = Vec::new();
+    for index in 0..5 {
+        let marker = format!("typed-over-attach-{index}");
+        let sent_at = Instant::now();
+        data.write_all(
+            &FrameCodec::encode(&Frame::input(format!("{marker}\n").into_bytes())).expect("encode"),
+        )
+        .expect("send input");
+        let diff = frames.until("the echo diff", |frame| {
+            frame.frame_type == FrameType::Grid
+                && frame
+                    .grid_payload()
+                    .ok()
+                    .flatten()
+                    .is_some_and(|update| grid_text(&update).contains(&marker))
+        });
+        interactive_latencies.push(sent_at.elapsed());
+        let update = diff.grid_payload().expect("decode").expect("grid");
+        assert!(
+            !update.is_full_snapshot,
+            "steady-state frames are diffs, not full repaints"
+        );
+    }
+    interactive_latencies.sort_unstable();
+    let median = interactive_latencies[interactive_latencies.len() / 2];
+    eprintln!("local input-to-grid median: {}us", median.as_micros());
     assert!(
-        !update.is_full_snapshot,
-        "steady-state frames are diffs, not full repaints"
+        median <= Duration::from_millis(8),
+        "local input-to-grid median was {median:?}; expected no fixed 16 ms frame boundary"
     );
 
     // Ping answers pong on the same channel.

--- a/diri/crates/diri-remote/src/holder.rs
+++ b/diri/crates/diri-remote/src/holder.rs
@@ -29,6 +29,7 @@ use crate::state::{
 
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
 const DIFF_COALESCE: Duration = Duration::from_millis(16);
+const INTERACTIVE_GRID_BUDGET: u8 = 2;
 const MAX_OUTBOUND_BYTES: usize = 20 << 20;
 const MAX_PENDING_INPUT_BYTES: usize = 1 << 20;
 const REPLAY_BUDGET_BYTES: usize = 4 << 20;
@@ -405,6 +406,7 @@ struct Holder {
     pending_connection: Option<Connection>,
     pending_input: PendingBytes,
     dirty_since: Option<Instant>,
+    interactive_grid_budget: u8,
     last_persisted_offset: u64,
 }
 
@@ -477,6 +479,7 @@ impl Holder {
             pending_connection: None,
             pending_input: PendingBytes::default(),
             dirty_since: None,
+            interactive_grid_budget: 0,
             last_persisted_offset: 0,
         })
     }
@@ -605,10 +608,9 @@ impl Holder {
             {
                 self.read_pending_connection()?;
             }
-            if self
-                .dirty_since
-                .is_some_and(|since| since.elapsed() >= DIFF_COALESCE)
-            {
+            if self.dirty_since.is_some_and(|since| {
+                self.interactive_grid_budget > 0 || since.elapsed() >= DIFF_COALESCE
+            }) {
                 self.emit_grid_delta()?;
             }
         }
@@ -956,6 +958,10 @@ impl Holder {
             ));
         }
         self.pending_input.push(bytes);
+        // One publication can be trailing output already in flight and the
+        // next the actual echo/TUI response. Keep the fast path bounded to
+        // those two frames so a keystroke cannot unthrottle a bulk stream.
+        self.interactive_grid_budget = INTERACTIVE_GRID_BUDGET;
         self.flush_input()
     }
 
@@ -997,6 +1003,7 @@ impl Holder {
     }
 
     fn emit_grid_delta(&mut self) -> io::Result<()> {
+        self.interactive_grid_budget = self.interactive_grid_budget.saturating_sub(1);
         self.dirty_since = None;
         if self
             .connection

--- a/diri/crates/diri-remote/tests/holder_e2e.rs
+++ b/diri/crates/diri-remote/tests/holder_e2e.rs
@@ -1028,7 +1028,7 @@ fn performance_gate_meets_remote_holder_latency_budget() {
 
     assert_percentile("snapshot p90", &mut snapshot_latencies, 90, 100);
     assert_percentile("input-to-PTY p95", &mut input_to_pty, 95, 10);
-    assert_percentile("output-to-diff p90", &mut output_to_diff, 90, 50);
+    assert_percentile("output-to-diff p90", &mut output_to_diff, 90, 8);
     assert_percentile("loopback median", &mut loopback.clone(), 50, 75);
     assert_percentile("loopback p90", &mut loopback, 90, 150);
 

--- a/diri/crates/diri-term/src/repaint.rs
+++ b/diri/crates/diri-term/src/repaint.rs
@@ -13,7 +13,10 @@ pub struct RepaintPacer {
     minimum_interval: Duration,
     last_repaint: Option<Duration>,
     scheduled_for: Option<Duration>,
+    interactive_damage_budget: u8,
 }
+
+const INTERACTIVE_DAMAGE_BUDGET: u8 = 2;
 
 impl RepaintPacer {
     #[must_use]
@@ -22,7 +25,18 @@ impl RepaintPacer {
             minimum_interval,
             last_repaint: None,
             scheduled_for: None,
+            interactive_damage_budget: 0,
         }
+    }
+
+    /// Make the next two damage publications paint immediately.
+    ///
+    /// Keyboard input uses this to avoid making its echo wait behind a timer
+    /// armed for unrelated streaming output. Two covers one trailing update
+    /// already in flight plus the actual response. The existing timer becomes
+    /// a harmless no-op when it fires.
+    pub fn prioritize_interactive_damage(&mut self) {
+        self.interactive_damage_budget = INTERACTIVE_DAMAGE_BUDGET;
     }
 
     /// Record newly applied damage.
@@ -30,6 +44,12 @@ impl RepaintPacer {
     /// The first frame paints immediately. Bursts receive one trailing timer,
     /// so every grid update reaches the buffer while host rendering is capped.
     pub fn on_damage(&mut self, now: Duration) -> RepaintAction {
+        if self.interactive_damage_budget > 0 {
+            self.interactive_damage_budget -= 1;
+            self.last_repaint = Some(now);
+            self.scheduled_for = None;
+            return RepaintAction::RepaintNow;
+        }
         let Some(last_repaint) = self.last_repaint else {
             self.last_repaint = Some(now);
             return RepaintAction::RepaintNow;
@@ -106,5 +126,32 @@ mod tests {
             repaint_count >= 19,
             "pacing should remain responsive, got only {repaint_count} paints"
         );
+    }
+
+    #[test]
+    fn interactive_damage_bypasses_an_armed_background_timer() {
+        let interval = Duration::from_millis(16);
+        let mut pacer = RepaintPacer::new(interval);
+        assert_eq!(pacer.on_damage(Duration::ZERO), RepaintAction::RepaintNow);
+        assert_eq!(
+            pacer.on_damage(Duration::from_millis(2)),
+            RepaintAction::Schedule(Duration::from_millis(14))
+        );
+
+        pacer.prioritize_interactive_damage();
+        assert_eq!(
+            pacer.on_damage(Duration::from_millis(4)),
+            RepaintAction::RepaintNow
+        );
+        assert_eq!(
+            pacer.on_damage(Duration::from_millis(5)),
+            RepaintAction::RepaintNow
+        );
+        assert_eq!(
+            pacer.on_damage(Duration::from_millis(6)),
+            RepaintAction::Schedule(Duration::from_millis(15))
+        );
+        assert!(!pacer.on_timer(Duration::from_millis(16)));
+        assert!(pacer.on_timer(Duration::from_millis(21)));
     }
 }


### PR DESCRIPTION
## Why

v0.5 removed idle grid polling, but active terminal input still crossed fixed 16 ms pacing boundaries. The release probe showed a 61 us PTY loopback median while output-to-grid p90 remained 16.096 ms, so the visible delay was scheduling rather than PTY, parser, or renderer work.

## What changed

- Give interactive input a bounded two-publication fast path through the remote Holder and local attachment pump. Two publications cover one trailing update already in flight plus the actual terminal response.
- Replace the local pump's uninterruptible coalescing sleep with its existing condition-variable wake, so input can interrupt a background-output wait.
- Carry the same bounded priority into the app repaint pacer, preventing an arrived echo from waiting behind a timer armed for unrelated output.
- Preserve the 16 ms cap for sustained/background output and preserve the no-poll idle path.
- Tighten the release output-to-diff p90 gate from 50 ms to 8 ms and add local timing plus deterministic pacing regressions.
- Update the remote architecture/performance documentation with the new contract and measurements.

### Release measurements

| Signal | v0.5 baseline | This PR |
| --- | ---: | ---: |
| Local input-to-grid median | ~16.6 ms in the regression case | 76 us release / 516 us debug |
| Remote output-to-diff p90 | 16.096 ms | 13 us |
| Remote input-to-PTY p95 | 308 us | 138 us |
| Remote loopback p90 | 82 us | 99 us |

The cached GPU replay remains at 60.2 updates/s with 21.1 us average wire+apply cost and 1.05 ms average renderer cost.

## Verification

- [x] `./scripts/check.sh` passes (release guards, 275 Swift tests, Rust workspace, and dependency license policy).
- [x] `cargo build --workspace --release --locked` passes.
- [x] Release holder latency gate passes with output-to-diff p90 at 13 us against the new 8 ms budget.
- [x] Local attach latency regression passes at 76 us release median and 516 us debug median.
- [x] The 23 MiB slow-client/backpressure snapshot recovery test passes.
- [x] Existing sessions still survive app and daemon restarts; full lifecycle/adoption tests pass.
- [x] Security and privacy impact considered: no protocol, authentication, payload, logging, or authority changes.
- [x] User-visible behavior and performance contract are documented in `diri/REMOTE_PORT.md`.
- [x] Screenshot/recording is not applicable; this changes scheduling only and has no visual design delta.
