### PR TITLE
Let attention settle before it interrupts

### DIFF
--- a/diri/crates/diri-app/Cargo.toml
+++ b/diri/crates/diri-app/Cargo.toml
@@ -53,6 +53,9 @@ url.workspace = true
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }
 gpui_platform = { workspace = true, features = ["test-support"] }
+# Pauses the clock so the notification settle window is exercised without
+# spending its wall-clock duration in the test suite.
+tokio = { workspace = true, features = ["test-util"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 block2 = "=0.6.2"

--- a/diri/crates/diri-app/src/notifications.rs
+++ b/diri/crates/diri-app/src/notifications.rs
@@ -2,6 +2,8 @@
 //!
 //! The behavior and per-agent answers carry over from the retired Swift client.
 
+use std::time::{Duration, Instant};
+
 use diri_proto::remote_pty::PersistenceCapability;
 use diri_proto::{
     AgentDescriptor, AgentKind, AttentionLevel, HibernationReason, NeedsInputKind, SessionId,
@@ -269,23 +271,17 @@ pub fn command_for_action(action_id: &str, data: &ActionData) -> Option<SendText
     })
 }
 
-/// Produce sound/banner work for a single authoritative session update.
+/// Produce the sound/banner work that a session update earns immediately.
 ///
-/// Chimes are emitted even for the focused session. Banners are suppressed only
-/// when that same session is selected and the app is active.
-///
-/// `descriptor` is the manifest descriptor for `current.effective_kind()`, when
-/// the daemon shipped one. It carries the agent's display name and its
-/// approve/deny keystrokes, so banner copy and quick actions stay
-/// manifest-driven instead of needing a client release per agent.
+/// These are one-shot facts — the host cannot keep processes alive, the
+/// governor froze a session — so there is nothing to wait out. Attention
+/// itself is a *state*, and states flap; it goes through the settle window
+/// instead (see [`attention_signal`]).
 #[must_use]
-pub fn transitions_for_update(
+pub fn immediate_transitions_for_update(
     previous: Option<&SessionRecord>,
     current: &SessionRecord,
-    selected_session_id: Option<&SessionId>,
-    app_is_active: bool,
     status_sounds_enabled: bool,
-    descriptor: Option<&AgentDescriptor>,
 ) -> Vec<StatusTransition> {
     let mut transitions = Vec::with_capacity(2);
 
@@ -321,27 +317,115 @@ pub fn transitions_for_update(
         });
     }
 
