### PR TITLE
fix: keep painting terminals on unfocused but visible windows

### DIFF
--- a/diri/crates/diri-app/src/inspector.rs
+++ b/diri/crates/diri-app/src/inspector.rs
@@ -4385,6 +4385,11 @@ mod tests {
             InspectorTab::Info
         );
         inspector.update(cx, |inspector, cx| inspector.set_visible(true, cx));
+        // Drain the Info refresh before asserts/teardown. Leaving a live
+        // `cx.spawn` + `tokio.spawn_blocking` task lets GPUI's test scheduler
+        // abort it on a worker thread ("local task dropped by a thread that
+        // didn't spawn it") after the test already reported ok.
+        cx.run_until_parked();
 
         let (generation, context, polling) = inspector.read_with(cx, |inspector, _| {
             (
@@ -4405,6 +4410,7 @@ mod tests {
             store.select(ids[1].clone());
         }
         inspector.update(cx, |inspector, cx| inspector.refresh_if_context_changed(cx));
+        cx.run_until_parked();
 
         let (next_generation, next_context, still_polling) = inspector.read_with(cx, |i, _| {
             (i.generation, i.context.clone(), i.poll_task.is_some())
@@ -4425,6 +4431,14 @@ mod tests {
             inspector.select_tab(InspectorTab::Info, cx);
         });
         assert!(inspector.read_with(cx, |inspector, _| inspector.poll_task.is_none()));
+        // Cancel any leftover refresh/review tasks on this thread before the
+        // TestAppContext tears the window down.
+        inspector.update(cx, |inspector, _| {
+            inspector.refresh_task = None;
+            inspector.review_task = None;
+            inspector.poll_task = None;
+        });
+        cx.run_until_parked();
     }
 
     #[test]

--- a/diri/crates/diri-app/src/terminal_pane.rs
+++ b/diri/crates/diri-app/src/terminal_pane.rs
@@ -1004,12 +1004,10 @@ impl TerminalPane {
         if !applied {
             return;
         }
-        let repaint = terminal_damage_should_repaint(
-            window.is_window_active(),
-            selected.as_ref(),
-            &id,
-            changed,
-        );
+        // Visibility/occlusion is GPUI's job (display-link stops when the
+        // window is truly hidden). `is_window_active` is only OS focus, so
+        // gating on it freezes a still-visible window on another monitor.
+        let repaint = terminal_damage_should_repaint(selected.as_ref(), &id, changed);
         if schedule_find {
             self.schedule_find(id, Duration::from_millis(100), window, cx);
         }
@@ -3251,12 +3249,11 @@ fn sorted_checks(pr: &PullRequestStatus) -> Vec<PrCheck> {
 }
 
 fn terminal_damage_should_repaint(
-    window_active: bool,
     selected: Option<&SessionId>,
     updated: &SessionId,
     changed: bool,
 ) -> bool {
-    window_active && changed && selected == Some(updated)
+    changed && selected == Some(updated)
 }
 
 /// What to do with a geometry change that just landed.
@@ -3880,33 +3877,27 @@ mod tests {
     }
 
     #[test]
-    fn offscreen_terminal_damage_updates_its_buffer_without_repainting_the_window() {
+    fn unselected_terminal_damage_updates_its_buffer_without_repainting_the_window() {
         let selected = SessionId::new("selected");
         let background = SessionId::new("background");
 
+        // Selected session damage always paints, including when the window is
+        // unfocused-but-visible on another monitor. GPUI occlusion handles
+        // truly hidden windows.
         assert!(terminal_damage_should_repaint(
-            true,
             Some(&selected),
             &selected,
             true
         ));
         assert!(!terminal_damage_should_repaint(
-            true,
             Some(&selected),
             &background,
             true
         ));
         assert!(!terminal_damage_should_repaint(
-            true,
             Some(&selected),
             &selected,
             false
-        ));
-        assert!(!terminal_damage_should_repaint(
-            false,
-            Some(&selected),
-            &selected,
-            true
         ));
     }
 


### PR DESCRIPTION
## Summary
- Stop gating selected-session terminal repaints on `is_window_active()`, which means OS focus rather than visibility.
- A Diri window left visible on another monitor was freezing while still on-screen; GPUI occlusion already handles truly hidden windows.

## Test plan
- [x] Unit: `unselected_terminal_damage_updates_its_buffer_without_repainting_the_window`
- [x] Multi-monitor: leave Diri visible on monitor B, focus another app on monitor A, confirm the selected terminal keeps updating
- [x] Minimize / fully cover Diri and confirm it still behaves normally when brought back