### PR TITLE
diri: give the sidebar one ordering model and show spawn lineage

### DIFF
--- a/diri/crates/diri-app/src/sidebar/fixture.rs
+++ b/diri/crates/diri-app/src/sidebar/fixture.rs
@@ -198,6 +198,9 @@ tokio::spawn(async move { clone_repository(request).await });
             occurred_at: DateMillis(now - 45_000.0),
         })
         .into();
+        // Two agents the Codex session spawned for itself, so the preview
+        // exercises the indent rail with one continuing and one terminating
+        // segment, plus a second level under the first child.
         let cursor: SessionRecord = session(
             "preview-cursor",
             AgentKind::CURSOR,
@@ -207,8 +210,32 @@ tokio::spawn(async move { clone_repository(request).await });
             Some("fix/focus-neighbor"),
             now - minutes(68.0),
         )
+        .child_of(&codex.id)
         .completed(now - 90_000.0)
         .seen(now - minutes(12.0))
+        .into();
+        let spawned_review: SessionRecord = session(
+            "preview-spawned-review",
+            AgentKind::CLAUDE_CODE,
+            &dirijor,
+            "Review the projection tests",
+            SessionStatus::Working,
+            Some("sidebar-craft"),
+            now - minutes(6.0),
+        )
+        .child_of(&codex.id)
+        .into();
+        let spawned_deep: SessionRecord = session(
+            "preview-spawned-deep",
+            AgentKind::CODEX,
+            &dirijor,
+            "Check the rail geometry",
+            SessionStatus::Idle,
+            Some("sidebar-craft"),
+            now - minutes(3.0),
+        )
+        .child_of(&cursor.id)
+        .seen(now - minutes(1.0))
         .into();
         let shell: SessionRecord = session(
             "preview-shell",
@@ -292,6 +319,8 @@ tokio::spawn(async move { clone_repository(request).await });
             codex.clone(),
             claude.clone(),
             cursor.clone(),
+            spawned_review,
+            spawned_deep,
             shell,
             gemini,
             question,
@@ -341,7 +370,7 @@ tokio::spawn(async move { clone_repository(request).await });
         let mut prefs = Prefs {
             sidebar_project_order: vec![dirijor.id.clone(), anara.id.clone(), settings.id.clone()],
             sidebar_session_order: sessions.iter().map(|session| session.id.clone()).collect(),
-            sidebar_pinned_sessions: vec![claude.id.clone(), cursor.id.clone()],
+            sidebar_pinned_sessions: vec![claude.id.clone()],
             sidebar_collapsed_projects: vec![anara.id.clone()],
             sidebar_expanded_archives: vec![settings.id.clone()],
             ..Prefs::default()
@@ -418,6 +447,13 @@ impl SessionBuilder {
         self.0.listening_ports = Some(ports);
         self
     }
+
+    /// Marks this session as spawned by another through the MCP tools, which
+    /// is what nests it under that row in the sidebar.
+    fn child_of(mut self, parent: &SessionId) -> Self {
+        self.0.parent = Some(parent.clone());
+        self
+    }
 }
 
 impl From<SessionBuilder> for SessionRecord {
@@ -491,8 +527,8 @@ mod tests {
     fn typical_fixture_matches_swift_counts_and_preferences() {
         let fixture = SidebarPreviewFixture::make(PreviewScenario::Typical);
         assert_eq!(fixture.list.projects.len(), 3);
-        assert_eq!(fixture.list.sessions.len(), 8);
-        assert_eq!(fixture.prefs.sidebar_pinned_sessions.len(), 2);
+        assert_eq!(fixture.list.sessions.len(), 10);
+        assert_eq!(fixture.prefs.sidebar_pinned_sessions.len(), 1);
         assert_eq!(fixture.prefs.sidebar_collapsed_projects.len(), 1);
         assert_eq!(fixture.prefs.sidebar_expanded_archives.len(), 1);
     }
@@ -500,13 +536,40 @@ mod tests {
     #[test]
     fn stress_fixture_adds_three_edge_cases() {
         let fixture = SidebarPreviewFixture::make(PreviewScenario::Stress);
-        assert_eq!(fixture.list.sessions.len(), 11);
+        assert_eq!(fixture.list.sessions.len(), 13);
         assert!(
             fixture
                 .list
                 .sessions
                 .iter()
                 .any(|session| { session.title.starts_with("Investigate why exceptionally") })
+        );
+    }
+
+    #[test]
+    fn typical_fixture_carries_a_two_level_spawn_tree() {
+        let mut store = SidebarPreviewFixture::make(PreviewScenario::Typical).into_store();
+        let projection = store.sidebar_projection();
+        let group = projection
+            .projects
+            .iter()
+            .find(|group| group.project.id == ProjectId::new("preview-dirijor"))
+            .expect("the dirijor group");
+        let nested: Vec<_> = group
+            .sessions
+            .iter()
+            .map(|row| (row.id().0.as_str(), row.depth))
+            .collect();
+        assert_eq!(
+            nested,
+            vec![
+                ("preview-claude", 0),
+                ("preview-codex", 0),
+                ("preview-cursor", 1),
+                ("preview-spawned-deep", 2),
+                ("preview-spawned-review", 1),
+                ("preview-shell", 0),
+            ]
         );
     }
 
@@ -536,6 +599,6 @@ mod tests {
             store.selected_session_id(),
             Some(&SessionId::new("preview-codex"))
         );
-        assert_eq!(store.sessions().len(), 8);
+        assert_eq!(store.sessions().len(), 10);
     }
 }

--- a/diri/crates/diri-app/src/sidebar/state.rs
+++ b/diri/crates/diri-app/src/sidebar/state.rs
@@ -13,6 +13,10 @@ pub enum DragItem {
     Session {
         id: SessionId,
         project: ProjectId,
+        /// The session that spawned this one, so a drop can tell a sibling
+        /// from a cousin. Reordering only ever moves a row inside its own
+        /// sibling run; re-parenting is the daemon's business, not a drag's.
+        parent: Option<SessionId>,
         archived: bool,
     },
     Sessions(Vec<SessionId>),

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -607,78 +607,9 @@ impl Sidebar {
             .into_any_element()
     }
 
-    fn pinned_section(
-        &mut self,
-        projects: &[crate::store::SidebarProject],
-        colors: SemanticColors,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> Option<AnyElement> {
-        let (pinned_projects, pinned_sessions) = {
-            let store = self.store.read().expect("session store lock poisoned");
-            (
-                store.preferences().sidebar_pinned_projects.clone(),
-                store.preferences().sidebar_pinned_sessions.clone(),
-            )
-        };
-        if pinned_projects.is_empty() && pinned_sessions.is_empty() {
-            return None;
-        }
-        let mut section = div().flex().flex_col().gap(px(1.0)).child(
-            div()
-                .px(px(Space::ROW_H))
-                .pt(px(4.0))
-                .pb(px(2.0))
-                .text_size(px(Typo::SECTION_HEADER.size))
-                .font_weight(Typo::SECTION_HEADER.weight)
-                .text_color(colors.tertiary)
-                .child("Pinned"),
-        );
-        for group in projects
-            .iter()
-            .filter(|group| pinned_projects.contains(&group.project.id))
-        {
-            section = section.child(self.project_section(group, true, colors, window, cx));
-        }
-        for id in pinned_sessions {
-            let session = projects
-                .iter()
-                .flat_map(|group| group.sessions.iter().chain(&group.archived))
-                .find(|session| session.id == id)
-                .cloned();
-            if let Some(session) = session {
-                let project_name = projects
-                    .iter()
-                    .find(|group| group.project.id == session.project_id)
-                    .map(|group| group.project.name.clone());
-                section = section.child(self.session_row(
-                    &session,
-                    project_name.as_deref(),
-                    None,
-                    true,
-                    colors,
-                    window,
-                    cx,
-                ));
-            }
-        }
-        Some(
-            section
-                .child(
-                    div()
-                        .mx(px(Space::ROW_H))
-                        .my(px(4.0))
-                        .h(px(1.0))
-                        .bg(colors.primary.alpha(0.06)),
-                )
-                .into_any_element(),
-        )
-    }
-
     fn project_section(
         &mut self,
         group: &crate::store::SidebarProject,
-        pinned_copy: bool,
         colors: SemanticColors,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -698,15 +629,7 @@ impl Sidebar {
         let drag_label: SharedString = group.project.name.clone().into();
         let mut section = div().flex().flex_col().gap(px(1.0)).child(
             div()
-                .id(format!(
-                    "{}:{}",
-                    if pinned_copy {
-                        "pinned-project"
-                    } else {
-                        "project"
-                    },
-                    id.0
-                ))
+                .id(format!("project:{}", id.0))
                 .mt(px(6.0))
                 .px(px(Space::ROW_H))
                 .py(px(5.0))
@@ -793,6 +716,7 @@ impl Sidebar {
                         .text_color(colors.primary.alpha(0.90))
                         .child(group.project.name.clone()),
                 )
+                .when(group.pinned, |row| row.child(pin_mark(colors)))
                 .child(
                     div()
                         .w(px(12.0))
@@ -869,34 +793,31 @@ impl Sidebar {
                     )
                 })
                 .when(!is_hovered && collapsed, |row| {
-                    row.child(AttentionDot::new(rollup_attention(&group.sessions), colors))
+                    row.child(AttentionDot::new(rollup_attention(&group.active), colors))
                 }),
         );
 
-        if !collapsed {
-            for session in &group.sessions {
-                let shortcut = self.shortcut_for(&session.id);
-                section = section
-                    .child(self.session_row(session, None, shortcut, false, colors, window, cx));
-            }
-            if !group.archived.is_empty() {
-                section = section.child(self.archived_bucket(group, colors, window, cx));
-            }
+        // The projection already folds a collapsed project away, so an empty
+        // row list here means "collapsed" without asking a second source.
+        for row in &group.sessions {
+            let shortcut = self.shortcut_for(row.id());
+            section = section.child(self.session_row(row, shortcut, colors, window, cx));
+        }
+        if !collapsed && !group.archived.is_empty() {
+            section = section.child(self.archived_bucket(group, colors, window, cx));
         }
         section.into_any_element()
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn session_row(
         &mut self,
-        session: &Arc<SessionRecord>,
-        project_name: Option<&str>,
+        row: &crate::store::SidebarRow,
         shortcut: Option<usize>,
-        pinned_copy: bool,
         colors: SemanticColors,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> AnyElement {
+        let session = &row.session;
         let id = session.id.clone();
         let (selected, multi, drag_selection, migrating) = {
             let mut store = self.store.write().expect("session store lock poisoned");
@@ -910,6 +831,7 @@ impl Sidebar {
         let hovered = self.ui.hovered_session.as_ref() == Some(&id);
         let archived = session.is_archived();
         let hibernated = session.hibernation.is_some();
+        let ended = matches!(session.status, diri_proto::SessionStatus::Exited(_)) && !archived;
         let host_label = session.host.as_ref().map(|host| {
             self.store
                 .read()
@@ -930,7 +852,7 @@ impl Sidebar {
         if self.ui.renaming.as_ref() == Some(&id) {
             return div()
                 .id(format!("rename:{}", id.0))
-                .pl(px(Space::ROW_H + Space::INDENT))
+                .pl(px(Space::ROW_H))
                 .pr(px(Space::ROW_H))
                 .h(px(Metrics::ROW_HEIGHT))
                 .flex()
@@ -938,7 +860,19 @@ impl Sidebar {
                 .gap(px(8.0))
                 .rounded(px(Radius::ROW))
                 .bg(RowFill::Selected.color(colors))
-                .child(self.status_glyph(session, migrating, colors, window, cx))
+                .children(indent_rails(row, colors))
+                // The fold control is inert mid-rename, but its column stays so
+                // the text does not slide sideways the moment editing starts.
+                .child(div().w(px(Space::INDENT)).flex_none())
+                .child(
+                    div()
+                        .size(px(16.0))
+                        .flex_none()
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .child(self.status_glyph(session, migrating, colors, window, cx)),
+                )
                 .child(
                     div()
                         .min_w(px(0.0))
@@ -962,6 +896,7 @@ impl Sidebar {
             DragItem::Session {
                 id: id.clone(),
                 project: session.project_id.clone(),
+                parent: session.parent.clone(),
                 archived,
             }
         };
@@ -969,16 +904,8 @@ impl Sidebar {
         let drag_label: SharedString = title.clone().into();
         let entity = cx.entity();
         div()
-            .id(format!(
-                "{}:{}",
-                if pinned_copy {
-                    "pinned-session"
-                } else {
-                    "session"
-                },
-                id.0
-            ))
-            .pl(px(Space::ROW_H + Space::INDENT))
+            .id(format!("session:{}", id.0))
+            .pl(px(Space::ROW_H))
             .pr(px(Space::ROW_H))
             .h(px(Metrics::ROW_HEIGHT))
             .flex()
@@ -1052,13 +979,19 @@ impl Sidebar {
             .drag_over::<DraggedSidebarItem>({
                 let target = id.clone();
                 let target_project = session.project_id.clone();
+                let target_parent = session.parent.clone();
                 move |element, dragged, _, cx| {
+                    // Siblings only. A row dropped on a cousin would shuffle
+                    // the manual order without moving anything on screen,
+                    // because each sibling run is sorted among itself.
                     if let DragItem::Session {
                         id: moved,
                         project,
+                        parent,
                         archived: false,
                     } = &dragged.0
                         && project == &target_project
+                        && parent == &target_parent
                     {
                         entity.update(cx, |this, cx| {
                             this.reorder_session(moved, &target);
@@ -1078,6 +1011,7 @@ impl Sidebar {
                         id,
                         project,
                         archived: true,
+                        ..
                     } = &dragged.0
                         && project == &target_project
                     {
@@ -1090,55 +1024,21 @@ impl Sidebar {
                     cx.notify();
                 }
             }))
-            .child({
-                let slot = div()
-                    .relative()
+            .children(indent_rails(row, colors))
+            .child(self.disclosure(row, colors, cx))
+            // The status glyph is the row's whole reason for existing at a
+            // glance, so it no longer yields its slot to the close button on
+            // hover -- pointing at a working agent used to hide the fact that
+            // it was working. The ✕ lives at the trailing edge instead.
+            .child(
+                div()
                     .size(px(16.0))
                     .flex_none()
                     .flex()
                     .items_center()
-                    .justify_center();
-                // On hover the identity mark yields its slot to a close
-                // button -- Safari-tab style; the glyph returns on mouse-out.
-                if hovered {
-                    let close_id = id.clone();
-                    slot.child(
-                        div()
-                            .id(format!("close:{}", id.0))
-                            // Spills 4px past the 16px slot so the target is a
-                            // comfortable 24px; the glyph stays centered.
-                            .absolute()
-                            .inset(px(-4.0))
-                            .flex()
-                            .items_center()
-                            .justify_center()
-                            .rounded(px(Radius::CHIP))
-                            .cursor_pointer()
-                            .text_color(colors.secondary)
-                            .hover(move |button| button.bg(Fill::subtle(colors)))
-                            // The row is draggable, and a press that wanders
-                            // 2px turns into a drag that swallows the click.
-                            // Keeping mouse-down off the row makes every press
-                            // on the ✕ a close.
-                            .on_mouse_down(MouseButton::Left, |_, _, cx| {
-                                cx.stop_propagation();
-                            })
-                            .child(sf_symbol_weighted(
-                                "xmark",
-                                8.5,
-                                SymbolWeight::Bold,
-                                colors.secondary,
-                            ))
-                            .on_click(cx.listener(move |this, _, _, cx| {
-                                cx.stop_propagation();
-                                this.close_sessions(vec![close_id.clone()], cx);
-                                cx.notify();
-                            })),
-                    )
-                } else {
-                    slot.child(self.status_glyph(session, migrating, colors, window, cx))
-                }
-            })
+                    .justify_center()
+                    .child(self.status_glyph(session, migrating, colors, window, cx)),
+            )
             .child(
                 div()
                     .min_w(px(0.0))
@@ -1148,81 +1048,119 @@ impl Sidebar {
                     .text_ellipsis()
                     .text_size(px(Typo::ROW.size))
                     .text_color(colors.primary.alpha(if selected { 1.0 } else { 0.82 }))
-                    .child(title),
+                    .child(title.clone()),
             )
-            .when(migrating, |row| {
-                row.child(
-                    div()
-                        .flex_none()
-                        .px(px(5.0))
-                        .py(px(1.0))
-                        .rounded(px(Radius::CHIP))
-                        .bg(Fill::subtle(colors))
-                        .text_size(px(Typo::META.size))
-                        .font_weight(Typo::META.weight)
-                        .text_color(colors.secondary)
-                        .whitespace_nowrap()
-                        .child("Moving…"),
-                )
+            .when(row.pinned, |element| element.child(pin_mark(colors)))
+            // Chips, in descending order of how much they explain an otherwise
+            // inert-looking row. Each is flex_none and the title absorbs the
+            // remaining width, so a narrow sidebar truncates the title rather
+            // than dropping the reason it is not moving.
+            .when(migrating, |element| {
+                element.child(state_chip("Moving…", colors.secondary, colors))
             })
-            .when_some(host_label, |row, host| {
-                // Remote-host chip: this session's agent runs on another machine.
-                row.child(
-                    div()
-                        .flex_none()
-                        .px(px(5.0))
-                        .py(px(1.0))
-                        .rounded(px(Radius::CHIP))
-                        .bg(Fill::subtle(colors))
-                        .text_size(px(Typo::META.size))
-                        .font_weight(Typo::META.weight)
-                        .text_color(colors.tertiary)
-                        .whitespace_nowrap()
-                        .child(host),
-                )
+            .when(ended && title != ENDED_TITLE, |element| {
+                // An exited session with a real title otherwise looks alive:
+                // the glyph goes quiet and nothing else says why.
+                element.child(state_chip("Ended", colors.tertiary, colors))
             })
-            .when_some(project_name.map(str::to_owned), |row, project_name| {
-                row.child(
-                    div()
-                        .max_w(px(72.0))
-                        .whitespace_nowrap()
-                        .overflow_hidden()
-                        .text_ellipsis()
-                        .text_size(px(Typo::META.size))
-                        .text_color(colors.tertiary)
-                        .child(project_name),
-                )
-            })
-            .when(hibernated, |row| {
+            .when(hibernated, |element| {
                 // Hibernation chip. An 8px moon glyph was a smudge at this
                 // size; the chip reads at a glance and matches the host badge.
-                row.child(
+                element.child(state_chip("Zzz", colors.tertiary, colors))
+            })
+            .when_some(host_label, |element, host| {
+                // Remote-host chip: this session's agent runs on another machine.
+                element.child(state_chip(host, colors.tertiary, colors))
+            })
+            .when(hovered, |element| {
+                let close_id = id.clone();
+                element.child(
                     div()
+                        .id(format!("close:{}", id.0))
+                        .size(px(16.0))
                         .flex_none()
-                        .px(px(5.0))
-                        .py(px(1.0))
+                        .flex()
+                        .items_center()
+                        .justify_center()
                         .rounded(px(Radius::CHIP))
-                        .bg(Fill::subtle(colors))
-                        .text_size(px(Typo::META.size - 1.0))
-                        .font_weight(Typo::META.weight)
-                        .text_color(colors.tertiary)
-                        .whitespace_nowrap()
-                        .child("Zzz"),
+                        .cursor_pointer()
+                        .text_color(colors.secondary)
+                        .hover(move |button| button.bg(Fill::subtle(colors)))
+                        // The row is draggable, and a press that wanders
+                        // 2px turns into a drag that swallows the click.
+                        // Keeping mouse-down off the row makes every press
+                        // on the ✕ a close.
+                        .on_mouse_down(MouseButton::Left, |_, _, cx| {
+                            cx.stop_propagation();
+                        })
+                        .child(sf_symbol_weighted(
+                            "xmark",
+                            8.5,
+                            SymbolWeight::Bold,
+                            colors.secondary,
+                        ))
+                        .on_click(cx.listener(move |this, _, _, cx| {
+                            cx.stop_propagation();
+                            this.close_sessions(vec![close_id.clone()], cx);
+                            cx.notify();
+                        })),
                 )
             })
+            // The hint and the ✕ share the trailing edge and never both apply:
+            // hovering a row is the moment you want to close it, not the
+            // moment you need to be told how to reach it from the keyboard.
             .when_some(
-                ((hovered || selected) && !pinned_copy)
-                    .then_some(shortcut)
-                    .flatten(),
-                |row, index| {
-                    row.child(
+                (!hovered && selected).then_some(shortcut).flatten(),
+                |element, index| {
+                    element.child(
                         div()
+                            .flex_none()
                             .text_size(px(Typo::META.size))
                             .text_color(colors.tertiary)
                             .child(format!("⌘{index}")),
                     )
                 },
             )
+            .into_any_element()
+    }
+
+    /// The fold control for a row that spawned children, drawn in the same
+    /// column a deeper row's rail occupies so titles stay on one axis whether
+    /// or not a row has children.
+    fn disclosure(
+        &self,
+        row: &crate::store::SidebarRow,
+        colors: SemanticColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let slot = div().w(px(Space::INDENT)).flex_none().flex().items_center();
+        if !row.has_children {
+            return slot.into_any_element();
+        }
+        let id = row.id().clone();
+        slot.id(format!("fold:{}", id.0))
+            .justify_center()
+            .cursor_pointer()
+            .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+            .on_click(cx.listener(move |this, _, _, cx| {
+                cx.stop_propagation();
+                let _ = this
+                    .store
+                    .write()
+                    .expect("session store lock poisoned")
+                    .toggle_session_collapsed(id.clone());
+                cx.notify();
+            }))
+            .child(sf_symbol_weighted(
+                if row.collapsed {
+                    "chevron.right"
+                } else {
+                    "chevron.down"
+                },
+                8.0,
+                SymbolWeight::Bold,
+                colors.tertiary,
+            ))
             .into_any_element()
     }
 
@@ -1284,6 +1222,7 @@ impl Sidebar {
                             id,
                             project,
                             archived: false,
+                            ..
                         } if project == &project_id => vec![id.clone()],
                         DragItem::Sessions(ids) => ids.clone(),
                         _ => Vec::new(),
@@ -1416,6 +1355,7 @@ impl Sidebar {
                 DraggedSidebarItem(DragItem::Session {
                     id: id.clone(),
                     project: session.project_id.clone(),
+                    parent: session.parent.clone(),
                     archived: true,
                 }),
                 move |_, _, _, cx| {
@@ -2707,16 +2647,14 @@ impl Sidebar {
 
     fn reorder_project(&mut self, moved: &ProjectId, target: &ProjectId) {
         let mut store = self.store.write().expect("session store lock poisoned");
-        let mut order = store.preferences().sidebar_project_order.clone();
-        ensure_present(&mut order, store.projects().keys().cloned());
+        let mut order = store.sidebar_project_order();
         move_before(&mut order, moved, target);
         self.ui.order_dirty |= store.stage_project_order(order);
     }
 
     fn reorder_session(&mut self, moved: &SessionId, target: &SessionId) {
         let mut store = self.store.write().expect("session store lock poisoned");
-        let mut order = store.preferences().sidebar_session_order.clone();
-        ensure_present(&mut order, store.sessions().keys().cloned());
+        let mut order = store.sidebar_session_order();
         move_before(&mut order, moved, target);
         self.ui.order_dirty |= store.stage_session_order(order);
     }
@@ -2741,8 +2679,7 @@ impl Sidebar {
     /// its own group" — which is what ⌃⌘↓ on the bottom-but-one row means.
     fn reorder_session_to_end(&mut self, moved: &SessionId) {
         let mut store = self.store.write().expect("session store lock poisoned");
-        let mut order = store.preferences().sidebar_session_order.clone();
-        ensure_present(&mut order, store.sessions().keys().cloned());
+        let mut order = store.sidebar_session_order();
         move_to_end(&mut order, moved);
         let _ = store.set_session_order(order);
     }
@@ -2866,9 +2803,11 @@ impl Sidebar {
         true
     }
 
-    /// ⌃⌘↑/⌃⌘↓: move the selected session one row inside its own project
-    /// group. Clamps at the group edges — a reorder that wrapped would
-    /// teleport the row past every other project.
+    /// ⌃⌘↑/⌃⌘↓: move the selected session one place among its own siblings —
+    /// the rows sharing its parent inside its project. Clamps at the ends of
+    /// that run: a reorder that wrapped would teleport the row past every
+    /// other project, and one that crossed levels would silently re-parent a
+    /// session, which is the daemon's call to make, not a keystroke's.
     pub fn reorder_selected(&mut self, delta: isize, cx: &mut Context<Self>) -> bool {
         self.commit_rename();
         let (moved, target) = {
@@ -2880,28 +2819,38 @@ impl Sidebar {
             let Some(group) = projection
                 .projects
                 .iter()
-                .find(|group| group.sessions.iter().any(|session| session.id == selected))
+                .find(|group| group.sessions.iter().any(|row| row.id() == &selected))
             else {
                 return false;
             };
-            let index = group
+            let parent = group
                 .sessions
                 .iter()
-                .position(|session| session.id == selected)
+                .find(|row| row.id() == &selected)
+                .and_then(|row| row.session.parent.clone());
+            let siblings: Vec<&SessionId> = group
+                .sessions
+                .iter()
+                .filter(|row| row.session.parent == parent)
+                .map(|row| row.id())
+                .collect();
+            let index = siblings
+                .iter()
+                .position(|id| *id == &selected)
                 .expect("the group was found by this id");
             let destination = index as isize + delta;
-            if destination < 0 || destination >= group.sessions.len() as isize {
+            if destination < 0 || destination >= siblings.len() as isize {
                 return false;
             }
-            // Moving up lands before the row above; moving down lands before
-            // the row two below, i.e. just after the row it swaps with. Off
-            // the end there is no anchor, so the move goes to the tail.
+            // Moving up lands before the sibling above; moving down lands
+            // before the one two below, i.e. just after the row it swaps with.
+            // Off the end there is no anchor, so the move goes to the tail.
             let target = if delta < 0 {
-                group.sessions.get(destination as usize)
+                siblings.get(destination as usize)
             } else {
-                group.sessions.get(destination as usize + 1)
+                siblings.get(destination as usize + 1)
             }
-            .map(|session| session.id.clone());
+            .map(|id| (*id).clone());
             (selected, target)
         };
         match target {
@@ -3016,11 +2965,8 @@ impl Render for Sidebar {
             .flex()
             .flex_col()
             .gap(px(2.0));
-        if let Some(pinned) = self.pinned_section(&projection.projects, colors, window, cx) {
-            list = list.child(pinned);
-        }
         for group in &projection.projects {
-            list = list.child(self.project_section(group, false, colors, window, cx));
+            list = list.child(self.project_section(group, colors, window, cx));
         }
 
         let mut root = div()
@@ -3084,6 +3030,69 @@ fn icon_button(
         .on_click(on_click)
         .on_hover(on_hover)
         .child(sf_symbol(system_image, 15.0, colors.secondary))
+        .into_any_element()
+}
+
+/// Title `display_title` gives a placeholder-named session that has exited.
+/// The "Ended" chip stands down when the title already says it.
+const ENDED_TITLE: &str = "Ended";
+
+/// One leading column per ancestor level. A column is drawn full height while
+/// that ancestor still has siblings below, and stops halfway on the last child
+/// so a subtree visibly closes instead of trailing a rail into the next row.
+fn indent_rails(row: &crate::store::SidebarRow, colors: SemanticColors) -> Vec<AnyElement> {
+    (0..row.depth)
+        .map(|column| {
+            let continues = row.rails & (1u32 << column.min(31)) != 0;
+            let last_column = column + 1 == row.depth;
+            div()
+                .w(px(Space::INDENT))
+                .h(px(Metrics::ROW_HEIGHT))
+                .flex_none()
+                .flex()
+                .justify_center()
+                .child(
+                    div()
+                        .w(px(1.0))
+                        // A rail that neither continues nor elbows into this
+                        // row has no business being drawn at all.
+                        .h(px(if continues {
+                            Metrics::ROW_HEIGHT
+                        } else if last_column {
+                            Metrics::ROW_HEIGHT / 2.0
+                        } else {
+                            0.0
+                        }))
+                        .bg(colors.primary.alpha(0.10)),
+                )
+                .into_any_element()
+        })
+        .collect()
+}
+
+fn pin_mark(colors: SemanticColors) -> AnyElement {
+    div()
+        .flex_none()
+        .flex()
+        .items_center()
+        .child(sf_symbol("pin.fill", 9.0, colors.tertiary))
+        .into_any_element()
+}
+
+/// The row's shared chip: one state, stated in the smallest space that still
+/// reads. Every chip on a row is the same shape so they scan as one lane.
+fn state_chip(label: impl Into<SharedString>, tint: Rgba, colors: SemanticColors) -> AnyElement {
+    div()
+        .flex_none()
+        .px(px(5.0))
+        .py(px(1.0))
+        .rounded(px(Radius::CHIP))
+        .bg(Fill::subtle(colors))
+        .text_size(px(Typo::META.size))
+        .font_weight(Typo::META.weight)
+        .text_color(tint)
+        .whitespace_nowrap()
+        .child(label.into())
         .into_any_element()
 }
 
@@ -3340,14 +3349,6 @@ const fn attention_rank(level: AttentionLevel) -> u8 {
         AttentionLevel::Working => 2,
         AttentionLevel::DoneUnseen => 3,
         AttentionLevel::NeedsInput { .. } => 4,
-    }
-}
-
-fn ensure_present<T: Clone + PartialEq>(order: &mut Vec<T>, values: impl IntoIterator<Item = T>) {
-    for value in values {
-        if !order.contains(&value) {
-            order.push(value);
-        }
     }
 }
 

--- a/diri/crates/diri-app/src/store/mod.rs
+++ b/diri/crates/diri-app/src/store/mod.rs
@@ -30,7 +30,7 @@ use crate::switcher::{
 };
 
 pub use prefs::{DefaultAgent, InspectorTab, Prefs, WindowMode, WindowPlacement};
-pub use projection::{SidebarProject, SidebarProjection};
+pub use projection::{SidebarProject, SidebarProjection, SidebarRow};
 pub use residency::{ResidencyUpdate, TerminalResidency};
 
 pub const AUXILIARY_TERMINAL_TITLE: &str = "Terminal";
@@ -537,6 +537,114 @@ impl SessionStore {
         self.persist_preferences()
     }
 
+    /// Brings the persisted sidebar order back in line with what actually
+    /// exists: dead ids are dropped, and anything new is appended.
+    ///
+    /// This is what makes the order a *total* one. Before it existed the
+    /// comparator split rows into "manually ordered" and "everything else",
+    /// which had two visible costs: a new session sorted into the middle of
+    /// the list rather than the end, and a row dragged to the bottom of a
+    /// group snapped back above its unordered siblings on the next frame.
+    ///
+    /// New ids are appended in arrival order — the same order the projection
+    /// falls back to — so materialising the order never moves a single row.
+    /// Runs on membership changes only, and reports whether it wrote anything.
+    fn reconcile_sidebar_order(&mut self) -> bool {
+        let live_sessions: HashSet<&SessionId> = self.sessions.keys().collect();
+        let live_projects: HashSet<&ProjectId> = self.projects.keys().collect();
+        let mut arrivals: Vec<(f64, &SessionId)> = self
+            .sessions
+            .values()
+            .map(|session| (session.created_at.0, &session.id))
+            .collect();
+        arrivals.sort_by(|(left, left_id), (right, right_id)| {
+            left.total_cmp(right)
+                .then_with(|| left_id.0.cmp(&right_id.0))
+        });
+
+        // A project arrives with its oldest session, matching the projection.
+        let mut project_arrivals: HashMap<&ProjectId, f64> = HashMap::new();
+        for session in self.sessions.values() {
+            let arrival = project_arrivals
+                .entry(&session.project_id)
+                .or_insert(f64::INFINITY);
+            *arrival = arrival.min(session.created_at.0);
+        }
+        let mut projects: Vec<(f64, &ProjectId)> = self
+            .projects
+            .keys()
+            .map(|id| {
+                (
+                    project_arrivals.get(id).copied().unwrap_or(f64::INFINITY),
+                    id,
+                )
+            })
+            .collect();
+        projects.sort_by(|(left, left_id), (right, right_id)| {
+            left.total_cmp(right)
+                .then_with(|| left_id.0.cmp(&right_id.0))
+        });
+
+        let sessions = reconcile_order(
+            &self.prefs.sidebar_session_order,
+            &live_sessions,
+            arrivals.into_iter().map(|(_, id)| id),
+        );
+        let ordered_projects = reconcile_order(
+            &self.prefs.sidebar_project_order,
+            &live_projects,
+            projects.into_iter().map(|(_, id)| id),
+        );
+        // Collapse and pin state for rows that no longer exist would otherwise
+        // accumulate in prefs.json forever and reattach to a recycled id.
+        let collapsed_sessions =
+            retain_live(&self.prefs.sidebar_collapsed_sessions, &live_sessions);
+        let pinned_sessions = retain_live(&self.prefs.sidebar_pinned_sessions, &live_sessions);
+
+        let mut changed = false;
+        if let Some(order) = sessions {
+            self.prefs.sidebar_session_order = order;
+            changed = true;
+        }
+        if let Some(order) = ordered_projects {
+            self.prefs.sidebar_project_order = order;
+            changed = true;
+        }
+        if let Some(collapsed) = collapsed_sessions {
+            self.prefs.sidebar_collapsed_sessions = collapsed;
+            changed = true;
+        }
+        if let Some(pinned) = pinned_sessions {
+            self.prefs.sidebar_pinned_sessions = pinned;
+            changed = true;
+        }
+        if changed {
+            self.invalidate_projection();
+        }
+        changed
+    }
+
+    /// [`Self::reconcile_sidebar_order`] plus the one prefs write it earns.
+    /// Session membership changes at human speed, so this is not hot.
+    fn sync_sidebar_order(&mut self) {
+        if self.reconcile_sidebar_order() {
+            let _ = self.persist_preferences();
+        }
+    }
+
+    /// The manual session order, guaranteed to name every live session, for a
+    /// caller about to move one row within it.
+    pub fn sidebar_session_order(&mut self) -> Vec<SessionId> {
+        self.reconcile_sidebar_order();
+        self.prefs.sidebar_session_order.clone()
+    }
+
+    /// See [`Self::sidebar_session_order`].
+    pub fn sidebar_project_order(&mut self) -> Vec<ProjectId> {
+        self.reconcile_sidebar_order();
+        self.prefs.sidebar_project_order.clone()
+    }
+
     pub fn set_project_order(&mut self, order: Vec<ProjectId>) -> io::Result<()> {
         self.update_preferences(|prefs| prefs.sidebar_project_order = order)
     }
@@ -582,6 +690,43 @@ impl SessionStore {
         self.update_preferences(|prefs| {
             toggle_vec_member(&mut prefs.sidebar_collapsed_projects, id)
         })
+    }
+
+    /// Folds or unfolds a session's spawned children. Collapsing the ancestor
+    /// of the current selection would hide it, so the selection moves up to
+    /// the row doing the folding rather than disappearing under it.
+    pub fn toggle_session_collapsed(&mut self, id: SessionId) -> io::Result<()> {
+        let collapsing = !self.prefs.sidebar_collapsed_sessions.contains(&id);
+        if collapsing
+            && let Some(selected) = self.selected_session_id.clone()
+            && self.is_descendant_of(&selected, &id)
+        {
+            self.select(id.clone());
+        }
+        self.update_preferences(|prefs| {
+            toggle_vec_member(&mut prefs.sidebar_collapsed_sessions, id)
+        })
+    }
+
+    fn is_descendant_of(&self, candidate: &SessionId, ancestor: &SessionId) -> bool {
+        let mut seen = HashSet::from([candidate.clone()]);
+        let mut cursor = self
+            .sessions
+            .get(candidate)
+            .and_then(|session| session.parent.clone());
+        while let Some(node) = cursor {
+            if &node == ancestor {
+                return true;
+            }
+            if !seen.insert(node.clone()) {
+                return false;
+            }
+            cursor = self
+                .sessions
+                .get(&node)
+                .and_then(|session| session.parent.clone());
+        }
+        false
     }
 
     pub fn toggle_archive_expanded(&mut self, id: ProjectId) -> io::Result<()> {
@@ -660,6 +805,7 @@ impl SessionStore {
             self.selected_session_id = None;
         }
         self.invalidate_projection();
+        self.sync_sidebar_order();
         self.auto_select_if_needed();
         // A restored selection did not travel through `focus_session`, so it
         // still needs terminal residency before the pane can attach.
@@ -754,6 +900,7 @@ impl SessionStore {
                     }
                     self.projects.insert(project.id.clone(), project);
                     self.invalidate_projection();
+                    self.sync_sidebar_order();
                     return StoreEventChange::Model;
                 }
             }
@@ -790,6 +937,11 @@ impl SessionStore {
             }
         }
         self.invalidate_projection();
+        // Only membership moves the order, and a session record is republished
+        // on every title, status, and resource tick.
+        if is_new {
+            self.sync_sidebar_order();
+        }
         for transition in transitions {
             self.emit(StoreEffect::StatusTransition(transition));
         }
@@ -818,6 +970,7 @@ impl SessionStore {
             self.emit(StoreEffect::DetachAttachment(id.clone()));
         }
         self.invalidate_projection();
+        self.sync_sidebar_order();
         self.reconcile_navigation();
     }
 
@@ -1427,8 +1580,7 @@ impl SessionStore {
             &self.closing,
         );
         projection
-            .ordered_sessions
-            .first()
+            .first_active()
             .map(|session| session.cwd.clone())
             .or_else(|| {
                 projection
@@ -1451,7 +1603,8 @@ impl SessionStore {
     fn focus_session(&mut self, id: SessionId) {
         let selection_changed = self.selected_session_id.as_ref() != Some(&id);
         self.selected_session_id = Some(id.clone());
-        if selection_changed || self.prefs.last_selected_session.as_ref() != Some(&id) {
+        let revealed = self.reveal(&id);
+        if selection_changed || revealed || self.prefs.last_selected_session.as_ref() != Some(&id) {
             self.prefs.last_selected_session = Some(id.clone());
             if let Err(error) = self.persist_preferences() {
                 eprintln!("diri: could not remember the selected session: {error}");
@@ -1504,8 +1657,7 @@ impl SessionStore {
         }
         let first = self
             .sidebar_projection()
-            .ordered_sessions
-            .first()
+            .first_active()
             .map(|session| session.id.clone());
         self.set_selected_survivor(first);
     }
@@ -1538,6 +1690,61 @@ impl SessionStore {
         self.overview.reconcile(&sessions);
     }
 
+    /// Unfolds whatever is hiding `id` so the selected row is on screen: its
+    /// project, every session up its spawn chain, and the archive bucket when
+    /// the row is parked. Reports whether anything actually moved.
+    ///
+    /// This is the invariant that keeps collapse honest. Without it ⌘J, the
+    /// switcher, and an MCP focus can all land on a row the user cannot see,
+    /// and the sidebar shows no selection at all while the workbench shows a
+    /// session — which reads as the app losing track of itself.
+    fn reveal(&mut self, id: &SessionId) -> bool {
+        let Some(session) = self.sessions.get(id).cloned() else {
+            return false;
+        };
+        let mut changed = false;
+        let project = session.project_id.clone();
+        if let Some(index) = self
+            .prefs
+            .sidebar_collapsed_projects
+            .iter()
+            .position(|candidate| candidate == &project)
+        {
+            self.prefs.sidebar_collapsed_projects.remove(index);
+            changed = true;
+        }
+        if session.is_archived() && !self.prefs.sidebar_expanded_archives.contains(&project) {
+            self.prefs.sidebar_expanded_archives.push(project);
+            changed = true;
+        }
+        // Walk up the spawn chain. `seen` guards against a cycle the daemon
+        // should never produce but which would spin here if it did.
+        let mut seen = HashSet::from([id.clone()]);
+        let mut cursor = session.parent.clone();
+        while let Some(ancestor) = cursor {
+            if !seen.insert(ancestor.clone()) {
+                break;
+            }
+            if let Some(index) = self
+                .prefs
+                .sidebar_collapsed_sessions
+                .iter()
+                .position(|candidate| candidate == &ancestor)
+            {
+                self.prefs.sidebar_collapsed_sessions.remove(index);
+                changed = true;
+            }
+            cursor = self
+                .sessions
+                .get(&ancestor)
+                .and_then(|record| record.parent.clone());
+        }
+        if changed {
+            self.invalidate_projection();
+        }
+        changed
+    }
+
     fn sidebar_visible_order(&mut self) -> Vec<SessionId> {
         let expanded: HashSet<_> = self
             .prefs
@@ -1549,14 +1756,14 @@ impl SessionStore {
             .projects
             .iter()
             .flat_map(|group| {
-                group.sessions.iter().chain(
+                group.sessions.iter().map(|row| row.id().clone()).chain(
                     group
                         .archived
                         .iter()
-                        .filter(|_| expanded.contains(&group.project.id)),
+                        .filter(|_| expanded.contains(&group.project.id))
+                        .map(|session| session.id.clone()),
                 )
             })
-            .map(|session| session.id.clone())
             .collect()
     }
 
@@ -1578,6 +1785,47 @@ fn attention_rank(attention: &AttentionLevel) -> u8 {
         AttentionLevel::DoneUnseen => 3,
         AttentionLevel::NeedsInput => 4,
     }
+}
+
+/// Drops ids that no longer exist and appends the ones the order has not seen,
+/// in `arriving` order. Returns `None` when the order already agreed, so a
+/// caller can skip a prefs write on the overwhelmingly common no-op.
+fn reconcile_order<'a, T>(
+    order: &[T],
+    live: &HashSet<&T>,
+    arriving: impl Iterator<Item = &'a T>,
+) -> Option<Vec<T>>
+where
+    T: Clone + Eq + std::hash::Hash + 'a,
+{
+    let mut next: Vec<T> = order
+        .iter()
+        .filter(|id| live.contains(id))
+        .cloned()
+        .collect();
+    let known: HashSet<&T> = order.iter().collect();
+    let appended: Vec<T> = arriving
+        .filter(|id| !known.contains(*id))
+        .cloned()
+        .collect();
+    if next.len() == order.len() && appended.is_empty() {
+        return None;
+    }
+    next.extend(appended);
+    Some(next)
+}
+
+/// Prunes ids that no longer exist, or `None` when there was nothing to prune.
+fn retain_live<T: Clone + Eq + std::hash::Hash>(
+    values: &[T],
+    live: &HashSet<&T>,
+) -> Option<Vec<T>> {
+    let kept: Vec<T> = values
+        .iter()
+        .filter(|id| live.contains(id))
+        .cloned()
+        .collect();
+    (kept.len() != values.len()).then_some(kept)
 }
 
 fn toggle_vec_member<T: PartialEq>(values: &mut Vec<T>, value: T) {

--- a/diri/crates/diri-app/src/store/prefs.rs
+++ b/diri/crates/diri-app/src/store/prefs.rs
@@ -102,6 +102,8 @@ pub struct Prefs {
     pub sidebar_pinned_projects: Vec<ProjectId>,
     pub sidebar_pinned_sessions: Vec<SessionId>,
     pub sidebar_collapsed_projects: Vec<ProjectId>,
+    /// Sessions whose spawned children are folded away.
+    pub sidebar_collapsed_sessions: Vec<SessionId>,
     pub sidebar_expanded_archives: Vec<ProjectId>,
     /// Session that should regain focus after the daemon's initial hydrate.
     pub last_selected_session: Option<SessionId>,
@@ -134,6 +136,7 @@ impl Default for Prefs {
             sidebar_pinned_projects: Vec::new(),
             sidebar_pinned_sessions: Vec::new(),
             sidebar_collapsed_projects: Vec::new(),
+            sidebar_collapsed_sessions: Vec::new(),
             sidebar_expanded_archives: Vec::new(),
             last_selected_session: None,
         }

--- a/diri/crates/diri-app/src/store/projection.rs
+++ b/diri/crates/diri-app/src/store/projection.rs
@@ -7,20 +7,68 @@ use diri_proto::{Project, ProjectId, SessionId, SessionRecord};
 
 use super::{Prefs, is_auxiliary_terminal};
 
+/// Rank given to an item the manual order has never seen. Reconciliation
+/// normally appends every live id (see [`super::SessionStore::reconcile_sidebar_order`]),
+/// so this only applies to stores built straight from a fixture — and the
+/// tie-breaks below then reproduce exactly the order reconciliation would have
+/// written, which is what lets both paths agree.
+const UNRANKED: usize = usize::MAX;
+
+/// One rendered session line inside a project group.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SidebarRow {
+    pub session: Arc<SessionRecord>,
+    /// Nesting level inside the group. Zero is a session a human started;
+    /// deeper rows were spawned by an ancestor through the MCP tools.
+    pub depth: u16,
+    /// This row has children, whether or not they are currently shown.
+    pub has_children: bool,
+    /// This row's subtree is folded away.
+    pub collapsed: bool,
+    pub pinned: bool,
+    /// One bit per indent column: set when that column's rail continues past
+    /// this row, i.e. the ancestor owning it still has siblings below. The
+    /// column directly parenting this row is bit `depth - 1`, so a last child
+    /// leaves it clear and the rail stops on its elbow.
+    pub rails: u32,
+}
+
+impl SidebarRow {
+    pub fn id(&self) -> &SessionId {
+        &self.session.id
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct SidebarProject {
     pub project: Project,
-    pub sessions: Vec<Arc<SessionRecord>>,
+    /// Visible rows in tree order. Subtrees under a collapsed row are omitted,
+    /// and the list is empty while the project itself is collapsed.
+    pub sessions: Vec<SidebarRow>,
+    /// Every active session in the group, in the same tree order, regardless of
+    /// what is folded away. Rollups and selection ranges read this.
+    pub active: Vec<Arc<SessionRecord>>,
     pub archived: Vec<Arc<SessionRecord>>,
+    pub pinned: bool,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct SidebarProjection {
     pub projects: Vec<SidebarProject>,
-    /// Flat command-1…9 order. Archived rows are omitted unless selected.
+    /// Flat ⌘1…⌘9 order over rows the user can actually see. Archived rows are
+    /// omitted unless selected.
     pub ordered_sessions: Vec<Arc<SessionRecord>>,
-    /// Active then archived rows per project, regardless of archive expansion.
+    /// Active then archived rows per project, regardless of what is collapsed.
     pub display_order: Vec<SessionId>,
+}
+
+impl SidebarProjection {
+    /// The row an empty selection should fall back to: the first active
+    /// session in sidebar order, whether or not its project is collapsed.
+    /// Selecting it unfolds whatever is hiding it (`SessionStore::reveal`).
+    pub fn first_active(&self) -> Option<&Arc<SessionRecord>> {
+        self.projects.iter().find_map(|group| group.active.first())
+    }
 }
 
 pub(super) fn build_projection(
@@ -45,36 +93,30 @@ pub(super) fn build_projection(
             .push(Arc::clone(session));
     }
 
-    let session_rank: HashMap<&SessionId, usize> = prefs
-        .sidebar_session_order
-        .iter()
-        .enumerate()
-        .map(|(rank, id)| (id, rank))
-        .collect();
-    let project_rank: HashMap<&ProjectId, usize> = prefs
-        .sidebar_project_order
-        .iter()
-        .enumerate()
-        .map(|(rank, id)| (id, rank))
-        .collect();
+    let session_rank = rank_map(&prefs.sidebar_session_order);
+    let project_rank = rank_map(&prefs.sidebar_project_order);
+    let pinned_sessions: HashSet<&SessionId> = prefs.sidebar_pinned_sessions.iter().collect();
+    let pinned_projects: HashSet<&ProjectId> = prefs.sidebar_pinned_projects.iter().collect();
+    let collapsed_sessions: HashSet<&SessionId> = prefs.sidebar_collapsed_sessions.iter().collect();
+    let collapsed_projects: HashSet<&ProjectId> = prefs.sidebar_collapsed_projects.iter().collect();
 
-    let mut result = Vec::with_capacity(grouped.len());
+    let mut ranked = Vec::with_capacity(grouped.len());
     for (project_id, group) in grouped {
         let project = projects
             .get(&project_id)
             .cloned()
             .unwrap_or_else(|| synthetic_project(&project_id, &group));
-        let (mut archived, mut active): (Vec<_>, Vec<_>) =
+        // A project is as old as its oldest session. That is the arrival order
+        // a first-time user perceives, and it keeps a project from jumping
+        // around as its sessions come and go.
+        let arrival = group
+            .iter()
+            .map(|session| session.created_at.0)
+            .fold(f64::INFINITY, f64::min);
+        let (mut archived, active): (Vec<_>, Vec<_>) =
             group.into_iter().partition(|session| session.is_archived());
-        active.sort_by(|left, right| {
-            manual_then(&session_rank, &left.id, &right.id).unwrap_or_else(|| {
-                right
-                    .created_at
-                    .partial_cmp(&left.created_at)
-                    .unwrap_or(Ordering::Equal)
-                    .then_with(|| left.id.0.cmp(&right.id.0))
-            })
-        });
+        // Most recently archived first: the bucket is a recovery surface, and
+        // the thing you just put away is the thing you are most likely after.
         archived.sort_by(|left, right| {
             right
                 .archived_at
@@ -82,39 +124,67 @@ pub(super) fn build_projection(
                 .unwrap_or(Ordering::Equal)
                 .then_with(|| left.id.0.cmp(&right.id.0))
         });
-        result.push(SidebarProject {
-            project,
-            sessions: active,
-            archived,
-        });
+        let expanded = !collapsed_projects.contains(&project_id);
+        let (sessions, active) = build_tree(
+            active,
+            &session_rank,
+            &pinned_sessions,
+            &collapsed_sessions,
+            expanded,
+        );
+        ranked.push((
+            arrival,
+            SidebarProject {
+                pinned: pinned_projects.contains(&project.id),
+                project,
+                sessions,
+                active,
+                archived,
+            },
+        ));
     }
 
-    result.sort_by(|left, right| {
-        manual_then(&project_rank, &left.project.id, &right.project.id).unwrap_or_else(|| {
-            left.project
-                .name
-                .to_lowercase()
-                .cmp(&right.project.name.to_lowercase())
-                .then_with(|| left.project.id.0.cmp(&right.project.id.0))
-        })
+    ranked.sort_by(|(left_arrival, left), (right_arrival, right)| {
+        // Pinned projects lead, then the manual order, then arrival. The last
+        // two agree by construction, so a project keeps its place whether or
+        // not the manual order has been materialised yet.
+        right
+            .pinned
+            .cmp(&left.pinned)
+            .then_with(|| {
+                rank_of(&project_rank, &left.project.id)
+                    .cmp(&rank_of(&project_rank, &right.project.id))
+            })
+            .then_with(|| left_arrival.total_cmp(right_arrival))
+            .then_with(|| left.project.id.0.cmp(&right.project.id.0))
     });
+    let result: Vec<SidebarProject> = ranked.into_iter().map(|(_, group)| group).collect();
 
     let display_order = result
         .iter()
-        .flat_map(|group| group.sessions.iter().chain(&group.archived))
-        .map(|session| session.id.clone())
+        .flat_map(|group| {
+            group
+                .active
+                .iter()
+                .chain(&group.archived)
+                .map(|session| session.id.clone())
+        })
         .collect();
     let ordered_sessions = result
         .iter()
         .flat_map(|group| {
-            group.sessions.iter().chain(
-                group
-                    .archived
-                    .iter()
-                    .filter(|session| selected == Some(&session.id)),
-            )
+            group
+                .sessions
+                .iter()
+                .map(|row| &row.session)
+                .chain(
+                    group
+                        .archived
+                        .iter()
+                        .filter(|session| selected == Some(&session.id)),
+                )
+                .cloned()
         })
-        .cloned()
         .collect();
 
     SidebarProjection {
@@ -124,17 +194,136 @@ pub(super) fn build_projection(
     }
 }
 
-fn manual_then<K: Eq + std::hash::Hash>(
-    ranks: &HashMap<&K, usize>,
-    left: &K,
-    right: &K,
-) -> Option<Ordering> {
-    match (ranks.get(left), ranks.get(right)) {
-        (Some(left), Some(right)) => Some(left.cmp(right)),
-        (Some(_), None) => Some(Ordering::Less),
-        (None, Some(_)) => Some(Ordering::Greater),
-        (None, None) => None,
+/// Arranges one project's active sessions into the lineage forest the sidebar
+/// draws, and returns `(visible rows, every session in tree order)`.
+fn build_tree(
+    active: Vec<Arc<SessionRecord>>,
+    session_rank: &HashMap<&SessionId, usize>,
+    pinned: &HashSet<&SessionId>,
+    collapsed: &HashSet<&SessionId>,
+    project_expanded: bool,
+) -> (Vec<SidebarRow>, Vec<Arc<SessionRecord>>) {
+    let parents = resolve_parents(&active);
+    let mut children: Vec<Vec<usize>> = vec![Vec::new(); active.len()];
+    let mut roots = Vec::new();
+    for (index, parent) in parents.iter().enumerate() {
+        match parent {
+            Some(parent) => children[*parent].push(index),
+            None => roots.push(index),
+        }
     }
+
+    let order = |left: &usize, right: &usize| {
+        sibling_cmp(&active[*left], &active[*right], session_rank, pinned)
+    };
+    roots.sort_by(order);
+    for list in &mut children {
+        list.sort_by(order);
+    }
+
+    let mut rows = Vec::with_capacity(active.len());
+    let mut tree_order = Vec::with_capacity(active.len());
+    // Explicit stack rather than recursion: a spawn chain is attacker-shaped
+    // input in the sense that nothing in the daemon bounds its depth.
+    let mut stack: Vec<(usize, u16, bool, u32)> = Vec::with_capacity(active.len());
+    for index in roots.iter().rev() {
+        stack.push((*index, 0, project_expanded, 0));
+    }
+    while let Some((index, depth, visible, rails)) = stack.pop() {
+        let session = &active[index];
+        tree_order.push(Arc::clone(session));
+        let has_children = !children[index].is_empty();
+        let is_collapsed = has_children && collapsed.contains(&session.id);
+        if visible {
+            rows.push(SidebarRow {
+                session: Arc::clone(session),
+                depth,
+                has_children,
+                collapsed: is_collapsed,
+                pinned: pinned.contains(&session.id),
+                rails,
+            });
+        }
+        let children_visible = visible && !is_collapsed;
+        let count = children[index].len();
+        // Children inherit this row's rails and light the column beside it,
+        // except for the last one — whose rail stops on its own elbow.
+        let inherited = rails | (1u32 << depth.min(31));
+        for (position, child) in children[index].iter().enumerate().rev() {
+            let child_rails = if position + 1 == count {
+                rails
+            } else {
+                inherited
+            };
+            stack.push((*child, depth + 1, children_visible, child_rails));
+        }
+    }
+    (rows, tree_order)
+}
+
+/// Maps each session to the index of its parent *within this project group*.
+///
+/// A parent that is archived, closing, in another project, or simply gone
+/// leaves the child at the root — a session must never vanish because the
+/// agent that spawned it did. Cycles cannot come from a well-behaved daemon,
+/// but one would hang the flatten below, so they are broken here.
+fn resolve_parents(active: &[Arc<SessionRecord>]) -> Vec<Option<usize>> {
+    let index: HashMap<&SessionId, usize> = active
+        .iter()
+        .enumerate()
+        .map(|(index, session)| (&session.id, index))
+        .collect();
+    let mut parents: Vec<Option<usize>> = active
+        .iter()
+        .enumerate()
+        .map(|(position, session)| {
+            session
+                .parent
+                .as_ref()
+                .and_then(|parent| index.get(parent).copied())
+                .filter(|parent| *parent != position)
+        })
+        .collect();
+    for start in 0..parents.len() {
+        let mut seen = HashSet::from([start]);
+        let mut cursor = parents[start];
+        while let Some(node) = cursor {
+            if !seen.insert(node) {
+                parents[start] = None;
+                break;
+            }
+            cursor = parents[node];
+        }
+    }
+    parents
+}
+
+/// Orders one run of siblings: pinned first, then the manual order, then
+/// arrival. New sessions carry the newest `created_at`, so they land last.
+fn sibling_cmp(
+    left: &SessionRecord,
+    right: &SessionRecord,
+    ranks: &HashMap<&SessionId, usize>,
+    pinned: &HashSet<&SessionId>,
+) -> Ordering {
+    pinned
+        .contains(&right.id)
+        .cmp(&pinned.contains(&left.id))
+        .then_with(|| rank_of(ranks, &left.id).cmp(&rank_of(ranks, &right.id)))
+        .then_with(|| left.created_at.0.total_cmp(&right.created_at.0))
+        .then_with(|| left.id.0.cmp(&right.id.0))
+}
+
+fn rank_map<T: Eq + std::hash::Hash>(order: &[T]) -> HashMap<&T, usize> {
+    order
+        .iter()
+        .enumerate()
+        .map(|(rank, id)| (id, rank))
+        .collect()
+}
+
+fn rank_of<T: Eq + std::hash::Hash>(ranks: &HashMap<&T, usize>, id: &T) -> usize {
+    ranks.get(id).copied().unwrap_or(UNRANKED)
 }
 
 fn synthetic_project(id: &ProjectId, sessions: &[Arc<SessionRecord>]) -> Project {

--- a/diri/crates/diri-app/src/store/tests.rs
+++ b/diri/crates/diri-app/src/store/tests.rs
@@ -11,8 +11,9 @@ use tokio::sync::mpsc;
 use crate::notifications::NotificationSound;
 
 use super::{
-    ClickModifiers, DefaultAgent, EventEnvelope, InspectorTab, Prefs, SessionStore, StoreEffect,
-    StoreEventChange, TerminalResidency, WindowMode, WindowPlacement, event_publication_policy,
+    ClickModifiers, DefaultAgent, EventEnvelope, InspectorTab, Prefs, SessionStore,
+    SidebarProjection, StoreEffect, StoreEventChange, TerminalResidency, WindowMode,
+    WindowPlacement, event_publication_policy,
 };
 use crate::switcher::{OverviewFilter, OverviewLane, SwitcherKey};
 
@@ -155,7 +156,7 @@ fn stale_restored_selection_falls_back_and_is_replaced() {
         ..Prefs::default()
     };
     let (store, _) = hydrated(
-        vec![session("one", "a", 2.0), session("two", "a", 1.0)],
+        vec![session("one", "a", 1.0), session("two", "a", 2.0)],
         vec![project("a", "A")],
         prefs,
     );
@@ -166,8 +167,8 @@ fn stale_restored_selection_falls_back_and_is_replaced() {
 
 #[test]
 fn overview_store_integration_filters_selects_and_bulk_closes() {
-    let live = session("live", "a", 2.0);
-    let mut ended = session("ended", "a", 1.0);
+    let live = session("live", "a", 1.0);
+    let mut ended = session("ended", "a", 2.0);
     ended.status = SessionStatus::Exited(ExitInfo {
         reason: ExitReason::Exited,
         code: Some(0),
@@ -190,7 +191,7 @@ fn overview_store_integration_filters_selects_and_bulk_closes() {
 }
 
 #[test]
-fn projection_uses_manual_ranks_then_created_at_fallback() {
+fn projection_keeps_manual_ranks_and_appends_the_rest_in_arrival_order() {
     let prefs = Prefs {
         sidebar_project_order: vec![pid("z")],
         sidebar_session_order: vec![id("old-ranked")],
@@ -210,13 +211,299 @@ fn projection_uses_manual_ranks_then_created_at_fallback() {
     let projection = store.sidebar_projection();
     assert_eq!(projection.projects[0].project.id, pid("z"));
     assert_eq!(
-        projection.projects[1]
+        rows(&projection, 1),
+        // Oldest first behind the one row that was ranked by hand. The newest
+        // session is last, which is the whole point: a session created now
+        // belongs at the bottom, not wherever its timestamp happens to sort.
+        vec![id("old-ranked"), id("middle"), id("new")]
+    );
+}
+
+/// The reported bug, from both ends: a session and a project created after the
+/// sidebar already has contents must land at the bottom, not in the middle.
+#[test]
+fn a_new_session_and_a_new_project_land_at_the_bottom() {
+    let (mut store, _) = hydrated(
+        vec![session("first", "a", 1.0), session("second", "a", 2.0)],
+        vec![project("a", "Alpha")],
+        Prefs::default(),
+    );
+    assert_eq!(
+        rows(&store.sidebar_projection(), 0),
+        vec![id("first"), id("second")]
+    );
+
+    // "Zed" sorts after "Alpha" alphabetically and "Ada" sorts before it; the
+    // old projection put a new project wherever its name fell, so use a name
+    // that would have jumped the queue.
+    store.upsert_session(session("third", "a", 3.0));
+    store.upsert_session(session("fresh", "ada", 4.0));
+
+    let projection = store.sidebar_projection();
+    assert_eq!(
+        rows(&projection, 0),
+        vec![id("first"), id("second"), id("third")],
+        "a new session appends to its project"
+    );
+    assert_eq!(
+        projection
+            .projects
+            .iter()
+            .map(|group| group.project.id.clone())
+            .collect::<Vec<_>>(),
+        vec![pid("a"), pid("ada")],
+        "a new project appends to the list, whatever it is called"
+    );
+}
+
+/// The order is total, so a row dragged to the end of its group stays there.
+/// Under the old ranked-before-unranked comparator it sprang back above every
+/// sibling that had never been dragged.
+#[test]
+fn a_session_dragged_to_the_end_stays_at_the_end() {
+    let (mut store, _) = hydrated(
+        vec![
+            session("one", "a", 1.0),
+            session("two", "a", 2.0),
+            session("three", "a", 3.0),
+        ],
+        vec![project("a", "Alpha")],
+        Prefs::default(),
+    );
+
+    let mut order = store.sidebar_session_order();
+    super::super::sidebar::move_to_end(&mut order, &id("one"));
+    store.set_session_order(order).expect("persist order");
+
+    assert_eq!(
+        rows(&store.sidebar_projection(), 0),
+        vec![id("two"), id("three"), id("one")]
+    );
+}
+
+/// Order and collapse state for departed sessions would otherwise pile up in
+/// prefs.json forever and reattach to a recycled id.
+#[test]
+fn removing_a_session_prunes_it_from_the_persisted_order() {
+    let (mut store, _) = hydrated(
+        vec![session("one", "a", 1.0), session("two", "a", 2.0)],
+        vec![project("a", "Alpha")],
+        Prefs::default(),
+    );
+    store
+        .toggle_session_collapsed(id("one"))
+        .expect("collapse one");
+    assert!(
+        store
+            .preferences()
+            .sidebar_session_order
+            .contains(&id("one"))
+    );
+
+    store.remove_session_record(&id("one"));
+
+    assert_eq!(store.preferences().sidebar_session_order, vec![id("two")]);
+    assert!(store.preferences().sidebar_collapsed_sessions.is_empty());
+}
+
+/// An MCP-spawned agent hangs off the session that spawned it, and a new child
+/// arrives at the bottom of its own sibling run rather than the project's.
+#[test]
+fn spawned_sessions_nest_under_their_parent() {
+    let child = |name: &str, parent: &str, created: f64| {
+        let mut record = session(name, "p", created);
+        record.parent = Some(id(parent));
+        record
+    };
+    let (mut store, _) = hydrated(
+        vec![
+            session("root", "p", 1.0),
+            child("child-b", "root", 3.0),
+            child("child-a", "root", 2.0),
+            child("grandchild", "child-a", 4.0),
+            session("sibling", "p", 5.0),
+        ],
+        vec![project("p", "P")],
+        Prefs::default(),
+    );
+
+    let projection = store.sidebar_projection();
+    let shape: Vec<_> = projection.projects[0]
+        .sessions
+        .iter()
+        .map(|row| (row.id().0.as_str().to_owned(), row.depth))
+        .collect();
+    assert_eq!(
+        shape,
+        vec![
+            ("root".to_owned(), 0),
+            ("child-a".to_owned(), 1),
+            ("grandchild".to_owned(), 2),
+            ("child-b".to_owned(), 1),
+            ("sibling".to_owned(), 0),
+        ]
+    );
+    assert!(projection.projects[0].sessions[0].has_children);
+    assert!(!projection.projects[0].sessions[4].has_children);
+}
+
+/// Collapsing a parent hides its whole subtree from the rows and from ⌘1…⌘9,
+/// but the sessions stay addressable for selection ranges.
+#[test]
+fn collapsing_a_parent_folds_away_its_subtree() {
+    let mut child = session("child", "p", 2.0);
+    child.parent = Some(id("root"));
+    let (mut store, _) = hydrated(
+        vec![session("root", "p", 1.0), child, session("other", "p", 3.0)],
+        vec![project("p", "P")],
+        Prefs::default(),
+    );
+
+    store
+        .toggle_session_collapsed(id("root"))
+        .expect("collapse");
+
+    let projection = store.sidebar_projection();
+    assert_eq!(rows(&projection, 0), vec![id("root"), id("other")]);
+    assert!(projection.projects[0].sessions[0].collapsed);
+    assert!(
+        !projection
+            .ordered_sessions
+            .iter()
+            .any(|session| session.id == id("child")),
+        "a folded row must not consume a ⌘1…⌘9 slot"
+    );
+    assert!(
+        projection.display_order.contains(&id("child")),
+        "it is hidden, not gone"
+    );
+}
+
+/// Selecting a hidden session unfolds whatever is covering it. Without this a
+/// ⌘J or an MCP focus lands on a row the sidebar never shows.
+#[test]
+fn selecting_a_folded_session_reveals_it() {
+    let mut child = session("child", "p", 2.0);
+    child.parent = Some(id("root"));
+    let prefs = Prefs {
+        sidebar_collapsed_projects: vec![pid("p")],
+        sidebar_collapsed_sessions: vec![id("root")],
+        ..Prefs::default()
+    };
+    let (mut store, _) = hydrated(
+        vec![session("root", "p", 1.0), child],
+        vec![project("p", "P")],
+        prefs,
+    );
+
+    store.select(id("child"));
+
+    assert!(store.preferences().sidebar_collapsed_projects.is_empty());
+    assert!(store.preferences().sidebar_collapsed_sessions.is_empty());
+    assert_eq!(
+        rows(&store.sidebar_projection(), 0),
+        vec![id("root"), id("child")]
+    );
+}
+
+/// Folding the ancestor of the selection would hide it, so the selection walks
+/// up to the row being folded instead of vanishing under it.
+#[test]
+fn folding_over_the_selection_moves_it_to_the_fold() {
+    let mut child = session("child", "p", 2.0);
+    child.parent = Some(id("root"));
+    let (mut store, _) = hydrated(
+        vec![session("root", "p", 1.0), child],
+        vec![project("p", "P")],
+        Prefs::default(),
+    );
+    store.select(id("child"));
+
+    store
+        .toggle_session_collapsed(id("root"))
+        .expect("collapse");
+
+    assert_eq!(store.selected_session_id(), Some(&id("root")));
+    assert_eq!(rows(&store.sidebar_projection(), 0), vec![id("root")]);
+}
+
+/// A parent in another project, or one that points back at its own descendant,
+/// must leave the row at the top level rather than dropping or hanging it.
+#[test]
+fn unusable_parents_leave_the_row_at_the_root() {
+    let mut foreign = session("foreign", "p", 2.0);
+    foreign.parent = Some(id("elsewhere"));
+    let mut left = session("left", "p", 3.0);
+    left.parent = Some(id("right"));
+    let mut right = session("right", "p", 4.0);
+    right.parent = Some(id("left"));
+    let (mut store, _) = hydrated(
+        vec![session("elsewhere", "other", 1.0), foreign, left, right],
+        vec![project("p", "P"), project("other", "Other")],
+        Prefs::default(),
+    );
+
+    let projection = store.sidebar_projection();
+    let group = projection
+        .projects
+        .iter()
+        .find(|group| group.project.id == pid("p"))
+        .expect("project p");
+    assert_eq!(
+        group
             .sessions
             .iter()
-            .map(|session| session.id.clone())
+            .map(|row| row.depth)
             .collect::<Vec<_>>(),
-        vec![id("old-ranked"), id("new"), id("middle")]
+        vec![0, 0, 1],
+        "the cross-project child roots, and the cycle keeps exactly one edge"
     );
+    assert_eq!(group.sessions.len(), 3, "no row is lost to a cycle");
+}
+
+/// Pinning sorts a row to the top of its own siblings instead of cloning it
+/// into a separate section, so one session is never two rows.
+#[test]
+fn pinned_rows_lead_their_siblings() {
+    let prefs = Prefs {
+        sidebar_pinned_sessions: vec![id("third")],
+        sidebar_pinned_projects: vec![pid("b")],
+        ..Prefs::default()
+    };
+    let (mut store, _) = hydrated(
+        vec![
+            session("first", "a", 1.0),
+            session("second", "a", 2.0),
+            session("third", "a", 3.0),
+            session("only", "b", 4.0),
+        ],
+        vec![project("a", "Alpha"), project("b", "Beta")],
+        prefs,
+    );
+
+    let projection = store.sidebar_projection();
+    assert_eq!(
+        projection
+            .projects
+            .iter()
+            .map(|group| group.project.id.clone())
+            .collect::<Vec<_>>(),
+        vec![pid("b"), pid("a")],
+        "a pinned project leads even though it arrived last"
+    );
+    assert_eq!(
+        rows(&projection, 1),
+        vec![id("third"), id("first"), id("second")]
+    );
+    assert!(projection.projects[1].sessions[0].pinned);
+}
+
+fn rows(projection: &SidebarProjection, group: usize) -> Vec<SessionId> {
+    projection.projects[group]
+        .sessions
+        .iter()
+        .map(|row| row.id().clone())
+        .collect()
 }
 
 #[test]
@@ -264,7 +551,7 @@ fn projection_reuses_one_session_record_per_sidebar_row() {
     );
 
     let projection = store.sidebar_projection();
-    let grouped: &SessionRecord = &projection.projects[0].sessions[0];
+    let grouped: &SessionRecord = &projection.projects[0].sessions[0].session;
     let ordered: &SessionRecord = &projection.ordered_sessions[0];
     assert!(
         std::ptr::eq(grouped, ordered),
@@ -282,9 +569,9 @@ fn multi_select_matches_finder_command_and_visible_shift_ranges() {
     };
     let (mut store, _) = hydrated(
         vec![
-            session("one", "p", 3.0),
+            session("one", "p", 1.0),
             session("two", "p", 2.0),
-            session("three", "p", 1.0),
+            session("three", "p", 3.0),
             archived,
         ],
         vec![project("p", "Project")],
@@ -325,10 +612,10 @@ fn multi_select_matches_finder_command_and_visible_shift_ranges() {
 #[test]
 fn focus_neighbor_prefers_same_project_below_then_above_then_global() {
     let records = vec![
-        session("a-top", "a", 4.0),
-        session("a-mid", "a", 3.0),
-        session("a-low", "a", 2.0),
-        session("b-top", "b", 1.0),
+        session("a-top", "a", 1.0),
+        session("a-mid", "a", 2.0),
+        session("a-low", "a", 3.0),
+        session("b-top", "b", 4.0),
     ];
     let projects = vec![project("a", "A"), project("b", "B")];
 
@@ -357,10 +644,10 @@ fn focus_neighbor_prefers_same_project_below_then_above_then_global() {
 fn selection_drives_mru_and_residency_eviction_signals_detach() {
     let (mut store, mut effects) = hydrated(
         vec![
-            session("one", "p", 4.0),
-            session("two", "p", 3.0),
-            session("three", "p", 2.0),
-            session("four", "p", 1.0),
+            session("one", "p", 1.0),
+            session("two", "p", 2.0),
+            session("three", "p", 3.0),
+            session("four", "p", 4.0),
         ],
         vec![project("p", "P")],
         Prefs::default(),
@@ -524,7 +811,9 @@ fn cold_boot_only_auto_resumes_the_selected_session() {
         Prefs::default(),
     );
 
-    assert_eq!(store.selected_session_id(), Some(&id("newest")));
+    // Nothing was remembered, so the selection falls to the top of the sidebar
+    // — which is the oldest session now that rows arrive at the bottom.
+    assert_eq!(store.selected_session_id(), Some(&id("oldest")));
     let automatic_resumes: Vec<_> = drain(&mut effects)
         .into_iter()
         .filter_map(|effect| match effect {
@@ -537,7 +826,7 @@ fn cold_boot_only_auto_resumes_the_selected_session() {
         .collect();
     assert_eq!(
         automatic_resumes,
-        vec![id("newest")],
+        vec![id("oldest")],
         "cold boot must not revive every previously running agent"
     );
 
@@ -703,7 +992,7 @@ fn selected_session_persists_across_store_reloads() {
 #[test]
 fn synthetic_events_upsert_project_and_remove_with_neighbor_focus() {
     let (mut store, _) = hydrated(
-        vec![session("one", "p", 2.0), session("two", "p", 1.0)],
+        vec![session("one", "p", 1.0), session("two", "p", 2.0)],
         vec![],
         Prefs::default(),
     );


### PR DESCRIPTION
A new session landed in the middle of its project and a new project landed wherever its name fell in the alphabet. Three defects stacked:

- unranked sessions tie-broke on `created_at` **descending**, so the newest row sorted first;
- unranked projects tie-broke alphabetically;
- `ensure_present` seeded the manual order from `sessions().keys()` and `projects().keys()` — both `HashMap`s — so the first drag of anything assigned every row a rank in hash-iteration order and permanently randomised the list.

Underneath all three, `manual_then` sorted ranked before unranked, so the order was never total. That is also why a row dragged to the bottom of a group sprang back above the siblings that had never been dragged.

The order is now total, persisted, and append-on-create. `reconcile_sidebar_order` prunes departed ids and appends new ones on membership changes only. New ids are appended in exactly the order the projection's fallback comparator produces, so materialising the order never moves a row — the behaviour is identical before and after the first prefs write.

## Other sidebar states this turned up

- **Pinned rows rendered twice**, once in a Pinned section and once in their project. Both copies keyed hover off the same session id, so pointing at one lit both, and an archived session in the section got a close button instead of a revive one. Pinning now sorts a row to the top of its sibling run: one session, one row.
- **The close button took over the status glyph's slot**, so pointing at a working agent hid the fact that it was working. It moved to the trailing edge, sharing a slot with the shortcut hint, which the same gesture makes redundant.
- **Selection could be invisible**: ⌘J, the switcher, and an MCP focus could all land inside a collapsed project. `reveal` now unfolds the project, the spawn chain, and the archive bucket on every focus, and ⌘1..9 only address rows that are on screen.
- **An exited session with a real title looked alive**, since the glyph just went quiet. It now carries an "Ended" chip unless the title already says so.

## Spawn lineage

`SessionRecord.parent` was already written by `spawn_agent` and `spawn_agent_remote` and thrown away by the sidebar. Children now nest under the session that spawned them, with an indent rail that stops on the last sibling, per-session collapse, and ordering applied per sibling run. A parent that is archived, in another project, or part of a cycle leaves the row at the root rather than dropping or hanging it.

Drag-reorder is confined to same-parent targets: re-parenting is the daemon's business, not a drag's.

---

⚠️ **Base is stale.** This branch forks from `0702a68` (#23) and `main` is now at `371cda0`. It needs a rebase before merge — `main`'s branch protection requires branches to be up to date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
