### PR TITLE
fix: bound the remote Agent scan and let Refresh restart it

### DIFF
--- a/diri/crates/diri-app/src/store/mod.rs
+++ b/diri/crates/diri-app/src/store/mod.rs
@@ -55,6 +55,11 @@ pub(crate) fn is_auxiliary_terminal(session: &SessionRecord) -> bool {
 // 20fps direct path.
 const UI_PUBLISH_INTERVAL: Duration = Duration::from_millis(50);
 
+// A stalled remote scan may be overlapped by exactly one forced rescan. Beyond
+// that, repeated Refresh clicks would queue daemon-side scans that each hold a
+// thread behind the same per-target single-flight lock.
+const MAX_AGENT_CATALOG_SCANS: u32 = 2;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum StoreEventChange {
     None,
@@ -324,7 +329,10 @@ pub struct SessionStore {
     /// Empty until the first successful connect, and empty forever against a
     /// daemon too old to send descriptors — every reader must have a fallback.
     agents: HashMap<String, AgentReadinessResult>,
-    agent_catalog_loading: HashSet<String>,
+    /// Scans outstanding per target, counted rather than flagged: a forced
+    /// rescan is allowed to overlap a scan that has not answered, and the
+    /// spinner has to stay up until the last of them replies.
+    agent_catalog_scans: HashMap<String, u32>,
     agent_catalog_errors: HashMap<String, String>,
     /// Attention states serving out their settle window, newest arming wins.
     /// Drained by the settle task in `StoreHandle`, which is what turns one of
@@ -388,7 +396,7 @@ impl SessionStore {
                 prefs_path,
                 hosts: Vec::new(),
                 agents: HashMap::new(),
-                agent_catalog_loading: HashSet::new(),
+                agent_catalog_scans: HashMap::new(),
                 agent_catalog_errors: HashMap::new(),
                 attention_settle: HashMap::new(),
                 attention_wake: Arc::new(Notify::new()),
@@ -411,7 +419,6 @@ impl SessionStore {
     pub fn set_agent_catalog(&mut self, agents: AgentReadinessResult) {
         let local = agents.host.is_none();
         let key = agent_target_key(agents.host.as_deref());
-        self.agent_catalog_loading.remove(&key);
         self.agent_catalog_errors.remove(&key);
         self.agents.insert(key, agents);
         // Preserve Main's repair policy for the local preference. A remote
@@ -446,22 +453,46 @@ impl SessionStore {
         if !force && self.agent_catalog_errors.contains_key(&key) {
             return;
         }
-        if self.agent_catalog_loading.insert(key) {
-            self.emit(StoreEffect::RefreshAgents { host, force });
+        // An outstanding scan absorbs passive requests, but never the explicit
+        // rescan: a remote scan can outlive its usefulness (an unreachable
+        // host, a Helper install that outlasts the round trip), and Refresh is
+        // the only control the user has. Suppressing it there left the target
+        // spinning until the app was relaunched. One rescue attempt may
+        // overlap a stalled scan; further clicks wait for those two to answer.
+        let outstanding = self.agent_catalog_scans.get(&key).copied().unwrap_or(0);
+        if outstanding >= if force { MAX_AGENT_CATALOG_SCANS } else { 1 } {
+            return;
         }
+        self.agent_catalog_scans.insert(key, outstanding + 1);
+        self.emit(StoreEffect::RefreshAgents { host, force });
     }
 
     pub fn configure_agent(&mut self, params: diri_proto::AgentConfigureParams) {
         // Configuration is a user mutation, not a cache refresh: it must reach
         // the engine even while a scan for the same target is in flight, or a
         // toggle flipped during a slow remote scan silently reverts.
-        self.agent_catalog_loading
-            .insert(agent_target_key(params.host.as_deref()));
+        let key = agent_target_key(params.host.as_deref());
+        let outstanding = self.agent_catalog_scans.get(&key).copied().unwrap_or(0);
+        self.agent_catalog_scans.insert(key, outstanding + 1);
         self.emit(StoreEffect::ConfigureAgent(params));
     }
 
+    /// Retires one outstanding scan. The catalog stops reading as loading only
+    /// once every request for the target has answered, so an early reply from
+    /// a rescue rescan does not hide the one still running.
+    fn finish_agent_catalog_request(&mut self, key: &str) {
+        let Some(outstanding) = self.agent_catalog_scans.get_mut(key) else {
+            return;
+        };
+        *outstanding -= 1;
+        if *outstanding == 0 {
+            self.agent_catalog_scans.remove(key);
+        }
+    }
+
     pub fn agent_catalog_is_loading(&self, host: Option<&str>) -> bool {
-        self.agent_catalog_loading.contains(&agent_target_key(host))
+        self.agent_catalog_scans
+            .contains_key(&agent_target_key(host))
     }
 
     pub fn agent_catalog_error(&self, host: Option<&str>) -> Option<&str> {
@@ -2714,11 +2745,11 @@ async fn run_effects(
                         .await;
                     let mut locked = store.write().expect("session store lock poisoned");
                     let key = agent_target_key(host.as_deref());
-                    // Clear the requested key, not the one the response names:
+                    // Retire the requested key, not the one the response names:
                     // a daemon too old for per-host params echoes no host, and
                     // keying off the response would leave this target loading
                     // (and every further request suppressed) forever.
-                    locked.agent_catalog_loading.remove(&key);
+                    locked.finish_agent_catalog_request(&key);
                     match result {
                         Ok(catalog) => {
                             locked.agent_catalog_errors.remove(&key);
@@ -2742,7 +2773,7 @@ async fn run_effects(
                     let mut locked = store.write().expect("session store lock poisoned");
                     let key = agent_target_key(host.as_deref());
                     // Requested key, not response key — see RefreshAgents.
-                    locked.agent_catalog_loading.remove(&key);
+                    locked.finish_agent_catalog_request(&key);
                     match result {
                         Ok(catalog) => {
                             locked.agent_catalog_errors.remove(&key);

--- a/diri/crates/diri-app/src/store/tests.rs
+++ b/diri/crates/diri-app/src/store/tests.rs
@@ -1339,8 +1339,8 @@ fn a_failed_scan_is_retried_only_by_an_explicit_rescan() {
         effects.try_recv(),
         Ok(StoreEffect::RefreshAgents { .. })
     ));
-    // The effect loop reports the failure: loading cleared, error recorded.
-    store.agent_catalog_loading.remove("forge");
+    // The effect loop reports the failure: the scan retires, error recorded.
+    store.finish_agent_catalog_request("forge");
     store
         .agent_catalog_errors
         .insert("forge".into(), "ssh: connect timed out".into());
@@ -1354,6 +1354,57 @@ fn a_failed_scan_is_retried_only_by_an_explicit_rescan() {
         effects.try_recv(),
         Ok(StoreEffect::RefreshAgents { force: true, .. })
     ));
+}
+
+#[test]
+fn refresh_reaches_the_engine_while_a_stalled_scan_is_still_outstanding() {
+    let (mut store, mut effects) = SessionStore::headless(Prefs::default());
+    store.request_agent_catalog(Some("forge".into()), false);
+    assert!(matches!(
+        effects.try_recv(),
+        Ok(StoreEffect::RefreshAgents { force: false, .. })
+    ));
+    // Nothing has answered. A passive re-ask on every paint must not pile up
+    // scans, but Refresh is the user's only escape from a wedged remote scan
+    // and has to reach the daemon.
+    store.request_agent_catalog(Some("forge".into()), false);
+    assert!(effects.try_recv().is_err());
+    store.request_agent_catalog(Some("forge".into()), true);
+    assert!(matches!(
+        effects.try_recv(),
+        Ok(StoreEffect::RefreshAgents { force: true, .. })
+    ));
+    // One rescue attempt is the cap: further clicks would queue daemon-side
+    // scans behind the same per-target lock.
+    store.request_agent_catalog(Some("forge".into()), true);
+    assert!(effects.try_recv().is_err());
+
+    // The rescue answers first. The target keeps reading as loading until the
+    // stalled scan retires too, and only then does a passive request resume.
+    store.finish_agent_catalog_request("forge");
+    assert!(store.agent_catalog_is_loading(Some("forge")));
+    store.finish_agent_catalog_request("forge");
+    assert!(!store.agent_catalog_is_loading(Some("forge")));
+    store.request_agent_catalog(Some("forge".into()), false);
+    assert!(matches!(
+        effects.try_recv(),
+        Ok(StoreEffect::RefreshAgents { .. })
+    ));
+}
+
+#[test]
+fn an_installed_catalog_leaves_an_outstanding_scan_running() {
+    let (mut store, _effects) = SessionStore::headless(Prefs::default());
+    store.request_agent_catalog(Some("forge".into()), false);
+    store.request_agent_catalog(Some("forge".into()), true);
+    // A catalog arriving out of band (the reply to the rescue, a connect-time
+    // install) is not a reply to every request: retiring the target here would
+    // drop the spinner while a scan is still on the wire.
+    store.set_agent_catalog(AgentReadinessResult {
+        host: Some("forge".into()),
+        ..AgentReadinessResult::default()
+    });
+    assert!(store.agent_catalog_is_loading(Some("forge")));
 }
 
 #[test]

--- a/diri/crates/diri-client/src/client.rs
+++ b/diri/crates/diri-client/src/client.rs
@@ -24,6 +24,14 @@ const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(10);
 const INITIAL_BACKOFF: Duration = Duration::from_millis(500);
 const MAX_BACKOFF: Duration = Duration::from_secs(8);
 const EVENT_CHANNEL_CAPACITY: usize = 4096;
+// A local catalog scan is filesystem metadata over the manifest list; nothing
+// in it blocks. A remote one crosses ssh and may bootstrap the Helper before it
+// can answer, which the Engine bounds far more generously than a user will wait
+// staring at a spinner. Timing out does not waste the scan: the Engine finishes
+// it and caches the result, so the retry this failure re-enables is usually
+// instant.
+const AGENT_CATALOG_TIMEOUT: Duration = Duration::from_secs(30);
+const REMOTE_AGENT_CATALOG_TIMEOUT: Duration = Duration::from_secs(240);
 
 /// Errors surfaced by daemon requests and the reconnecting transport.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -657,18 +665,30 @@ impl DaemonClient {
         self.empty(Method::GOVERNOR_CONFIGURE, &params).await
     }
 
+    /// `agent.readiness`: PATH metadata locally, but a remote target crosses
+    /// ssh and may install the Helper first, so the two carry very different
+    /// bounds. Both are explicit: the settings page shows a spinner for the
+    /// whole call, and an unbounded one has no way back to the user.
     pub async fn agent_readiness(
         &self,
         params: diri_proto::AgentReadinessParams,
     ) -> Result<AgentReadinessResult, ClientError> {
-        self.typed(Method::AGENT_READINESS, &params).await
+        let timeout = agent_catalog_timeout(params.host.is_some());
+        self.core
+            .request_typed(Method::AGENT_READINESS, Some(&params), Some(timeout))
+            .await
     }
 
+    /// `agent.configure`: writes the preference, then answers with the same
+    /// catalog `agent.readiness` builds — and can therefore scan.
     pub async fn configure_agent(
         &self,
         params: diri_proto::AgentConfigureParams,
     ) -> Result<diri_proto::AgentConfigureResult, ClientError> {
-        self.typed(Method::AGENT_CONFIGURE, &params).await
+        let timeout = agent_catalog_timeout(params.host.is_some());
+        self.core
+            .request_typed(Method::AGENT_CONFIGURE, Some(&params), Some(timeout))
+            .await
     }
 
     pub async fn hibernate(&self, session_id: &SessionId) -> Result<(), ClientError> {
@@ -819,6 +839,14 @@ impl Drop for DaemonClient {
 impl ConnectionState {
     fn is_connected(&self) -> bool {
         matches!(self, Self::Connected(_))
+    }
+}
+
+const fn agent_catalog_timeout(remote: bool) -> Duration {
+    if remote {
+        REMOTE_AGENT_CATALOG_TIMEOUT
+    } else {
+        AGENT_CATALOG_TIMEOUT
     }
 }
 


### PR DESCRIPTION
Follow-up to #61.

## The report

Settings → Agents → a remote host sat on "Checking installed Agents…" indefinitely: no result, no error, and the Refresh button did nothing.

The Engine side turned out to be healthy. Probing the running daemon over `daemon.sock` exactly as the app does (`hello` → `events.subscribe` → `agent.readiness`) answers in under half a second and finds the right binaries:

```
resp id=3 at 0.43s bytes=22287   host: "forge"
  claude-code  /home/cristi/.local/bin/claude   system-path
  codex        /home/cristi/.local/bin/codex    system-path
```

What was broken is the client's ability to ever stop waiting, and the user's ability to ask again.

## The request is unbounded

`agent.readiness` and `agent.configure` were the only remote-crossing calls in `diri-client` without an explicit timeout — `migrate`, `sync_prefs`, `initialize_host`, `list_directories` and `locate_repo` all carry one. Meanwhile the Engine bounds a cold remote scan generously and correctly: `PROBE_TIMEOUT` + `UPLOAD_TIMEOUT` + `RPC_TIMEOUT`, with `discover_executables` retrying the whole sequence once after `forget_current_helper`. A client with no deadline in front of that turns a slow first scan — the one that also installs the Helper — into a permanent spinner.

Both calls now carry a bound: 30s for the local PATH walk, 240s for a remote target that may bootstrap the Helper first. Timing out doesn't waste the work — the Engine completes the scan and caches it, so the retry this failure re-enables usually answers instantly.

## Refresh could not restart it

`request_agent_catalog` flagged a target as loading and dropped every later request for it, forced ones included. The Refresh button exists exactly to escape a scan that will not answer, and it was the one control the flag disabled; recovery meant relaunching the app.

Scans are now counted rather than flagged, so an explicit rescan may overlap a stalled one — capped at that single rescue attempt, since each queues an Engine-side scan behind the same per-target single-flight lock — and the target stops reading as loading only when the last reply lands, not the first.

## Verification

- `cargo test -p diri-app` — 335 passed, including two new cases: Refresh reaches the Engine while a scan is outstanding (and the spinner survives the first of two replies), and an out-of-band catalog install no longer retires a scan still on the wire.
- `cargo fmt --all --check`, `cargo clippy -p diri-app -p diri-client --all-targets` clean.
- Daemon-side remote discovery re-verified live against a VPS host, as above.

App-side only; no protocol change, so only the app needs reinstalling to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)