### PR TITLE
diri: make status chimes gentler and less repetitive

### DIFF
--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -21,7 +21,7 @@ use crate::notifications::{InAppBanner, NotificationSound};
 use crate::seam::{SeamSlide, toggle_has_settled};
 use crate::session_surfaces::SessionSurfaces;
 use crate::sidebar::{PreviewScenario, Sidebar, SidebarEvent};
-use crate::sounds::{self, AfplayPlayer, StatusSound};
+use crate::sounds::{self, AfplayPlayer, SoundGate, StatusSound};
 use crate::store::{DefaultAgent, SpawnOptions};
 use crate::surface_shell::UtilitySurfaces;
 use crate::terminal_pane::{TerminalPane, TerminalPaneEvent, TerminalViewport};
@@ -173,6 +173,7 @@ pub struct RootView {
     window_bounds_save: Option<Task<()>>,
     status_banner: Option<InAppBanner>,
     status_banner_generation: u64,
+    sound_gate: SoundGate,
     preview: bool,
     preview_scenario: PreviewScenario,
     #[cfg(target_os = "macos")]
@@ -393,7 +394,9 @@ impl RootView {
                                     NotificationSound::Done => StatusSound::Done,
                                     NotificationSound::Frozen => StatusSound::Frozen,
                                 };
-                                let _ = sounds::play(&AfplayPlayer, sound);
+                                if this.sound_gate.should_play(sound, Instant::now()) {
+                                    let _ = sounds::play(&AfplayPlayer, sound);
+                                }
                             }
                             #[cfg(target_os = "macos")]
                             if let Some(notification) = &status.notification
