### PR TITLE
docs: add a keyboard shortcuts reference (#36)

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -26,6 +26,13 @@ Claude Code and Codex have first-class status detection and resume support.
 Other agents may offer partial detection; every agent can still run as a normal
 terminal.
 
+## Working from the keyboard
+
+⌘N opens the launcher, ⌘T starts a session with the default agent, ⌘K is the
+command palette, and ⌃⇥ switches between running sessions. The
+[keyboard shortcuts reference](KEYBOARD_SHORTCUTS.md) lists every binding grouped
+by task, and explains which surface wins when two of them want the same key.
+
 ## Parallel work with worktrees
 
 Create separate sessions with separate git worktrees when agents may edit the

--- a/docs/KEYBOARD_SHORTCUTS.md
+++ b/docs/KEYBOARD_SHORTCUTS.md
@@ -1,0 +1,190 @@
+# Keyboard shortcuts
+
+Diri is keyboard-first. This page groups every user-facing binding by what you
+are trying to do, rather than by the file it lives in.
+
+Modifiers use the macOS glyphs — ⌘ Command, ⇧ Shift, ⌥ Option, ⌃ Control — with
+a plain-language name wherever the glyph alone is ambiguous. Unless a row says
+otherwise, a shortcut works whenever the main window is focused, including while
+you are typing in a terminal.
+
+## Sessions
+
+| Shortcut | Keys | Action |
+| --- | --- | --- |
+| ⌘N | Command-N | Open the launcher: pick a project and agent, then type the first prompt |
+| ⌘T | Command-T | Start a session with the default agent immediately, no launcher |
+| ⌥⌘T | Option-Command-T | Start a plain shell session |
+| ⇧⌘N | Shift-Command-N | Start a Codex session |
+| ⌘R | Command-R | Rename the selected session in place |
+| ⇧⌘W | Shift-Command-W | Archive the selected session |
+| ⌘W | Command-W | Close the selected session; with no session selected, close the window |
+| ⇧⌘T | Shift-Command-T | Reopen the most recently closed session |
+| ⌘Q | Command-Q | Quit Diri (the daemon keeps sessions alive) |
+| ⌘H | Command-H | Hide Diri |
+
+⌘T, ⌥⌘T and ⇧⌘N are no-ops when the app cannot spawn — the keystroke is left
+alone rather than swallowed, so nothing else changes.
+
+## Moving between sessions
+
+| Shortcut | Keys | Action |
+| --- | --- | --- |
+| ⌘1 … ⌘8 | Command-1 to Command-8 | Select the nth session, matching the row hints in the sidebar |
+| ⌘9 | Command-9 | Select the last session, the browser convention |
+| ⌘[ / ⌘] | Command-bracket | Previous / next session in sidebar order, wrapping |
+| ⌥⌘↑ / ⌥⌘↓ | Option-Command-arrow | Previous / next session |
+| ⌥⌘← / ⌥⌘→ | Option-Command-arrow | Previous / next session |
+| ⌃⌘↑ / ⌃⌘↓ | Control-Command-arrow | Move the selected row up or down within its project group |
+| ⇧⌘J | Shift-Command-J | Jump to the next session that needs input |
+| ⌃⇥ | Control-Tab | Open the most-recently-used switcher; hold ⌃ and press ⇥ again to advance |
+
+Selecting a session also focuses its terminal.
+
+While the switcher overlay is open: ⇧⌃⇥ cycles backwards, ← ↑ go back, → ↓ go
+forward, ↵ commits the highlighted session, Esc cancels, and releasing ⌃ commits.
+Every other key is swallowed until it closes.
+
+Session navigation with arrows and brackets stands down while the switcher or
+the overview is open, so those surfaces keep the arrow keys.
+
+## Surfaces
+
+| Shortcut | Keys | Action |
+| --- | --- | --- |
+| ⌘K | Command-K | Command palette |
+| ⌘P | Command-P | Quick Open — start a session in a recent directory |
+| ⇧⌘O | Shift-Command-O | Overview of all sessions |
+| ⇧⌘H | Shift-Command-H | History of past conversations |
+| ⌥⌘W | Option-Command-W | Worktrees overview |
+| ⌘, | Command-comma | Settings |
+| ⌘B | Command-B | Show or hide the sidebar |
+| ⇧⌘D | Shift-Command-D | Show or hide the inspector |
+| ⌘J | Command-J | Open or focus a terminal below the selected agent's workbench |
+
+The command palette lists ⌘T (or ⇧⌘N, depending on which agent is the default
+host), ⌥⌘T, ⌘P, ⇧⌘O, ⌥⌘W, ⌘B and ⌘, next to their commands, so the palette
+doubles as a reminder for the shortcuts you use least.
+
+### Inside the command palette and Quick Open
+
+| Shortcut | Keys | Action |
+| --- | --- | --- |
+| ↑ / ↓ | Arrow keys | Move the highlight |
+| ⌃P / ⌃N | Control-P / Control-N | Move the highlight, readline style |
+| ↵ | Return | Run the highlighted entry |
+| ⌘↵ | Command-Return | Quick Open only: open a plain shell in that directory instead of the default agent |
+| Esc | Escape | Close the overlay |
+
+Anything else edits the query through the [shared text keymap](#text-fields).
+
+### Inside the launcher
+
+| Shortcut | Keys | Action |
+| --- | --- | --- |
+| ⇥ / ⇧⇥ | Tab / Shift-Tab | Cycle the agent forward or backward |
+| ↵ | Return | Submit and start the session |
+| ⇧↵ | Shift-Return | Insert a newline in the prompt |
+| ↑ / ↓ | Arrow keys | Move within the prompt; ⇧ extends the selection |
+| Esc | Escape | Close the launcher |
+
+When the agent or project picker is open it takes the arrows first: ↑ ↓ move the
+highlight, ↵ commits it, and Esc closes the picker without closing the launcher.
+
+### Inside the overview
+
+| Shortcut | Keys | Action |
+| --- | --- | --- |
+| ← → ↑ ↓ | Arrow keys | Move focus between sessions |
+| ↵ | Return | Activate the focused session |
+| ⌘A | Command-A | Select every session |
+| Any character | — | Append to the filter query, space included |
+| ⌫ / ⌦ | Delete | Delete back through the filter query |
+| Esc | Escape | Step back, then close |
+
+### Inside history, settings and worktrees
+
+| Shortcut | Keys | Action |
+| --- | --- | --- |
+| ↑ / ↓ | Arrow keys | Move the highlight in history |
+| ↵ | Return | Open the highlighted conversation |
+| Esc | Escape | Close the surface |
+
+In history, other keys filter the list. In settings, Esc first dismisses an open
+menu or the remote-host editor and only then closes the surface; inside that
+editor ⇥ and ⇧⇥ move between fields and ↵ saves the host.
+
+While one of these surfaces is open, only ⌘H, ⌘K, ⌘P and ⌘, still reach the app.
+Everything else belongs to the surface.
+
+### Inside the inspector
+
+Ask and commit composers both take ↵ to submit and Esc to cancel.
+
+## Terminal
+
+| Shortcut | Keys | Action |
+| --- | --- | --- |
+| ⌘F | Command-F | Open find |
+| ⌘G | Command-G | Next match |
+| ⇧⌘G | Shift-Command-G | Previous match |
+| ⌘C | Command-C | Copy the selection |
+| ⌘V | Command-V | Paste, including images |
+| ⌘= or ⌘+ | Command-plus | Zoom in |
+| ⌘- | Command-minus | Zoom out |
+| ⌘0 | Command-zero | Reset zoom |
+
+With the find bar open, ↵ jumps to the next match, ⇧↵ to the previous one, and
+Esc closes it. Typing edits the query through the [shared text keymap](#text-fields);
+⌘V stays the paste action rather than a find-bar edit, so it never inserts twice.
+
+Keys without ⌘ go to the running program, modifiers and all. Keys with ⌘ do not
+reach the program — ⌫ is the one exception, so ⌥⌫ and ⌘⌫ still delete a word or a
+line inside the shell.
+
+## Text fields
+
+The command palette, Quick Open, the terminal find bar, the history filter, the
+launcher prompt and the inspector composers share one keymap.
+
+| Shortcut | Keys | Action |
+| --- | --- | --- |
+| ⌘A | Command-A | Select all |
+| ⌘C / ⌘X / ⌘V | Command-C / X / V | Copy, cut, paste |
+| ← / → | Arrow keys | Move the caret; ⇧ extends the selection |
+| ⌥← / ⌥→ | Option-arrow | Move by word |
+| ⌘← / ⌘→ | Command-arrow | Move to the start or end of the line |
+| Home / End | — | Start or end of the line |
+| ⌫ / ⌦ | Delete | Delete a character; ⌥ deletes a word, ⌘ deletes to the line edge |
+| ⌃A / ⌃E | Control-A / E | Start or end of the line, readline style |
+| ⌃B / ⌃F | Control-B / F | Back or forward one character |
+| ⌃H / ⌃D | Control-H / D | Delete the character before or after the caret |
+| ⌃W | Control-W | Delete the word before the caret |
+| ⌃U / ⌃K | Control-U / K | Delete to the start or end of the line |
+
+## Context and conflicts
+
+Diri resolves an ambiguous keystroke by asking which surface is in front, then
+falling back to the terminal:
+
+- **A global shortcut that is not handled is not swallowed.** ⌘R with nothing
+  selected, ⌘9 with one session, ⌘T when spawning is unavailable — each leaves
+  the keystroke alone rather than eating it.
+- **The launcher takes everything while it is open**, except ⌘N, which stays
+  available.
+- **History, settings and worktrees take everything** except ⌘H, ⌘K, ⌘P and ⌘,.
+- **The switcher and the overview own the arrow keys** while they are visible, so
+  ⌥⌘↑, ⌘[ and ⌃⌘↑ stand down for as long as either is up.
+- **Esc is shared.** With the overview closed, Esc clears a multi-session sidebar
+  selection but is deliberately not swallowed — the focused terminal still gets
+  it, so pressing Esc in vim never depends on what the sidebar is doing.
+- **⌘W is two commands.** The sidebar closes the selected session; only with no
+  session selected does it reach the window and close it.
+- **⌘J and ⇧⌘J are unrelated.** ⌘J opens a workbench terminal; ⇧⌘J is the
+  attention jump that used to live on plain ⌘J.
+
+The following bindings are internal or contextual rather than user-facing, and
+are documented above only where they surface in the UI: the switcher's swallowing
+of stray keys while it is open, the key-up and modifiers-changed fallbacks that
+commit the switcher when ⌃ is released, and the per-field ⇥ traversal inside the
+remote-host editor.

--- a/docs/KEYBOARD_SHORTCUTS.md
+++ b/docs/KEYBOARD_SHORTCUTS.md
@@ -18,13 +18,10 @@ you are typing in a terminal.
 | ⇧⌘N | Shift-Command-N | Start a Codex session |
 | ⌘R | Command-R | Rename the selected session in place |
 | ⇧⌘W | Shift-Command-W | Archive the selected session |
-| ⌘W | Command-W | Close the selected session; with no session selected, close the window |
+| ⌘W | Command-W | Close a focused auxiliary terminal; otherwise close the selected session, or the window when none is selected |
 | ⇧⌘T | Shift-Command-T | Reopen the most recently closed session |
 | ⌘Q | Command-Q | Quit Diri (the daemon keeps sessions alive) |
 | ⌘H | Command-H | Hide Diri |
-
-⌘T, ⌥⌘T and ⇧⌘N are no-ops when the app cannot spawn — the keystroke is left
-alone rather than swallowed, so nothing else changes.
 
 ## Moving between sessions
 
@@ -35,7 +32,7 @@ alone rather than swallowed, so nothing else changes.
 | ⌘[ / ⌘] | Command-bracket | Previous / next session in sidebar order, wrapping |
 | ⌥⌘↑ / ⌥⌘↓ | Option-Command-arrow | Previous / next session |
 | ⌥⌘← / ⌥⌘→ | Option-Command-arrow | Previous / next session |
-| ⌃⌘↑ / ⌃⌘↓ | Control-Command-arrow | Move the selected row up or down within its project group |
+| ⌃⌘↑ / ⌃⌘↓ | Control-Command-arrow | Move the selected row up or down among its siblings within the project group |
 | ⇧⌘J | Shift-Command-J | Jump to the next session that needs input |
 | ⌃⇥ | Control-Tab | Open the most-recently-used switcher; hold ⌃ and press ⇥ again to advance |
 
@@ -60,11 +57,12 @@ the overview is open, so those surfaces keep the arrow keys.
 | ⌘, | Command-comma | Settings |
 | ⌘B | Command-B | Show or hide the sidebar |
 | ⇧⌘D | Shift-Command-D | Show or hide the inspector |
-| ⌘J | Command-J | Open or focus a terminal below the selected agent's workbench |
+| ⌘J | Command-J | Show or hide an auxiliary terminal below the selected agent's workbench |
 
-The command palette lists ⌘T (or ⇧⌘N, depending on which agent is the default
-host), ⌥⌘T, ⌘P, ⇧⌘O, ⌥⌘W, ⌘B and ⌘, next to their commands, so the palette
-doubles as a reminder for the shortcuts you use least.
+The command palette always lists ⌘T for the default agent. When Codex is not
+the default, its command also shows ⇧⌘N. The palette lists ⌥⌘T, ⌘P, ⇧⌘O,
+⌥⌘W, ⌘B and ⌘, too, so it doubles as a reminder for the shortcuts you use
+least.
 
 ### Inside the command palette and Quick Open
 
@@ -99,7 +97,7 @@ highlight, ↵ commits it, and Esc closes the picker without closing the launche
 | ↵ | Return | Activate the focused session |
 | ⌘A | Command-A | Select every session |
 | Any character | — | Append to the filter query, space included |
-| ⌫ / ⌦ | Delete | Delete back through the filter query |
+| ⌫ / ⌦ | Delete | Delete back through the filter query; with an empty query and a selection, close the selected sessions |
 | Esc | Escape | Step back, then close |
 
 ### Inside history, settings and worktrees
@@ -138,9 +136,9 @@ With the find bar open, ↵ jumps to the next match, ⇧↵ to the previous one,
 Esc closes it. Typing edits the query through the [shared text keymap](#text-fields);
 ⌘V stays the paste action rather than a find-bar edit, so it never inserts twice.
 
-Keys without ⌘ go to the running program, modifiers and all. Keys with ⌘ do not
-reach the program — ⌫ is the one exception, so ⌥⌫ and ⌘⌫ still delete a word or a
-line inside the shell.
+Apart from ⌃⇥ and the active-surface shortcuts above, keys without ⌘ go to the
+running program, modifiers and all. Keys with ⌘ do not reach the program — ⌫ is the
+one exception, so ⌥⌫ and ⌘⌫ still delete a word or a line inside the shell.
 
 ## Text fields
 
@@ -167,9 +165,9 @@ launcher prompt and the inspector composers share one keymap.
 Diri resolves an ambiguous keystroke by asking which surface is in front, then
 falling back to the terminal:
 
-- **A global shortcut that is not handled is not swallowed.** ⌘R with nothing
-  selected, ⌘9 with one session, ⌘T when spawning is unavailable — each leaves
-  the keystroke alone rather than eating it.
+- **A global shortcut that is not handled is not swallowed.** ⌘R or ⌘J with
+  nothing selected, and ⌘9 with no sessions, leave the keystroke alone rather
+  than eating it.
 - **The launcher takes everything while it is open**, except ⌘N, which stays
   available.
 - **History, settings and worktrees take everything** except ⌘H, ⌘K, ⌘P and ⌘,.
@@ -178,10 +176,11 @@ falling back to the terminal:
 - **Esc is shared.** With the overview closed, Esc clears a multi-session sidebar
   selection but is deliberately not swallowed — the focused terminal still gets
   it, so pressing Esc in vim never depends on what the sidebar is doing.
-- **⌘W is two commands.** The sidebar closes the selected session; only with no
-  session selected does it reach the window and close it.
-- **⌘J and ⇧⌘J are unrelated.** ⌘J opens a workbench terminal; ⇧⌘J is the
-  attention jump that used to live on plain ⌘J.
+- **⌘W is three commands.** It closes a focused auxiliary terminal first;
+  otherwise the sidebar closes the selected session, and only with no session
+  selected does it reach the window and close it.
+- **⌘J and ⇧⌘J are unrelated.** ⌘J toggles an auxiliary workbench terminal;
+  ⇧⌘J is the attention jump that used to live on plain ⌘J.
 
 The following bindings are internal or contextual rather than user-facing, and
 are documented above only where they surface in the UI: the switcher's swallowing

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 - [Getting started](GETTING_STARTED.md) — installation, first session, worktrees,
   remote hosts, diagnostics, and local data.
+- [Keyboard shortcuts](KEYBOARD_SHORTCUTS.md) — every binding, grouped by task,
+  plus how Diri resolves an ambiguous keystroke.
 - [Security model](SECURITY-MODEL.md) — trust boundaries and safe-use guidance.
 - [Remote nodes](../diri/NODE.md) — run sessions over SSH and tmux.
 - [Packaging](../diri/PACKAGING.md) — build, signing, and notarization.


### PR DESCRIPTION
Mycroft again — Anton's synthetic co-founder, same arrangement as #26: he owns the account, I wrote the patch and this text, he reviews before it ships.

Closes #36.

### What this is

`docs/KEYBOARD_SHORTCUTS.md`, grouped by task as the issue asks — sessions, moving between sessions, surfaces, terminal, text fields — plus a link from `docs/README.md` and a short "Working from the keyboard" paragraph in `docs/GETTING_STARTED.md`. Documentation only; no binding changes.

### How the rows were produced

Read off the current dispatch code, not from memory or from the UI: the fourteen `KeyBinding::new` registrations in `main.rs` and `terminal_pane.rs`, the `⌘`-gated match in `RootView::on_key_down`, the `new_session_shortcut` / `session_navigation_delta` policies, and the overlay handlers in `launcher.rs`, `navigation.rs`, `switcher.rs`, `session_surfaces.rs`, `surface_shell.rs` and `inspector.rs`, plus the shared keymap in `query_editor.rs`.

Two of those I would not have found from the UI and they are the reason the doc is worth having: `⌃P` / `⌃N` also move the palette highlight, and `⌘↵` in Quick Open opens a plain shell instead of the default agent.

### The part actually worth reviewing

Not the tables — the **Context and conflicts** section. A shortcut list is easy; what is undiscoverable is which surface wins a contested key. It states that the launcher keeps everything but `⌘N`; that history, settings and worktrees pass only `⌘H`, `⌘K`, `⌘P`, `⌘,`; that arrow navigation stands down while the switcher or overview is up; that `Esc` clears a sidebar selection *without* being swallowed, so `Esc` in vim never depends on the sidebar; that an unhandled global shortcut is left alone rather than eaten; and that `⌘W` is two commands depending on selection. Each of those is a claim about your dispatch order — if I read any of them backwards, that is the thing to catch.

The issue's "deliberately called out as internal/contextual" clause is honoured in a closing paragraph: the switcher swallowing stray keys, the key-up / modifiers-changed fallbacks that commit it when `⌃` is released, and per-field `⇥` in the remote-host editor.

### Verified, and not verified

Verified: `bash -n scripts/*.sh diri/scripts/*.sh` (your CI guard) still passes; every relative link in the three touched files resolves on disk, and both in-page `#text-fields` anchors match a real heading; the diff is documentation-only, so `cargo` and `swift` targets are untouched.

Not verified: I did not run `swift test` or `cargo test` — nothing they compile changed. I also did not press all ~70 shortcuts in a running build; correctness here rests on the dispatch code, and mis-transcription is the failure mode to look for.

### One conflict to be aware of

#48 also touches `docs/README.md`. The collision is a single link line and trivial to resolve either direction; nothing else here overlaps it, and `crates/diri-app/src` is untouched by this PR.

### One observation, no change made

`palette.rs` renders its hints as `⌘⇧O` and `⌘⇧N`, while macOS orders modifiers `⌃⌥⇧⌘` — i.e. `⇧⌘O`. The doc uses the macOS order. If you would rather the two agree, say which way and I will follow up; I did not touch it here because #36 is explicitly documentation-only.