### PR TITLE
Drive agent launch surfaces from the manifest catalog

### DIFF
--- a/diri/Cargo.lock
+++ b/diri/Cargo.lock
@@ -1391,6 +1391,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "unicode-segmentation",
+ "url",
 ]
 
 [[package]]

--- a/diri/Cargo.toml
+++ b/diri/Cargo.toml
@@ -51,6 +51,7 @@ sha2 = "0.11"
 tempfile = "3"
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
 unicode-segmentation = "1"
+url = "2"
 zeroize = { version = "1", features = ["derive"] }
 
 # No [profile.release] overrides, deliberately: both `lto = "thin"` and

--- a/diri/README.md
+++ b/diri/README.md
@@ -130,6 +130,16 @@ Removing the file leaves the app in local-only mode. Tailscale IPv4 addresses
 and MagicDNS names work like any other SSH destination when OpenSSH can resolve
 them; Diri neither requires nor configures Tailscale for Remote Holder sessions.
 
+## Agent preferences
+
+The default agent is stored in
+`~/Library/Application Support/diri/prefs.json` as the agent manifest's stable
+`id`. Preferences written before the manifest catalog (`claudeCode`, `codex`,
+`cursor`, or `gemini`) remain readable and are rewritten with the canonical id
+on the next save. If a saved agent is removed or is no longer available, Diri
+chooses the first installed first-class agent; when none are installed it falls
+back to the terminal shell.
+
 ## Coexistence
 
 `diri` launches the daemon bundled beside it when none is running, and

--- a/diri/crates/diri-app/Cargo.toml
+++ b/diri/crates/diri-app/Cargo.toml
@@ -47,6 +47,7 @@ smallvec.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 unicode-segmentation.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }

