### PR TITLE
Fix terminal selections after daemon-owned repaints

### DIFF
--- a/diri/crates/diri-term/src/element.rs
+++ b/diri/crates/diri-term/src/element.rs
@@ -436,7 +436,39 @@ impl TerminalElement {
     /// Terminal hosts use this to keep the authoritative buffer current while
     /// coalescing bursts and suppressing paints for offscreen residents.
     pub fn apply_damage(&self, update: GridUpdate) -> ApplySummary {
-        write_lock(&self.buffer).apply(update)
+        // Absolute rows keep a selection attached while the viewport moves,
+        // but not when the daemon replaces cells at those rows. Damage is
+        // row-granular, so unrelated live output and history remain selected.
+        let live_start_row = mutex_lock(&self.shared.viewport).live_start_row();
+        let mut buffer = write_lock(&self.buffer);
+        let replaces_grid =
+            update.is_full_snapshot || buffer.cols != update.cols || buffer.rows != update.rows;
+        let damaged_cols = usize::from(if replaces_grid {
+            buffer.cols.max(update.cols)
+        } else {
+            update.cols
+        });
+        let mut selection = mutex_lock(&self.shared.selection);
+        let selection_overlaps_damage = if selection.range().is_none() {
+            false
+        } else if replaces_grid {
+            (0..buffer.rows.max(update.rows)).any(|row| {
+                selection.overlaps_row(live_start_row.saturating_add(i64::from(row)), damaged_cols)
+            })
+        } else {
+            update.changed_rows.iter().any(|changed| {
+                changed.y < update.rows
+                    && selection.overlaps_row(
+                        live_start_row.saturating_add(i64::from(changed.y)),
+                        damaged_cols,
+                    )
+            })
+        };
+        let summary = buffer.apply(update);
+        if selection_overlaps_damage {
+            selection.clear();
+        }
+        summary
     }
 
     #[must_use]
@@ -476,11 +508,18 @@ impl TerminalElement {
         mutex_lock(&self.shared.viewport).scroll_to_absolute(absolute_row, anchor, visible_rows)
     }
 
+    /// Updates daemon-owned terminal modes and reports whether entering the
+    /// alternate screen also moved a scrolled viewport back to live. Either
+    /// alternate-screen transition invalidates the previous screen's rows.
     pub fn set_modes(&self, alt_screen: bool, mouse: MouseModes) -> bool {
         let mut modes = mutex_lock(&self.shared.modes);
         let entered_alt = alt_screen && !modes.alt_screen;
+        let alt_screen_changed = alt_screen != modes.alt_screen;
         *modes = TerminalModes { alt_screen, mouse };
         drop(modes);
+        if alt_screen_changed {
+            mutex_lock(&self.shared.selection).clear();
+        }
         entered_alt && mutex_lock(&self.shared.viewport).enter_alt_screen()
     }
 
@@ -495,8 +534,13 @@ impl TerminalElement {
     pub fn route_wheel(&self, event: WheelEvent) -> Option<WheelRoute> {
         let modes = *mutex_lock(&self.shared.modes);
         let route = mutex_lock(&self.shared.scroll_router).route(modes, event)?;
-        if let WheelRoute::Local { lines } = route {
-            mutex_lock(&self.shared.viewport).scroll_by(lines, usize::from(event.visible_rows));
+        match route {
+            WheelRoute::Local { lines } => {
+                mutex_lock(&self.shared.viewport).scroll_by(lines, usize::from(event.visible_rows));
+            }
+            // This route leaves the viewport still while the foreground
+            // program may repaint beneath the selection's coordinates.
+            WheelRoute::Daemon { .. } => mutex_lock(&self.shared.selection).clear(),
         }
         Some(route)
     }
@@ -1796,5 +1840,184 @@ mod history_cache_tests {
         assert!(cache.get(anchor, digest).is_some(), "the window survives");
         assert!(cache.get(0, digest).is_none(), "distant rows are dropped");
         assert!(cache.lines.len() <= HistoryLineCache::MAX_ROWS);
+    }
+}
+
+#[cfg(test)]
+mod selection_repaint_tests {
+    use diri_proto::grid::{ChangedRow, GridCell, GridUpdate, TermColor, TermStyle};
+    use diri_proto::terminal::MouseModes;
+
+    use super::{TerminalElement, mutex_lock};
+    use crate::buffer::GridBuffer;
+    use crate::scrollback::{WheelDelta, WheelEvent, WheelRoute};
+
+    const COLS: u16 = 8;
+    const ROWS: u16 = 3;
+
+    fn cell(ch: char) -> GridCell {
+        GridCell::new(
+            u32::from(ch),
+            TermColor::Default,
+            TermColor::DefaultInverted,
+            TermStyle::empty(),
+        )
+    }
+
+    fn row(text: &str) -> Vec<GridCell> {
+        let mut cells: Vec<_> = text.chars().map(cell).collect();
+        cells.resize(usize::from(COLS), GridCell::BLANK);
+        cells
+    }
+
+    fn update(full: bool, rows: &[(u16, &str)]) -> GridUpdate {
+        GridUpdate {
+            cols: COLS,
+            rows: ROWS,
+            cursor_col: 0,
+            cursor_row: 0,
+            cursor_visible: false,
+            is_full_snapshot: full,
+            changed_rows: rows
+                .iter()
+                .map(|(y, text)| ChangedRow::new(*y, row(text)))
+                .collect(),
+        }
+    }
+
+    fn populated_element() -> TerminalElement {
+        let element = TerminalElement::with_buffer(GridBuffer::new(COLS, ROWS));
+        element.apply_damage(update(true, &[(0, "zero"), (1, "one"), (2, "two")]));
+        element
+    }
+
+    fn wheel(delta: f32) -> WheelEvent {
+        WheelEvent {
+            delta: WheelDelta::Lines(delta),
+            col: 2,
+            row: 1,
+            visible_rows: ROWS,
+            line_height: 16.0,
+        }
+    }
+
+    fn visible_selection_count(element: &TerminalElement) -> usize {
+        let viewport = mutex_lock(&element.shared.viewport).clone();
+        mutex_lock(&element.shared.selection)
+            .visible_spans(&viewport, usize::from(ROWS), usize::from(COLS))
+            .len()
+    }
+
+    #[test]
+    fn daemon_wheel_drops_the_selection_before_the_tui_can_repaint() {
+        for modes in [(true, MouseModes::OFF), (false, MouseModes::UNKNOWN)] {
+            let element = populated_element();
+            element.set_modes(modes.0, modes.1);
+            element.begin_selection(0, 1);
+            element.drag_selection(3, 1);
+            assert_eq!(element.selected_text(), "one");
+
+            assert!(matches!(
+                element.route_wheel(wheel(1.0)),
+                Some(WheelRoute::Daemon { .. })
+            ));
+            assert_eq!(element.selected_text(), "", "modes: {modes:?}");
+            assert_eq!(visible_selection_count(&element), 0, "modes: {modes:?}");
+        }
+    }
+
+    #[test]
+    fn local_scroll_keeps_selection_attached_across_the_history_live_seam() {
+        let element = populated_element();
+        {
+            let mut viewport = mutex_lock(&element.shared.viewport);
+            viewport.apply_rows(
+                vec![row("hist six"), row("hist sev")],
+                6,
+                8,
+                11,
+                1,
+                usize::from(ROWS),
+            );
+            assert!(viewport.set_view_offset(2, usize::from(ROWS)));
+        }
+        element.begin_selection(0, 0);
+        element.drag_selection(3, 2);
+        let selected = element.selected_text();
+        assert_eq!(selected, "hist six\nhist sev\nzer");
+
+        assert_eq!(
+            element.route_wheel(wheel(1.0)),
+            Some(WheelRoute::Local { lines: 1 })
+        );
+        assert_eq!(element.selected_text(), selected);
+        assert_eq!(visible_selection_count(&element), 2);
+    }
+
+    #[test]
+    fn entering_and_leaving_alt_screen_drop_active_selections() {
+        let element = populated_element();
+        element.begin_selection(0, 1);
+        element.drag_selection(3, 1);
+
+        element.set_modes(true, MouseModes::OFF);
+        assert_eq!(element.selected_text(), "", "entering alt screen");
+
+        element.begin_selection(0, 2);
+        element.drag_selection(3, 2);
+        element.set_modes(false, MouseModes::OFF);
+        assert_eq!(element.selected_text(), "", "leaving alt screen");
+    }
+
+    #[test]
+    fn alt_screen_repaint_only_drops_a_selection_when_damage_overlaps_it() {
+        let element = populated_element();
+        element.set_modes(true, MouseModes::OFF);
+        element.begin_selection(0, 1);
+        element.drag_selection(3, 1);
+
+        element.apply_damage(update(false, &[(0, "ZERO")]));
+        assert_eq!(element.selected_text(), "one");
+        assert_eq!(visible_selection_count(&element), 1);
+
+        element.apply_damage(update(false, &[(1, "new")]));
+        assert_eq!(element.selected_text(), "");
+        assert_eq!(visible_selection_count(&element), 0);
+    }
+
+    #[test]
+    fn normal_screen_output_missing_the_selection_preserves_highlight_and_copy() {
+        let element = populated_element();
+        element.begin_selection(0, 1);
+        element.drag_selection(3, 1);
+
+        element.apply_damage(update(false, &[(2, "TWO")]));
+
+        assert_eq!(element.selected_text(), "one");
+        assert_eq!(visible_selection_count(&element), 1);
+    }
+
+    #[test]
+    fn normal_screen_output_replacing_selected_text_drops_highlight_and_copy() {
+        let element = populated_element();
+        element.begin_selection(0, 1);
+        element.drag_selection(3, 1);
+
+        element.apply_damage(update(false, &[(1, "new")]));
+
+        assert_eq!(element.selected_text(), "");
+        assert_eq!(visible_selection_count(&element), 0);
+    }
+
+    #[test]
+    fn full_snapshot_reseed_drops_any_selection_in_the_live_grid() {
+        let element = populated_element();
+        element.begin_selection(0, 1);
+        element.drag_selection(3, 1);
+
+        element.apply_damage(update(true, &[(0, "zero"), (1, "one"), (2, "two")]));
+
+        assert_eq!(element.selected_text(), "");
+        assert_eq!(visible_selection_count(&element), 0);
     }
 }

--- a/diri/crates/diri-term/src/selection.rs
+++ b/diri/crates/diri-term/src/selection.rs
@@ -133,6 +133,23 @@ impl TerminalSelection {
         Some(SelectionRange { start, end })
     }
 
+    /// Whether a full-row content repaint would replace any selected cell.
+    ///
+    /// Selection endpoints are exclusive, so an endpoint at column zero does
+    /// not make that final row overlap. Keeping that distinction prevents a
+    /// repaint immediately below a selection from dismissing it.
+    #[must_use]
+    pub(crate) fn overlaps_row(&self, absolute_row: i64, cols: usize) -> bool {
+        let Some(range) = self.range() else {
+            return false;
+        };
+        if absolute_row < range.start.row || absolute_row > range.end.row {
+            return false;
+        }
+        let (start, end) = columns_for_row(range, absolute_row, cols);
+        start < end
+    }
+
     #[must_use]
     pub fn visible_spans(
         &self,
@@ -308,5 +325,16 @@ mod tests {
         selection.select_word(&viewport, &buffer, 0, 6);
 
         assert_eq!(selection.selected_text(&viewport, &buffer), "two_three");
+    }
+
+    #[test]
+    fn row_overlap_respects_the_exclusive_endpoint() {
+        let viewport = ScrollbackViewport::default();
+        let mut selection = TerminalSelection::default();
+        selection.set_from_window(&viewport, 2, 0, 0, 2);
+
+        assert!(selection.overlaps_row(0, 8));
+        assert!(selection.overlaps_row(1, 8));
+        assert!(!selection.overlaps_row(2, 8));
     }
 }


### PR DESCRIPTION
## Summary

- clear active selections before wheel input is routed to the daemon
- clear selections when entering or leaving alternate-screen mode
- invalidate selections only when incoming grid damage overlaps selected live rows, while preserving local scrollback selections and unrelated normal-screen output
- keep highlight rendering and copied text consistent by clearing both through the shared selection model

## Root cause

`TerminalSelection` correctly stores scroll-invariant absolute rows, but daemon-owned scrolling does not move Diri's viewport. A TUI instead repaints the live grid in place, so the same absolute row began naming new content while the old selection highlight and copy range survived. Mode transitions similarly replace the coordinate space without invalidating it.

The terminal element now expires the shared selection at the three boundaries where those coordinates lose meaning: a daemon wheel route, an alternate-screen transition, or grid damage overlapping a selected live row. Local viewport movement still preserves absolute-row selection.

## Test evidence

- Before fix: `cargo test -p diri-term selection_repaint_tests -- --nocapture` — 3 failed, 2 passed; daemon wheel, alt-screen transition, and overlapping repaint reproduced the stale selection/copy bug
- After fix: `cargo test -p diri-term` — 69 passed
- `cargo test -p diri-app` — 345 passed, 2 ignored
- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed

Coverage includes alt-screen and mouse-reporting daemon wheel routes, local scrolling across the history/live seam, alternate-screen enter/exit, overlapping versus non-overlapping damage, full snapshot reseeds, and highlighted/copy text consistency.

Closes #75