@@ -552,6 +555,7 @@ impl RootView {
             window_bounds_save: None,
             status_banner: None,
             status_banner_generation: 0,
+            sound_gate: SoundGate::default(),
             preview,
             preview_scenario,
             #[cfg(target_os = "macos")]

--- a/diri/crates/diri-app/src/sounds.rs
+++ b/diri/crates/diri-app/src/sounds.rs
@@ -1,11 +1,19 @@
-//! Pure status-chime synthesis plus an opt-in playback boundary.
+//! Gentle status-chime synthesis plus an opt-in playback boundary.
 
 use std::io;
+use std::time::{Duration, Instant};
 
 pub const SAMPLE_RATE: u32 = 44_100;
 pub const CHANNELS: u16 = 1;
 pub const BITS_PER_SAMPLE: u16 = 16;
-pub const PLAYBACK_VOLUME: f32 = 0.9;
+/// Leave plenty of headroom below the user's system volume. These are ambient
+/// confirmations, not alarms.
+pub const PLAYBACK_VOLUME: f32 = 0.52;
+
+const TAIL_DECAYS: f64 = 4.0;
+const TAIL_FADE_SECONDS: f64 = 0.065;
+const MIN_CHIME_INTERVAL: Duration = Duration::from_millis(900);
+const SAME_CHIME_COOLDOWN: Duration = Duration::from_secs(4);
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum StatusSound {
@@ -18,46 +26,125 @@ pub enum StatusSound {
 struct Strike {
     frequency: f64,
     start: f64,
+    attack: f64,
     decay: f64,
     amplitude: f64,
+    brightness: f64,
 }
 
-const PARTIALS: [(f64, f64); 3] = [(1.0, 1.0), (2.0, 0.35), (3.0, 0.12)];
+// A quiet subharmonic and restrained upper partials make the notes feel more
+// like a felt mallet than the buzzy additive beeps this replaced.
+const PARTIALS: [(f64, f64); 4] = [(0.5, 0.055), (1.0, 1.0), (2.0, 0.12), (3.0, 0.025)];
 
+// A small rising major third: noticeable enough to ask for attention without
+// repeating the same high note twice.
 const NEEDS_INPUT: [Strike; 2] = [
     Strike {
-        frequency: 587.33,
+        frequency: 392.00,
         start: 0.0,
-        decay: 0.16,
-        amplitude: 0.24,
+        attack: 0.014,
+        decay: 0.14,
+        amplitude: 0.155,
+        brightness: 0.70,
     },
     Strike {
-        frequency: 587.33,
-        start: 0.14,
-        decay: 0.26,
-        amplitude: 0.24,
+        frequency: 493.88,
+        start: 0.16,
+        attack: 0.016,
+        decay: 0.18,
+        amplitude: 0.135,
+        brightness: 0.62,
     },
 ];
-const DONE: [Strike; 2] = [
+
+// A compact C-major arpeggio supplies the bit of earned, game-like delight.
+// Each successive note is quieter so the sound resolves instead of demanding
+// another look.
+const DONE: [Strike; 3] = [
+    Strike {
+        frequency: 523.25,
+        start: 0.0,
+        attack: 0.016,
+        decay: 0.14,
+        amplitude: 0.135,
+        brightness: 0.82,
+    },
     Strike {
         frequency: 659.25,
-        start: 0.0,
-        decay: 0.18,
-        amplitude: 0.20,
+        start: 0.08,
+        attack: 0.017,
+        decay: 0.17,
+        amplitude: 0.115,
+        brightness: 0.72,
     },
     Strike {
-        frequency: 987.77,
-        start: 0.11,
-        decay: 0.34,
-        amplitude: 0.17,
+        frequency: 783.99,
+        start: 0.16,
+        attack: 0.019,
+        decay: 0.20,
+        amplitude: 0.090,
+        brightness: 0.60,
     },
 ];
-const FROZEN: [Strike; 1] = [Strike {
-    frequency: 220.0,
-    start: 0.0,
-    decay: 0.45,
-    amplitude: 0.22,
-}];
+
+// A low falling fifth distinguishes memory pressure from positive events, but
+// stays consonant and soft rather than sounding like an error buzzer.
+const FROZEN: [Strike; 2] = [
+    Strike {
+        frequency: 293.66,
+        start: 0.0,
+        attack: 0.022,
+        decay: 0.21,
+        amplitude: 0.145,
+        brightness: 0.38,
+    },
+    Strike {
+        frequency: 220.00,
+        start: 0.07,
+        attack: 0.024,
+        decay: 0.24,
+        amplitude: 0.115,
+        brightness: 0.30,
+    },
+];
+
+/// Prevent a group of agents finishing together from turning into a cascade of
+/// overlapping chimes. The authoritative state and notification still arrive;
+/// only redundant audio is dropped.
+#[derive(Debug, Default)]
+pub struct SoundGate {
+    last_any: Option<Instant>,
+    last_by_kind: [Option<Instant>; 3],
+}
+
+impl SoundGate {
+    #[must_use]
+    pub fn should_play(&mut self, event: StatusSound, now: Instant) -> bool {
+        let index = event.index();
+        let repeated_too_soon = self.last_by_kind[index]
+            .is_some_and(|previous| now.duration_since(previous) < SAME_CHIME_COOLDOWN);
+        let burst_too_close = self
+            .last_any
+            .is_some_and(|previous| now.duration_since(previous) < MIN_CHIME_INTERVAL);
+        if repeated_too_soon || burst_too_close {
+            return false;
+        }
+
+        self.last_any = Some(now);
+        self.last_by_kind[index] = Some(now);
+        true
+    }
+}
+
+impl StatusSound {
+    const fn index(self) -> usize {
+        match self {
+            Self::NeedsInput => 0,
+            Self::Done => 1,
+            Self::Frozen => 2,
+        }
+    }
+}
 
 /// Render one 44.1 kHz, signed 16-bit, mono PCM RIFF/WAVE chime.
 #[must_use]
@@ -69,7 +156,7 @@ pub fn synthesize_wav(event: StatusSound) -> Vec<u8> {
     };
     let tail = strikes
         .iter()
-        .map(|strike| strike.start + strike.decay * 5.0)
+        .map(|strike| strike.start + strike.attack + strike.decay * TAIL_DECAYS)
         .fold(0.0_f64, f64::max);
     let frame_count = (tail * f64::from(SAMPLE_RATE)) as usize;
     let mut samples = Vec::with_capacity(frame_count);
@@ -79,17 +166,30 @@ pub fn synthesize_wav(event: StatusSound) -> Vec<u8> {
         let mut value = 0.0;
         for strike in strikes.iter().filter(|strike| time >= strike.start) {
             let local = time - strike.start;
-            let attack = (local / 0.003).min(1.0);
-            let envelope = attack * (-local / strike.decay).exp() * strike.amplitude;
-            for (harmonic, weight) in PARTIALS {
+            let attack_progress = (local / strike.attack).clamp(0.0, 1.0);
+            let attack = smoothstep(attack_progress);
+            let decay_time = (local - strike.attack).max(0.0);
+            let envelope = attack * (-decay_time / strike.decay).exp() * strike.amplitude;
+            for (partial, weight) in PARTIALS {
+                let color = if partial > 1.0 {
+                    strike.brightness
+                } else {
+                    1.0
+                };
                 value += envelope
                     * weight
-                    * (2.0 * std::f64::consts::PI * strike.frequency * harmonic * local).sin();
+                    * color
+                    * (2.0 * std::f64::consts::PI * strike.frequency * partial * local).sin();
             }
         }
-        samples.push((value.clamp(-1.0, 1.0) * f64::from(i16::MAX)) as i16);
+        let fade = smoothstep(((tail - time) / TAIL_FADE_SECONDS).clamp(0.0, 1.0));
+        samples.push(((value * fade).clamp(-1.0, 1.0) * f64::from(i16::MAX)) as i16);
     }
     wav_container(&samples)
+}
+
+fn smoothstep(value: f64) -> f64 {
+    value * value * (3.0 - 2.0 * value)
 }
 
 fn wav_container(samples: &[i16]) -> Vec<u8> {
@@ -177,11 +277,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn wav_headers_frame_counts_and_peaks_match_the_swift_synth() {
-        for (event, expected_frames, expected_peak) in [
-            (StatusSound::NeedsInput, 63_504, 10_578_i16),
-            (StatusSound::Done, 79_821, 9_651_i16),
-            (StatusSound::Frozen, 99_225, 8_427_i16),
+    fn wav_headers_and_gentle_output_levels_are_valid() {
+        for (event, duration_range) in [
+            (StatusSound::NeedsInput, 0.80..0.95),
+            (StatusSound::Done, 0.90..1.05),
+            (StatusSound::Frozen, 1.00..1.10),
         ] {
             let wav = synthesize_wav(event);
             assert_eq!(&wav[0..4], b"RIFF");
@@ -192,18 +292,49 @@ mod tests {
                 SAMPLE_RATE
             );
             assert_eq!(u16::from_le_bytes(wav[34..36].try_into().unwrap()), 16);
-            assert_eq!((wav.len() - 44) / 2, expected_frames);
+            let frames = (wav.len() - 44) / 2;
+            let seconds = frames as f64 / f64::from(SAMPLE_RATE);
+            assert!(duration_range.contains(&seconds), "{event:?}: {seconds}s");
             let peak = wav[44..]
                 .chunks_exact(2)
                 .map(|bytes| i16::from_le_bytes([bytes[0], bytes[1]]).unsigned_abs())
                 .max()
                 .unwrap();
-            assert!(peak.abs_diff(expected_peak.unsigned_abs()) <= 2);
+            assert!(
+                (3_000..=10_000).contains(&peak),
+                "{event:?}: unexpected peak {peak}"
+            );
+            assert_eq!(&wav[44..46], &[0, 0]);
         }
     }
 
     #[test]
-    fn playback_uses_synthesized_bytes_and_swift_volume() {
+    fn each_status_has_its_own_audio_signature() {
+        let needs_input = synthesize_wav(StatusSound::NeedsInput);
+        let done = synthesize_wav(StatusSound::Done);
+        let frozen = synthesize_wav(StatusSound::Frozen);
+        assert_ne!(needs_input, done);
+        assert_ne!(needs_input, frozen);
+        assert_ne!(done, frozen);
+    }
+
+    #[test]
+    fn sound_gate_quiets_bursts_and_repeated_events() {
+        let start = Instant::now();
+        let mut gate = SoundGate::default();
+
+        assert!(gate.should_play(StatusSound::Done, start));
+        assert!(!gate.should_play(StatusSound::NeedsInput, start + Duration::from_millis(500)));
+        assert!(gate.should_play(StatusSound::NeedsInput, start + Duration::from_millis(900)));
+        assert!(!gate.should_play(StatusSound::Done, start + Duration::from_secs(2)));
+        assert!(gate.should_play(
+            StatusSound::Done,
+            start + SAME_CHIME_COOLDOWN + Duration::from_millis(1)
+        ));
+    }
+
+    #[test]
+    fn playback_uses_synthesized_bytes_and_gentle_volume() {
         use std::cell::RefCell;
 
         #[derive(Default)]
@@ -221,6 +352,6 @@ mod tests {
         let recorded = recorder.0.borrow();
         let (wav, volume) = recorded.as_ref().unwrap();
         assert_eq!(&wav[0..4], b"RIFF");
-        assert_eq!(*volume, 0.9);
+        assert_eq!(*volume, PLAYBACK_VOLUME);
     }
 }

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -1565,8 +1565,8 @@ impl UtilitySurfaces {
                         ))
                         .child(setting_divider(colors))
                         .child(toggle_row(
-                            "Chime on agent status changes",
-                            "Play a sound when an agent needs input or finishes.",
+                            "Gentle status chimes",
+                            "Quiet cues for input, completion, and memory pauses.",
                             self.prefs.status_sounds,
                             "toggle-status-sounds",
                             colors,


### PR DESCRIPTION
## Why

The current status tones are bright, loud, and prone to stacking when several agents change state together. Status audio should feel calm and rewarding without becoming background noise.

## What changed

- replace the sharp additive beeps with warmer, softer input, completion, and memory-pause cues
- turn completion into a compact C-major arpeggio while keeping attention and warning cues distinct
- reduce playback volume from 90% to 52% and add smooth attacks and tail fades
- suppress clustered chimes within 900 ms and repeated cues of the same kind within four seconds
- rename the setting to Gentle status chimes and clarify which events produce audio
- add synthesis, output-level, cue-distinction, and burst-gating coverage

## Verification

- cargo test -p diri-app: 295 passed, 1 ignored
- cargo clippy -p diri-app --tests -- -D warnings
- rustfmt checked on all three changed Rust files

- [x] Full contributor script not run; the targeted app test and lint suites cover this isolated Rust-only change.
- [x] Existing sessions are unaffected; this changes client-side synthesis and playback gating only.
- [x] Security and privacy impact considered; no process, IPC, logging, update, or remote-host behavior changes.
- [x] User-visible behavior is documented in the updated settings copy.
- [x] Screenshot is not applicable to an audio-only behavior change beyond two strings of settings copy.