--- a/diri/crates/diri-app/src/agent_catalog.rs
+++ b/diri/crates/diri-app/src/agent_catalog.rs
@@ -284,7 +284,7 @@ mod tests {
         unavailable.descriptor.as_mut().unwrap().setup = Some(AgentSetup {
             url: Some("https://ampcode.com/manual".into()),
             install_hint: Some("Install Amp's CLI.".into()),
-            sign_in_hint: Some("Run amp login.".into()),
+            sign_in_hint: Some("Sign in at ampcode.com, then run amp.".into()),
         });
         let options = agent_options(&AgentReadinessResult {
             agents: vec![unavailable],
@@ -296,7 +296,7 @@ mod tests {
         assert_eq!(options[0].install_hint, "Install Amp's CLI.");
         assert_eq!(
             options[0].unavailable_detail().as_deref(),
-            Some("Missing amp-bin · Install Amp's CLI. · Run amp login.")
+            Some("Missing amp-bin · Install Amp's CLI. · Sign in at ampcode.com, then run amp.")
         );
         assert_eq!(
             options[0].setup_url.as_deref(),

--- a/diri/crates/diri-app/src/agent_catalog.rs
+++ b/diri/crates/diri-app/src/agent_catalog.rs
@@ -22,6 +22,15 @@ impl AgentOption {
     pub(crate) fn unavailable_label(&self) -> Option<String> {
         (!self.available).then(|| missing_binary_label(&self.binary))
     }
+
+    pub(crate) fn unavailable_detail(&self) -> Option<String> {
+        let mut detail = format!("{} · {}", self.unavailable_label()?, self.install_hint);
+        if let Some(sign_in_hint) = &self.sign_in_hint {
+            detail.push_str(" · ");
+            detail.push_str(sign_in_hint);
+        }
+        Some(detail)
+    }
 }
 
 /// Catalog rows in deterministic product order. An empty response means an
@@ -51,11 +60,16 @@ pub(crate) fn agent_options(catalog: &AgentReadinessResult) -> Vec<AgentOption> 
     options
 }
 
-/// Settings needs to expose the shell fallback when no manifest Agent can be
-/// launched, so a repaired preference remains visible and user-selectable.
+/// Settings and the launcher must expose the shell whenever default resolution
+/// can choose it. Available catalog extensions are valid explicit defaults,
+/// but they do not replace the first-class-or-shell repair policy for a removed
+/// preference.
 pub(crate) fn default_agent_options(catalog: &AgentReadinessResult) -> Vec<AgentOption> {
     let mut options = agent_options(catalog);
-    if !options.iter().any(|option| option.available) {
+    if !options
+        .iter()
+        .any(|option| option.available && option.first_class)
+    {
         options.push(AgentOption {
             kind: AgentKind::SHELL,
             display_name: "Terminal".to_owned(),
@@ -270,7 +284,7 @@ mod tests {
         unavailable.descriptor.as_mut().unwrap().setup = Some(AgentSetup {
             url: Some("https://ampcode.com/manual".into()),
             install_hint: Some("Install Amp's CLI.".into()),
-            sign_in_hint: None,
+            sign_in_hint: Some("Run amp login.".into()),
         });
         let options = agent_options(&AgentReadinessResult {
             agents: vec![unavailable],
@@ -280,6 +294,10 @@ mod tests {
             Some("Missing amp-bin")
         );
         assert_eq!(options[0].install_hint, "Install Amp's CLI.");
+        assert_eq!(
+            options[0].unavailable_detail().as_deref(),
+            Some("Missing amp-bin · Install Amp's CLI. · Run amp login.")
+        );
         assert_eq!(
             options[0].setup_url.as_deref(),
             Some("https://ampcode.com/manual")
@@ -309,6 +327,14 @@ mod tests {
             resolved_default_agent(&AgentKind::new("removed"), &catalog),
             AgentKind::SHELL
         );
+        let options = default_agent_options(&catalog);
+        let resolved = resolved_default_agent(&AgentKind::new("removed"), &catalog);
+        let selected = options
+            .iter()
+            .find(|option| option.kind == resolved)
+            .expect("launcher/settings options represent the repaired default");
+        assert_eq!(selected.display_name, "Terminal");
+        assert!(selected.available);
     }
 
     #[test]

--- a/diri/crates/diri-app/src/agent_catalog.rs
+++ b/diri/crates/diri-app/src/agent_catalog.rs
@@ -1,0 +1,333 @@
+//! The client-side view of the daemon's manifest/readiness catalog.
+//!
+//! Launch surfaces consume this module instead of each rebuilding a partial
+//! four-agent list. It also centralizes unavailable/setup language so the
+//! launcher, sidebar, Settings, and command palette tell the same story.
+
+use diri_proto::{AgentKind, AgentReadinessItem, AgentReadinessResult};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct AgentOption {
+    pub kind: AgentKind,
+    pub display_name: String,
+    pub binary: String,
+    pub available: bool,
+    pub first_class: bool,
+    pub setup_url: Option<String>,
+    pub install_hint: String,
+    pub sign_in_hint: Option<String>,
+}
+
+impl AgentOption {
+    pub(crate) fn unavailable_label(&self) -> Option<String> {
+        (!self.available).then(|| missing_binary_label(&self.binary))
+    }
+}
+
+/// Catalog rows in deterministic product order. An empty response means an
+/// old daemon that predates descriptors, so retain the original four choices
+/// as optimistic compatibility entries instead of making the app unusable.
+pub(crate) fn agent_options(catalog: &AgentReadinessResult) -> Vec<AgentOption> {
+    if catalog.agents.is_empty() {
+        return legacy_options();
+    }
+
+    let mut options: Vec<_> = catalog
+        .agents
+        .iter()
+        .filter(|item| !item.kind.is_terminal())
+        .map(option_from_readiness)
+        .collect();
+    options.sort_by(|left, right| {
+        option_order(left)
+            .cmp(&option_order(right))
+            .then_with(|| {
+                left.display_name
+                    .to_lowercase()
+                    .cmp(&right.display_name.to_lowercase())
+            })
+            .then_with(|| left.kind.id().cmp(right.kind.id()))
+    });
+    options
+}
+
+/// Settings needs to expose the shell fallback when no manifest Agent can be
+/// launched, so a repaired preference remains visible and user-selectable.
+pub(crate) fn default_agent_options(catalog: &AgentReadinessResult) -> Vec<AgentOption> {
+    let mut options = agent_options(catalog);
+    if !options.iter().any(|option| option.available) {
+        options.push(AgentOption {
+            kind: AgentKind::SHELL,
+            display_name: "Terminal".to_owned(),
+            binary: "login shell".to_owned(),
+            available: true,
+            first_class: false,
+            setup_url: None,
+            install_hint: "Uses your login shell.".to_owned(),
+            sign_in_hint: None,
+        });
+    }
+    options
+}
+
+/// Keep a saved default only while it is launchable. Removed/unknown ids fall
+/// back to an installed first-class agent, and finally to a shell session so
+/// Command-T never becomes a dead shortcut.
+pub(crate) fn resolved_default_agent(
+    saved: &AgentKind,
+    catalog: &AgentReadinessResult,
+) -> AgentKind {
+    let options = agent_options(catalog);
+    if options
+        .iter()
+        .any(|option| option.available && option.kind == *saved)
+    {
+        return saved.clone();
+    }
+    options
+        .iter()
+        .find(|option| option.available && option.first_class)
+        .map_or(AgentKind::SHELL, |option| option.kind.clone())
+}
+
+pub(crate) fn display_name(kind: &AgentKind, catalog: &AgentReadinessResult) -> String {
+    agent_options(catalog)
+        .into_iter()
+        .find(|option| option.kind == *kind)
+        .map(|option| option.display_name)
+        .unwrap_or_else(|| builtin_name(kind).unwrap_or_else(|| title_case_id(kind.id())))
+}
+
+pub(crate) fn system_image(kind: &AgentKind) -> &'static str {
+    match kind.id() {
+        AgentKind::CLAUDE_CODE_ID => "sparkle",
+        AgentKind::CODEX_ID => "chevron.left.forwardslash.chevron.right",
+        AgentKind::CURSOR_ID => "cube",
+        AgentKind::GEMINI_ID => "sparkles",
+        AgentKind::SHELL_ID | AgentKind::GENERIC_ID => "terminal",
+        _ => "terminal",
+    }
+}
+
+/// Only ordinary browser URLs are handed to GPUI's established external-link
+/// path. Whitespace/control characters are rejected as malformed input.
+pub(crate) fn normal_web_url(url: &str) -> Option<String> {
+    if url
+        .chars()
+        .any(|character| character.is_whitespace() || character.is_control())
+    {
+        return None;
+    }
+    // `url::Url` deliberately treats `https:///setup` as host `setup`. Setup
+    // metadata should not be repaired or guessed, so require a lexically
+    // nonempty authority exactly where the manifest declared it.
+    let authority = url
+        .split_once("://")?
+        .1
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or_default();
+    if authority.is_empty() {
+        return None;
+    }
+    let parsed = url::Url::parse(url).ok()?;
+    (matches!(parsed.scheme(), "http" | "https")
+        && parsed.host_str().is_some_and(|host| !host.is_empty())
+        && parsed.username().is_empty()
+        && parsed.password().is_none())
+    .then(|| url.to_owned())
+}
+
+pub(crate) fn missing_binary_label(binary: &str) -> String {
+    format!("Missing {binary}")
+}
+
+fn option_from_readiness(item: &AgentReadinessItem) -> AgentOption {
+    let descriptor = item.descriptor.as_ref();
+    let setup = descriptor.and_then(|descriptor| descriptor.setup.as_ref());
+    let display_name = descriptor
+        .map(|descriptor| descriptor.display_name.trim())
+        .filter(|name| !name.is_empty())
+        .map(str::to_owned)
+        .or_else(|| builtin_name(&item.kind))
+        .unwrap_or_else(|| title_case_id(item.kind.id()));
+    let install_hint = setup
+        .and_then(|setup| setup.install_hint.as_deref())
+        .map(str::trim)
+        .filter(|hint| !hint.is_empty())
+        .map(str::to_owned)
+        .unwrap_or_else(|| format!("Install {} and add it to PATH.", item.binary));
+    AgentOption {
+        kind: item.kind.clone(),
+        display_name,
+        binary: item.binary.clone(),
+        available: item.available(),
+        first_class: descriptor.is_some_and(|descriptor| descriptor.first_class)
+            || is_legacy_first_class(&item.kind),
+        setup_url: setup
+            .and_then(|setup| setup.url.as_deref())
+            .and_then(normal_web_url),
+        install_hint,
+        sign_in_hint: setup
+            .and_then(|setup| setup.sign_in_hint.as_deref())
+            .map(str::trim)
+            .filter(|hint| !hint.is_empty())
+            .map(str::to_owned),
+    }
+}
+
+fn legacy_options() -> Vec<AgentOption> {
+    [
+        (AgentKind::CLAUDE_CODE, "Claude Code", "claude"),
+        (AgentKind::CODEX, "Codex", "codex"),
+        (AgentKind::CURSOR, "Cursor", "cursor-agent"),
+        (AgentKind::GEMINI, "Gemini", "gemini"),
+    ]
+    .into_iter()
+    .map(|(kind, display_name, binary)| AgentOption {
+        kind,
+        display_name: display_name.to_owned(),
+        binary: binary.to_owned(),
+        available: true,
+        first_class: true,
+        setup_url: None,
+        install_hint: format!("Install {binary} and add it to PATH."),
+        sign_in_hint: None,
+    })
+    .collect()
+}
+
+fn option_order(option: &AgentOption) -> (u8, usize) {
+    let pinned = [
+        AgentKind::CLAUDE_CODE_ID,
+        AgentKind::CODEX_ID,
+        AgentKind::CURSOR_ID,
+        AgentKind::GEMINI_ID,
+    ];
+    pinned
+        .iter()
+        .position(|id| *id == option.kind.id())
+        .map_or((1, usize::MAX), |index| (0, index))
+}
+
+fn is_legacy_first_class(kind: &AgentKind) -> bool {
+    matches!(
+        kind.id(),
+        AgentKind::CLAUDE_CODE_ID
+            | AgentKind::CODEX_ID
+            | AgentKind::CURSOR_ID
+            | AgentKind::GEMINI_ID
+    )
+}
+
+fn builtin_name(kind: &AgentKind) -> Option<String> {
+    match kind.id() {
+        AgentKind::CLAUDE_CODE_ID => Some("Claude Code".to_owned()),
+        AgentKind::CODEX_ID => Some("Codex".to_owned()),
+        AgentKind::CURSOR_ID => Some("Cursor".to_owned()),
+        AgentKind::GEMINI_ID => Some("Gemini".to_owned()),
+        AgentKind::SHELL_ID => Some("Terminal".to_owned()),
+        _ => None,
+    }
+}
+
+pub(crate) fn title_case_id(id: &str) -> String {
+    id.split(['-', '_'])
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            let mut chars = part.chars();
+            chars.next().map_or_else(String::new, |first| {
+                first.to_uppercase().collect::<String>() + chars.as_str()
+            })
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use diri_proto::{AgentDescriptor, AgentReadinessItem, AgentSetup};
+
+    use super::*;
+
+    fn item(id: &str, available: bool, first_class: bool) -> AgentReadinessItem {
+        AgentReadinessItem {
+            kind: AgentKind::new(id),
+            binary: format!("{id}-bin"),
+            path: available.then(|| format!("/bin/{id}")),
+            descriptor: Some(AgentDescriptor {
+                id: id.to_owned(),
+                display_name: title_case_id(id),
+                first_class,
+                ..AgentDescriptor::default()
+            }),
+        }
+    }
+
+    #[test]
+    fn unavailable_guidance_and_web_url_validation_are_shared() {
+        let mut unavailable = item("amp", false, false);
+        unavailable.descriptor.as_mut().unwrap().setup = Some(AgentSetup {
+            url: Some("https://ampcode.com/manual".into()),
+            install_hint: Some("Install Amp's CLI.".into()),
+            sign_in_hint: None,
+        });
+        let options = agent_options(&AgentReadinessResult {
+            agents: vec![unavailable],
+        });
+        assert_eq!(
+            options[0].unavailable_label().as_deref(),
+            Some("Missing amp-bin")
+        );
+        assert_eq!(options[0].install_hint, "Install Amp's CLI.");
+        assert_eq!(
+            options[0].setup_url.as_deref(),
+            Some("https://ampcode.com/manual")
+        );
+        assert_eq!(normal_web_url("javascript:alert(1)"), None);
+        assert_eq!(normal_web_url("file:///tmp/setup"), None);
+        assert_eq!(normal_web_url("https://?guide=1"), None);
+        assert_eq!(normal_web_url("https:///setup"), None);
+        assert_eq!(normal_web_url("https://example.com/\u{0}setup"), None);
+        assert_eq!(normal_web_url("https://example.com/\nsetup"), None);
+        assert_eq!(normal_web_url("https://user@example.com/setup"), None);
+    }
+
+    #[test]
+    fn unknown_defaults_fall_back_to_first_class_then_shell() {
+        let catalog = AgentReadinessResult {
+            agents: vec![item("amp", true, false), item("codex", true, true)],
+        };
+        assert_eq!(
+            resolved_default_agent(&AgentKind::new("removed"), &catalog),
+            AgentKind::CODEX
+        );
+        let catalog = AgentReadinessResult {
+            agents: vec![item("amp", true, false), item("codex", false, true)],
+        };
+        assert_eq!(
+            resolved_default_agent(&AgentKind::new("removed"), &catalog),
+            AgentKind::SHELL
+        );
+    }
+
+    #[test]
+    fn old_daemon_entries_without_descriptors_keep_useful_availability_copy() {
+        let catalog = AgentReadinessResult {
+            agents: vec![AgentReadinessItem {
+                kind: AgentKind::CODEX,
+                binary: "codex".into(),
+                path: None,
+                descriptor: None,
+            }],
+        };
+        let options = agent_options(&catalog);
+        assert_eq!(options[0].display_name, "Codex");
+        assert_eq!(
+            options[0].unavailable_label().as_deref(),
+            Some("Missing codex")
+        );
+        assert_eq!(options[0].install_hint, "Install codex and add it to PATH.");
+        assert_eq!(options[0].setup_url, None);
+    }
+}

--- a/diri/crates/diri-app/src/launcher.rs
+++ b/diri/crates/diri-app/src/launcher.rs
@@ -433,7 +433,10 @@ impl LauncherOverlay {
     }
 
     fn choose_folder(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        self.picker = None;
+        close_picker_for_folder_choice(&mut self.picker);
+        // The native sheet temporarily owns focus. Keep the composer focused
+        // on both sides so a cancel or completion returns keyboard input to
+        // the untouched draft.
         window.focus(&self.focus, cx);
         let paths = cx.prompt_for_paths(PathPromptOptions {
             files: false,
@@ -469,8 +472,7 @@ impl LauncherOverlay {
             let kind = choice.kind.clone();
             let logo = ui_agent_kind(&choice.kind);
             let setup_url = choice.setup_url.clone();
-            let unavailable = choice.unavailable_label();
-            let install_hint = choice.install_hint.clone();
+            let unavailable = choice.unavailable_detail();
             list = list.child(
                 div()
                     .id(format!("launcher-harness-{index}"))
@@ -515,7 +517,7 @@ impl LauncherOverlay {
                                         .text_ellipsis()
                                         .text_size(px(9.5))
                                         .text_color(colors.tertiary)
-                                        .child(format!("{unavailable} · {install_hint}")),
+                                        .child(unavailable),
                                 )
                             }),
                     )
@@ -1070,6 +1072,10 @@ fn project_commit(project_count: usize, highlight: usize) -> ProjectCommit {
     }
 }
 
+fn close_picker_for_folder_choice(picker: &mut Option<Picker>) {
+    *picker = None;
+}
+
 fn apply_folder_choice(selected_root: &mut String, chosen: Option<&Path>) -> bool {
     let Some(chosen) = chosen else {
         return false;
@@ -1097,15 +1103,23 @@ mod tests {
     }
 
     #[test]
-    fn folder_chooser_cancel_preserves_selection_and_completion_replaces_it() {
+    fn folder_chooser_closes_picker_and_preserves_draft_across_cancel_and_completion() {
+        let mut prompt = PromptComposer::default();
+        prompt.insert_multiline("keep this\nunfinished prompt");
+        let mut picker = Some(Picker::Project);
         let mut selected = "/work/current".to_owned();
+
+        close_picker_for_folder_choice(&mut picker);
+        assert!(picker.is_none(), "native chooser must dismiss the popover");
         assert!(!apply_folder_choice(&mut selected, None));
         assert_eq!(selected, "/work/current");
+        assert_eq!(prompt.text(), "keep this\nunfinished prompt");
 
         assert!(apply_folder_choice(
             &mut selected,
             Some(Path::new("/work/chosen"))
         ));
         assert_eq!(selected, "/work/chosen");
+        assert_eq!(prompt.text(), "keep this\nunfinished prompt");
     }
 }

--- a/diri/crates/diri-app/src/launcher.rs
+++ b/diri/crates/diri-app/src/launcher.rs
@@ -13,6 +13,7 @@ use gpui::{
 };
 
 use crate::AppServices;
+use crate::agent_catalog::{AgentOption, default_agent_options, title_case_id};
 use crate::composer::PromptComposer;
 use crate::macos::sf_symbols::{SymbolWeight, sf_symbol, sf_symbol_weighted};
 use crate::navigation::CARET;
@@ -57,13 +58,6 @@ const fn composer_text_height(lines: usize) -> f32 {
     visible as f32 * COMPOSER_LINE_HEIGHT + COMPOSER_PAD_TOP + COMPOSER_PAD_BOTTOM
 }
 
-#[derive(Clone)]
-struct HarnessChoice {
-    kind: AgentKind,
-    label: String,
-    available: bool,
-}
-
 pub(crate) enum LauncherEvent {
     Closed,
 }
@@ -87,6 +81,12 @@ pub(crate) struct LauncherOverlay {
 enum Picker {
     Harness,
     Project,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProjectCommit {
+    Recent(usize),
+    ChooseFolder,
 }
 
 impl EventEmitter<LauncherEvent> for LauncherOverlay {}
@@ -157,44 +157,14 @@ impl LauncherOverlay {
         cx.notify();
     }
 
-    fn harness_choices(&self) -> Vec<HarnessChoice> {
+    fn harness_choices(&self) -> Vec<AgentOption> {
         let store = self
             .services
             .store
             .store
             .read()
             .expect("session store lock poisoned");
-        let catalog = &store.agent_catalog().agents;
-        if catalog.is_empty() {
-            return [
-                (AgentKind::CLAUDE_CODE, "Claude Code"),
-                (AgentKind::CODEX, "Codex"),
-                (AgentKind::CURSOR, "Cursor"),
-                (AgentKind::GEMINI, "Gemini"),
-            ]
-            .into_iter()
-            .map(|(kind, label)| HarnessChoice {
-                kind,
-                label: label.to_owned(),
-                available: true,
-            })
-            .collect();
-        }
-
-        catalog
-            .iter()
-            .filter(|item| !item.kind.is_terminal())
-            .map(|item| HarnessChoice {
-                kind: item.kind.clone(),
-                label: item
-                    .descriptor
-                    .as_ref()
-                    .map(|descriptor| descriptor.display_name.clone())
-                    .filter(|label| !label.is_empty())
-                    .unwrap_or_else(|| title_case_id(item.kind.id())),
-                available: item.available(),
-            })
-            .collect()
+        default_agent_options(store.agent_catalog())
     }
 
     fn projects(&self) -> Vec<Project> {
@@ -218,7 +188,7 @@ impl LauncherOverlay {
         self.harness_choices()
             .into_iter()
             .find(|choice| choice.kind == self.selected_harness)
-            .map(|choice| choice.label)
+            .map(|choice| choice.display_name)
             .unwrap_or_else(|| title_case_id(self.selected_harness.id()))
     }
 
@@ -250,7 +220,13 @@ impl LauncherOverlay {
             .find(|choice| choice.kind == self.selected_harness)
         {
             Some(choice) if choice.available => None,
-            Some(choice) => Some(format!("{} is not installed", choice.label)),
+            Some(choice) => Some(format!(
+                "{}: {}",
+                choice.display_name,
+                choice
+                    .unavailable_label()
+                    .expect("unavailable choice has a missing-binary label")
+            )),
             None => Some(format!(
                 "{} is not available on this machine",
                 self.selected_harness_label()
@@ -288,10 +264,10 @@ impl LauncherOverlay {
     pub(crate) fn handle_key_down(
         &mut self,
         event: &KeyDownEvent,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {
-        if self.picker.is_some() && self.handle_picker_key(event, cx) {
+        if self.picker.is_some() && self.handle_picker_key(event, window, cx) {
             return true;
         }
         let shift = event.keystroke.modifiers.shift;
@@ -329,10 +305,15 @@ impl LauncherOverlay {
     }
 
     /// Arrow keys drive the open picker instead of the prompt behind it.
-    fn handle_picker_key(&mut self, event: &KeyDownEvent, cx: &mut Context<Self>) -> bool {
+    fn handle_picker_key(
+        &mut self,
+        event: &KeyDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
         let count = match self.picker {
             Some(Picker::Harness) => self.harness_choices().len(),
-            Some(Picker::Project) => self.projects().len(),
+            Some(Picker::Project) => self.projects().len() + 1,
             None => return false,
         };
         match event.keystroke.key.as_str() {
@@ -351,7 +332,7 @@ impl LauncherOverlay {
                 true
             }
             "enter" => {
-                self.commit_highlight();
+                self.commit_highlight(window, cx);
                 cx.notify();
                 true
             }
@@ -359,7 +340,7 @@ impl LauncherOverlay {
         }
     }
 
-    fn commit_highlight(&mut self) {
+    fn commit_highlight(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         match self.picker {
             Some(Picker::Harness) => {
                 if let Some(choice) = self
@@ -371,9 +352,18 @@ impl LauncherOverlay {
                 }
             }
             Some(Picker::Project) => {
-                if let Some(project) = self.projects().get(self.highlight) {
-                    self.selected_root.clone_from(&project.root);
+                let projects = self.projects();
+                match project_commit(projects.len(), self.highlight) {
+                    ProjectCommit::Recent(index) => {
+                        self.selected_root.clone_from(&projects[index].root);
+                        self.picker = None;
+                        window.focus(&self.focus, cx);
+                    }
+                    ProjectCommit::ChooseFolder => {
+                        self.choose_folder(window, cx);
+                    }
                 }
+                return;
             }
             None => return,
         }
@@ -444,6 +434,7 @@ impl LauncherOverlay {
 
     fn choose_folder(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.picker = None;
+        window.focus(&self.focus, cx);
         let paths = cx.prompt_for_paths(PathPromptOptions {
             files: false,
             directories: true,
@@ -451,14 +442,13 @@ impl LauncherOverlay {
             prompt: Some("Start Here".into()),
         });
         cx.spawn_in(window, async move |this, cx| {
-            let Ok(Ok(Some(mut paths))) = paths.await else {
-                return;
+            let selected = match paths.await {
+                Ok(Ok(Some(mut paths))) => paths.pop(),
+                _ => None,
             };
-            let Some(path) = paths.pop() else {
-                return;
-            };
-            let _ = this.update_in(cx, |this, _window, cx| {
-                this.selected_root = path.to_string_lossy().into_owned();
+            let _ = this.update_in(cx, |this, window, cx| {
+                apply_folder_choice(&mut this.selected_root, selected.as_deref());
+                window.focus(&this.focus, cx);
                 cx.notify();
             });
         })
@@ -469,7 +459,7 @@ impl LauncherOverlay {
         let mut list = div()
             .id("launcher-harness-list")
             .py(px(6.0))
-            .w(px(260.0))
+            .w(px(350.0))
             .max_h(px(PICKER_HEIGHT))
             .overflow_y_scroll();
         for (index, choice) in self.harness_choices().into_iter().enumerate() {
@@ -478,11 +468,14 @@ impl LauncherOverlay {
             let highlighted = self.highlight == index;
             let kind = choice.kind.clone();
             let logo = ui_agent_kind(&choice.kind);
+            let setup_url = choice.setup_url.clone();
+            let unavailable = choice.unavailable_label();
+            let install_hint = choice.install_hint.clone();
             list = list.child(
                 div()
                     .id(format!("launcher-harness-{index}"))
                     .mx(px(6.0))
-                    .h(px(38.0))
+                    .min_h(px(48.0))
                     .px(px(9.0))
                     .flex()
                     .items_center()
@@ -507,13 +500,39 @@ impl LauncherOverlay {
                             }))
                     })
                     .child(AgentLogo::new(logo, 21.0, colors))
-                    .child(div().flex_1().child(choice.label))
-                    .when(!enabled, |row| {
+                    .child(
+                        div()
+                            .min_w_0()
+                            .flex_1()
+                            .flex()
+                            .flex_col()
+                            .child(choice.display_name)
+                            .when_some(unavailable, |label, unavailable| {
+                                label.child(
+                                    div()
+                                        .whitespace_nowrap()
+                                        .overflow_hidden()
+                                        .text_ellipsis()
+                                        .text_size(px(9.5))
+                                        .text_color(colors.tertiary)
+                                        .child(format!("{unavailable} · {install_hint}")),
+                                )
+                            }),
+                    )
+                    .when_some(setup_url, |row, url| {
                         row.child(
                             div()
-                                .text_size(px(9.0))
-                                .text_color(colors.tertiary)
-                                .child("Unavailable"),
+                                .id(format!("launcher-harness-setup-{index}"))
+                                .px(px(6.0))
+                                .py(px(3.0))
+                                .rounded(px(Radius::CHIP))
+                                .cursor_pointer()
+                                .text_size(px(9.5))
+                                .text_color(colors.secondary)
+                                .bg(Fill::subtle(colors))
+                                .hover(move |button| button.bg(colors.primary.alpha(0.10)))
+                                .on_click(move |_, _, cx| cx.open_url(&url))
+                                .child("Setup…"),
                         )
                     })
                     .when(selected, |row| {
@@ -537,18 +556,6 @@ impl LauncherOverlay {
             .w(px(310.0))
             .max_h(px(PICKER_HEIGHT))
             .overflow_y_scroll();
-        if projects.is_empty() {
-            list = list.child(
-                div()
-                    .h(px(38.0))
-                    .px(px(11.0))
-                    .flex()
-                    .items_center()
-                    .text_size(px(11.0))
-                    .text_color(colors.tertiary)
-                    .child("No recent projects"),
-            );
-        }
         for (index, project) in projects.into_iter().enumerate() {
             let selected = project.root == self.selected_root;
             let highlighted = self.highlight == index;
@@ -605,6 +612,32 @@ impl LauncherOverlay {
                     }),
             );
         }
+        let choose_index = self.projects().len();
+        let highlighted = self.highlight == choose_index;
+        list = list.child(
+            div()
+                .id("launcher-project-choose-folder")
+                .mx(px(6.0))
+                .h(px(42.0))
+                .px(px(9.0))
+                .flex()
+                .items_center()
+                .gap(px(9.0))
+                .rounded(px(8.0))
+                .cursor_pointer()
+                .when(highlighted, |row| row.bg(colors.primary.alpha(0.08)))
+                .hover(move |row| row.bg(colors.primary.alpha(0.06)))
+                .on_click(cx.listener(|this, _, window, cx| {
+                    this.choose_folder(window, cx);
+                }))
+                .child(sf_symbol("folder.badge.plus", 12.0, colors.secondary))
+                .child(
+                    div()
+                        .text_size(px(12.0))
+                        .text_color(colors.primary)
+                        .child("Choose Folder…"),
+                ),
+        );
         FloatingSurface::new(colors, list).into_any_element()
     }
 
@@ -737,10 +770,12 @@ impl LauncherOverlay {
                                     .child(
                                         div()
                                             .id("launcher-add-project")
-                                            .size(px(CONTROL_SIZE))
+                                            .h(px(CONTROL_SIZE))
+                                            .px(px(9.0))
                                             .flex()
                                             .items_center()
                                             .justify_center()
+                                            .gap(px(6.0))
                                             .rounded(px(CONTROL_RADIUS))
                                             .cursor_pointer()
                                             .hover(move |button| button.bg(Fill::subtle(colors)))
@@ -748,6 +783,12 @@ impl LauncherOverlay {
                                                 button.bg(colors.primary.alpha(0.10))
                                             })
                                             .child(sf_symbol("plus", 11.0, colors.secondary))
+                                            .child(
+                                                div()
+                                                    .text_size(px(10.0))
+                                                    .text_color(colors.secondary)
+                                                    .child("Choose folder"),
+                                            )
                                             .on_click(cx.listener(|this, _, window, cx| {
                                                 this.choose_folder(window, cx);
                                             })),
@@ -894,7 +935,7 @@ impl LauncherOverlay {
                             .hover(move |button| button.bg(colors.primary.alpha(0.08)))
                             .active(move |button| button.bg(colors.primary.alpha(0.11)))
                             .child(sf_symbol("plus", 9.0, colors.tertiary))
-                            .child("New project")
+                            .child("Choose folder…")
                             .on_click(cx.listener(|this, _, window, cx| {
                                 this.choose_folder(window, cx);
                             })),
@@ -1007,7 +1048,7 @@ fn initial_target(services: &AppServices) -> (AgentKind, String) {
                 .map(|project| project.root.clone())
         })
         .unwrap_or_default();
-    (store.preferences().default_agent.kind(), selected_root)
+    (store.preferences().default_agent.clone(), selected_root)
 }
 
 fn ui_agent_kind(kind: &AgentKind) -> UiAgentKind {
@@ -1021,17 +1062,20 @@ fn ui_agent_kind(kind: &AgentKind) -> UiAgentKind {
     }
 }
 
-fn title_case_id(id: &str) -> String {
-    id.split(['-', '_'])
-        .filter(|part| !part.is_empty())
-        .map(|part| {
-            let mut chars = part.chars();
-            chars.next().map_or_else(String::new, |first| {
-                first.to_uppercase().collect::<String>() + chars.as_str()
-            })
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
+fn project_commit(project_count: usize, highlight: usize) -> ProjectCommit {
+    if highlight < project_count {
+        ProjectCommit::Recent(highlight)
+    } else {
+        ProjectCommit::ChooseFolder
+    }
+}
+
+fn apply_folder_choice(selected_root: &mut String, chosen: Option<&Path>) -> bool {
+    let Some(chosen) = chosen else {
+        return false;
+    };
+    *selected_root = chosen.to_string_lossy().into_owned();
+    true
 }
 
 #[cfg(test)]
@@ -1042,5 +1086,26 @@ mod tests {
     fn manifest_ids_have_readable_fallback_labels() {
         assert_eq!(title_case_id("claude-code"), "Claude Code");
         assert_eq!(title_case_id("open_code"), "Open Code");
+    }
+
+    #[test]
+    fn project_picker_always_ends_with_choose_folder() {
+        assert_eq!(project_commit(0, 0), ProjectCommit::ChooseFolder);
+        assert_eq!(project_commit(2, 0), ProjectCommit::Recent(0));
+        assert_eq!(project_commit(2, 1), ProjectCommit::Recent(1));
+        assert_eq!(project_commit(2, 2), ProjectCommit::ChooseFolder);
+    }
+
+    #[test]
+    fn folder_chooser_cancel_preserves_selection_and_completion_replaces_it() {
+        let mut selected = "/work/current".to_owned();
+        assert!(!apply_folder_choice(&mut selected, None));
+        assert_eq!(selected, "/work/current");
+
+        assert!(apply_folder_choice(
+            &mut selected,
+            Some(Path::new("/work/chosen"))
+        ));
+        assert_eq!(selected, "/work/chosen");
     }
 }

--- a/diri/crates/diri-app/src/main.rs
+++ b/diri/crates/diri-app/src/main.rs
@@ -1,3 +1,4 @@
+mod agent_catalog;
 mod app_theme;
 mod clipboard_transfer;
 mod code_intelligence;

--- a/diri/crates/diri-app/src/navigation.rs
+++ b/diri/crates/diri-app/src/navigation.rs
@@ -560,9 +560,14 @@ impl NavigationOverlay {
                             options.cwd = Some(store.local_fallback_directory());
                         }
                     }
-                    store.spawn_kind(agent.kind(), options);
+                    store.spawn_kind(agent, options);
                 }
                 self.close_overlay(cx);
+            }
+            PaletteCommand::UnavailableAgent { setup_url } => {
+                if let Some(url) = setup_url {
+                    cx.open_url(&url);
+                }
             }
             PaletteCommand::MigrateSelected { target_host } => {
                 {
@@ -640,7 +645,8 @@ impl NavigationOverlay {
             let selected = store.selected_session().cloned();
             let default_host = store.default_spawn_host();
             let actions = palette::actions_for_default_host(
-                store.preferences().default_agent,
+                store.preferences().default_agent.clone(),
+                store.agent_catalog(),
                 &projects,
                 &hosts,
                 selected.as_ref(),
@@ -794,10 +800,15 @@ impl NavigationOverlay {
     ) -> AnyElement {
         let action = ranked.item;
         let command = action.command.clone();
+        let trailing = action
+            .detail
+            .clone()
+            .map(SharedString::from)
+            .or_else(|| action.shortcut.map(SharedString::from));
         palette_row(
             highlighted_label(action.title, &ranked.title_matches),
             sf_symbol(action.system_image, 12.5, colors.secondary),
-            action.shortcut.map(SharedString::from),
+            trailing,
             index == self.highlight,
             index,
             colors,
@@ -945,14 +956,13 @@ impl NavigationOverlay {
         } else {
             colors.secondary
         };
-        let default_name = self
-            .store
-            .read()
-            .expect("session store lock poisoned")
-            .preferences()
-            .default_agent
-            .display_name()
-            .to_owned();
+        let default_name = {
+            let store = self.store.read().expect("session store lock poisoned");
+            crate::agent_catalog::display_name(
+                &store.preferences().default_agent,
+                store.agent_catalog(),
+            )
+        };
         let row = div()
             .id(format!("quick-row-{index}"))
             .flex()

--- a/diri/crates/diri-app/src/navigation.rs
+++ b/diri/crates/diri-app/src/navigation.rs
@@ -486,7 +486,10 @@ impl NavigationOverlay {
         match self.overlay {
             Some(Overlay::CommandPalette) => {
                 let selection = if let Some(action) = self.ranked_actions.get(self.highlight) {
-                    Some(CommandSelection::Action(action.item.command.clone()))
+                    action
+                        .item
+                        .enabled
+                        .then(|| CommandSelection::Action(action.item.command.clone()))
                 } else {
                     self.ranked_sessions
                         .get(self.highlight.saturating_sub(self.ranked_actions.len()))
@@ -800,6 +803,7 @@ impl NavigationOverlay {
     ) -> AnyElement {
         let action = ranked.item;
         let command = action.command.clone();
+        let enabled = action.enabled;
         let trailing = action
             .detail
             .clone()
@@ -811,6 +815,7 @@ impl NavigationOverlay {
             trailing,
             index == self.highlight,
             index,
+            enabled,
             colors,
         )
         .on_hover(cx.listener(move |this, hovered: &bool, _, cx| {
@@ -819,9 +824,11 @@ impl NavigationOverlay {
                 cx.notify();
             }
         }))
-        .on_click(cx.listener(move |this, _, _, cx| {
-            this.run_command_selection(CommandSelection::Action(command.clone()), cx);
-        }))
+        .when(enabled, |row| {
+            row.on_click(cx.listener(move |this, _, _, cx| {
+                this.run_command_selection(CommandSelection::Action(command.clone()), cx);
+            }))
+        })
         .into_any_element()
     }
 
@@ -847,6 +854,7 @@ impl NavigationOverlay {
             Some(SharedString::from(chip)),
             index == self.highlight,
             index,
+            true,
             colors,
         )
         .on_hover(cx.listener(move |this, hovered: &bool, _, cx| {
@@ -1175,6 +1183,7 @@ fn palette_row(
     trailing: Option<SharedString>,
     highlighted: bool,
     index: usize,
+    enabled: bool,
     colors: SemanticColors,
 ) -> gpui::Stateful<gpui::Div> {
     div()
@@ -1194,7 +1203,8 @@ fn palette_row(
         } else {
             colors.primary.alpha(0.0)
         })
-        .cursor_pointer()
+        .opacity(if enabled { 1.0 } else { 0.48 })
+        .when(enabled, |row| row.cursor_pointer())
         .text_size(px(13.0))
         .child(
             div()

--- a/diri/crates/diri-app/src/notifications.rs
+++ b/diri/crates/diri-app/src/notifications.rs
@@ -584,6 +584,7 @@ mod tests {
                 text: "n".to_owned(),
                 submit: true,
             }),
+            setup: None,
         };
         let current = session(
             amp.clone(),

--- a/diri/crates/diri-app/src/palette.rs
+++ b/diri/crates/diri-app/src/palette.rs
@@ -26,7 +26,7 @@ pub enum PaletteCommand {
         host: Option<String>,
     },
     /// An unavailable local Agent row. A verified HTTP(S) setup URL is opened
-    /// on activation; without one the row remains informational.
+    /// on activation; without one the containing action is disabled.
     UnavailableAgent {
         setup_url: Option<String>,
     },
@@ -54,6 +54,9 @@ pub struct PaletteAction {
     pub shortcut: Option<&'static str>,
     /// Availability copy displayed in the trailing chip.
     pub detail: Option<String>,
+    /// Disabled rows remain searchable as setup guidance, but cannot be
+    /// activated when the manifest provides no safe setup destination.
+    pub enabled: bool,
     pub command: PaletteCommand,
     /// Scored alongside the title but never rendered: the folder path behind
     /// "New Claude Code in anara", a host's ssh target, and the synonyms people
@@ -90,6 +93,7 @@ pub fn actions_for_default_host(
             system_image: "terminal",
             shortcut: Some("⌘T"),
             detail: None,
+            enabled: true,
             command: PaletteCommand::SpawnShell {
                 host: default_host.map(|host| host.id.clone()),
             },
@@ -115,6 +119,7 @@ pub fn actions_for_default_host(
             system_image: "terminal",
             shortcut: Some("⌥⌘T"),
             detail: None,
+            enabled: true,
             command: PaletteCommand::SpawnShell {
                 host: default_host.map(|host| host.id.clone()),
             },
@@ -126,6 +131,7 @@ pub fn actions_for_default_host(
             system_image: "magnifyingglass",
             shortcut: Some("⌘P"),
             detail: None,
+            enabled: true,
             command: PaletteCommand::OpenQuickOpen,
             keywords: "folder project directory jump goto find".into(),
         },
@@ -135,6 +141,7 @@ pub fn actions_for_default_host(
             system_image: "square.grid.2x2",
             shortcut: Some("⌘⇧O"),
             detail: None,
+            enabled: true,
             command: PaletteCommand::OpenSessionOverview,
             keywords: "board grid switcher all sessions".into(),
         },
@@ -148,6 +155,7 @@ pub fn actions_for_default_host(
             system_image: "folder",
             shortcut: None,
             detail: None,
+            enabled: true,
             command: PaletteCommand::SpawnAgent {
                 agent: default_agent.clone(),
                 cwd: Some(PathBuf::from(&project.root)),
@@ -167,6 +175,7 @@ pub fn actions_for_default_host(
                 system_image: "network",
                 shortcut: None,
                 detail: None,
+                enabled: true,
                 command: PaletteCommand::SpawnAgent {
                     agent: option.kind.clone(),
                     cwd: None,
@@ -191,6 +200,7 @@ pub fn actions_for_default_host(
                     system_image: "arrow.left.arrow.right",
                     shortcut: None,
                     detail: None,
+                    enabled: true,
                     command: PaletteCommand::MigrateSelected { target_host: None },
                     keywords: "migrate handoff move back local".into(),
                 });
@@ -203,6 +213,7 @@ pub fn actions_for_default_host(
                     system_image: "arrow.left.arrow.right",
                     shortcut: None,
                     detail: None,
+                    enabled: true,
                     command: PaletteCommand::MigrateSelected {
                         target_host: Some(host.id.clone()),
                     },
@@ -220,6 +231,7 @@ pub fn actions_for_default_host(
             system_image: "arrow.triangle.2.circlepath",
             shortcut: None,
             detail: None,
+            enabled: true,
             command: PaletteCommand::SyncPrefs {
                 host: host.id.clone(),
             },
@@ -234,6 +246,7 @@ pub fn actions_for_default_host(
             system_image: "square.stack.3d.up",
             shortcut: Some("⌥⌘W"),
             detail: None,
+            enabled: true,
             command: PaletteCommand::OpenWorktrees,
             keywords: "git branch checkout".into(),
         },
@@ -243,6 +256,7 @@ pub fn actions_for_default_host(
             system_image: "sidebar.left",
             shortcut: Some("⌘B"),
             detail: None,
+            enabled: true,
             command: PaletteCommand::ToggleSidebar,
             keywords: "hide show panel".into(),
         },
@@ -252,6 +266,7 @@ pub fn actions_for_default_host(
             system_image: "gearshape",
             shortcut: Some("⌘,"),
             detail: None,
+            enabled: true,
             command: PaletteCommand::OpenSettings,
             keywords: "preferences config options".into(),
         },
@@ -261,6 +276,7 @@ pub fn actions_for_default_host(
             system_image: "arrow.triangle.2.circlepath",
             shortcut: None,
             detail: None,
+            enabled: true,
             command: PaletteCommand::CheckForUpdates,
             keywords: "upgrade version release".into(),
         },
@@ -294,15 +310,8 @@ fn new_agent_action(
         } else {
             None
         },
-        detail: (!available).then(|| {
-            format!(
-                "{} · {}",
-                option
-                    .unavailable_label()
-                    .expect("unavailable option has a missing-binary label"),
-                option.install_hint
-            )
-        }),
+        detail: (!available).then(|| option.unavailable_detail()).flatten(),
+        enabled: available || option.setup_url.is_some(),
         command: if available {
             PaletteCommand::SpawnAgent {
                 agent: option.kind.clone(),
@@ -459,6 +468,7 @@ mod tests {
         display_name: &str,
         available: bool,
         setup_url: Option<&str>,
+        sign_in_hint: Option<&str>,
     ) -> AgentReadinessItem {
         AgentReadinessItem {
             kind: AgentKind::new(id),
@@ -470,7 +480,7 @@ mod tests {
                 setup: setup_url.map(|url| AgentSetup {
                     url: Some(url.into()),
                     install_hint: Some(format!("Install {display_name}.")),
-                    sign_in_hint: None,
+                    sign_in_hint: sign_in_hint.map(str::to_owned),
                 }),
                 ..AgentDescriptor::default()
             }),
@@ -480,7 +490,7 @@ mod tests {
     #[test]
     fn manifest_only_agents_get_local_and_remote_actions_with_open_dispatch() {
         let catalog = AgentReadinessResult {
-            agents: vec![catalog_item("amp", "Amp", true, None)],
+            agents: vec![catalog_item("amp", "Amp", true, None, None)],
         };
         let host = HostEntry {
             id: "forge".into(),
@@ -525,6 +535,7 @@ mod tests {
                 "Amp",
                 false,
                 Some("https://ampcode.com/manual"),
+                Some("Run amp login."),
             )],
         };
         let actions = actions(AgentKind::new("amp"), &catalog, &[], &[], None);
@@ -534,13 +545,35 @@ mod tests {
             .expect("unavailable Amp row");
         assert_eq!(
             amp.detail.as_deref(),
-            Some("Missing amp-bin · Install Amp.")
+            Some("Missing amp-bin · Install Amp. · Run amp login.")
         );
+        assert!(amp.enabled);
         assert_eq!(
             amp.command,
             PaletteCommand::UnavailableAgent {
                 setup_url: Some("https://ampcode.com/manual".into())
             }
+        );
+    }
+
+    #[test]
+    fn unavailable_action_without_setup_metadata_is_disabled_not_a_noop() {
+        let catalog = AgentReadinessResult {
+            agents: vec![catalog_item("private", "Private", false, None, None)],
+        };
+        let actions = actions(AgentKind::new("private"), &catalog, &[], &[], None);
+        let private = actions
+            .iter()
+            .find(|action| action.id == "new-private")
+            .expect("unavailable informational row");
+        assert!(!private.enabled);
+        assert_eq!(
+            private.detail.as_deref(),
+            Some("Missing private-bin · Install private-bin and add it to PATH.")
+        );
+        assert_eq!(
+            private.command,
+            PaletteCommand::UnavailableAgent { setup_url: None }
         );
     }
 

--- a/diri/crates/diri-app/src/palette.rs
+++ b/diri/crates/diri-app/src/palette.rs
@@ -535,7 +535,7 @@ mod tests {
                 "Amp",
                 false,
                 Some("https://ampcode.com/manual"),
-                Some("Run amp login."),
+                Some("Sign in at ampcode.com, then run amp."),
             )],
         };
         let actions = actions(AgentKind::new("amp"), &catalog, &[], &[], None);
@@ -545,7 +545,7 @@ mod tests {
             .expect("unavailable Amp row");
         assert_eq!(
             amp.detail.as_deref(),
-            Some("Missing amp-bin · Install Amp. · Run amp login.")
+            Some("Missing amp-bin · Install Amp. · Sign in at ampcode.com, then run amp.")
         );
         assert!(amp.enabled);
         assert_eq!(

--- a/diri/crates/diri-app/src/palette.rs
+++ b/diri/crates/diri-app/src/palette.rs
@@ -6,15 +6,17 @@
 use std::ops::Range;
 use std::path::PathBuf;
 
-use diri_proto::{AgentKind, HostEntry, Project, SessionRecord};
+use diri_proto::{AgentKind, AgentReadinessResult, HostEntry, Project, SessionRecord};
 
+use crate::agent_catalog::{
+    AgentOption, agent_options, display_name, resolved_default_agent, system_image,
+};
 use crate::fuzzy::{FuzzyMatcher, FuzzyQuery, PreparedText, Score};
-use crate::store::DefaultAgent;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PaletteCommand {
     SpawnAgent {
-        agent: DefaultAgent,
+        agent: AgentKind,
         cwd: Option<PathBuf>,
         /// `HostEntry.id` — spawn on that remote host (cwd then comes from the
         /// host's defaultCwd unless overridden).
@@ -22,6 +24,11 @@ pub enum PaletteCommand {
     },
     SpawnShell {
         host: Option<String>,
+    },
+    /// An unavailable local Agent row. A verified HTTP(S) setup URL is opened
+    /// on activation; without one the row remains informational.
+    UnavailableAgent {
+        setup_url: Option<String>,
     },
     /// `session.migrate` the SELECTED session; None = back to local.
     MigrateSelected {
@@ -45,6 +52,8 @@ pub struct PaletteAction {
     pub title: String,
     pub system_image: &'static str,
     pub shortcut: Option<&'static str>,
+    /// Availability copy displayed in the trailing chip.
+    pub detail: Option<String>,
     pub command: PaletteCommand,
     /// Scored alongside the title but never rendered: the folder path behind
     /// "New Claude Code in anara", a host's ssh target, and the synonyms people
@@ -53,29 +62,47 @@ pub struct PaletteAction {
 }
 
 pub fn actions(
-    default_agent: DefaultAgent,
+    default_agent: AgentKind,
+    catalog: &AgentReadinessResult,
     projects: &[Project],
     hosts: &[HostEntry],
     selected: Option<&SessionRecord>,
 ) -> Vec<PaletteAction> {
-    actions_for_default_host(default_agent, projects, hosts, selected, None)
+    actions_for_default_host(default_agent, catalog, projects, hosts, selected, None)
 }
 
 pub fn actions_for_default_host(
-    default_agent: DefaultAgent,
+    default_agent: AgentKind,
+    catalog: &AgentReadinessResult,
     projects: &[Project],
     hosts: &[HostEntry],
     selected: Option<&SessionRecord>,
     default_host_id: Option<&str>,
 ) -> Vec<PaletteAction> {
     let default_host = default_host_id.and_then(|id| hosts.iter().find(|host| host.id == id));
-    let mut result = vec![new_agent_action(default_agent, true, default_host)];
+    let default_agent = resolved_default_agent(&default_agent, catalog);
+    let options = agent_options(catalog);
+    let mut result = Vec::new();
+    if default_agent == AgentKind::SHELL {
+        result.push(PaletteAction {
+            id: "new-default".into(),
+            title: "New Terminal".into(),
+            system_image: "terminal",
+            shortcut: Some("⌘T"),
+            detail: None,
+            command: PaletteCommand::SpawnShell {
+                host: default_host.map(|host| host.id.clone()),
+            },
+            keywords: "shell console zsh bash tty default".into(),
+        });
+    } else if let Some(option) = options.iter().find(|option| option.kind == default_agent) {
+        result.push(new_agent_action(option, true, default_host));
+    }
     result.extend(
-        DefaultAgent::ALL
+        options
             .iter()
-            .copied()
-            .filter(|agent| *agent != default_agent)
-            .map(|agent| new_agent_action(agent, false, default_host)),
+            .filter(|option| option.kind != default_agent)
+            .map(|option| new_agent_action(option, false, default_host)),
     );
     let terminal_title = default_host.map_or_else(
         || "New Terminal".to_owned(),
@@ -87,6 +114,7 @@ pub fn actions_for_default_host(
             title: terminal_title,
             system_image: "terminal",
             shortcut: Some("⌥⌘T"),
+            detail: None,
             command: PaletteCommand::SpawnShell {
                 host: default_host.map(|host| host.id.clone()),
             },
@@ -97,6 +125,7 @@ pub fn actions_for_default_host(
             title: "Quick Open…".into(),
             system_image: "magnifyingglass",
             shortcut: Some("⌘P"),
+            detail: None,
             command: PaletteCommand::OpenQuickOpen,
             keywords: "folder project directory jump goto find".into(),
         },
@@ -105,19 +134,22 @@ pub fn actions_for_default_host(
             title: "Session Overview".into(),
             system_image: "square.grid.2x2",
             shortcut: Some("⌘⇧O"),
+            detail: None,
             command: PaletteCommand::OpenSessionOverview,
             keywords: "board grid switcher all sessions".into(),
         },
     ]);
 
+    let default_name = display_name(&default_agent, catalog);
     for project in projects {
         result.push(PaletteAction {
             id: format!("new-default-in-{}", project.root),
-            title: format!("New {} in {}", default_agent.display_name(), project.name),
+            title: format!("New {default_name} in {}", project.name),
             system_image: "folder",
             shortcut: None,
+            detail: None,
             command: PaletteCommand::SpawnAgent {
-                agent: default_agent,
+                agent: default_agent.clone(),
                 cwd: Some(PathBuf::from(&project.root)),
                 host: None,
             },
@@ -128,14 +160,15 @@ pub fn actions_for_default_host(
     // Remote spawns: one entry per agent per configured host, in the host's
     // default cwd (hosts.json).
     for host in hosts {
-        for agent in DefaultAgent::ALL {
+        for option in &options {
             result.push(PaletteAction {
-                id: format!("new-{}-on-{}", agent.raw_value(), host.id),
-                title: format!("New {} on {}", agent.display_name(), host.display_name()),
+                id: format!("new-{}-on-{}", option.kind.id(), host.id),
+                title: format!("New {} on {}", option.display_name, host.display_name()),
                 system_image: "network",
                 shortcut: None,
+                detail: None,
                 command: PaletteCommand::SpawnAgent {
-                    agent,
+                    agent: option.kind.clone(),
                     cwd: None,
                     host: Some(host.id.clone()),
                 },
@@ -157,6 +190,7 @@ pub fn actions_for_default_host(
                     title: "Move Session to Local".into(),
                     system_image: "arrow.left.arrow.right",
                     shortcut: None,
+                    detail: None,
                     command: PaletteCommand::MigrateSelected { target_host: None },
                     keywords: "migrate handoff move back local".into(),
                 });
@@ -168,6 +202,7 @@ pub fn actions_for_default_host(
                     title: format!("Move Session to {}", host.display_name()),
                     system_image: "arrow.left.arrow.right",
                     shortcut: None,
+                    detail: None,
                     command: PaletteCommand::MigrateSelected {
                         target_host: Some(host.id.clone()),
                     },
@@ -184,6 +219,7 @@ pub fn actions_for_default_host(
             title: format!("Sync Prefs to {}", host.display_name()),
             system_image: "arrow.triangle.2.circlepath",
             shortcut: None,
+            detail: None,
             command: PaletteCommand::SyncPrefs {
                 host: host.id.clone(),
             },
@@ -197,6 +233,7 @@ pub fn actions_for_default_host(
             title: "Worktrees Overview".into(),
             system_image: "square.stack.3d.up",
             shortcut: Some("⌥⌘W"),
+            detail: None,
             command: PaletteCommand::OpenWorktrees,
             keywords: "git branch checkout".into(),
         },
@@ -205,6 +242,7 @@ pub fn actions_for_default_host(
             title: "Toggle Sidebar".into(),
             system_image: "sidebar.left",
             shortcut: Some("⌘B"),
+            detail: None,
             command: PaletteCommand::ToggleSidebar,
             keywords: "hide show panel".into(),
         },
@@ -213,6 +251,7 @@ pub fn actions_for_default_host(
             title: "Settings…".into(),
             system_image: "gearshape",
             shortcut: Some("⌘,"),
+            detail: None,
             command: PaletteCommand::OpenSettings,
             keywords: "preferences config options".into(),
         },
@@ -221,6 +260,7 @@ pub fn actions_for_default_host(
             title: "Check for Updates…".into(),
             system_image: "arrow.triangle.2.circlepath",
             shortcut: None,
+            detail: None,
             command: PaletteCommand::CheckForUpdates,
             keywords: "upgrade version release".into(),
         },
@@ -229,34 +269,56 @@ pub fn actions_for_default_host(
 }
 
 fn new_agent_action(
-    agent: DefaultAgent,
+    option: &AgentOption,
     is_default: bool,
     host: Option<&HostEntry>,
 ) -> PaletteAction {
+    let available = host.is_some() || option.available;
     PaletteAction {
         id: if is_default {
             "new-default".into()
         } else {
-            format!("new-{}", agent.raw_value())
+            format!("new-{}", option.kind.id())
         },
         title: host.map_or_else(
-            || format!("New {} Session", agent.display_name()),
-            |host| format!("New {} on {}", agent.display_name(), host.display_name()),
+            || format!("New {} Session", option.display_name),
+            |host| format!("New {} on {}", option.display_name, host.display_name()),
         ),
-        system_image: agent.system_image(),
-        shortcut: if is_default {
+        system_image: system_image(&option.kind),
+        shortcut: if !available {
+            None
+        } else if is_default {
             Some("⌘T")
-        } else if agent == DefaultAgent::Codex {
+        } else if option.kind == AgentKind::CODEX {
             Some("⌘⇧N")
         } else {
             None
         },
-        command: PaletteCommand::SpawnAgent {
-            agent,
-            cwd: None,
-            host: host.map(|host| host.id.clone()),
+        detail: (!available).then(|| {
+            format!(
+                "{} · {}",
+                option
+                    .unavailable_label()
+                    .expect("unavailable option has a missing-binary label"),
+                option.install_hint
+            )
+        }),
+        command: if available {
+            PaletteCommand::SpawnAgent {
+                agent: option.kind.clone(),
+                cwd: None,
+                host: host.map(|host| host.id.clone()),
+            }
+        } else {
+            PaletteCommand::UnavailableAgent {
+                setup_url: option.setup_url.clone(),
+            }
         },
-        keywords: format!("{} agent spawn start create tab", agent.raw_value()),
+        keywords: format!(
+            "{} {} agent spawn start create tab setup install",
+            option.kind.id(),
+            option.binary
+        ),
     }
 }
 
@@ -382,42 +444,105 @@ fn agent_keyword(kind: &AgentKind) -> &str {
     }
 }
 
-impl DefaultAgent {
-    pub const ALL: [Self; 4] = [Self::ClaudeCode, Self::Codex, Self::Cursor, Self::Gemini];
-
-    pub const fn raw_value(self) -> &'static str {
-        match self {
-            Self::ClaudeCode => "claudeCode",
-            Self::Codex => "codex",
-            Self::Cursor => "cursor",
-            Self::Gemini => "gemini",
-        }
-    }
-
-    pub const fn display_name(self) -> &'static str {
-        match self {
-            Self::ClaudeCode => "Claude Code",
-            Self::Codex => "Codex",
-            Self::Cursor => "Cursor",
-            Self::Gemini => "Gemini",
-        }
-    }
-
-    const fn system_image(self) -> &'static str {
-        match self {
-            Self::ClaudeCode => "sparkle",
-            Self::Codex => "chevron.left.forwardslash.chevron.right",
-            Self::Cursor => "cube",
-            Self::Gemini => "sparkles",
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use diri_proto::ProjectId;
+    use diri_proto::{AgentDescriptor, AgentReadinessItem, AgentSetup, ProjectId};
 
     use super::*;
+
+    fn catalog() -> AgentReadinessResult {
+        AgentReadinessResult::default()
+    }
+
+    fn catalog_item(
+        id: &str,
+        display_name: &str,
+        available: bool,
+        setup_url: Option<&str>,
+    ) -> AgentReadinessItem {
+        AgentReadinessItem {
+            kind: AgentKind::new(id),
+            binary: format!("{id}-bin"),
+            path: available.then(|| format!("/bin/{id}")),
+            descriptor: Some(AgentDescriptor {
+                id: id.into(),
+                display_name: display_name.into(),
+                setup: setup_url.map(|url| AgentSetup {
+                    url: Some(url.into()),
+                    install_hint: Some(format!("Install {display_name}.")),
+                    sign_in_hint: None,
+                }),
+                ..AgentDescriptor::default()
+            }),
+        }
+    }
+
+    #[test]
+    fn manifest_only_agents_get_local_and_remote_actions_with_open_dispatch() {
+        let catalog = AgentReadinessResult {
+            agents: vec![catalog_item("amp", "Amp", true, None)],
+        };
+        let host = HostEntry {
+            id: "forge".into(),
+            name: Some("Forge".into()),
+            ssh: "forge.local".into(),
+            default_cwd: None,
+            node: None,
+        };
+        let actions = actions(
+            AgentKind::new("amp"),
+            &catalog,
+            &[],
+            std::slice::from_ref(&host),
+            None,
+        );
+        assert_eq!(actions[0].title, "New Amp Session");
+        assert_eq!(actions[0].shortcut, Some("⌘T"));
+        assert_eq!(
+            actions[0].command,
+            PaletteCommand::SpawnAgent {
+                agent: AgentKind::new("amp"),
+                cwd: None,
+                host: None,
+            }
+        );
+        assert!(actions.iter().any(|action| {
+            action.id == "new-amp-on-forge"
+                && action.command
+                    == PaletteCommand::SpawnAgent {
+                        agent: AgentKind::new("amp"),
+                        cwd: None,
+                        host: Some("forge".into()),
+                    }
+        }));
+    }
+
+    #[test]
+    fn unavailable_catalog_action_uses_shared_missing_binary_and_safe_setup() {
+        let catalog = AgentReadinessResult {
+            agents: vec![catalog_item(
+                "amp",
+                "Amp",
+                false,
+                Some("https://ampcode.com/manual"),
+            )],
+        };
+        let actions = actions(AgentKind::new("amp"), &catalog, &[], &[], None);
+        let amp = actions
+            .iter()
+            .find(|action| action.id == "new-amp")
+            .expect("unavailable Amp row");
+        assert_eq!(
+            amp.detail.as_deref(),
+            Some("Missing amp-bin · Install Amp.")
+        );
+        assert_eq!(
+            amp.command,
+            PaletteCommand::UnavailableAgent {
+                setup_url: Some("https://ampcode.com/manual".into())
+            }
+        );
+    }
 
     #[test]
     fn action_list_matches_swift_order_and_dynamic_default() {
@@ -427,13 +552,13 @@ mod tests {
             name: "diri".into(),
             pinned_order: None,
         };
-        let result = actions(DefaultAgent::Codex, &[project], &[], None);
+        let result = actions(AgentKind::CODEX, &catalog(), &[project], &[], None);
         let ids: Vec<_> = result.iter().map(|action| action.id.as_str()).collect();
         assert_eq!(
             ids,
             [
                 "new-default",
-                "new-claudeCode",
+                "new-claude-code",
                 "new-cursor",
                 "new-gemini",
                 "new-terminal",
@@ -470,7 +595,7 @@ mod tests {
                 node: None,
             },
         ];
-        let result = actions(DefaultAgent::ClaudeCode, &[], &hosts, None);
+        let result = actions(AgentKind::CLAUDE_CODE, &catalog(), &[], &hosts, None);
         let forge_actions: Vec<_> = result
             .iter()
             .filter(|action| action.id.ends_with("-on-forge"))
@@ -479,8 +604,8 @@ mod tests {
             .iter()
             .filter(|action| action.id.ends_with("-on-studio"))
             .collect();
-        assert_eq!(forge_actions.len(), DefaultAgent::ALL.len());
-        assert_eq!(studio_actions.len(), DefaultAgent::ALL.len());
+        assert_eq!(forge_actions.len(), 4);
+        assert_eq!(studio_actions.len(), 4);
         assert_eq!(forge_actions[0].title, "New Claude Code on Forge");
         assert_eq!(forge_actions[0].system_image, "network");
         assert_eq!(studio_actions[0].title, "New Claude Code on Studio Mac");
@@ -488,7 +613,7 @@ mod tests {
         assert_eq!(
             forge_actions[0].command,
             PaletteCommand::SpawnAgent {
-                agent: DefaultAgent::ClaudeCode,
+                agent: AgentKind::CLAUDE_CODE,
                 cwd: None,
                 host: Some("forge".into()),
             }
@@ -496,7 +621,7 @@ mod tests {
         // Remote entries slot between the per-project block and the tail.
         let first_remote = result
             .iter()
-            .position(|action| action.id == "new-claudeCode-on-forge")
+            .position(|action| action.id == "new-claude-code-on-forge")
             .unwrap();
         let worktrees = result
             .iter()
@@ -515,7 +640,8 @@ mod tests {
             node: None,
         };
         let result = actions_for_default_host(
-            DefaultAgent::ClaudeCode,
+            AgentKind::CLAUDE_CODE,
+            &catalog(),
             &[],
             std::slice::from_ref(&host),
             None,
@@ -527,7 +653,7 @@ mod tests {
         assert_eq!(
             result[0].command,
             PaletteCommand::SpawnAgent {
-                agent: DefaultAgent::ClaudeCode,
+                agent: AgentKind::CLAUDE_CODE,
                 cwd: None,
                 host: Some("forge".into()),
             }
@@ -593,7 +719,7 @@ mod tests {
 
         // Local Claude session → one "Move Session to <host>" per host.
         let local = claude_session(None);
-        let result = actions(DefaultAgent::ClaudeCode, &[], hosts, Some(&local));
+        let result = actions(AgentKind::CLAUDE_CODE, &catalog(), &[], hosts, Some(&local));
         let migrate = result
             .iter()
             .find(|action| action.id == "migrate-to-forge")
@@ -608,7 +734,13 @@ mod tests {
 
         // Remote Claude session → a single "Move Session to Local".
         let remote = claude_session(Some("forge"));
-        let result = actions(DefaultAgent::ClaudeCode, &[], hosts, Some(&remote));
+        let result = actions(
+            AgentKind::CLAUDE_CODE,
+            &catalog(),
+            &[],
+            hosts,
+            Some(&remote),
+        );
         let back = result
             .iter()
             .find(|action| action.id == "migrate-to-local")
@@ -622,7 +754,7 @@ mod tests {
         // Non-Claude selections get no move entries; sync entries always show.
         let mut shell = claude_session(None);
         shell.kind = AgentKind::SHELL;
-        let result = actions(DefaultAgent::ClaudeCode, &[], hosts, Some(&shell));
+        let result = actions(AgentKind::CLAUDE_CODE, &catalog(), &[], hosts, Some(&shell));
         assert!(
             !result
                 .iter()
@@ -641,7 +773,7 @@ mod tests {
         );
 
         // No hosts configured → neither family appears.
-        let result = actions(DefaultAgent::ClaudeCode, &[], &[], Some(&local));
+        let result = actions(AgentKind::CLAUDE_CODE, &catalog(), &[], &[], Some(&local));
         assert!(!result.iter().any(|action| {
             action.id.starts_with("migrate-") || action.id.starts_with("sync-prefs-")
         }));
@@ -659,7 +791,8 @@ mod tests {
     #[test]
     fn empty_query_keeps_every_action_in_curated_order() {
         let all = actions(
-            DefaultAgent::ClaudeCode,
+            AgentKind::CLAUDE_CODE,
+            &catalog(),
             &[project("/work/diri", "diri")],
             &[],
             None,
@@ -674,7 +807,8 @@ mod tests {
     #[test]
     fn actions_are_found_by_title_acronym_synonym_and_project_path() {
         let all = actions(
-            DefaultAgent::ClaudeCode,
+            AgentKind::CLAUDE_CODE,
+            &catalog(),
             &[project("/work/anara", "anara")],
             &[],
             None,
@@ -700,7 +834,7 @@ mod tests {
 
     #[test]
     fn title_matches_outrank_keyword_matches_and_carry_highlights() {
-        let all = actions(DefaultAgent::ClaudeCode, &[], &[], None);
+        let all = actions(AgentKind::CLAUDE_CODE, &catalog(), &[], &[], None);
         let ranked = rank_actions(all, &FuzzyQuery::new("terminal"), &mut FuzzyMatcher::text());
         assert_eq!(ranked[0].item.id, "new-terminal");
         // "Terminal" starts at byte 4 of "New Terminal".

--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use diri_proto::SessionId;
+use diri_proto::{AgentKind, SessionId};
 use diri_ui::{FloatingSurface, Ink, Radius, SemanticColors, Typo};
 use gpui::{
     AnyElement, App, Context, CursorStyle, DragMoveEvent, Entity, FocusHandle, Focusable,
@@ -22,7 +22,7 @@ use crate::seam::{SeamSlide, toggle_has_settled};
 use crate::session_surfaces::SessionSurfaces;
 use crate::sidebar::{PreviewScenario, Sidebar, SidebarEvent};
 use crate::sounds::{self, AfplayPlayer, SoundGate, StatusSound};
-use crate::store::{DefaultAgent, SpawnOptions};
+use crate::store::SpawnOptions;
 use crate::surface_shell::UtilitySurfaces;
 use crate::terminal_pane::{TerminalPane, TerminalPaneEvent, TerminalViewport};
 use crate::updates::UpdatePhase;
@@ -692,7 +692,7 @@ impl RootView {
                     }
                 }
                 Some(NewSessionShortcut::Codex) => {
-                    if !self.spawn(Some(DefaultAgent::Codex)) {
+                    if !self.spawn(Some(AgentKind::CODEX)) {
                         return;
                     }
                 }
@@ -801,7 +801,7 @@ impl RootView {
     /// Spawns a shell (`None`) or a specific agent straight from a shortcut,
     /// bypassing the sidebar's picker. No-ops in preview, which has no daemon
     /// to spawn into. Reports whether the spawn was dispatched.
-    fn spawn(&self, agent: Option<DefaultAgent>) -> bool {
+    fn spawn(&self, agent: Option<AgentKind>) -> bool {
         if self.preview {
             return false;
         }
@@ -815,7 +815,7 @@ impl RootView {
             Some(agent) => {
                 let host = store.default_spawn_host();
                 store.spawn_kind(
-                    agent.kind(),
+                    agent,
                     SpawnOptions {
                         host,
                         ..SpawnOptions::default()

--- a/diri/crates/diri-app/src/settings.rs
+++ b/diri/crates/diri-app/src/settings.rs
@@ -3,10 +3,10 @@
 //! General, Terminal, and Resources mutate diri's preferences. Remote manages
 //! the shared execution-host catalog used by the SSH Remote Holder transport.
 
-use diri_proto::{HostEntry, HostNodeConfig};
+use diri_proto::{AgentKind, AgentReadinessResult, HostEntry, HostNodeConfig};
 use diri_term::theme::TermTheme;
 
-use crate::store::{DefaultAgent, Prefs};
+use crate::store::Prefs;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum SettingsTab {
@@ -169,13 +169,8 @@ fn unique_host_id<'a>(name: &str, existing: impl Iterator<Item = &'a str>) -> St
     unreachable!()
 }
 
-pub fn default_agent_label(agent: DefaultAgent) -> &'static str {
-    match agent {
-        DefaultAgent::ClaudeCode => "Claude Code",
-        DefaultAgent::Codex => "Codex",
-        DefaultAgent::Cursor => "Cursor",
-        DefaultAgent::Gemini => "Gemini",
-    }
+pub fn default_agent_label(agent: &AgentKind, catalog: &AgentReadinessResult) -> String {
+    crate::agent_catalog::display_name(agent, catalog)
 }
 
 pub fn theme(id: &str) -> TermTheme {
@@ -223,7 +218,6 @@ mod tests {
         assert_eq!(cycle_hibernate_minutes(60), 0);
         assert_eq!(cycle_memory_limit(2), 4);
         assert_eq!(cycle_memory_limit(8), 2);
-        assert_eq!(DefaultAgent::ALL.len(), 4);
         assert!(
             SettingsTab::ALL
                 .into_iter()

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -2170,10 +2170,8 @@ impl Sidebar {
             let agent_kind = ui_agent_kind(&option.kind);
             let spawn_kind = option.kind.clone();
             let available = selected_host.is_some() || option.available;
-            let unavailable =
-                (!available).then(|| crate::agent_catalog::missing_binary_label(&option.binary));
+            let unavailable = (!available).then_some(option.unavailable_detail).flatten();
             let setup_url = (!available).then_some(option.setup_url).flatten();
-            let install_hint = option.install_hint;
             content = content.child(
                 div()
                     .id(row_id)
@@ -2237,7 +2235,7 @@ impl Sidebar {
                                         .text_ellipsis()
                                         .text_size(px(Typo::META.size))
                                         .text_color(colors.tertiary)
-                                        .child(format!("{unavailable} · {install_hint}")),
+                                        .child(unavailable),
                                 )
                             }),
                     )
@@ -3854,24 +3852,27 @@ struct AgentPickerOption {
     binary: String,
     available: bool,
     setup_url: Option<String>,
-    install_hint: String,
+    unavailable_detail: Option<String>,
 }
 
 fn agent_picker_options(catalog: &diri_proto::AgentReadinessResult) -> Vec<AgentPickerOption> {
     let mut options: Vec<_> = crate::agent_catalog::agent_options(catalog)
         .into_iter()
-        .map(|option| AgentPickerOption {
-            title: option.display_name,
-            shortcut: if option.kind == ProtoAgentKind::CODEX {
-                "⌘⇧N"
-            } else {
-                ""
-            },
-            kind: option.kind,
-            binary: option.binary,
-            available: option.available,
-            setup_url: option.setup_url,
-            install_hint: option.install_hint,
+        .map(|option| {
+            let unavailable_detail = option.unavailable_detail();
+            AgentPickerOption {
+                title: option.display_name,
+                shortcut: if option.kind == ProtoAgentKind::CODEX {
+                    "⌘⇧N"
+                } else {
+                    ""
+                },
+                kind: option.kind,
+                binary: option.binary,
+                available: option.available,
+                setup_url: option.setup_url,
+                unavailable_detail,
+            }
         })
         .collect();
     // Terminal is last on purpose: it is the escape hatch, not an agent.
@@ -3882,7 +3883,7 @@ fn agent_picker_options(catalog: &diri_proto::AgentReadinessResult) -> Vec<Agent
         binary: "login shell".to_owned(),
         available: true,
         setup_url: None,
-        install_hint: "Uses your login shell.".to_owned(),
+        unavailable_detail: None,
     });
     options
 }
@@ -4126,7 +4127,7 @@ mod tests {
                         setup: Some(diri_proto::AgentSetup {
                             url: Some("https://opencode.ai/docs".into()),
                             install_hint: Some("Install OpenCode.".into()),
-                            sign_in_hint: None,
+                            sign_in_hint: Some("Run /connect.".into()),
                         }),
                         ..diri_proto::AgentDescriptor::default()
                     }),
@@ -4145,6 +4146,10 @@ mod tests {
             .expect("unavailable option remains visible");
         assert!(!opencode.available);
         assert_eq!(opencode.binary, "opencode");
+        assert_eq!(
+            opencode.unavailable_detail.as_deref(),
+            Some("Missing opencode · Install OpenCode. · Run /connect.")
+        );
         assert_eq!(
             opencode.setup_url.as_deref(),
             Some("https://opencode.ai/docs")

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -510,7 +510,10 @@ impl Sidebar {
         let hovering = self.ui.hovered_control == Some("new-agent");
         let (agent, location) = {
             let store = self.store.read().expect("session store lock poisoned");
-            let agent = store.preferences().default_agent.display_name().to_owned();
+            let agent = crate::agent_catalog::display_name(
+                &store.preferences().default_agent,
+                store.agent_catalog(),
+            );
             let location = store
                 .default_spawn_host()
                 .map_or_else(|| "This Mac".to_owned(), |id| store.host_display_name(&id));
@@ -1821,7 +1824,7 @@ impl Sidebar {
                 directory
                     .clone()
                     .unwrap_or_else(|| store.default_new_agent_directory()),
-                store.preferences().default_agent.kind(),
+                store.preferences().default_agent.clone(),
                 store.hosts().to_vec(),
                 store.selected_session().cloned(),
                 store.repo_target(selected_host_id).cloned(),
@@ -2155,17 +2158,22 @@ impl Sidebar {
         } else {
             None
         };
-        for (index, (title, kind, shortcut)) in options.into_iter().enumerate() {
+        for (index, option) in options.into_iter().enumerate() {
             let row_id = format!("agent-option-{index}");
             let target = target.clone();
             let spawn_host = selected_host.as_ref().map(|entry| entry.id.clone());
             let same_repo_as = same_repo_reference.clone();
             // The picker selection is also the global shortcut destination,
             // so every shortcut stays visible and follows the checkmark.
-            let shortcut = agent_picker_shortcut(&kind, &default_kind, shortcut);
+            let shortcut = agent_picker_shortcut(&option.kind, &default_kind, option.shortcut);
             let shortcut = shortcut.to_owned();
-            let agent_kind = ui_agent_kind(&kind);
-            let spawn_kind = kind.clone();
+            let agent_kind = ui_agent_kind(&option.kind);
+            let spawn_kind = option.kind.clone();
+            let available = selected_host.is_some() || option.available;
+            let unavailable =
+                (!available).then(|| crate::agent_catalog::missing_binary_label(&option.binary));
+            let setup_url = (!available).then_some(option.setup_url).flatten();
+            let install_hint = option.install_hint;
             content = content.child(
                 div()
                     .id(row_id)
@@ -2173,29 +2181,32 @@ impl Sidebar {
                     .mx(px(6.0))
                     .my(px(1.0))
                     .px(px(8.0))
-                    .h(px(34.0))
+                    .min_h(px(42.0))
+                    .py(px(4.0))
                     .flex()
                     .items_center()
                     .gap(px(10.0))
                     .rounded(px(Radius::ROW))
-                    .cursor_pointer()
-                    .hover(move |element| element.bg(colors.primary.alpha(0.06)))
-                    .on_click(cx.listener(move |this, _, _, cx| {
-                        this.store
-                            .write()
-                            .expect("session store lock poisoned")
-                            .spawn_kind(
-                                spawn_kind.clone(),
-                                SpawnOptions {
-                                    cwd: Some(target.clone()),
-                                    host: spawn_host.clone(),
-                                    same_repo_as: same_repo_as.clone(),
-                                    ..SpawnOptions::default()
-                                },
-                            );
-                        this.ui.popover = None;
-                        cx.notify();
-                    }))
+                    .when(available, |row| {
+                        row.cursor_pointer()
+                            .hover(move |element| element.bg(colors.primary.alpha(0.06)))
+                            .on_click(cx.listener(move |this, _, _, cx| {
+                                this.store
+                                    .write()
+                                    .expect("session store lock poisoned")
+                                    .spawn_kind(
+                                        spawn_kind.clone(),
+                                        SpawnOptions {
+                                            cwd: Some(target.clone()),
+                                            host: spawn_host.clone(),
+                                            same_repo_as: same_repo_as.clone(),
+                                            ..SpawnOptions::default()
+                                        },
+                                    );
+                                this.ui.popover = None;
+                                cx.notify();
+                            }))
+                    })
                     .child(
                         div()
                             .w(px(24.0))
@@ -2207,11 +2218,45 @@ impl Sidebar {
                     )
                     .child(
                         div()
+                            .min_w_0()
                             .flex_1()
+                            .flex()
+                            .flex_col()
                             .text_size(px(Typo::ROW.size))
-                            .text_color(colors.primary)
-                            .child(title),
+                            .text_color(if available {
+                                colors.primary
+                            } else {
+                                colors.secondary
+                            })
+                            .child(option.title)
+                            .when_some(unavailable, |label, unavailable| {
+                                label.child(
+                                    div()
+                                        .whitespace_nowrap()
+                                        .overflow_hidden()
+                                        .text_ellipsis()
+                                        .text_size(px(Typo::META.size))
+                                        .text_color(colors.tertiary)
+                                        .child(format!("{unavailable} · {install_hint}")),
+                                )
+                            }),
                     )
+                    .when_some(setup_url, |row, url| {
+                        row.child(
+                            div()
+                                .id(format!("agent-setup-{index}"))
+                                .px(px(6.0))
+                                .py(px(3.0))
+                                .rounded(px(Radius::CHIP))
+                                .cursor_pointer()
+                                .text_size(px(Typo::META.size))
+                                .text_color(colors.secondary)
+                                .bg(Fill::subtle(colors))
+                                .hover(move |button| button.bg(colors.primary.alpha(0.10)))
+                                .on_click(move |_, _, cx| cx.open_url(&url))
+                                .child("Setup…"),
+                        )
+                    })
                     .when(!shortcut.is_empty(), |row| {
                         row.child(
                             div()
@@ -3797,39 +3842,48 @@ fn status_state(session: &SessionRecord, migrating: bool) -> StatusState {
     }
 }
 
-/// Rows for the new-agent picker: the hand-branded agents in their pinned
-/// order, then every OTHER catalog agent whose CLI is actually installed.
-///
-/// Sourcing the tail from the daemon's catalog is what makes a new agent
-/// manifest reachable without a client release. Gating it on `available()` is
-/// what keeps the menu from becoming a nineteen-row wall of CLIs the user has
-/// never installed — the four pinned rows stay visible either way because they
-/// are what the app is *about*.
-fn agent_picker_options(
-    catalog: &diri_proto::AgentReadinessResult,
-) -> Vec<(String, ProtoAgentKind, &'static str)> {
-    let pinned = [
-        ("Claude Code", ProtoAgentKind::CLAUDE_CODE, ""),
-        ("Codex", ProtoAgentKind::CODEX, "⌘⇧N"),
-        ("Cursor", ProtoAgentKind::CURSOR, ""),
-        ("Gemini", ProtoAgentKind::GEMINI, ""),
-    ];
-    let mut options: Vec<(String, ProtoAgentKind, &'static str)> = pinned
-        .iter()
-        .map(|(title, kind, shortcut)| ((*title).to_owned(), kind.clone(), *shortcut))
+/// Rows for the new-agent picker come wholly from the runtime catalog. Local
+/// unavailable rows stay visible with the same missing-binary/setup guidance
+/// as the launcher; remote rows stay launchable because local readiness cannot
+/// describe the selected host.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct AgentPickerOption {
+    title: String,
+    kind: ProtoAgentKind,
+    shortcut: &'static str,
+    binary: String,
+    available: bool,
+    setup_url: Option<String>,
+    install_hint: String,
+}
+
+fn agent_picker_options(catalog: &diri_proto::AgentReadinessResult) -> Vec<AgentPickerOption> {
+    let mut options: Vec<_> = crate::agent_catalog::agent_options(catalog)
+        .into_iter()
+        .map(|option| AgentPickerOption {
+            title: option.display_name,
+            shortcut: if option.kind == ProtoAgentKind::CODEX {
+                "⌘⇧N"
+            } else {
+                ""
+            },
+            kind: option.kind,
+            binary: option.binary,
+            available: option.available,
+            setup_url: option.setup_url,
+            install_hint: option.install_hint,
+        })
         .collect();
-    for item in &catalog.agents {
-        if pinned.iter().any(|(_, kind, _)| kind == &item.kind) || !item.available() {
-            continue;
-        }
-        let title = item
-            .descriptor
-            .as_ref()
-            .map_or_else(|| item.kind.id().to_owned(), |d| d.display_name.clone());
-        options.push((title, item.kind.clone(), ""));
-    }
     // Terminal is last on purpose: it is the escape hatch, not an agent.
-    options.push(("Terminal".to_owned(), ProtoAgentKind::SHELL, "⌥⌘T"));
+    options.push(AgentPickerOption {
+        title: "Terminal".to_owned(),
+        kind: ProtoAgentKind::SHELL,
+        shortcut: "⌥⌘T",
+        binary: "login shell".to_owned(),
+        available: true,
+        setup_url: None,
+        install_hint: "Uses your login shell.".to_owned(),
+    });
     options
 }
 
@@ -4045,6 +4099,55 @@ mod tests {
         assert_eq!(
             agent_picker_shortcut(&ProtoAgentKind::SHELL, &ProtoAgentKind::CLAUDE_CODE, "⌥⌘T"),
             "⌥⌘T"
+        );
+    }
+
+    #[test]
+    fn agent_picker_keeps_manifest_only_and_unavailable_guidance_rows() {
+        let catalog = diri_proto::AgentReadinessResult {
+            agents: vec![
+                diri_proto::AgentReadinessItem {
+                    kind: ProtoAgentKind::new("amp"),
+                    binary: "amp".into(),
+                    path: Some("/bin/amp".into()),
+                    descriptor: Some(diri_proto::AgentDescriptor {
+                        id: "amp".into(),
+                        display_name: "Amp".into(),
+                        ..diri_proto::AgentDescriptor::default()
+                    }),
+                },
+                diri_proto::AgentReadinessItem {
+                    kind: ProtoAgentKind::new("opencode"),
+                    binary: "opencode".into(),
+                    path: None,
+                    descriptor: Some(diri_proto::AgentDescriptor {
+                        id: "opencode".into(),
+                        display_name: "OpenCode".into(),
+                        setup: Some(diri_proto::AgentSetup {
+                            url: Some("https://opencode.ai/docs".into()),
+                            install_hint: Some("Install OpenCode.".into()),
+                            sign_in_hint: None,
+                        }),
+                        ..diri_proto::AgentDescriptor::default()
+                    }),
+                },
+            ],
+        };
+        let options = agent_picker_options(&catalog);
+        let amp = options
+            .iter()
+            .find(|option| option.kind == ProtoAgentKind::new("amp"))
+            .expect("manifest-only option");
+        assert!(amp.available);
+        let opencode = options
+            .iter()
+            .find(|option| option.kind == ProtoAgentKind::new("opencode"))
+            .expect("unavailable option remains visible");
+        assert!(!opencode.available);
+        assert_eq!(opencode.binary, "opencode");
+        assert_eq!(
+            opencode.setup_url.as_deref(),
+            Some("https://opencode.ai/docs")
         );
     }
 

--- a/diri/crates/diri-app/src/store/mod.rs
+++ b/diri/crates/diri-app/src/store/mod.rs
@@ -30,7 +30,7 @@ use crate::switcher::{
     SessionSwitcherState, SwitcherKey, SwitcherOutcome,
 };
 
-pub use prefs::{DefaultAgent, InspectorTab, Prefs, WindowMode, WindowPlacement};
+pub use prefs::{InspectorTab, Prefs, WindowMode, WindowPlacement};
 pub use projection::{SidebarProject, SidebarProjection, SidebarRow};
 pub use residency::{ResidencyUpdate, TerminalResidency};
 
@@ -335,6 +335,13 @@ impl SessionStore {
     /// Installs the agent catalog fetched on connect.
     pub fn set_agent_catalog(&mut self, agents: AgentReadinessResult) {
         self.agents = agents;
+        let repaired =
+            crate::agent_catalog::resolved_default_agent(&self.prefs.default_agent, &self.agents);
+        if repaired != self.prefs.default_agent {
+            self.prefs.default_agent = repaired;
+            let _ = self.persist_preferences();
+            self.invalidate_projection();
+        }
     }
 
     pub fn agent_catalog(&self) -> &AgentReadinessResult {
@@ -1589,7 +1596,7 @@ impl SessionStore {
         if options.host.is_none() && options.cwd.is_none() && options.same_repo_as.is_none() {
             options.host = self.default_spawn_host();
         }
-        self.spawn_kind(self.prefs.default_agent.kind(), options);
+        self.spawn_kind(self.prefs.default_agent.clone(), options);
     }
 
     pub fn spawn_shell(&mut self, mut options: SpawnOptions) {

--- a/diri/crates/diri-app/src/store/prefs.rs
+++ b/diri/crates/diri-app/src/store/prefs.rs
@@ -3,7 +3,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use diri_proto::{AgentKind, ProjectId, SessionId};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 const DEFAULT_THEME: &str = "dirijor-dark";
 
@@ -40,31 +40,40 @@ pub enum InspectorTab {
     Artifacts,
 }
 
-#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub enum DefaultAgent {
-    #[default]
-    ClaudeCode,
-    Codex,
-    Cursor,
-    Gemini,
+/// Preferences intentionally persist the manifest id as a plain string. The
+/// four pre-catalog enum spellings are accepted forever because prefs survive
+/// upgrades; new saves use the canonical manifest ids (for example
+/// `"claude-code"` and `"opencode"`).
+fn serialize_default_agent<S>(agent: &AgentKind, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(agent.id())
 }
 
-impl DefaultAgent {
-    pub fn kind(self) -> AgentKind {
-        match self {
-            Self::ClaudeCode => AgentKind::CLAUDE_CODE,
-            Self::Codex => AgentKind::CODEX,
-            Self::Cursor => AgentKind::CURSOR,
-            Self::Gemini => AgentKind::GEMINI,
-        }
-    }
+fn deserialize_default_agent<'de, D>(deserializer: D) -> Result<AgentKind, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let saved = String::deserialize(deserializer)?;
+    Ok(match saved.as_str() {
+        "claudeCode" | AgentKind::CLAUDE_CODE_ID => AgentKind::CLAUDE_CODE,
+        "codex" => AgentKind::CODEX,
+        "cursor" => AgentKind::CURSOR,
+        "gemini" => AgentKind::GEMINI,
+        "shell" => AgentKind::SHELL,
+        _ => AgentKind::new(saved),
+    })
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct Prefs {
-    pub default_agent: DefaultAgent,
+    #[serde(
+        serialize_with = "serialize_default_agent",
+        deserialize_with = "deserialize_default_agent"
+    )]
+    pub default_agent: AgentKind,
     /// Persistent destination for global new-session shortcuts. `None` means
     /// this Mac; a host id means that configured remote host. The alias
     /// migrates preferences written by the earlier last-used implementation.
@@ -114,7 +123,7 @@ pub struct Prefs {
 impl Default for Prefs {
     fn default() -> Self {
         Self {
-            default_agent: DefaultAgent::ClaudeCode,
+            default_agent: AgentKind::CLAUDE_CODE,
             default_spawn_host: None,
             start_at_login: false,
             confirm_before_closing_session: true,

--- a/diri/crates/diri-app/src/store/tests.rs
+++ b/diri/crates/diri-app/src/store/tests.rs
@@ -2,8 +2,9 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use diri_proto::{
-    AgentKind, AttentionLevel, DateMillis, ExitInfo, ExitReason, Project, ProjectId, Resumability,
-    SessionId, SessionListResult, SessionRecord, SessionStatus, TitleSource,
+    AgentDescriptor, AgentKind, AgentReadinessItem, AgentReadinessResult, AttentionLevel,
+    DateMillis, ExitInfo, ExitReason, Project, ProjectId, Resumability, SessionId,
+    SessionListResult, SessionRecord, SessionStatus, TitleSource,
 };
 use tempfile::tempdir;
 use tokio::sync::mpsc;
@@ -11,9 +12,9 @@ use tokio::sync::mpsc;
 use crate::notifications::NotificationSound;
 
 use super::{
-    ClickModifiers, DefaultAgent, EventEnvelope, InspectorTab, Prefs, SessionStore,
-    SidebarProjection, StoreEffect, StoreEventChange, TerminalResidency, WindowMode,
-    WindowPlacement, event_publication_policy,
+    ClickModifiers, EventEnvelope, InspectorTab, Prefs, SessionStore, SidebarProjection,
+    StoreEffect, StoreEventChange, TerminalResidency, WindowMode, WindowPlacement,
+    event_publication_policy,
 };
 use crate::switcher::{OverviewFilter, OverviewLane, SwitcherKey};
 
@@ -1099,7 +1100,7 @@ fn prefs_round_trip_and_zoom_clamp() {
     let directory = tempdir().unwrap();
     let path = directory.path().join("nested/prefs.json");
     let prefs = Prefs {
-        default_agent: DefaultAgent::Gemini,
+        default_agent: AgentKind::GEMINI,
         default_spawn_host: Some("forge".to_owned()),
         terminal_font_size: 19.5,
         window_placement: Some(WindowPlacement {
@@ -1130,6 +1131,72 @@ fn prefs_round_trip_and_zoom_clamp() {
     assert_eq!(store.prefs.terminal_font_size, 10.0);
     store.reset_terminal_zoom().unwrap();
     assert_eq!(Prefs::load(&path).unwrap().terminal_font_size, 13.0);
+}
+
+#[test]
+fn default_agent_preferences_migrate_legacy_values_and_persist_manifest_ids() {
+    for (saved, expected) in [
+        ("claudeCode", AgentKind::CLAUDE_CODE),
+        ("codex", AgentKind::CODEX),
+        ("cursor", AgentKind::CURSOR),
+        ("gemini", AgentKind::GEMINI),
+    ] {
+        let prefs: Prefs = serde_json::from_value(serde_json::json!({
+            "defaultAgent": saved
+        }))
+        .expect("legacy prefs decode");
+        assert_eq!(prefs.default_agent, expected);
+    }
+
+    let prefs = Prefs {
+        default_agent: AgentKind::new("amp"),
+        ..Prefs::default()
+    };
+    let encoded = serde_json::to_value(&prefs).expect("prefs encode");
+    assert_eq!(encoded["defaultAgent"], "amp");
+    let decoded: Prefs = serde_json::from_value(encoded).expect("manifest id decodes");
+    assert_eq!(decoded.default_agent, AgentKind::new("amp"));
+}
+
+#[test]
+fn unknown_saved_default_repairs_to_available_first_class_then_shell() {
+    let prefs = Prefs {
+        default_agent: AgentKind::new("removed-agent"),
+        ..Prefs::default()
+    };
+    let (mut store, _) = SessionStore::headless(prefs);
+    store.set_agent_catalog(AgentReadinessResult {
+        agents: vec![AgentReadinessItem {
+            kind: AgentKind::CODEX,
+            binary: "codex".into(),
+            path: Some("/bin/codex".into()),
+            descriptor: Some(AgentDescriptor {
+                id: AgentKind::CODEX_ID.into(),
+                display_name: "Codex".into(),
+                first_class: true,
+                ..AgentDescriptor::default()
+            }),
+        }],
+    });
+    assert_eq!(store.preferences().default_agent, AgentKind::CODEX);
+
+    store
+        .update_preferences(|prefs| prefs.default_agent = AgentKind::new("removed-again"))
+        .expect("headless prefs update");
+    store.set_agent_catalog(AgentReadinessResult {
+        agents: vec![AgentReadinessItem {
+            kind: AgentKind::new("amp"),
+            binary: "amp".into(),
+            path: Some("/bin/amp".into()),
+            descriptor: Some(AgentDescriptor {
+                id: "amp".into(),
+                display_name: "Amp".into(),
+                first_class: false,
+                ..AgentDescriptor::default()
+            }),
+        }],
+    });
+    assert_eq!(store.preferences().default_agent, AgentKind::SHELL);
 }
 
 #[test]

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -9,7 +9,7 @@ use crate::macos::sf_symbols::{SymbolWeight, sf_symbol, sf_symbol_weighted};
 use crate::navigation::query_label;
 use crate::query_editor::{self, ClipboardEdit, Edit, QueryEditor};
 use crate::settings::{HostDraft, SettingsTab, default_agent_label, theme};
-use crate::store::{DefaultAgent, Prefs, SessionStore, StoreRuntime};
+use crate::store::{Prefs, SessionStore, StoreRuntime};
 use crate::updates::{UpdateCommand, UpdateHandle, UpdatePhase};
 use crate::worktrees::WorktreesSheet;
 use diri_proto::{AgentKind as ProtoAgentKind, HistoryEntry, HostEntry, HostsConfig};
@@ -1632,10 +1632,16 @@ impl UtilitySurfaces {
 
     fn default_agent_dropdown(&self, cx: &mut Context<Self>) -> AnyElement {
         let colors = self.settings_colors();
-        let selected = self.prefs.default_agent;
+        let (selected, catalog) = {
+            let store = self.store.read().expect("session store lock poisoned");
+            (
+                store.preferences().default_agent.clone(),
+                store.agent_catalog().clone(),
+            )
+        };
         let open = self.settings_menu == Some(SettingsMenu::DefaultAgent);
         let trigger = settings_select_button(
-            default_agent_label(selected),
+            default_agent_label(&selected, &catalog),
             "default-agent-dropdown",
             open,
             SettingsMenu::DefaultAgent,
@@ -1646,34 +1652,79 @@ impl UtilitySurfaces {
         let mut control = div().relative().min_w(px(154.0)).child(trigger);
         if open {
             let mut options = div().p(px(4.0)).flex().flex_col();
-            for (index, agent) in DefaultAgent::ALL.into_iter().enumerate() {
-                let is_selected = agent == selected;
+            for (index, option) in crate::agent_catalog::default_agent_options(&catalog)
+                .into_iter()
+                .enumerate()
+            {
+                let is_selected = option.kind == selected;
+                let enabled = option.available;
+                let agent = option.kind.clone();
+                let setup_url = option.setup_url.clone();
+                let unavailable = option.unavailable_label();
+                let install_hint = option.install_hint.clone();
                 options = options.child(
                     div()
                         .id(SharedString::from(format!("default-agent-option-{index}")))
-                        .h(px(Metrics::ROW_HEIGHT))
+                        .min_h(px(Metrics::ROW_HEIGHT))
                         .px(px(8.0))
+                        .py(px(5.0))
                         .flex()
                         .items_center()
                         .gap(px(8.0))
                         .rounded(px(Radius::ROW))
                         .bg(Fill::selected(colors, is_selected))
-                        .cursor_pointer()
-                        .hover(move |style| style.bg(colors.primary.alpha(0.08)))
-                        .on_click(cx.listener(move |this, _, _, cx| {
-                            this.prefs.default_agent = agent;
-                            this.settings_menu = None;
-                            this.persist_prefs();
-                            cx.notify();
-                        }))
-                        .child(AgentLogo::new(ui_default_agent(agent), 16.0, colors).badged(false))
+                        .when(enabled, |row| {
+                            row.cursor_pointer()
+                                .hover(move |style| style.bg(colors.primary.alpha(0.08)))
+                                .on_click(cx.listener(move |this, _, _, cx| {
+                                    this.prefs.default_agent = agent.clone();
+                                    this.settings_menu = None;
+                                    this.persist_prefs();
+                                    cx.notify();
+                                }))
+                        })
+                        .child(AgentLogo::new(ui_agent(&option.kind), 16.0, colors).badged(false))
                         .child(
                             div()
+                                .min_w_0()
                                 .flex_1()
+                                .flex()
+                                .flex_col()
                                 .text_size(px(Typo::ROW.size))
-                                .text_color(colors.primary)
-                                .child(default_agent_label(agent)),
+                                .text_color(if enabled {
+                                    colors.primary
+                                } else {
+                                    colors.secondary
+                                })
+                                .child(option.display_name)
+                                .when_some(unavailable, |label, unavailable| {
+                                    label.child(
+                                        div()
+                                            .whitespace_nowrap()
+                                            .overflow_hidden()
+                                            .text_ellipsis()
+                                            .text_size(px(Typo::META.size))
+                                            .text_color(colors.tertiary)
+                                            .child(format!("{unavailable} · {install_hint}")),
+                                    )
+                                }),
                         )
+                        .when_some(setup_url, |row, url| {
+                            row.child(
+                                div()
+                                    .id(format!("default-agent-setup-{index}"))
+                                    .px(px(6.0))
+                                    .py(px(3.0))
+                                    .rounded(px(Radius::CHIP))
+                                    .cursor_pointer()
+                                    .text_size(px(Typo::META.size))
+                                    .text_color(colors.secondary)
+                                    .bg(Fill::subtle(colors))
+                                    .hover(move |button| button.bg(colors.primary.alpha(0.10)))
+                                    .on_click(move |_, _, cx| cx.open_url(&url))
+                                    .child("Setup…"),
+                            )
+                        })
                         .when(is_selected, |row| {
                             row.child(sf_symbol_weighted(
                                 "checkmark",
@@ -3477,15 +3528,6 @@ fn ui_agent(kind: &ProtoAgentKind) -> diri_ui::AgentKind {
         ProtoAgentKind::GEMINI_ID => diri_ui::AgentKind::Gemini,
         ProtoAgentKind::SHELL_ID => diri_ui::AgentKind::Shell,
         _ => diri_ui::AgentKind::Generic,
-    }
-}
-
-fn ui_default_agent(agent: DefaultAgent) -> diri_ui::AgentKind {
-    match agent {
-        DefaultAgent::ClaudeCode => diri_ui::AgentKind::ClaudeCode,
-        DefaultAgent::Codex => diri_ui::AgentKind::Codex,
-        DefaultAgent::Cursor => diri_ui::AgentKind::Cursor,
-        DefaultAgent::Gemini => diri_ui::AgentKind::Gemini,
     }
 }
 

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -1660,8 +1660,7 @@ impl UtilitySurfaces {
                 let enabled = option.available;
                 let agent = option.kind.clone();
                 let setup_url = option.setup_url.clone();
-                let unavailable = option.unavailable_label();
-                let install_hint = option.install_hint.clone();
+                let unavailable = option.unavailable_detail();
                 options = options.child(
                     div()
                         .id(SharedString::from(format!("default-agent-option-{index}")))
@@ -1705,7 +1704,7 @@ impl UtilitySurfaces {
                                             .text_ellipsis()
                                             .text_size(px(Typo::META.size))
                                             .text_color(colors.tertiary)
-                                            .child(format!("{unavailable} · {install_hint}")),
+                                            .child(unavailable),
                                     )
                                 }),
                         )

--- a/diri/crates/diri-engine/manifests/aider.json
+++ b/diri/crates/diri-engine/manifests/aider.json
@@ -14,6 +14,11 @@
       "aider-chat"
     ],
     "firstClass": true,
+    "setup": {
+      "url": "https://aider.chat/docs/install.html",
+      "installHint": "Install Aider with its official installer or pipx.",
+      "signInHint": "Configure an API key for your chosen model provider."
+    },
     "statusAuthority": "screen",
     "binary": "aider",
     "returnToLoginShell": true,

--- a/diri/crates/diri-engine/manifests/amp.json
+++ b/diri/crates/diri-engine/manifests/amp.json
@@ -18,7 +18,7 @@
     "setup": {
       "url": "https://ampcode.com/manual",
       "installHint": "Install Amp with its official installer or Homebrew.",
-      "signInHint": "Run amp login or sign in at ampcode.com."
+      "signInHint": "Sign in at ampcode.com, then run amp."
     },
     "statusAuthority": "screen",
     "binary": "amp",

--- a/diri/crates/diri-engine/manifests/amp.json
+++ b/diri/crates/diri-engine/manifests/amp.json
@@ -15,6 +15,11 @@
       "sourcegraph-amp"
     ],
     "firstClass": true,
+    "setup": {
+      "url": "https://ampcode.com/manual",
+      "installHint": "Install Amp with its official installer or Homebrew.",
+      "signInHint": "Run amp login or sign in at ampcode.com."
+    },
     "statusAuthority": "screen",
     "binary": "amp",
     "returnToLoginShell": true,

--- a/diri/crates/diri-engine/manifests/antigravity.json
+++ b/diri/crates/diri-engine/manifests/antigravity.json
@@ -15,6 +15,11 @@
       "agy"
     ],
     "firstClass": true,
+    "setup": {
+      "url": "https://antigravity.google/docs/cli-install",
+      "installHint": "Install agy with Google's platform installer.",
+      "signInHint": "Run agy and complete the Google OAuth flow."
+    },
     "statusAuthority": "screen",
     "binary": "agy",
     "resume": {

--- a/diri/crates/diri-engine/manifests/claude-code.json
+++ b/diri/crates/diri-engine/manifests/claude-code.json
@@ -14,6 +14,11 @@
       "cc"
     ],
     "firstClass": true,
+    "setup": {
+      "url": "https://docs.anthropic.com/en/docs/claude-code/getting-started",
+      "installHint": "Follow Anthropic's Claude Code installation guide.",
+      "signInHint": "Run claude and choose an Anthropic Console or Claude account."
+    },
     "statusAuthority": "hooks",
     "binary": "claude",
     "returnToLoginShell": true,

--- a/diri/crates/diri-engine/manifests/codex.json
+++ b/diri/crates/diri-engine/manifests/codex.json
@@ -13,6 +13,11 @@
       "openai-codex"
     ],
     "firstClass": true,
+    "setup": {
+      "url": "https://developers.openai.com/codex/cli/",
+      "installHint": "Follow OpenAI's Codex CLI installation guide.",
+      "signInHint": "Run codex and choose Sign in with ChatGPT or another offered method."
+    },
     "statusAuthority": "screen",
     "binary": "codex",
     "returnToLoginShell": true,

--- a/diri/crates/diri-engine/manifests/copilot.json
+++ b/diri/crates/diri-engine/manifests/copilot.json
@@ -15,6 +15,11 @@
       "ghcs"
     ],
     "firstClass": true,
+    "setup": {
+      "url": "https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli",
+      "installHint": "Install Copilot CLI with GitHub's installer or a supported package manager.",
+      "signInHint": "Run copilot login and complete GitHub OAuth."
+    },
     "statusAuthority": "screen",
     "binary": "copilot",
     "resume": {

--- a/diri/crates/diri-engine/manifests/cursor.json
+++ b/diri/crates/diri-engine/manifests/cursor.json
@@ -13,6 +13,11 @@
       "cursor-agent"
     ],
     "firstClass": true,
+    "setup": {
+      "url": "https://docs.cursor.com/en/cli/installation",
+      "installHint": "Follow Cursor's CLI installation guide.",
+      "signInHint": "Run cursor-agent and complete authentication when prompted."
+    },
     "statusAuthority": "screen",
     "binary": "cursor-agent",
     "foregroundExecNames": [

--- a/diri/crates/diri-engine/manifests/devin.json
+++ b/diri/crates/diri-engine/manifests/devin.json
@@ -14,6 +14,11 @@
       "devin-cli"
     ],
     "firstClass": true,
+    "setup": {
+      "url": "https://docs.devin.ai/cli",
+      "installHint": "Install Devin CLI with Cognition's installer or Homebrew.",
+      "signInHint": "Run devin auth login."
+    },
     "statusAuthority": "screen",
     "binary": "devin",
     "resume": {

--- a/diri/crates/diri-engine/manifests/droid.json
+++ b/diri/crates/diri-engine/manifests/droid.json
@@ -15,6 +15,11 @@
       "factory-droid"
     ],
     "firstClass": true,
+    "setup": {
+      "url": "https://docs.factory.ai/cli/getting-started/quickstart",
+      "installHint": "Install Droid with Factory's installer or a supported package manager.",
+      "signInHint": "Run droid, then use /login if prompted."
+    },
     "statusAuthority": "screen",
     "binary": "droid",
     "resume": {

--- a/diri/crates/diri-engine/manifests/gemini.json
+++ b/diri/crates/diri-engine/manifests/gemini.json
@@ -13,6 +13,11 @@
       "gemini-cli"
     ],
     "firstClass": true,
+    "setup": {
+      "url": "https://github.com/google-gemini/gemini-cli",
+      "installHint": "Follow Google's Gemini CLI installation guide.",
+      "signInHint": "Run gemini and choose an available Google or API-key authentication method."
+    },
     "statusAuthority": "screen",
     "binary": "gemini",
     "sessionIDFlag": "--session-id",

--- a/diri/crates/diri-engine/manifests/grok.json
+++ b/diri/crates/diri-engine/manifests/grok.json
@@ -15,6 +15,11 @@
       "grok-build"
     ],
     "firstClass": true,
+    "setup": {
+      "url": "https://docs.x.ai/build/overview",
+      "installHint": "Install Grok with xAI's official installer.",
+      "signInHint": "Run grok login, or set XAI_API_KEY."
+    },
     "statusAuthority": "screen",
     "binary": "grok",
     "resume": {

--- a/diri/crates/diri-engine/manifests/hermes.json
+++ b/diri/crates/diri-engine/manifests/hermes.json
@@ -14,6 +14,11 @@
       "hermes-agent"
     ],
     "firstClass": true,
+    "setup": {
+      "url": "https://github.com/NousResearch/hermes-agent/blob/main/website/docs/getting-started/quickstart.md",
+      "installHint": "Install Hermes with the official Nous Research installer.",
+      "signInHint": "Run hermes setup --portal or hermes model to configure a provider."
+    },
     "statusAuthority": "screen",
     "binary": "hermes",
     "resume": {

--- a/diri/crates/diri-engine/manifests/kilo.json
+++ b/diri/crates/diri-engine/manifests/kilo.json
@@ -14,6 +14,11 @@
       "kilo-code"
     ],
     "firstClass": true,
+    "setup": {
+      "url": "https://kilo.ai/docs/code-with-ai/platforms/cli",
+      "installHint": "Install Kilo Code CLI with npm.",
+      "signInHint": "Run kilo, then use /connect to configure credentials."
+    },
     "statusAuthority": "screen",
     "binary": "kilo",
     "resume": {

--- a/diri/crates/diri-engine/manifests/kimi.json
+++ b/diri/crates/diri-engine/manifests/kimi.json
@@ -15,6 +15,11 @@
       "kimi-cli"
     ],
     "firstClass": true,
+    "setup": {
+      "url": "https://moonshotai.github.io/kimi-code/en/guides/getting-started.html",
+      "installHint": "Install Kimi Code CLI with its official installer or npm.",
+      "signInHint": "Run kimi, then use /login."
+    },
     "statusAuthority": "screen",
     "binary": "kimi",
     "resume": {

--- a/diri/crates/diri-engine/manifests/kiro.json
+++ b/diri/crates/diri-engine/manifests/kiro.json
@@ -14,6 +14,11 @@
       "kiro-cli"
     ],
     "firstClass": true,
+    "setup": {
+      "url": "https://kiro.dev/docs/cli/installation/",
+      "installHint": "Install Kiro CLI with its official platform installer.",
+      "signInHint": "Run kiro-cli login."
+    },
     "statusAuthority": "screen",
     "binary": "kiro-cli",
     "resume": {

--- a/diri/crates/diri-engine/manifests/opencode.json
+++ b/diri/crates/diri-engine/manifests/opencode.json
@@ -14,6 +14,11 @@
       "open-code"
     ],
     "firstClass": true,
+    "setup": {
+      "url": "https://opencode.ai/docs/",
+      "installHint": "Install OpenCode with its official installer or a supported package manager.",
+      "signInHint": "Run opencode, then use /connect to configure a provider."
+    },
     "statusAuthority": "screen",
     "binary": "opencode",
     "resume": {

--- a/diri/crates/diri-engine/manifests/qoder.json
+++ b/diri/crates/diri-engine/manifests/qoder.json
@@ -15,6 +15,11 @@
       "qoder-cli"
     ],
     "firstClass": true,
+    "setup": {
+      "url": "https://docs.qoder.com/en/cli/quick-start",
+      "installHint": "Install Qoder CLI with its official installer or a supported package manager.",
+      "signInHint": "Run qodercli, then use /login."
+    },
     "statusAuthority": "screen",
     "binary": "qodercli",
     "resume": {

--- a/diri/crates/diri-engine/src/agent.rs
+++ b/diri/crates/diri-engine/src/agent.rs
@@ -62,6 +62,19 @@ pub struct ApproveSpec {
     pub submit: bool,
 }
 
+/// Display-only setup metadata. It is parsed here so user overrides can carry
+/// it, but the Engine never executes the hint or opens the URL.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetupSpec {
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub install_hint: Option<String>,
+    #[serde(default)]
+    pub sign_in_hint: Option<String>,
+}
+
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentDescriptor {
@@ -105,6 +118,8 @@ pub struct AgentDescriptor {
     pub env_scrub_prefixes: Vec<String>,
     #[serde(default)]
     pub approve: Option<ApproveSpec>,
+    #[serde(default)]
+    pub setup: Option<SetupSpec>,
 }
 
 impl AgentDescriptor {

--- a/diri/crates/diri-engine/src/detect/mod.rs
+++ b/diri/crates/diri-engine/src/detect/mod.rs
@@ -337,24 +337,29 @@ mod tests {
     #[test]
     fn first_class_agents_ship_verified_official_setup_links() {
         let engine = engine();
-        for (id, expected_url) in [
-            (
-                "claude-code",
-                "https://docs.anthropic.com/en/docs/claude-code/getting-started",
-            ),
-            ("codex", "https://developers.openai.com/codex/cli/"),
-            ("cursor", "https://docs.cursor.com/en/cli/installation"),
-            ("gemini", "https://github.com/google-gemini/gemini-cli"),
-        ] {
-            let descriptor: diri_proto::AgentDescriptor = serde_json::from_value(
-                engine
-                    .raw_agent(id)
-                    .expect("first-class descriptor")
-                    .clone(),
-            )
-            .expect("client descriptor");
+        let mut first_class_count = 0;
+        for id in engine.ids() {
+            let descriptor: diri_proto::AgentDescriptor =
+                serde_json::from_value(engine.raw_agent(id).expect("bundled descriptor").clone())
+                    .expect("client descriptor");
+            if !descriptor.first_class {
+                continue;
+            }
+            first_class_count += 1;
             let setup = descriptor.setup.expect("first-class setup metadata");
-            assert_eq!(setup.url.as_deref(), Some(expected_url));
+            let url = setup
+                .url
+                .as_deref()
+                .filter(|url| url.starts_with("https://") || url.starts_with("http://"))
+                .unwrap_or_else(|| panic!("{id} needs a verified HTTP(S) setup URL"));
+            let authority = url
+                .split_once("://")
+                .expect("checked scheme")
+                .1
+                .split(['/', '?', '#'])
+                .next()
+                .unwrap_or_default();
+            assert!(!authority.is_empty(), "{id} setup URL has no host");
             assert!(
                 setup
                     .install_hint
@@ -362,7 +367,18 @@ mod tests {
                     .is_some_and(|hint| !hint.trim().is_empty()),
                 "{id} needs an install hint"
             );
+            assert!(
+                setup
+                    .sign_in_hint
+                    .as_deref()
+                    .is_some_and(|hint| !hint.trim().is_empty()),
+                "{id} needs a sign-in hint"
+            );
         }
+        assert!(
+            first_class_count >= 17,
+            "the bundled first-class roster unexpectedly shrank"
+        );
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/detect/mod.rs
+++ b/diri/crates/diri-engine/src/detect/mod.rs
@@ -448,6 +448,13 @@ mod tests {
                     .is_some_and(|hint| !hint.trim().is_empty()),
                 "{id} needs a sign-in hint"
             );
+            if id == "amp" {
+                assert_eq!(
+                    setup.sign_in_hint.as_deref(),
+                    Some("Sign in at ampcode.com, then run amp."),
+                    "Amp guidance must stay within its official manual"
+                );
+            }
         }
         assert!(
             first_class_count >= 17,

--- a/diri/crates/diri-engine/src/detect/mod.rs
+++ b/diri/crates/diri-engine/src/detect/mod.rs
@@ -335,6 +335,37 @@ mod tests {
     }
 
     #[test]
+    fn first_class_agents_ship_verified_official_setup_links() {
+        let engine = engine();
+        for (id, expected_url) in [
+            (
+                "claude-code",
+                "https://docs.anthropic.com/en/docs/claude-code/getting-started",
+            ),
+            ("codex", "https://developers.openai.com/codex/cli/"),
+            ("cursor", "https://docs.cursor.com/en/cli/installation"),
+            ("gemini", "https://github.com/google-gemini/gemini-cli"),
+        ] {
+            let descriptor: diri_proto::AgentDescriptor = serde_json::from_value(
+                engine
+                    .raw_agent(id)
+                    .expect("first-class descriptor")
+                    .clone(),
+            )
+            .expect("client descriptor");
+            let setup = descriptor.setup.expect("first-class setup metadata");
+            assert_eq!(setup.url.as_deref(), Some(expected_url));
+            assert!(
+                setup
+                    .install_hint
+                    .as_deref()
+                    .is_some_and(|hint| !hint.trim().is_empty()),
+                "{id} needs an install hint"
+            );
+        }
+    }
+
+    #[test]
     fn rules_are_sorted_by_descending_priority() {
         let engine = engine();
         for id in engine.ids() {

--- a/diri/crates/diri-engine/src/detect/mod.rs
+++ b/diri/crates/diri-engine/src/detect/mod.rs
@@ -335,53 +335,6 @@ mod tests {
     }
 
     #[test]
-    fn first_class_agents_ship_verified_official_setup_links() {
-        let engine = engine();
-        let mut first_class_count = 0;
-        for id in engine.ids() {
-            let descriptor: diri_proto::AgentDescriptor =
-                serde_json::from_value(engine.raw_agent(id).expect("bundled descriptor").clone())
-                    .expect("client descriptor");
-            if !descriptor.first_class {
-                continue;
-            }
-            first_class_count += 1;
-            let setup = descriptor.setup.expect("first-class setup metadata");
-            let url = setup
-                .url
-                .as_deref()
-                .filter(|url| url.starts_with("https://") || url.starts_with("http://"))
-                .unwrap_or_else(|| panic!("{id} needs a verified HTTP(S) setup URL"));
-            let authority = url
-                .split_once("://")
-                .expect("checked scheme")
-                .1
-                .split(['/', '?', '#'])
-                .next()
-                .unwrap_or_default();
-            assert!(!authority.is_empty(), "{id} setup URL has no host");
-            assert!(
-                setup
-                    .install_hint
-                    .as_deref()
-                    .is_some_and(|hint| !hint.trim().is_empty()),
-                "{id} needs an install hint"
-            );
-            assert!(
-                setup
-                    .sign_in_hint
-                    .as_deref()
-                    .is_some_and(|hint| !hint.trim().is_empty()),
-                "{id} needs a sign-in hint"
-            );
-        }
-        assert!(
-            first_class_count >= 17,
-            "the bundled first-class roster unexpectedly shrank"
-        );
-    }
-
-    #[test]
     fn rules_are_sorted_by_descending_priority() {
         let engine = engine();
         for id in engine.ids() {
@@ -453,5 +406,52 @@ mod tests {
         let engine = engine();
         let snapshot = ScreenSnapshot::from_lines(["anything"]);
         assert!(engine.evaluate(&snapshot, "no-such-agent").is_none());
+    }
+
+    #[test]
+    fn first_class_agents_ship_verified_official_setup_links() {
+        let engine = engine();
+        let mut first_class_count = 0;
+        for id in engine.ids() {
+            let descriptor: diri_proto::AgentDescriptor =
+                serde_json::from_value(engine.raw_agent(id).expect("bundled descriptor").clone())
+                    .expect("client descriptor");
+            if !descriptor.first_class {
+                continue;
+            }
+            first_class_count += 1;
+            let setup = descriptor.setup.expect("first-class setup metadata");
+            let url = setup
+                .url
+                .as_deref()
+                .filter(|url| url.starts_with("https://") || url.starts_with("http://"))
+                .unwrap_or_else(|| panic!("{id} needs a verified HTTP(S) setup URL"));
+            let authority = url
+                .split_once("://")
+                .expect("checked scheme")
+                .1
+                .split(['/', '?', '#'])
+                .next()
+                .unwrap_or_default();
+            assert!(!authority.is_empty(), "{id} setup URL has no host");
+            assert!(
+                setup
+                    .install_hint
+                    .as_deref()
+                    .is_some_and(|hint| !hint.trim().is_empty()),
+                "{id} needs an install hint"
+            );
+            assert!(
+                setup
+                    .sign_in_hint
+                    .as_deref()
+                    .is_some_and(|hint| !hint.trim().is_empty()),
+                "{id} needs a sign-in hint"
+            );
+        }
+        assert!(
+            first_class_count >= 17,
+            "the bundled first-class roster unexpectedly shrank"
+        );
     }
 }

--- a/diri/crates/diri-proto/src/methods.rs
+++ b/diri/crates/diri-proto/src/methods.rs
@@ -158,6 +158,20 @@ pub struct AgentKeystroke {
     pub submit: bool,
 }
 
+/// Optional, display-only guidance for installing and authenticating an
+/// Agent. Clients must never execute either hint; the URL is opened only after
+/// an explicit user action and is validated by the client as HTTP(S).
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentSetup {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_hint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sign_in_hint: Option<String>,
+}
+
 /// The daemon-side manifest descriptor for one agent, as much of it as the
 /// client needs. Deliberately partial and tolerant: the daemon owns the full
 /// schema (spawn args, env hygiene, injection), and unknown fields are ignored
@@ -181,6 +195,11 @@ pub struct AgentDescriptor {
     pub approve: Option<AgentKeystroke>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deny: Option<AgentKeystroke>,
+    /// Additive setup guidance. Older clients ignore this field and older
+    /// daemons omit it, so user manifest overrides remain forwards/backwards
+    /// compatible.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub setup: Option<AgentSetup>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/diri/crates/diri-proto/tests/control_roundtrip.rs
+++ b/diri/crates/diri-proto/tests/control_roundtrip.rs
@@ -1,6 +1,6 @@
 use diri_proto::{
-    AgentKind, AgentReadinessResult, AttachRequest, ClientRole, ControlMessage, DateMillis,
-    EventName, EventsSubscribeParams, ExitReason, HostInitializeParams, Method,
+    AgentDescriptor, AgentKind, AgentReadinessResult, AttachRequest, ClientRole, ControlMessage,
+    DateMillis, EventName, EventsSubscribeParams, ExitReason, HostInitializeParams, Method,
     ReadScrollbackCellsResult, SessionDiffBase, SessionId, SessionListResult,
     SessionReadDiffParams, SessionReadDiffResult, SessionStatus, StateSnapshotResult,
     WorktreeListResult,
@@ -130,6 +130,30 @@ fn additive_unknown_variants_fall_back_and_unknown_fields_are_ignored() {
     }))
     .unwrap();
     assert_eq!(worktree.path, "/tmp/wt");
+}
+
+#[test]
+fn setup_metadata_is_additive_for_old_and_new_catalog_entries() {
+    let old: AgentDescriptor = serde_json::from_value(json!({
+        "id": "amp",
+        "displayName": "Amp"
+    }))
+    .expect("old daemon descriptor");
+    assert_eq!(old.setup, None);
+
+    let guided: AgentDescriptor = serde_json::from_value(json!({
+        "id": "amp",
+        "displayName": "Amp",
+        "setup": {
+            "url": "https://ampcode.com/manual",
+            "installHint": "Install Amp.",
+            "signInHint": "Run amp and sign in."
+        }
+    }))
+    .expect("new descriptor");
+    let setup = guided.setup.as_ref().expect("setup metadata");
+    assert_eq!(setup.url.as_deref(), Some("https://ampcode.com/manual"));
+    typed_round_trip(&guided);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- replace the closed four-agent UI lists with a shared manifest/readiness catalog across the launcher, sidebar, Settings, command palette, and shortcuts
- persist arbitrary manifest IDs as default agents while migrating legacy preference spellings and repairing removed or unavailable defaults to installed first-class agents, then Terminal
- add additive setup metadata to the protocol and built-in manifests, render consistent missing-binary guidance, and restrict setup actions to strictly parsed HTTP(S) URLs with nonempty hosts and no credentials or control characters
- keep command-palette ordering and legacy shortcuts stable while dispatching arbitrary AgentKind values locally and remotely
- make the launcher project picker always end in a keyboard-accessible Choose Folder row, preserve the prompt and selection on cancellation, and restore input focus after the native chooser
- document the persisted preference format and upgrade fallback behavior

## QA follow-up

- always expose Terminal when default resolution can choose the shell fallback, including when only non-first-class agents are installed; regression coverage asserts launcher/settings options can represent the repaired selection
- add official setup URL, install guidance, and sign-in guidance for every bundled first-class agent; a roster-wide invariant now enforces complete guidance for current and future first-class manifests
- make unavailable command-palette rows without setup metadata disabled instead of selectable no-ops, while setup-capable rows open the verified URL and all surfaces render sign-in hints
- strengthen project-picker coverage for close behavior, multiline prompt preservation, cancellation, completion, and project selection

## Official setup sources

- Aider: https://aider.chat/docs/install.html
- Amp: https://ampcode.com/manual
- Antigravity: https://antigravity.google/docs/cli-install
- GitHub Copilot CLI: https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli
- Devin: https://docs.devin.ai/cli
- Droid: https://docs.factory.ai/cli/getting-started/quickstart
- Grok: https://docs.x.ai/build/overview
- Hermes Agent: https://github.com/NousResearch/hermes-agent/blob/main/website/docs/getting-started/quickstart.md
- Kilo Code: https://kilo.ai/docs/code-with-ai/platforms/cli
- Kimi Code: https://moonshotai.github.io/kimi-code/en/guides/getting-started.html
- Kiro CLI: https://kiro.dev/docs/cli/installation/
- OpenCode: https://opencode.ai/docs/
- Qoder CLI: https://docs.qoder.com/en/cli/quick-start

## Test evidence

- `cargo fmt --all -- --check`
- `cargo clippy -p diri-app -p diri-engine --all-targets -- -D warnings`
- `cargo check -p diri-app -p diri-engine --all-targets`
- `cargo test -p diri-app -p diri-engine` (diri-app: 306 passed, 1 ignored; diri-engine unit: 251 passed, 3 ignored; integration and doc tests passed)
- focused regressions for shell fallback representability, roster-wide setup completeness, disabled no-metadata palette actions, sign-in guidance, and chooser state/focus contracts
- `cargo test --workspace`
- `cargo test -p diri-remote --test holder_e2e list_kill_and_gc_complete_the_session_lifecycle -- --exact` (isolated retry of a transient first-run failure; passed, followed by a green full workspace rerun)

## Merge ordering

This PR has no functional dependency on #57 or #59. The coordinated stack order is #59, then #57, then #58; the roster invariant is anchored after #57's Cline/Maki setup tests so that sequence applies without the prior textual conflict. #57 supplies setup metadata for Cline and Maki, so both entries satisfy the invariant introduced here.

Closes #39
Closes #40
Closes #43
Closes #45
