### PR TITLE
docs: prepare official Homebrew cask submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ silicon and Intel), signed and notarized. diri updates itself from there.
 
 The tap has to be named in full — a bare `diri` resolves only against Homebrew's default
 taps. The cask lives in [cristicretu/homebrew-diri](https://github.com/cristicretu/homebrew-diri)
-rather than `homebrew-cask`, which requires a notability threshold diri does not meet yet.
+rather than `homebrew-cask` until the repository-age gate for an official submission opens
+on September 3, 2026, at 10:08:23 UTC. The current status and tested migration procedure are
+recorded in the [official-cask submission runbook](docs/HOMEBREW_CASK_SUBMISSION.md).
 
 macOS 15 or newer.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,9 +24,12 @@ in [Issues](https://github.com/cristicretu/diri/issues).
 - Continue publishing signed, notarized releases and the maintained Homebrew
   tap.
 - Submit Diri to the official Homebrew cask repository once it is eligible.
-  Homebrew normally requires a repository to be at least 30 days old and applies
-  a higher notability threshold to owner submissions. Until then, the supported
-  command is `brew install --cask cristicretu/diri/diri`.
+  The owner-submission notability threshold is met; the remaining normal policy
+  gate opens on September 3, 2026, at 10:08:23 UTC, when the repository is 30
+  days old. The [submission runbook](docs/HOMEBREW_CASK_SUBMISSION.md) keeps the
+  candidate, checksum verification, and validation commands ready. Until
+  acceptance, the supported command is
+  `brew install --cask cristicretu/diri/diri`.
 
 ## Not planned
 

--- a/diri/PACKAGING.md
+++ b/diri/PACKAGING.md
@@ -64,3 +64,8 @@ Before a public release:
 1. Install the real Developer ID Application certificate and configure a notarytool keychain profile or CI secrets.
 2. Run the signed/notarized DMG flow and test it on a second Mac outside the build environment.
 3. Publish through the release host with `scripts/release.sh <version>`, which wraps this script and also writes the update feed — see [UPDATING.md](UPDATING.md).
+
+The maintained tap remains the release target until the official cask is
+accepted. See the [official-cask submission
+runbook](../docs/HOMEBREW_CASK_SUBMISSION.md) for the one-time migration and the
+post-acceptance release change.

--- a/diri/README.md
+++ b/diri/README.md
@@ -34,11 +34,13 @@ Either way you get the same universal build, signed and notarized, so it opens
 without a Gatekeeper prompt.
 
 The cask lives in [cristicretu/homebrew-diri](https://github.com/cristicretu/homebrew-diri)
-rather than `homebrew-cask`, which requires a notability threshold the project
-does not meet yet. It declares `auto_updates true`, so Homebrew installs diri
-once and then leaves it alone — diri updates itself after that, and
-`brew upgrade` will not clobber a build the app moved itself to. See
-[UPDATING.md](UPDATING.md) for how that works.
+rather than `homebrew-cask` until the repository-age gate for an official
+submission opens on September 3, 2026, at 10:08:23 UTC. It declares
+`auto_updates true`, so Homebrew compares the installed app version before an
+ordinary upgrade and does not replace a same or newer build installed by Diri's
+updater. See [UPDATING.md](UPDATING.md) for how that works and the
+[official-cask submission runbook](../docs/HOMEBREW_CASK_SUBMISSION.md) for the
+verified migration path.
 
 ## Toolchain and GPUI pin
 

--- a/docs/HOMEBREW_CASK_SUBMISSION.md
+++ b/docs/HOMEBREW_CASK_SUBMISSION.md
@@ -1,0 +1,114 @@
+# Official Homebrew cask submission
+
+Diri is currently installed from the maintained
+[`cristicretu/homebrew-diri`](https://github.com/cristicretu/homebrew-diri)
+tap. This runbook records the remaining eligibility gate and the exact process
+for moving the proven cask to
+[`Homebrew/homebrew-cask`](https://github.com/Homebrew/homebrew-cask) without
+changing the artifact users receive.
+
+## Eligibility snapshot
+
+Checked on August 12, 2026:
+
+- The canonical repository was created on August 4, 2026, at 10:08:23 UTC.
+- The repository has 254 stars, above Homebrew's 225-star threshold for a
+  self-submission by the repository owner.
+- Homebrew says a repository less than 30 days old is normally ineligible. The
+  remaining normal gate therefore opens on **September 3, 2026 at 10:08:23
+  UTC**.
+
+Do not submit before that date merely because the notability threshold is met.
+On the submission day, re-read Homebrew's current
+[Package Acceptance Policy](https://docs.brew.sh/Package-Acceptance-Policy) and
+[Acceptable Casks](https://docs.brew.sh/Acceptable-Casks); the policy, commands,
+and thresholds can change.
+
+Recheck the live repository values rather than relying on this snapshot:
+
+```sh
+gh repo view cristicretu/diri --json createdAt,stargazerCount
+```
+
+## Source of truth
+
+Do not hand-reconstruct the official cask. Start from
+[`Casks/diri.rb`](https://github.com/cristicretu/homebrew-diri/blob/main/Casks/diri.rb)
+in the maintained tap. Every Diri release updates that cask only after
+`diri/scripts/publish-homebrew-cask.sh` proves that its SHA-256 matches the
+immutable GitHub Release DMG and reads the pushed cask back from the remote.
+
+Before copying it, verify the current release and digest again:
+
+```sh
+version="$(gh release view --repo cristicretu/diri --json tagName --jq '.tagName | ltrimstr("v")')"
+gh release view "v${version}" --repo cristicretu/diri \
+  --json assets \
+  --jq ".assets[] | select(.name == \"diri-${version}-universal.dmg\") | .digest"
+gh api repos/cristicretu/homebrew-diri/contents/Casks/diri.rb \
+  --jq '.content' | base64 --decode
+```
+
+The release digest must be `sha256:<64 lowercase hexadecimal digits>`, and the
+same 64 digits must appear in the cask's `sha256` stanza. The URL must continue
+to name the versioned GitHub Release DMG.
+
+## Prepare the Homebrew contribution
+
+Follow Homebrew's current
+[adding-software guide](https://docs.brew.sh/Adding-Software-to-Homebrew) to fork
+and check out `Homebrew/homebrew-cask` from its latest default branch. Search
+open and closed pull requests and the cask tree for an existing `diri`
+submission before creating another one.
+
+Copy the maintained cask into Homebrew's token directory:
+
+```sh
+cp /path/to/homebrew-diri/Casks/diri.rb \
+  /path/to/homebrew-cask/Casks/d/diri.rb
+```
+
+Review the copied file against the current Cask Cookbook. In particular, keep:
+
+- the versioned, developer-published GitHub Release URL and exact checksum;
+- `depends_on macos: :sequoia`, matching Diri's macOS 15 deployment target;
+- `auto_updates true`, because Diri has a signed, user-approved in-app updater;
+- the conservative `zap` list, which deliberately preserves daemon session
+  state under `~/Library/Application Support/Dirijor`.
+
+## Validate the candidate
+
+Run Homebrew's current new-cask checks from the contribution checkout:
+
+```sh
+brew style --fix --cask diri
+brew audit --new --cask diri
+HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask diri
+brew uninstall --cask diri
+brew lgtm --online
+```
+
+Inspect the installed application as well as the exit codes. Confirm that it is
+the universal, signed, notarized `diri.app`, launches on a clean current macOS
+system, and uninstalls without deleting existing Dirijor session state.
+
+Follow Homebrew's current
+[pull-request guide](https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request),
+including its AI/LLM rules: disclose the tool and model used in the initial
+upstream pull request, personally review all assisted content before requesting
+review, and answer maintainer questions yourself without AI/LLM assistance.
+Open the pull request with concise test results and no generated or unrelated
+files. Meeting the published thresholds does not guarantee acceptance; respond
+to Homebrew maintainer feedback in the upstream pull request.
+
+## After acceptance
+
+Only after the official cask is merged:
+
+1. Change installation examples to `brew install --cask diri`.
+2. Keep `cristicretu/homebrew-diri` available as a transition path rather than
+   breaking existing installations immediately.
+3. Update the release flow so official-cask updates follow Homebrew's supported
+   contribution automation instead of pushing to the maintained tap directly.
+4. Confirm `brew upgrade --cask diri` and Diri's in-app updater still agree on
+   the latest version before closing the tracking issue.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,8 @@
   capture safe fixtures, and validate both engines.
 - [Remote nodes](../diri/NODE.md) — run sessions over SSH and tmux.
 - [Packaging](../diri/PACKAGING.md) — build, signing, and notarization.
+- [Official Homebrew cask submission](HOMEBREW_CASK_SUBMISSION.md) — eligibility,
+  release verification, validation, and migration from the maintained tap.
 - [Updates and releases](../diri/UPDATING.md) — updater design and release flow.
 - [Engine port history](../diri/PORT.md) — record of the completed Rust migration.
 - [Performance](../diri/PERF.md) — budgets and measurement workflow.


### PR DESCRIPTION
Refs #11.

This prepares the repository side of the official-cask migration without opening a premature upstream PR. PR #56 must remain draft until the repository-age gate opens.

Live audit on August 12, 2026:
- Homebrew Package Acceptance Policy, Acceptable Casks, Adding Software, Cask Cookbook, and pull-request guidance re-read
- canonical repository created 2026-08-04 10:08:23 UTC
- 254 stars, above the current 225-star owner-submission threshold
- remaining normal eligibility gate: 2026-09-03 10:08:23 UTC (30 days)
- latest release is v0.5.0; GitHub asset digest and maintained tap cask both use `284f9c1fb0832b878ce4b02c089ec8e17c906d55ca1dc5a9527259fd0be264a1`
- downloaded DMG digest and disk-image integrity verified; app passes strict code-signature and notarization assessment and contains arm64 + x86_64 architectures
- no existing `diri` cask or open/closed Diri submission found in Homebrew/homebrew-cask

The runbook now uses the current token-based new-cask commands (`brew style --fix --cask`, `brew audit --new --cask`, local install/uninstall, and `brew lgtm --online`), documents the current `auto_updates` behavior, and records Homebrew AI/LLM disclosure and maintainer-response requirements. The branch is rebased onto current `main`.

Validation:
- `git diff --check`
- shell syntax checks
- GitHub-release publishing regression test
- Homebrew-cask publishing regression test
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`

The upstream Homebrew cask PR is intentionally still pending. On or after 2026-09-03 10:08:23 UTC, re-read the live policies, recheck repository metrics and duplicate submissions, refresh the release/cask digest, run every Homebrew validation and clean install/uninstall step in the runbook, and only then open the Homebrew/homebrew-cask PR with the required AI disclosure.