### PR TITLE
Stop publishing half-drawn repaints, and fix the first scroll of a session

### DIFF
--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -97,6 +97,36 @@ const LAUNCH_DEBOUNCE: Duration = Duration::from_millis(120);
 /// Elapsed-based so the probe cadence is the same on fast and idle ticks.
 const LIVENESS_INTERVAL: Duration = Duration::from_secs(2);
 
+/// How long a half-erased screen waits for the rest of its repaint.
+///
+/// A TUI repaint is not one write. Ink, Ratatui and friends erase the old
+/// frame and draw the new one in separate `write`s, and a PTY hands each one
+/// over the instant it lands — so a reader that publishes per read publishes
+/// the half-erased screen in between, which is the flash users see as
+/// flickering. A terminal emulator never shows that state because its reader
+/// drains everything queued before it renders. Draining alone is not enough
+/// here: the daemon is usually parked in `poll` and wakes on the *first* write
+/// of a repaint, with the rest microseconds behind. This is the quiet window
+/// that lets the rest arrive. It is only ever waited out by a screen that
+/// just lost content, so typed echo is not slowed by it.
+const OUTPUT_SETTLE: Duration = Duration::from_millis(3);
+
+/// Ceiling on how long one batch may hold back a repaint. Output that never
+/// goes quiet (a build log) would otherwise wait on `OUTPUT_SETTLE` forever.
+/// Well under the 16ms grid flush interval, so continuous streaming publishes
+/// at exactly the same rate it did before.
+const OUTPUT_BATCH_CEILING: Duration = Duration::from_millis(8);
+
+/// Byte ceiling on one batch, matching `alacritty_terminal`'s
+/// `MAX_LOCKED_READ`. A child that writes faster than it can be parsed must
+/// not starve the grid indefinitely.
+const OUTPUT_BATCH_BYTES: usize = 1 << 20;
+
+/// How much of a held session's log the follow pump reads per pass. A full
+/// read means more is already waiting, which is how that pump recognizes a
+/// repaint it has only half consumed.
+const LOG_READ_BUDGET: usize = 64 << 10;
+
 /// What a session looks like from the outside.
 #[derive(Clone, Debug)]
 pub struct SessionView {
@@ -2239,16 +2269,11 @@ fn pump(
             Ok(usize::MAX) => {}
             Ok(0) => break, // the child closed the terminal
             Ok(n) => {
-                let chunk = &buffer[..n];
-                {
-                    let mut log = shared.log.lock().expect("log");
-                    // A failed disk write must not stop the session: the child
-                    // is still running and its status still matters.
-                    let _ = log.append(chunk);
-                }
+                let closed = feed_output_batch(&shared, &mut reader, &mut buffer, n);
+                // One detection pass per batch, not per read: the reducer
+                // discards observations it has already judged anyway.
                 let observation = {
                     let mut screen = shared.screen.lock().expect("screen");
-                    screen.feed(chunk);
                     evaluate_if_screen_changed(
                         &shared,
                         &mut screen,
@@ -2268,10 +2293,15 @@ fn pump(
                     drop(reducer);
                     apply(&shared, &outcome);
                 }
+                if closed {
+                    break;
+                }
             }
             Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
             Err(_) => break,
         }
+
+        release_stalled_sync(&shared);
 
         // Ticks drive the debounce timers even when the child is quiet.
         if last_tick.elapsed().unwrap_or_default() >= TICK_INTERVAL {
@@ -2300,6 +2330,81 @@ fn pump(
     apply(&shared, &outcome);
     shared.exited.store(true, Ordering::SeqCst);
     let _ = shared.log.lock().expect("log").flush();
+}
+
+/// Feeds one batch of PTY output: the read the caller already made, plus every
+/// continuation that arrives before the batch settles.
+///
+/// The point of the batch is that the caller publishes the grid *once*, after
+/// it returns. A repaint the child split across several writes therefore
+/// reaches attached clients as one frame instead of as an erase followed by a
+/// redraw, which is what a pane paints as a flicker. See [`OUTPUT_SETTLE`].
+///
+/// The screen lock is released between chunks so the grid can still be read
+/// mid-batch, which is safe because nothing wakes a reader until the caller
+/// publishes.
+///
+/// Returns true when the child closed the terminal.
+fn feed_output_batch(
+    shared: &Shared,
+    reader: &mut crate::pty::PtyStream,
+    buffer: &mut [u8],
+    first: usize,
+) -> bool {
+    let deadline = Instant::now() + OUTPUT_BATCH_CEILING;
+    let mut count = first;
+    let mut total = 0usize;
+    let mut filled_before = None;
+    loop {
+        {
+            let mut log = shared.log.lock().expect("log");
+            // A failed disk write must not stop the session: the child is
+            // still running and its status still matters.
+            let _ = log.append(&buffer[..count]);
+        }
+        let mid_repaint = {
+            let mut screen = shared.screen.lock().expect("screen");
+            let before = *filled_before.get_or_insert_with(|| screen.filled_cells());
+            screen.feed(&buffer[..count]);
+            screen.filled_cells() < before
+        };
+        total += count;
+
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if total >= OUTPUT_BATCH_BYTES || remaining.is_zero() {
+            return false;
+        }
+        // Bytes already queued are always folded in — that costs nothing and
+        // is what a terminal emulator's reader does. Waiting for bytes that
+        // have not arrived is reserved for a screen that currently holds less
+        // than it did when the batch opened, which is a repaint caught between
+        // its erase and its redraw. An echo, which only adds, never waits.
+        let settle = if mid_repaint {
+            OUTPUT_SETTLE
+        } else {
+            Duration::ZERO
+        };
+        if !matches!(reader.wait_readable(remaining.min(settle)), Ok(true)) {
+            return false;
+        }
+        count = match reader.read(buffer) {
+            Ok(0) => return true, // the child closed the terminal
+            Ok(next) => next,
+            // Ending the batch here is safe: the caller polls again straight
+            // away and picks the rest up.
+            Err(_) => return false,
+        };
+    }
+}
+
+/// Publishes a synchronized update the child opened and never closed.
+///
+/// Cheap enough to run every loop iteration: it is an `Option<Instant>` test
+/// unless an update is actually overdue.
+fn release_stalled_sync(shared: &Shared) {
+    if shared.screen.lock().expect("screen").flush_expired_sync() {
+        shared.grid_wake.notify();
+    }
 }
 
 /// Runs manifest detection only when the visible screen actually changed.
@@ -2399,6 +2504,8 @@ fn pump_held(
     let mut last_scan_at = None;
     let mut last_scan_seq = 0u64;
     let mut exit_status: Option<HolderExitStatus> = None;
+    // Set while a repaint is being assembled across more than one log read.
+    let mut publish_pending: Option<Instant> = None;
     // Until the tail is first caught up, bytes are history, not activity:
     // they must render, but not flip a quiet adopted session to Working.
     let mut replaying = true;
@@ -2408,10 +2515,19 @@ fn pump_held(
         let (start, chunk) = {
             let mut log = shared.log.lock().expect("log");
             log.refresh_from_disk();
-            log.read(offset, 64 << 10)
+            log.read(offset, LOG_READ_BUDGET)
         };
+        // A full read means the tail is not caught up, so this pass may hold
+        // half a repaint. Publishing it would flicker; fold the rest into the
+        // same frame instead — bounded, so a holder streaming faster than we
+        // parse still updates.
+        let caught_up = chunk.len() < LOG_READ_BUDGET;
 
         if chunk.is_empty() {
+            if publish_pending.take().is_some() {
+                shared.grid_wake.notify();
+            }
+            release_stalled_sync(&shared);
             if replaying {
                 replaying = false;
                 // The replay tail is drained: checkpoint immediately, as the
@@ -2521,7 +2637,11 @@ fn pump_held(
                     &mut last_eval_seq,
                 )
             };
-            shared.grid_wake.notify();
+            let batch_started = *publish_pending.get_or_insert_with(Instant::now);
+            if caught_up || batch_started.elapsed() >= OUTPUT_BATCH_CEILING {
+                publish_pending = None;
+                shared.grid_wake.notify();
+            }
             let now = SystemTime::now();
             let mut reducer = shared.reducer.lock().expect("reducer");
             if !replaying {
@@ -2534,6 +2654,12 @@ fn pump_held(
                 apply(&shared, &outcome);
             }
         }
+    }
+
+    // A repaint still being assembled when the holder exited is the last thing
+    // clients will ever see of this session: publish it.
+    if publish_pending.take().is_some() {
+        shared.grid_wake.notify();
     }
 
     // Detaching or exiting: capture the final screen, so the next daemon

--- a/diri/crates/diri-engine/tests/repaint.rs
+++ b/diri/crates/diri-engine/tests/repaint.rs
@@ -1,0 +1,204 @@
+//! A repaint reaches an attached client as one frame.
+//!
+//! TUIs do not repaint in a single write: they erase the old frame and draw
+//! the new one separately, and a PTY hands each write over the moment it
+//! lands. A reader that publishes the grid per read publishes the half-erased
+//! screen in between, which is what a pane paints as a flicker.
+
+#![cfg(unix)]
+
+use std::io::{BufRead, Read, Write};
+use std::os::unix::net::UnixStream;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use diri_engine::control::ControlServer;
+use diri_engine::detect::ManifestEngine;
+use diri_engine::registry::Registry;
+use diri_proto::ControlMessage;
+use diri_proto::frames::{Frame, FrameCodec, FrameType};
+use diri_proto::grid::GridUpdate;
+use serde_json::json;
+
+/// Mirrors the grid the way the app does: a seed plus changed-row diffs.
+#[derive(Default)]
+struct Mirror {
+    rows: Vec<String>,
+}
+
+impl Mirror {
+    fn apply(&mut self, update: &GridUpdate) {
+        self.rows.resize(usize::from(update.rows), String::new());
+        for row in &update.changed_rows {
+            let text: String = row
+                .cells
+                .iter()
+                .map(|cell| char::from_u32(cell.scalar).unwrap_or(' '))
+                .collect();
+            if let Some(slot) = self.rows.get_mut(usize::from(row.y)) {
+                *slot = text;
+            }
+        }
+    }
+
+    fn is_blank(&self) -> bool {
+        !self.rows.is_empty() && self.rows.iter().all(|row| row.trim().is_empty())
+    }
+
+    fn text(&self) -> String {
+        self.rows.join("\n")
+    }
+}
+
+struct FrameReader {
+    stream: UnixStream,
+    codec: FrameCodec,
+    queue: std::collections::VecDeque<Frame>,
+}
+
+impl FrameReader {
+    fn new(stream: UnixStream) -> Self {
+        Self {
+            stream,
+            codec: FrameCodec::new(),
+            queue: std::collections::VecDeque::new(),
+        }
+    }
+
+    fn next_frame(&mut self, what: &str, deadline: Instant) -> Frame {
+        let mut chunk = [0u8; 64 << 10];
+        loop {
+            if let Some(frame) = self.queue.pop_front() {
+                return frame;
+            }
+            assert!(Instant::now() < deadline, "timed out waiting for {what}");
+            let count = self.stream.read(&mut chunk).expect("read frames");
+            assert!(count > 0, "data channel closed while waiting for {what}");
+            self.queue
+                .extend(self.codec.feed(&chunk[..count]).expect("valid frames"));
+        }
+    }
+}
+
+fn engine() -> Arc<ManifestEngine> {
+    let dir = diri_engine::detect::bundled_manifest_dir()
+        .canonicalize()
+        .expect("manifests");
+    let (engine, _) = ManifestEngine::load_dir(&dir).expect("load");
+    Arc::new(engine)
+}
+
+#[test]
+fn an_erase_and_redraw_never_reach_a_client_as_a_blank_screen() {
+    let temp = tempfile::tempdir().expect("temp");
+    let registry = Arc::new(Mutex::new(Registry::new(
+        engine(),
+        temp.path().join("state.json"),
+    )));
+    let server = Arc::new(
+        ControlServer::new(Arc::clone(&registry), temp.path().join("daemon.sock"))
+            .with_logs_dir(temp.path().join("logs")),
+    );
+    let listener = server.bind().expect("bind");
+    {
+        let server = Arc::clone(&server);
+        std::thread::spawn(move || {
+            while let Ok((stream, _)) = listener.accept() {
+                let server = Arc::clone(&server);
+                std::thread::spawn(move || {
+                    let _ = server.serve(stream);
+                });
+            }
+        });
+    }
+
+    // A minimal TUI: every line of input repaints the screen the way a real
+    // one does — erase, then draw — as two separate writes.
+    let control = UnixStream::connect(server.socket_path()).expect("connect control");
+    let send = |message: &ControlMessage| {
+        let mut bytes = serde_json::to_vec(message).expect("encode");
+        bytes.push(b'\n');
+        (&control).write_all(&bytes).expect("write");
+    };
+    send(&ControlMessage::Request {
+        id: 1,
+        method: "session.spawn".into(),
+        params: Some(json!({
+            "kind": { "shell": {} },
+            "cwd": "/tmp",
+            "argv": [
+                "/bin/sh",
+                "-c",
+                "stty -echo; printf 'frame-0\\r\\n'; \
+                 while read -r turn; do \
+                   printf '\\033[2J\\033[H'; \
+                   printf 'frame-%s\\r\\n' \"$turn\"; \
+                 done",
+            ],
+        })),
+    });
+    let mut reader = std::io::BufReader::new(control.try_clone().expect("clone"));
+    let id = {
+        let mut line = String::new();
+        reader.read_line(&mut line).expect("spawn reply");
+        match serde_json::from_str::<ControlMessage>(&line).expect("decode") {
+            ControlMessage::Response {
+                result: Ok(result), ..
+            } => result["id"].as_str().expect("id").to_string(),
+            other => panic!("spawn failed: {other:?}"),
+        }
+    };
+
+    std::thread::sleep(Duration::from_millis(400));
+
+    let mut data = UnixStream::connect(server.socket_path()).expect("connect data");
+    let mut attach_line = serde_json::to_vec(&json!({ "attach": id })).expect("encode");
+    attach_line.push(b'\n');
+    data.write_all(&attach_line).expect("attach");
+
+    let mut frames = FrameReader::new(data.try_clone().expect("clone data"));
+    let mut mirror = Mirror::default();
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let frame = frames.next_frame("the seed grid", deadline);
+        if frame.frame_type != FrameType::Grid {
+            continue;
+        }
+        let update = frame.grid_payload().expect("decode").expect("grid");
+        mirror.apply(&update);
+        if mirror.text().contains("frame-0") {
+            break;
+        }
+    }
+
+    // One turn is a coin flip on scheduling; a run of them is not. Every
+    // repaint must land whole.
+    for turn in 1..=20 {
+        let expected = format!("frame-{turn}");
+        data.write_all(
+            &FrameCodec::encode(&Frame::input(format!("{turn}\n").into_bytes())).expect("encode"),
+        )
+        .expect("send turn");
+        loop {
+            let frame = frames.next_frame(&expected, deadline);
+            if frame.frame_type != FrameType::Grid {
+                continue;
+            }
+            let update = frame.grid_payload().expect("decode").expect("grid");
+            mirror.apply(&update);
+            assert!(
+                !mirror.is_blank(),
+                "turn {turn} published the erased half of a repaint as its own frame"
+            );
+            if mirror.text().contains(&expected) {
+                break;
+            }
+        }
+    }
+
+    send(&ControlMessage::Request {
+        id: 2,
+        method: "session.kill".into(),
+        params: Some(json!({ "sessionID": id })),
+    });
+}

--- a/diri/crates/diri-term/src/scrollback.rs
+++ b/diri/crates/diri-term/src/scrollback.rs
@@ -221,9 +221,17 @@ impl ScrollbackViewport {
 
     /// Re-pins the anchor to whatever content the window now shows. Returning
     /// to live drops the anchor so the view follows the bottom again.
+    ///
+    /// An anchor is an absolute row, so it only exists once geometry is known.
+    /// Before the first fetch answers, `live_start_row` is still zero and any
+    /// anchor derived from it names a row that does not exist: the first wheel
+    /// event of a session recorded a negative anchor, and the arriving geometry
+    /// re-derived the offset from it and threw the reader to the top of
+    /// history. While geometry is unknown the offset is the state, and it
+    /// carries over unchanged.
     fn sync_anchor(&mut self) {
-        self.anchor =
-            (self.view_offset > 0).then(|| self.live_start_row.saturating_sub(self.view_offset));
+        self.anchor = (self.geometry_known && self.view_offset > 0)
+            .then(|| self.live_start_row.saturating_sub(self.view_offset));
     }
 
     pub fn scroll_by(&mut self, lines: i64, visible_rows: usize) -> bool {
@@ -657,6 +665,45 @@ mod tests {
             viewport.view_offset(),
             546,
             "scrolling clamps at the oldest retained row"
+        );
+    }
+
+    #[test]
+    fn the_first_scroll_of_a_session_stays_where_the_wheel_put_it() {
+        // The very first wheel event happens before any fetch has told the
+        // viewport where the live edge is, so `live_start_row` is still 0. The
+        // anchor derived from it was a negative absolute row, and the moment
+        // real geometry landed the offset was recomputed against it and threw
+        // the reader to the oldest retained row.
+        let mut viewport = ScrollbackViewport::default();
+        assert!(!viewport.geometry_known());
+        viewport.scroll_by(5, 40);
+        assert_eq!(viewport.view_offset(), 5);
+
+        let request = viewport.begin_fetch(40).expect("first scroll wants rows");
+        let start = request.first_row.max(0);
+        let rows: Vec<_> = (start..start + request.max_rows)
+            .map(|_| row("history", 8))
+            .collect();
+        viewport
+            .complete_fetch(
+                ReadScrollbackCellsResult {
+                    payload: GridRowCodec::encode_rows(&rows).unwrap(),
+                    first_row: start,
+                    row_count: i64::try_from(rows.len()).unwrap(),
+                    total_rows: 1_040,
+                    live_start_row: 1_000,
+                    cols: 8,
+                    content_seq: 1,
+                },
+                40,
+            )
+            .unwrap();
+
+        assert_eq!(
+            viewport.view_offset(),
+            5,
+            "learning the live edge must not move the window"
         );
     }
 

--- a/diri/crates/diri-terminal-state/src/lib.rs
+++ b/diri/crates/diri-terminal-state/src/lib.rs
@@ -292,6 +292,7 @@ pub struct HeadlessScreen {
 
     content_seq: u64,
     last_digest: u64,
+    filled_cells: usize,
     /// Trailing bytes of the previous chunk, so an OSC split across a read
     /// boundary is still recognized.
     progress_carry: Vec<u8>,
@@ -327,6 +328,7 @@ impl HeadlessScreen {
             progress_value: None,
             content_seq: 0,
             last_digest: 0,
+            filled_cells: 0,
             progress_carry: Vec::new(),
             last_cells: Vec::new(),
             last_grid_cols: 0,
@@ -343,24 +345,65 @@ impl HeadlessScreen {
         self.scan_progress(bytes);
         let title_before = self.title.clone();
         self.parser.advance(&mut self.term, bytes);
-        self.drain_events();
+        self.settle(title_before);
+    }
 
-        // Damage is the cheap gate: when the emulator reports nothing
-        // touched, skip fingerprinting entirely. When it does (which includes
-        // invisible changes like a cursor toggle), a direct cell hash — no
-        // per-line String allocation — decides whether the *content* changed.
+    /// Ends a synchronized update (DECSET 2026) whose deadline has passed.
+    ///
+    /// Between `\e[?2026h` and `\e[?2026l` the parser holds every byte back so
+    /// the repaint lands as one atomic screen — which is exactly what we want,
+    /// and the reason a TUI that speaks this protocol never flickers. But the
+    /// escape hatch is the host's job: vte's timeout only records a deadline,
+    /// and nothing expires it. A child that opens a synchronized update and
+    /// then dies, stalls, or simply overruns 150ms would otherwise freeze the
+    /// pane until 2 MiB of output had piled up behind it. Callers tick this.
+    ///
+    /// Returns true when a held update was released.
+    pub fn flush_expired_sync(&mut self) -> bool {
+        let Some(deadline) = self.parser.sync_timeout().sync_timeout() else {
+            return false;
+        };
+        if std::time::Instant::now() < deadline {
+            return false;
+        }
+        let title_before = self.title.clone();
+        self.parser.stop_sync(&mut self.term);
+        self.settle(title_before);
+        true
+    }
+
+    /// Post-parse bookkeeping shared by `feed` and `flush_expired_sync`.
+    ///
+    /// Damage is the cheap gate: when the emulator reports nothing touched,
+    /// skip fingerprinting entirely. When it does (which includes invisible
+    /// changes like a cursor toggle), a direct cell hash — no per-line String
+    /// allocation — decides whether the *content* changed.
+    fn settle(&mut self, title_before: Option<String>) {
+        self.drain_events();
         let damaged = match self.term.damage() {
             alacritty_terminal::term::TermDamage::Full => true,
             alacritty_terminal::term::TermDamage::Partial(mut lines) => lines.next().is_some(),
         };
         self.term.reset_damage();
         if damaged || self.title != title_before {
-            let digest = self.digest_cells();
+            let (digest, filled) = self.fingerprint_cells();
+            self.filled_cells = filled;
             if digest != self.last_digest {
                 self.last_digest = digest;
                 self.content_seq += 1;
             }
         }
+    }
+
+    /// How many cells currently hold something other than a blank.
+    ///
+    /// A repaint that has erased but not yet redrawn is the one screen state
+    /// no observer should ever see, and this is what makes it recognizable:
+    /// output that only *removes* content is a repaint caught halfway. Free to
+    /// maintain — it falls out of the fingerprint walk already done per feed.
+    #[must_use]
+    pub fn filled_cells(&self) -> usize {
+        self.filled_cells
     }
 
     pub fn resize(&mut self, cols: usize, rows: usize) {
@@ -756,19 +799,25 @@ impl HeadlessScreen {
     /// Content fingerprint hashed straight off the grid cells, so
     /// `content_seq` only advances when the visible screen actually changed.
     /// Detection uses that to skip re-evaluating a frame it has already
-    /// judged.
-    fn digest_cells(&self) -> u64 {
+    /// judged. The non-blank count rides the same walk — see
+    /// [`filled_cells`](Self::filled_cells).
+    fn fingerprint_cells(&self) -> (u64, usize) {
         use std::hash::{Hash, Hasher};
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        let mut filled = 0;
         let grid = self.term.grid();
         for row in 0..self.geometry.rows {
             let line = Line(row as i32);
             for column in 0..self.geometry.cols {
-                grid[line][Column(column)].c.hash(&mut hasher);
+                let character = grid[line][Column(column)].c;
+                character.hash(&mut hasher);
+                if character != ' ' && character != '\0' {
+                    filled += 1;
+                }
             }
         }
         self.title.hash(&mut hasher);
-        hasher.finish()
+        (hasher.finish(), filled)
     }
 
     /// Extracts `ESC ] 9 ; 4 ; state ; value` progress reports.
@@ -1027,6 +1076,45 @@ mod tests {
         screen.feed(b"\x1b]9;4;1");
         screen.feed(b";75\x07");
         assert_eq!(screen.progress(), Some((1, 75)));
+    }
+
+    #[test]
+    fn a_synchronized_repaint_never_shows_its_erased_half() {
+        // What DECSET 2026 exists for: the child erases and redraws inside the
+        // bracket, and no observer may see the gap between the two.
+        let mut screen = screen_with(b"before the repaint\r\n");
+        let quiet = screen.content_seq();
+
+        screen.feed(b"\x1b[?2026h\x1b[2J\x1b[H");
+        assert_eq!(
+            screen.lines(),
+            vec!["before the repaint"],
+            "the erase is held back until the update closes"
+        );
+        assert_eq!(screen.content_seq(), quiet);
+
+        screen.feed(b"after the repaint\r\n\x1b[?2026l");
+        assert_eq!(screen.lines(), vec!["after the repaint"]);
+        assert!(screen.content_seq() > quiet);
+    }
+
+    #[test]
+    fn a_synchronized_update_the_child_never_closes_is_released() {
+        // vte records the 150ms deadline but nothing expires it, so without a
+        // host-side flush an abandoned bracket freezes the pane until 2 MiB of
+        // output has piled up behind it.
+        let mut screen = screen_with(b"before the repaint\r\n");
+        screen.feed(b"\x1b[?2026h\x1b[2J\x1b[Hafter the repaint\r\n");
+        assert!(!screen.flush_expired_sync(), "the deadline has not passed");
+        assert_eq!(screen.lines(), vec!["before the repaint"]);
+
+        std::thread::sleep(std::time::Duration::from_millis(160));
+        assert!(screen.flush_expired_sync(), "an overdue update is released");
+        assert_eq!(screen.lines(), vec!["after the repaint"]);
+        assert!(
+            !screen.flush_expired_sync(),
+            "releasing it once clears the deadline"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two artifacts from a friend's screen recordings of cursor-cli running in diri.

## The flicker

A TUI repaint is not one write. Ink, Ratatui and friends erase the old frame and draw the new one in separate `write`s, and a PTY hands each one over the instant it lands. The engine's pump published the grid **per read**, so attached clients got the erased half as its own frame.

In the recordings that shows up as cursor-cli's footer line (`~/GitHub/diri · main`) blinking out and back ~3×/second, and as a whole-screen blank flash when the repaint was a full clear:

| mid-repaint (published) | complete |
| --- | --- |
| footer line missing | footer line present |

A terminal emulator never shows that state, because its reader drains everything queued before it renders (alacritty reads up to 1 MiB per synchronization).

**Fix.** The pump now feeds a *batch* rather than a read:

- bytes already queued are always folded in — free, and what an emulator's reader does;
- a screen that just **lost** content — a repaint caught between its erase and its redraw — waits up to `OUTPUT_SETTLE` (3ms) for the rest, bounded by `OUTPUT_BATCH_CEILING` (8ms) and 1 MiB.

The "lost content" gate is what keeps this free: an echo only ever *adds*, so typed input never waits. `filled_cells` rides the fingerprint walk `feed` already does, so it costs nothing to maintain.

The holder follow pump gets the same treatment through its read budget: a full 64 KiB read means the tail is not caught up, so it holds the frame until it is.

### Synchronized updates

DECSET 2026 is the protocol for exactly this, and vte already honours it — but its 150ms deadline is only *recorded*, never expired. A child that opened a bracket and then stalled or died froze the pane until 2 MiB of output had piled up behind it. `HeadlessScreen::flush_expired_sync` releases it; both pumps tick it.

## The scroll

The first wheel event of a session happens before any fetch has told the viewport where the live edge is, so `live_start_row` was still `0` and the anchor derived from it named a *negative* absolute row. The moment real geometry landed, `apply_rows` re-derived the offset from that anchor and clamped it — throwing the reader to the oldest retained row. That is the "randomly scrolled to the very top" report.

An anchor is an absolute row, so it only exists once geometry is known; until then the offset is the state and carries over unchanged.

## Tests

- `diri-engine/tests/repaint.rs` — a child that erases and redraws over 20 turns; the mirrored grid must never go blank. Verified to fail on turn 1 without the batching (`OUTPUT_BATCH_CEILING = 0`).
- `a_synchronized_repaint_never_shows_its_erased_half`, `a_synchronized_update_the_child_never_closes_is_released`.
- `the_first_scroll_of_a_session_stays_where_the_wheel_put_it` — fails without the anchor fix (`view_offset` 1000 instead of 5).
- `attach.rs`'s existing input-to-grid median guard is unchanged: ~450µs, same as before this branch.

Full workspace suite green; clippy and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)