+    transitions
+}
+
+/// How long an attention state has to hold before it is worth interrupting for.
+///
+/// Attention is scraped off a moving terminal: an agent touches idle for a beat
+/// between tool calls, a permission prompt is answered by a hook before anyone
+/// could have read it, a session is done for one tick and back to work on the
+/// next. Announcing the transition itself turns every one of those into a chime
+/// and a Notification Center entry. Arming a deadline and re-reading the
+/// session when it expires means only states that actually survived get
+/// announced — and a state that resolves inside the window costs nothing.
+pub const ATTENTION_SETTLE: Duration = Duration::from_millis(1000);
+
+/// A noteworthy attention state waiting out [`ATTENTION_SETTLE`].
+///
+/// Only the level is held. The banner is built from the live record when the
+/// deadline expires, so a session that swapped one blocker for another during
+/// the window is described by the blocker it actually has.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PendingAttention {
+    pub level: AttentionLevel,
+    pub deadline: Instant,
+}
+
+impl PendingAttention {
+    #[must_use]
+    pub fn armed_at(level: AttentionLevel, now: Instant) -> Self {
+        Self {
+            level,
+            // Saturating: a deadline that cannot be represented is one we would
+            // rather fire late than never.
+            deadline: now.checked_add(ATTENTION_SETTLE).unwrap_or(now),
+        }
+    }
+}
+
+/// The attention state this update entered, if any — the trigger that arms a
+/// settle window.
+///
+/// Entering the state is what counts. A session already blocked that swaps
+/// blockers is still the same interruption and does not re-arm.
+#[must_use]
+pub fn attention_signal(
+    previous: Option<&SessionRecord>,
+    current: &SessionRecord,
+) -> Option<AttentionLevel> {
     let previous_attention = previous.map(SessionRecord::attention);
     let current_attention = current.attention();
-    let became_blocked = previous_attention != Some(AttentionLevel::NeedsInput)
-        && current_attention == AttentionLevel::NeedsInput;
-    let became_done = previous_attention != Some(AttentionLevel::DoneUnseen)
-        && current_attention == AttentionLevel::DoneUnseen;
-    if became_blocked || became_done {
-        let is_focused = selected_session_id == Some(&current.id) && app_is_active;
-        transitions.push(StatusTransition {
-            sound: status_sounds_enabled.then_some(if became_blocked {
-                NotificationSound::NeedsInput
-            } else {
-                NotificationSound::Done
-            }),
-            notification: (!is_focused)
-                .then(|| attention_request(current, status_sounds_enabled, descriptor)),
-            in_app_banner: None,
-        });
+    let entered =
+        |level: AttentionLevel| previous_attention != Some(level) && current_attention == level;
+    if entered(AttentionLevel::NeedsInput) {
+        Some(AttentionLevel::NeedsInput)
+    } else if entered(AttentionLevel::DoneUnseen) {
+        Some(AttentionLevel::DoneUnseen)
+    } else {
+        None
     }
+}
 
-    transitions
+/// Whether a pending settle window still describes the session.
+///
+/// This is the whole point of the delay: the record is re-read at the deadline,
+/// and a session that moved on — went back to work, got archived, had its
+/// prompt answered — is never announced at all.
+#[must_use]
+pub fn attention_still_holds(current: &SessionRecord, pending: AttentionLevel) -> bool {
+    !current.is_archived() && current.attention() == pending
+}
+
+/// Sound/banner work for an attention state that outlived its settle window.
+///
+/// Returns `None` when the session no longer holds the state that armed it.
+///
+/// Chimes are emitted even for the focused session. Banners are suppressed only
+/// when that same session is selected and the app is active — both judged
+/// against where the user is *now*, so selecting the session during the window
+/// is enough to stop the banner.
+///
+/// `descriptor` is the manifest descriptor for `current.effective_kind()`, when
+/// the daemon shipped one. It carries the agent's display name and its
+/// approve/deny keystrokes, so banner copy and quick actions stay
+/// manifest-driven instead of needing a client release per agent.
+#[must_use]
+pub fn settled_attention_transition(
+    current: &SessionRecord,
+    pending: AttentionLevel,
+    selected_session_id: Option<&SessionId>,
+    app_is_active: bool,
+    status_sounds_enabled: bool,
+    descriptor: Option<&AgentDescriptor>,
+) -> Option<StatusTransition> {
+    let sound = match pending {
+        AttentionLevel::NeedsInput => NotificationSound::NeedsInput,
+        AttentionLevel::DoneUnseen => NotificationSound::Done,
+        // No other level is worth interrupting for, so none is ever armed and
+        // none has banner copy to build.
+        _ => return None,
+    };
+    if !attention_still_holds(current, pending) {
+        return None;
+    }
+    let is_focused = selected_session_id == Some(&current.id) && app_is_active;
+    Some(StatusTransition {
+        sound: status_sounds_enabled.then_some(sound),
+        notification: (!is_focused)
+            .then(|| attention_request(current, status_sounds_enabled, descriptor)),
+        in_app_banner: None,
+    })
 }
 
 fn attention_request(
@@ -470,7 +554,7 @@ mod tests {
         current.host = Some("forge".to_owned());
         current.remote_persistence = Some(PersistenceCapability::NonPersistent);
 
-        let first = transitions_for_update(None, &current, None, true, false, None);
+        let first = immediate_transitions_for_update(None, &current, false);
         let banner = first
             .iter()
             .find_map(|transition| transition.in_app_banner.as_ref())
@@ -478,9 +562,7 @@ mod tests {
         assert!(banner.title.contains("cannot survive"));
         assert!(banner.body.contains("forge"));
 
-        assert!(
-            transitions_for_update(Some(&current), &current, None, true, false, None).is_empty()
-        );
+        assert!(immediate_transitions_for_update(Some(&current), &current, false).is_empty());
     }
     use diri_proto::{
         AgentKeystroke, DateMillis, NeedsInputDetail, NeedsInputSource, ProjectId, Resumability,
@@ -530,6 +612,26 @@ mod tests {
         }
     }
 
+    /// What the settle task does at the deadline for a session that is still in
+    /// the state that armed it.
+    fn settled(
+        current: &SessionRecord,
+        selected_session_id: Option<&SessionId>,
+        app_is_active: bool,
+        status_sounds_enabled: bool,
+        descriptor: Option<&AgentDescriptor>,
+    ) -> StatusTransition {
+        settled_attention_transition(
+            current,
+            current.attention(),
+            selected_session_id,
+            app_is_active,
+            status_sounds_enabled,
+            descriptor,
+        )
+        .expect("a session still in its armed state is announced")
+    }
+
     #[test]
     fn approve_and_deny_map_to_each_agents_exact_keystrokes() {
         for (kind, text, submit) in [
@@ -539,7 +641,7 @@ mod tests {
             (AgentKind::GEMINI, "", true),
         ] {
             let current = session(kind, SessionStatus::NeedsInput(NeedsInputKind::Permission));
-            let transition = &transitions_for_update(None, &current, None, true, true, None)[0];
+            let transition = settled(&current, None, true, true, None);
             let data = transition
                 .notification
                 .as_ref()
@@ -592,8 +694,7 @@ mod tests {
             amp.clone(),
             SessionStatus::NeedsInput(NeedsInputKind::Permission),
         );
-        let transition =
-            &transitions_for_update(None, &current, None, true, true, Some(&descriptor))[0];
+        let transition = settled(&current, None, true, true, Some(&descriptor));
         let notification = transition.notification.as_ref().unwrap();
         assert_eq!(notification.title, "Amp needs you");
         let data = notification.action_data.as_ref().unwrap();
@@ -621,15 +722,14 @@ mod tests {
             approve: None,
             ..descriptor.clone()
         };
-        let transition =
-            &transitions_for_update(None, &current, None, true, true, Some(&unverified))[0];
+        let transition = settled(&current, None, true, true, Some(&unverified));
         let notification = transition.notification.as_ref().unwrap();
         assert_eq!(notification.title, "Amp needs you");
         assert!(notification.action_data.is_none());
 
         // Without a descriptor (daemon too old to send one) an unknown agent
         // falls back to the generic name and no quick actions.
-        let transition = &transitions_for_update(None, &current, None, true, true, None)[0];
+        let transition = settled(&current, None, true, true, None);
         assert_eq!(
             transition.notification.as_ref().unwrap().title,
             "Agent needs you"
@@ -642,23 +742,122 @@ mod tests {
             AgentKind::CODEX,
             SessionStatus::NeedsInput(NeedsInputKind::Permission),
         );
-        let hidden = transitions_for_update(
-            None,
-            &current,
-            Some(&SessionId::new("other")),
-            true,
-            true,
-            None,
+        let hidden = settled(&current, Some(&SessionId::new("other")), true, true, None);
+        assert_eq!(hidden.sound, Some(NotificationSound::NeedsInput));
+        assert!(hidden.notification.is_some());
+
+        let focused = settled(&current, Some(&current.id), true, true, None);
+        assert_eq!(focused.sound, Some(NotificationSound::NeedsInput));
+        assert!(focused.notification.is_none());
+
+        let inactive = settled(&current, Some(&current.id), false, true, None);
+        assert!(inactive.notification.is_some());
+    }
+
+    #[test]
+    fn entering_an_attention_state_arms_it_and_holding_it_does_not_rearm() {
+        let working = session(AgentKind::CODEX, SessionStatus::Working);
+        let blocked = session(
+            AgentKind::CODEX,
+            SessionStatus::NeedsInput(NeedsInputKind::Permission),
         );
-        assert_eq!(hidden[0].sound, Some(NotificationSound::NeedsInput));
-        assert!(hidden[0].notification.is_some());
+        assert_eq!(
+            attention_signal(Some(&working), &blocked),
+            Some(AttentionLevel::NeedsInput)
+        );
+        // Still blocked on the next tick — same interruption, no second window.
+        assert_eq!(attention_signal(Some(&blocked), &blocked), None);
+        assert_eq!(attention_signal(Some(&blocked), &working), None);
 
-        let focused = transitions_for_update(None, &current, Some(&current.id), true, true, None);
-        assert_eq!(focused[0].sound, Some(NotificationSound::NeedsInput));
-        assert!(focused[0].notification.is_none());
+        let mut done = session(AgentKind::CODEX, SessionStatus::Idle);
+        done.needs_input = None;
+        done.last_turn_completed_at = Some(DateMillis(50.0));
+        done.last_seen_at = Some(DateMillis(40.0));
+        assert_eq!(done.attention(), AttentionLevel::DoneUnseen);
+        assert_eq!(
+            attention_signal(Some(&working), &done),
+            Some(AttentionLevel::DoneUnseen)
+        );
+    }
 
-        let inactive = transitions_for_update(None, &current, Some(&current.id), false, true, None);
-        assert!(inactive[0].notification.is_some());
+    #[test]
+    fn a_state_that_does_not_outlive_its_window_is_never_announced() {
+        // The blip this whole delay exists for: idle for a beat between tool
+        // calls, back to working before anyone could have read a banner.
+        let working = session(AgentKind::CODEX, SessionStatus::Working);
+        assert!(
+            settled_attention_transition(
+                &working,
+                AttentionLevel::DoneUnseen,
+                None,
+                true,
+                true,
+                None
+            )
+            .is_none()
+        );
+
+        // A prompt answered inside the window — by a hook, or by the user in
+        // the terminal — leaves nothing to interrupt for either.
+        let mut answered = session(
+            AgentKind::CODEX,
+            SessionStatus::NeedsInput(NeedsInputKind::Permission),
+        );
+        answered.status = SessionStatus::Working;
+        answered.needs_input = None;
+        assert!(
+            settled_attention_transition(
+                &answered,
+                AttentionLevel::NeedsInput,
+                None,
+                true,
+                true,
+                None
+            )
+            .is_none()
+        );
+
+        // Archiving a session is the user saying they are done with it.
+        let mut archived = session(
+            AgentKind::CODEX,
+            SessionStatus::NeedsInput(NeedsInputKind::Permission),
+        );
+        archived.archived_at = Some(DateMillis(3.0));
+        assert!(
+            settled_attention_transition(
+                &archived,
+                AttentionLevel::NeedsInput,
+                None,
+                true,
+                true,
+                None
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn the_window_describes_the_blocker_the_session_ended_up_with() {
+        // Armed on one prompt, expired on another: the banner has to name the
+        // question actually on screen, and carry its identity so Notification
+        // Center treats it as a new blocker rather than a duplicate.
+        let armed = session(
+            AgentKind::CODEX,
+            SessionStatus::NeedsInput(NeedsInputKind::Permission),
+        );
+        let mut replaced = armed.clone();
+        replaced.needs_input.as_mut().unwrap().summary = "Delete the branch?".to_owned();
+
+        let transition = settled(&replaced, None, true, true, None);
+        let notification = transition.notification.as_ref().unwrap();
+        assert_eq!(notification.body, "Delete the branch?");
+        assert_ne!(
+            notification.identifier,
+            settled(&armed, None, true, true, None)
+                .notification
+                .unwrap()
+                .identifier
+        );
     }
 
     #[test]
@@ -668,7 +867,7 @@ mod tests {
             SessionStatus::NeedsInput(NeedsInputKind::Question),
         );
         question.needs_input.as_mut().unwrap().kind = NeedsInputKind::Question;
-        let transition = &transitions_for_update(None, &question, None, true, true, None)[0];
+        let transition = settled(&question, None, true, true, None);
         assert!(
             transition
                 .notification
@@ -682,7 +881,7 @@ mod tests {
             AgentKind::SHELL,
             SessionStatus::NeedsInput(NeedsInputKind::Permission),
         );
-        let transition = &transitions_for_update(None, &shell, None, true, true, None)[0];
+        let transition = settled(&shell, None, true, true, None);
         assert!(
             transition
                 .notification
@@ -758,7 +957,7 @@ mod tests {
             AgentKind::CODEX,
             SessionStatus::NeedsInput(NeedsInputKind::Permission),
         );
-        let transition = &transitions_for_update(None, &current, None, true, false, None)[0];
+        let transition = settled(&current, None, true, false, None);
         assert_eq!(transition.sound, None);
         assert!(transition.notification.as_ref().unwrap().use_system_sound);
     }

--- a/diri/crates/diri-app/src/store/mod.rs
+++ b/diri/crates/diri-app/src/store/mod.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, RwLock};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use diri_client::{ClientError, ConnectionState, DaemonClient, EventEnvelope};
 use diri_proto::paths::DirijorPaths;
@@ -18,12 +18,13 @@ use diri_proto::{
     ExitReason, GovernorConfigureParams, HelloResult, HostEntry, HostsConfig, Project, ProjectId,
     Resumability, SessionId, SessionListResult, SessionRecord, SessionSpawnParams, SessionStatus,
 };
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::{Notify, broadcast, mpsc};
 use tokio::task::JoinHandle;
 
 use crate::notifications::{
-    SendTextCommand, StatusTransition, migration_transition, prefs_sync_transition,
-    reach_failure_transition, transitions_for_update,
+    PendingAttention, SendTextCommand, StatusTransition, attention_signal,
+    immediate_transitions_for_update, migration_transition, prefs_sync_transition,
+    reach_failure_transition, settled_attention_transition,
 };
 use crate::switcher::{
     OverviewArrow, OverviewFilter, OverviewMode, OverviewOutcome, SessionOverviewState,
@@ -314,6 +315,13 @@ pub struct SessionStore {
     /// Empty until the first successful connect, and empty forever against a
     /// daemon too old to send descriptors — every reader must have a fallback.
     agents: AgentReadinessResult,
+    /// Attention states serving out their settle window, newest arming wins.
+    /// Drained by the settle task in `StoreHandle`, which is what turns one of
+    /// these into a chime and a banner — see `drain_settled_attention`.
+    attention_settle: HashMap<SessionId, PendingAttention>,
+    /// Wakes the settle task when a window is armed early enough to beat the
+    /// one it is currently sleeping on.
+    attention_wake: Arc<Notify>,
     effects: mpsc::UnboundedSender<StoreEffect>,
 }
 
@@ -369,6 +377,8 @@ impl SessionStore {
                 prefs_path,
                 hosts: Vec::new(),
                 agents: AgentReadinessResult::default(),
+                attention_settle: HashMap::new(),
+                attention_wake: Arc::new(Notify::new()),
                 effects,
             },
             receiver,
@@ -1112,14 +1122,13 @@ impl SessionStore {
         let previous = self.sessions.get(&session.id).cloned();
         let is_new = previous.is_none();
         let id = session.id.clone();
-        let transitions = transitions_for_update(
+        let transitions = immediate_transitions_for_update(
             previous.as_deref(),
             &session,
-            self.selected_session_id.as_ref(),
-            self.app_is_active,
             self.prefs.status_sounds,
-            self.agents.descriptor(session.effective_kind()),
         );
+        let attention = attention_signal(previous.as_deref(), &session);
+        let arriving_attention = session.attention();
         let arriving_archived = session.is_archived();
         // Closing the tab also drops the Engine record and deletes the
         // session's output log, so it may only happen where nothing is lost.
@@ -1141,6 +1150,7 @@ impl SessionStore {
                 .as_deref()
                 .is_none_or(|record| !matches!(record.status, SessionStatus::Exited(_)));
         self.sessions.insert(id.clone(), Arc::new(session));
+        self.settle_attention(&id, attention, arriving_attention, arriving_archived);
         // Spawn selects the id before the authoritative record arrives, and
         // only focus_session grants terminal residency -- without this, a
         // session created from the UI stays "Preparing terminal" forever.
@@ -1181,11 +1191,88 @@ impl SessionStore {
         self.reconcile_navigation();
     }
 
+    /// Arms, replaces, or abandons a session's settle window after an update.
+    ///
+    /// A fresh signal always re-arms: the newest reason to interrupt is the one
+    /// worth waiting on. Without a signal, a window whose state the session no
+    /// longer holds is dropped here rather than at the deadline, so a blip that
+    /// resolves immediately never even keeps the settle task awake.
+    fn settle_attention(
+        &mut self,
+        id: &SessionId,
+        signal: Option<AttentionLevel>,
+        attention: AttentionLevel,
+        archived: bool,
+    ) {
+        if let Some(level) = signal {
+            self.attention_settle.insert(
+                id.clone(),
+                PendingAttention::armed_at(level, Instant::now()),
+            );
+            self.attention_wake.notify_one();
+        } else if self
+            .attention_settle
+            .get(id)
+            .is_some_and(|pending| archived || pending.level != attention)
+        {
+            self.attention_settle.remove(id);
+        }
+    }
+
+    /// The earliest settle window still to run, for the task that sleeps on it.
+    #[must_use]
+    pub fn next_attention_deadline(&self) -> Option<Instant> {
+        self.attention_settle
+            .values()
+            .map(|pending| pending.deadline)
+            .min()
+    }
+
+    /// Handle to the signal raised whenever a settle window is armed.
+    #[must_use]
+    pub fn attention_wake(&self) -> Arc<Notify> {
+        Arc::clone(&self.attention_wake)
+    }
+
+    /// Turns every expired settle window into the chime and banner it earned,
+    /// judged against the session as it is now — not as it was when the window
+    /// was armed. States that did not survive produce nothing.
+    #[must_use]
+    pub fn drain_settled_attention(&mut self, now: Instant) -> Vec<StatusTransition> {
+        let due: Vec<SessionId> = self
+            .attention_settle
+            .iter()
+            .filter(|(_, pending)| pending.deadline <= now)
+            .map(|(id, _)| id.clone())
+            .collect();
+        let mut transitions = Vec::with_capacity(due.len());
+        for id in due {
+            let Some(pending) = self.attention_settle.remove(&id) else {
+                continue;
+            };
+            let Some(session) = self.sessions.get(&id) else {
+                continue;
+            };
+            if let Some(transition) = settled_attention_transition(
+                session,
+                pending.level,
+                self.selected_session_id.as_ref(),
+                self.app_is_active,
+                self.prefs.status_sounds,
+                self.agents.descriptor(session.effective_kind()),
+            ) {
+                transitions.push(transition);
+            }
+        }
+        transitions
+    }
+
     pub fn remove_session_record(&mut self, id: &SessionId) {
         if self.selected_session_id.as_ref() == Some(id) {
             self.focus_neighbor(&HashSet::from([id.clone()]));
         }
         self.sessions.remove(id);
+        self.attention_settle.remove(id);
         self.closing.remove(id);
         self.sidebar_selection.remove(id);
         self.mru_order.retain(|candidate| candidate != id);
@@ -2258,6 +2345,11 @@ impl StoreRuntime {
             status_tx.clone(),
         )));
 
+        tasks.push(tokio::spawn(run_attention_settle(
+            Arc::clone(&store),
+            status_tx.clone(),
+        )));
+
         let action_client = Arc::clone(&client);
         let action_status = status_tx.clone();
         tasks.push(tokio::spawn(async move {
@@ -2326,6 +2418,47 @@ impl Drop for StoreRuntime {
             for task in tasks.drain(..) {
                 task.abort();
             }
+        }
+    }
+}
+
+/// Announces attention states that outlived their settle window.
+///
+/// Every chime and banner for a blocked or finished session comes from here,
+/// one window after the transition and only if the session still holds the
+/// state — see `SessionStore::drain_settled_attention`. The loop sleeps on the
+/// nearest deadline and is woken early whenever a closer one is armed, so a
+/// quiet fleet costs no timer at all.
+async fn run_attention_settle(
+    store: Arc<RwLock<SessionStore>>,
+    status_tx: broadcast::Sender<StatusTransition>,
+) {
+    let wake = store
+        .read()
+        .expect("session store lock poisoned")
+        .attention_wake();
+    loop {
+        let deadline = store
+            .read()
+            .expect("session store lock poisoned")
+            .next_attention_deadline();
+        match deadline {
+            Some(deadline) => {
+                tokio::select! {
+                    () = tokio::time::sleep_until(deadline.into()) => {}
+                    // A window closer than the one being slept on, or one that
+                    // replaced it: recompute rather than oversleep.
+                    () = wake.notified() => continue,
+                }
+            }
+            None => wake.notified().await,
+        }
+        let transitions = store
+            .write()
+            .expect("session store lock poisoned")
+            .drain_settled_attention(Instant::now());
+        for transition in transitions {
+            let _ = status_tx.send(transition);
         }
     }
 }

--- a/diri/crates/diri-app/src/store/tests.rs
+++ b/diri/crates/diri-app/src/store/tests.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use diri_proto::{
     AgentDescriptor, AgentKind, AgentReadinessItem, AgentReadinessResult, AttentionLevel,
@@ -735,7 +736,7 @@ fn attention_rollup_and_needs_input_sort_use_proto_derivation() {
 }
 
 #[test]
-fn hidden_needs_input_update_emits_chime_and_notification_effect() {
+fn hidden_needs_input_update_chimes_and_posts_once_its_window_expires() {
     let (mut store, mut effects) = hydrated(
         vec![session("visible", "p", 2.0)],
         vec![project("p", "P")],
@@ -747,15 +748,117 @@ fn hidden_needs_input_update_emits_chime_and_notification_effect() {
     hidden.status = SessionStatus::NeedsInput(diri_proto::NeedsInputKind::Permission);
     store.upsert_session(hidden);
 
-    let transition = drain(&mut effects)
-        .into_iter()
-        .find_map(|effect| match effect {
-            StoreEffect::StatusTransition(transition) => Some(transition),
-            _ => None,
-        })
-        .expect("needs-input update should emit a status transition");
+    // Nothing is announced on the transition itself, and nothing is due yet.
+    assert!(
+        drain(&mut effects)
+            .into_iter()
+            .all(|effect| !matches!(effect, StoreEffect::StatusTransition(_)))
+    );
+    assert!(store.drain_settled_attention(Instant::now()).is_empty());
+
+    let transitions = store.drain_settled_attention(
+        store
+            .next_attention_deadline()
+            .expect("needs-input update should arm a settle window"),
+    );
+    let transition = transitions
+        .first()
+        .expect("a session still blocked at its deadline is announced");
     assert_eq!(transition.sound, Some(NotificationSound::NeedsInput));
     assert!(transition.notification.is_some());
+    assert!(store.next_attention_deadline().is_none());
+}
+
+#[tokio::test(start_paused = true)]
+async fn the_settle_task_sleeps_on_the_window_and_then_publishes() {
+    let (store, _effects) = SessionStore::headless(Prefs::default());
+    let store = Arc::new(std::sync::RwLock::new(store));
+    let (status_tx, mut status_rx) = tokio::sync::broadcast::channel(8);
+    let task = tokio::spawn(super::run_attention_settle(
+        Arc::clone(&store),
+        status_tx.clone(),
+    ));
+
+    // The session the user is looking at, so the blocked one is not the
+    // selected row and earns a banner as well as a chime.
+    store
+        .write()
+        .expect("session store lock poisoned")
+        .upsert_session(session("visible", "p", 2.0));
+    let mut blocked = session("blocked", "p", 1.0);
+    blocked.status = SessionStatus::NeedsInput(diri_proto::NeedsInputKind::Permission);
+    store
+        .write()
+        .expect("session store lock poisoned")
+        .upsert_session(blocked);
+
+    // Nothing is published until the window is served — the task is asleep on
+    // the deadline it was woken to install.
+    assert!(status_rx.try_recv().is_err());
+
+    let transition = tokio::time::timeout(Duration::from_secs(30), status_rx.recv())
+        .await
+        .expect("the settle task must publish once the window expires")
+        .expect("status channel stays open");
+    assert_eq!(transition.sound, Some(NotificationSound::NeedsInput));
+    assert!(transition.notification.is_some());
+
+    task.abort();
+}
+
+#[test]
+fn a_session_that_unblocks_inside_its_window_is_never_announced() {
+    let (mut store, mut effects) = hydrated(
+        vec![session("visible", "p", 2.0)],
+        vec![project("p", "P")],
+        Prefs::default(),
+    );
+    drain(&mut effects);
+
+    let mut blocked = session("hidden", "p", 1.0);
+    blocked.status = SessionStatus::NeedsInput(diri_proto::NeedsInputKind::Permission);
+    store.upsert_session(blocked.clone());
+    assert!(store.next_attention_deadline().is_some());
+
+    // Answered before the window expired: the pending state goes with it, so
+    // the settle task is not even kept awake for it.
+    blocked.status = SessionStatus::Working;
+    blocked.needs_input = None;
+    store.upsert_session(blocked);
+
+    assert!(store.next_attention_deadline().is_none());
+    assert!(
+        store
+            .drain_settled_attention(Instant::now() + Duration::from_secs(60))
+            .is_empty()
+    );
+}
+
+#[test]
+fn selecting_a_session_inside_its_window_leaves_the_chime_but_drops_the_banner() {
+    let (mut store, mut effects) = hydrated(
+        vec![session("visible", "p", 2.0)],
+        vec![project("p", "P")],
+        Prefs::default(),
+    );
+    drain(&mut effects);
+
+    let mut blocked = session("hidden", "p", 1.0);
+    blocked.status = SessionStatus::NeedsInput(diri_proto::NeedsInputKind::Permission);
+    store.upsert_session(blocked);
+    store.select(id("hidden"));
+
+    let transitions = store.drain_settled_attention(
+        store
+            .next_attention_deadline()
+            .expect("needs-input update should arm a settle window"),
+    );
+    let transition = transitions.first().expect("the chime still fires");
+    assert_eq!(transition.sound, Some(NotificationSound::NeedsInput));
+    assert!(
+        transition.notification.is_none(),
+        "the session the user is looking at needs no system banner"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Ports the part of [herdr](https://github.com/herdrdev/herdr)'s notification model we do not have: a settle window between an attention transition and the interruption it earns.

## The problem

Attention is scraped off a moving terminal, so it flaps. An agent touches idle for a beat between tool calls; a hook answers a permission prompt before anyone could have read it; a session is done for one tick and back at work on the next. We announced the transition itself, so every one of those became a chime and a Notification Center entry for a session that had already moved on.

herdr queues each state change as a `PendingAgentNotification` with a deadline (`ui.toast.delay_seconds`, default 1s) and re-reads the pane when it expires, dropping anything whose state or agent no longer matches (`src/app/actions.rs`).

## What this does

Entering needs-input or done now arms a one-second window instead of firing:

- **Re-validation at the deadline.** The session is read again; a state that did not survive is never announced.
- **Newest arming wins.** A fresh signal replaces the pending window; a session that leaves the state has its window dropped on the spot, so a blip never even keeps the settle task awake.
- **Live copy.** The banner is built from the record as it is at the deadline, so it names the blocker the session actually has, not the one it had a second ago — and carries that blocker's identity, so Notification Center treats it as new rather than a duplicate.
- **Focus judged late.** Selecting the session inside the window drops the banner and leaves only the chime.

Memory-pressure freezes and the remote-persistence warning are events, not states, so they still fire immediately (`immediate_transitions_for_update`).

The settle task sleeps on the nearest deadline and is woken by a `Notify` when a closer one is armed — a quiet fleet costs no timer.

Approve/deny quick actions and per-session threading are untouched; herdr has no equivalent.

## Tests

`cargo test -p diri-app` — 325 pass. New coverage: arming semantics, a state that does not outlive its window, an archived session, blocker replacement inside the window, cancellation on unblock, focus at the deadline, and the settle task's sleep/publish loop under a paused clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)