### PR TITLE
Add keyboard navigation to the sidebar

### DIFF
--- a/diri/crates/diri-app/src/commands.rs
+++ b/diri/crates/diri-app/src/commands.rs
@@ -30,6 +30,7 @@ actions!(
         OpenWorktrees,
         OpenSettings,
         ToggleSidebar,
+        FocusSidebar,
         ToggleInspector,
         ToggleAuxiliaryTerminal,
         ArchiveSelectedSession,
@@ -89,6 +90,7 @@ pub enum CommandId {
     OpenWorktrees,
     OpenSettings,
     ToggleSidebar,
+    FocusSidebar,
     ToggleInspector,
     ToggleAuxiliaryTerminal,
     ArchiveSelectedSession,
@@ -291,6 +293,16 @@ pub const COMMANDS: &[CommandSpec] = &[
         "Toggle Sidebar",
         "sidebar.left",
         "hide show panel"
+    ),
+    spec!(
+        FocusSidebar,
+        "focus-sidebar",
+        Some("cmd-shift-b"),
+        Some("⇧⌘B"),
+        Some(APP_CONTEXT),
+        "Focus Sidebar",
+        "sidebar.left",
+        "keyboard sessions navigation focus"
     ),
     spec!(
         ToggleInspector,
@@ -544,6 +556,7 @@ impl CommandSpec {
             CommandId::OpenWorktrees => KeyBinding::new(key, OpenWorktrees, context),
             CommandId::OpenSettings => KeyBinding::new(key, OpenSettings, context),
             CommandId::ToggleSidebar => KeyBinding::new(key, ToggleSidebar, context),
+            CommandId::FocusSidebar => KeyBinding::new(key, FocusSidebar, context),
             CommandId::ToggleInspector => KeyBinding::new(key, ToggleInspector, context),
             CommandId::ToggleAuxiliaryTerminal => {
                 KeyBinding::new(key, ToggleAuxiliaryTerminal, context)
@@ -608,6 +621,7 @@ impl CommandId {
             Self::OpenWorktrees => Box::new(OpenWorktrees),
             Self::OpenSettings => Box::new(OpenSettings),
             Self::ToggleSidebar => Box::new(ToggleSidebar),
+            Self::FocusSidebar => Box::new(FocusSidebar),
             Self::ToggleInspector => Box::new(ToggleInspector),
             Self::ToggleAuxiliaryTerminal => Box::new(ToggleAuxiliaryTerminal),
             Self::ArchiveSelectedSession => Box::new(ArchiveSelectedSession),
@@ -705,6 +719,14 @@ mod tests {
             command(CommandId::SelectNextSession).alternate_keystrokes,
             ["cmd-alt-down", "cmd-]"]
         );
+    }
+
+    #[test]
+    fn sidebar_focus_has_a_global_explicit_shortcut() {
+        let focus = command(CommandId::FocusSidebar);
+        assert_eq!(focus.keystroke, Some("cmd-shift-b"));
+        assert_eq!(focus.context, Some(APP_CONTEXT));
+        assert_eq!(focus.shortcut, Some("⇧⌘B"));
     }
 
     #[test]

--- a/diri/crates/diri-app/src/navigation.rs
+++ b/diri/crates/diri-app/src/navigation.rs
@@ -288,6 +288,12 @@ impl NavigationOverlay {
         cx.notify();
     }
 
+    pub(crate) fn dismiss(&mut self, cx: &mut Context<Self>) {
+        if self.overlay.is_some() {
+            self.close_overlay(cx);
+        }
+    }
+
     /// Back to the first row, scrolled back to the top of the list.
     fn reset_selection(&mut self) {
         self.highlight = 0;

--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -13,13 +13,13 @@ use gpui::{
 use crate::AppServices;
 use crate::commands::{
     self, APP_CONTEXT, ArchiveSelectedSession, CheckForUpdates, CloseSession, CommandId,
-    MoveSelectedSessionDown, MoveSelectedSessionUp, NewCodexSession, NewDefaultSession,
-    NewTerminal, OpenLauncher, OpenSettings, OpenWorktrees, RenameSelectedSession, ReopenSession,
-    SESSION_NAVIGATION_CONTEXT, SelectLastSession, SelectNextAttentionSession, SelectNextSession,
-    SelectPreviousSession, SelectSession1, SelectSession2, SelectSession3, SelectSession4,
-    SelectSession5, SelectSession6, SelectSession7, SelectSession8, ToggleAuxiliaryTerminal,
-    ToggleCommandPalette, ToggleHistory, ToggleInspector, ToggleOverview, ToggleQuickOpen,
-    ToggleSidebar,
+    FocusSidebar, MoveSelectedSessionDown, MoveSelectedSessionUp, NewCodexSession,
+    NewDefaultSession, NewTerminal, OpenLauncher, OpenSettings, OpenWorktrees,
+    RenameSelectedSession, ReopenSession, SESSION_NAVIGATION_CONTEXT, SelectLastSession,
+    SelectNextAttentionSession, SelectNextSession, SelectPreviousSession, SelectSession1,
+    SelectSession2, SelectSession3, SelectSession4, SelectSession5, SelectSession6, SelectSession7,
+    SelectSession8, ToggleAuxiliaryTerminal, ToggleCommandPalette, ToggleHistory, ToggleInspector,
+    ToggleOverview, ToggleQuickOpen, ToggleSidebar,
 };
 use crate::external_drop::ExternalDropAction;
 use crate::inspector::{InspectorEvent, WorkbenchInspector};
@@ -265,6 +265,14 @@ impl RootView {
                 if let Some(terminal) = &this.terminal {
                     terminal.update(cx, |terminal, cx| terminal.focus(window, cx));
                     this.sync_auxiliary_terminal(window, cx);
+                }
+            }
+            if matches!(event, SidebarEvent::FocusTerminal) {
+                if let Some(terminal) = &this.terminal {
+                    terminal.update(cx, |terminal, cx| terminal.focus(window, cx));
+                    this.sync_auxiliary_terminal(window, cx);
+                } else {
+                    window.focus(&this.focus, cx);
                 }
             }
             if let SidebarEvent::Update(command) = event {
@@ -633,12 +641,22 @@ impl RootView {
     }
 
     fn on_key_down(&mut self, event: &KeyDownEvent, _window: &mut Window, cx: &mut Context<Self>) {
+        // The sidebar is a real keyboard surface. Let its bubble handler own
+        // navigation and rename input instead of mirroring the same keystroke
+        // into the live terminal during root capture.
+        if self.sidebar.read(cx).is_focused(_window) {
+            return;
+        }
         if self.launcher.read(cx).is_open() {
             let reopen = commands::matches_keystroke(CommandId::OpenLauncher, &event.keystroke);
-            self.launcher.update(cx, |launcher, cx| {
-                launcher.handle_key_down(event, _window, cx);
-            });
-            if !reopen {
+            let focus_sidebar =
+                commands::matches_keystroke(CommandId::FocusSidebar, &event.keystroke);
+            if !focus_sidebar {
+                self.launcher.update(cx, |launcher, cx| {
+                    launcher.handle_key_down(event, _window, cx);
+                });
+            }
+            if !reopen && !focus_sidebar {
                 cx.stop_propagation();
             }
             return;
@@ -651,6 +669,7 @@ impl RootView {
                 CommandId::OpenSettings,
                 CommandId::ToggleCommandPalette,
                 CommandId::ToggleQuickOpen,
+                CommandId::FocusSidebar,
             ]
             .into_iter()
             .any(|command| commands::matches_keystroke(command, &event.keystroke));
@@ -726,6 +745,23 @@ impl RootView {
             }
             CommandId::ToggleSidebar => {
                 self.sidebar.update(cx, |sidebar, cx| sidebar.toggle(cx));
+            }
+            CommandId::FocusSidebar => {
+                if self.launcher.read(cx).is_open() {
+                    self.launcher
+                        .update(cx, |launcher, cx| launcher.dismiss(cx));
+                }
+                if let Some(navigation) = &self.navigation {
+                    navigation.update(cx, |navigation, cx| navigation.dismiss(cx));
+                }
+                if let Some(surfaces) = &self.utility_surfaces {
+                    surfaces.update(cx, |surfaces, cx| surfaces.dismiss(cx));
+                }
+                if let Some(surfaces) = &self.session_surfaces {
+                    surfaces.update(cx, |surfaces, cx| surfaces.dismiss(cx));
+                }
+                self.sidebar
+                    .update(cx, |sidebar, cx| sidebar.focus(window, cx));
             }
             CommandId::ToggleInspector => self.toggle_inspector(cx),
             CommandId::ToggleAuxiliaryTerminal => {
@@ -2079,6 +2115,9 @@ impl Render for RootView {
             }))
             .on_action(cx.listener(|this, _: &ToggleSidebar, window, cx| {
                 this.run_command(CommandId::ToggleSidebar, window, cx);
+            }))
+            .on_action(cx.listener(|this, _: &FocusSidebar, window, cx| {
+                this.run_command(CommandId::FocusSidebar, window, cx);
             }))
             .on_action(cx.listener(|this, _: &ToggleInspector, window, cx| {
                 this.run_command(CommandId::ToggleInspector, window, cx);

--- a/diri/crates/diri-app/src/session_surfaces.rs
+++ b/diri/crates/diri-app/src/session_surfaces.rs
@@ -113,6 +113,14 @@ impl SessionSurfaces {
         store.toggle_overview();
         cx.notify();
     }
+
+    pub(crate) fn dismiss(&mut self, cx: &mut Context<Self>) {
+        let mut store = self.store.write().expect("session store lock poisoned");
+        store.cancel_switcher();
+        store.dismiss_overview();
+        drop(store);
+        cx.notify();
+    }
 }
 
 impl Render for SessionSurfaces {

--- a/diri/crates/diri-app/src/sidebar/mod.rs
+++ b/diri/crates/diri-app/src/sidebar/mod.rs
@@ -5,6 +5,6 @@ mod state;
 mod view;
 
 pub use fixture::{PreviewScenario, SidebarPreviewFixture};
-pub use state::{DragItem, Popover, SidebarUiState, move_before, move_to_end};
+pub use state::{CursorMove, DragItem, Popover, SidebarUiState, move_before, move_to_end};
 pub use view::Sidebar;
 pub(crate) use view::SidebarEvent;

--- a/diri/crates/diri-app/src/sidebar/state.rs
+++ b/diri/crates/diri-app/src/sidebar/state.rs
@@ -7,6 +7,14 @@ pub const DEFAULT_SIDEBAR_WIDTH: f32 = 248.0;
 pub const MIN_SIDEBAR_WIDTH: f32 = 200.0;
 pub const MAX_SIDEBAR_WIDTH: f32 = 400.0;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CursorMove {
+    Up,
+    Down,
+    Home,
+    End,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DragItem {
     Project(ProjectId),
@@ -62,6 +70,11 @@ pub struct SidebarUiState {
     pub order_dirty: bool,
     pub resize_origin: Option<(f32, f32)>,
     pub preview_account: bool,
+    /// Keyboard focus follows a session identity, not a visual index. The
+    /// previous order is retained solely to choose the next row (or the
+    /// previous row at the end) if that session disappears.
+    pub focus_cursor: Option<SessionId>,
+    focus_order: Vec<SessionId>,
 }
 
 impl SidebarUiState {
@@ -81,7 +94,65 @@ impl SidebarUiState {
             order_dirty: false,
             resize_origin: None,
             preview_account: false,
+            focus_cursor: None,
+            focus_order: Vec::new(),
         }
+    }
+
+    /// Reconciles the identity cursor with the rows the sidebar is actually
+    /// painting. Reorders leave the identity untouched. A removed or newly
+    /// hidden row gives its position to the row that followed it, falling back
+    /// to the previous row when it was last.
+    pub fn reconcile_focus_cursor(&mut self, visible: &[SessionId], preferred: Option<&SessionId>) {
+        let next = match self.focus_cursor.as_ref() {
+            Some(cursor) if visible.contains(cursor) => Some(cursor.clone()),
+            Some(cursor) => {
+                let previous_index = self
+                    .focus_order
+                    .iter()
+                    .position(|candidate| candidate == cursor)
+                    .unwrap_or(0);
+                visible
+                    .get(previous_index.min(visible.len().saturating_sub(1)))
+                    .cloned()
+            }
+            None => preferred
+                .filter(|candidate| visible.contains(candidate))
+                .cloned()
+                .or_else(|| visible.first().cloned()),
+        };
+        self.focus_cursor = next;
+        self.focus_order = visible.to_vec();
+    }
+
+    pub fn set_focus_cursor(&mut self, id: SessionId, visible: &[SessionId]) {
+        if visible.contains(&id) {
+            self.focus_cursor = Some(id);
+            self.focus_order = visible.to_vec();
+        }
+    }
+
+    pub fn move_focus_cursor(&mut self, movement: CursorMove, visible: &[SessionId]) -> bool {
+        if visible.is_empty() {
+            self.focus_cursor = None;
+            self.focus_order.clear();
+            return false;
+        }
+        let current = self
+            .focus_cursor
+            .as_ref()
+            .and_then(|cursor| visible.iter().position(|candidate| candidate == cursor));
+        let index = match movement {
+            CursorMove::Home => 0,
+            CursorMove::End => visible.len() - 1,
+            CursorMove::Up => current.map_or(visible.len() - 1, |index| index.saturating_sub(1)),
+            CursorMove::Down => current.map_or(0, |index| (index + 1).min(visible.len() - 1)),
+        };
+        let next = visible[index].clone();
+        let changed = self.focus_cursor.as_ref() != Some(&next);
+        self.focus_cursor = Some(next);
+        self.focus_order = visible.to_vec();
+        changed
     }
 
     pub fn set_width(&mut self, width: f32) {
@@ -170,5 +241,46 @@ mod tests {
         let mut state = SidebarUiState::new(DEFAULT_SIDEBAR_WIDTH);
         state.begin_rename(SessionId::new("one"), "  ");
         assert!(state.take_rename().is_none());
+    }
+
+    #[test]
+    fn focus_cursor_moves_and_clamps_across_visible_rows() {
+        let rows = ["one", "two", "three"].map(SessionId::new);
+        let mut state = SidebarUiState::new(DEFAULT_SIDEBAR_WIDTH);
+        state.reconcile_focus_cursor(&rows, Some(&rows[1]));
+
+        assert_eq!(state.focus_cursor, Some(rows[1].clone()));
+        assert!(state.move_focus_cursor(CursorMove::Up, &rows));
+        assert_eq!(state.focus_cursor, Some(rows[0].clone()));
+        assert!(!state.move_focus_cursor(CursorMove::Up, &rows));
+        assert!(state.move_focus_cursor(CursorMove::End, &rows));
+        assert_eq!(state.focus_cursor, Some(rows[2].clone()));
+        assert!(state.move_focus_cursor(CursorMove::Home, &rows));
+        assert_eq!(state.focus_cursor, Some(rows[0].clone()));
+    }
+
+    #[test]
+    fn focus_cursor_tracks_identity_across_reorders() {
+        let rows = ["one", "two", "three"].map(SessionId::new);
+        let mut state = SidebarUiState::new(DEFAULT_SIDEBAR_WIDTH);
+        state.reconcile_focus_cursor(&rows, Some(&rows[1]));
+
+        state.reconcile_focus_cursor(&[rows[2].clone(), rows[1].clone(), rows[0].clone()], None);
+
+        assert_eq!(state.focus_cursor, Some(rows[1].clone()));
+    }
+
+    #[test]
+    fn removed_focus_cursor_lands_on_a_sensible_neighbour() {
+        let rows = ["one", "two", "three"].map(SessionId::new);
+        let mut state = SidebarUiState::new(DEFAULT_SIDEBAR_WIDTH);
+        state.reconcile_focus_cursor(&rows, Some(&rows[1]));
+
+        state.reconcile_focus_cursor(&[rows[0].clone(), rows[2].clone()], None);
+        assert_eq!(state.focus_cursor, Some(rows[2].clone()));
+
+        state.set_focus_cursor(rows[2].clone(), &[rows[0].clone(), rows[2].clone()]);
+        state.reconcile_focus_cursor(&[rows[0].clone()], None);
+        assert_eq!(state.focus_cursor, Some(rows[0].clone()));
     }
 }

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -1,4 +1,6 @@
-use std::collections::HashMap;
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
+use std::rc::Rc;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
@@ -13,7 +15,7 @@ use diri_ui::{
     RowFill, SemanticColors, Space, StateChip, StatusGlyph, StatusState, Typo,
 };
 use gpui::{
-    Anchor, Animation, AnimationExt, AnyElement, App, AppContext as _, Context, Entity,
+    Anchor, Animation, AnimationExt, AnyElement, App, AppContext as _, Bounds, Context, Entity,
     EventEmitter, ExternalPaths, FocusHandle, Focusable, FontWeight, Hsla, IntoElement,
     MouseButton, Pixels, Point, Render, Rgba, ScrollHandle, SharedString, Task, Window, anchored,
     deferred, div, linear_color_stop, linear_gradient, point, prelude::*, px,
@@ -33,11 +35,27 @@ use crate::updates::{UpdateCommand, UpdatePhase, UpdateState};
 use crate::usage::{UsageFormat, UsageSnapshot};
 
 use super::{
-    DragItem, Popover, PreviewScenario, SidebarPreviewFixture, SidebarUiState, move_before,
-    move_to_end,
+    CursorMove, DragItem, Popover, PreviewScenario, SidebarPreviewFixture, SidebarUiState,
+    move_before, move_to_end,
 };
 
 const PREVIEW_USAGE: f64 = 4.82;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct FocusRow {
+    id: SessionId,
+    parent: Option<SessionId>,
+    has_children: bool,
+    collapsed: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum HorizontalFocusAction {
+    Collapse(SessionId),
+    Expand(SessionId),
+    MoveTo(SessionId),
+    Unchanged,
+}
 
 #[derive(Clone, Debug)]
 pub(crate) enum SidebarEvent {
@@ -52,6 +70,9 @@ pub(crate) enum SidebarEvent {
     /// A plain click (or shortcut) selected a session: hand keyboard focus
     /// to its terminal surface so the user can type immediately.
     SessionActivated,
+    /// Escape left keyboard-navigation mode without changing the active
+    /// session. Root owns the terminal entity, so it completes the handoff.
+    FocusTerminal,
     /// The user acted on the update pill. The sidebar holds no updater of its
     /// own; RootView owns the handle and forwards these.
     Update(UpdateCommand),
@@ -100,12 +121,15 @@ pub struct Sidebar {
     /// Session list scroll position, read back each frame to size the top and
     /// bottom fades.
     list_scroll: ScrollHandle,
+    /// Window-space row bounds from the latest prepaint. Keyboard navigation
+    /// uses these to reveal only rows that actually crossed the viewport edge.
+    row_bounds: Rc<RefCell<HashMap<SessionId, Bounds<Pixels>>>>,
     directory_scroll: ScrollHandle,
     glyphs: HashMap<SessionId, Entity<StatusGlyph>>,
     /// Rebuilt once per projection render. Looking up ⌘1…⌘9 inside every row
     /// previously re-locked the store and scanned the full session list N times.
     shortcut_ranks: HashMap<SessionId, usize>,
-    rename_focus: FocusHandle,
+    focus_handle: FocusHandle,
     hover_generation: u64,
     usage: Option<UsageSnapshot>,
     update: UpdateState,
@@ -126,7 +150,7 @@ impl EventEmitter<SidebarEvent> for Sidebar {}
 
 impl Focusable for Sidebar {
     fn focus_handle(&self, _cx: &App) -> FocusHandle {
-        self.rename_focus.clone()
+        self.focus_handle.clone()
     }
 }
 
@@ -184,10 +208,11 @@ impl Sidebar {
             _store_changes: store_changes,
             ui,
             list_scroll: ScrollHandle::new(),
+            row_bounds: Rc::new(RefCell::new(HashMap::new())),
             directory_scroll: ScrollHandle::new(),
             glyphs: HashMap::new(),
             shortcut_ranks: HashMap::new(),
-            rename_focus: cx.focus_handle(),
+            focus_handle: cx.focus_handle(),
             hover_generation: 0,
             usage: None,
             update: UpdateState::default(),
@@ -314,6 +339,11 @@ impl Sidebar {
             eprintln!("diri: could not remember sidebar visibility: {error}");
         }
         cx.emit(SidebarEvent::VisibilityChanged);
+        if !visible {
+            // A hidden focus owner cannot receive Escape or hand keys onward.
+            // Return to the terminal for every collapse entry point.
+            cx.emit(SidebarEvent::FocusTerminal);
+        }
         cx.notify();
     }
 
@@ -424,9 +454,10 @@ impl Sidebar {
         cx: &mut Context<Self>,
     ) {
         self.commit_rename();
+        self.ui.focus_cursor = Some(session.id.clone());
         self.ui
             .begin_rename(session.id.clone(), session.title.clone());
-        self.rename_focus.focus(window, cx);
+        self.focus_handle.focus(window, cx);
         cx.notify();
     }
 
@@ -439,45 +470,207 @@ impl Sidebar {
         }
     }
 
+    pub fn is_focused(&self, window: &Window) -> bool {
+        self.focus_handle.is_focused(window)
+    }
+
+    /// Enters keyboard-navigation mode from any other surface. An active row
+    /// is the initial landmark, while an existing identity cursor survives
+    /// subsequent trips to the terminal.
+    pub fn focus(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if !self.ui.visible {
+            self.ui.visible = true;
+            self.last_toggle = Some(Instant::now());
+            if let Err(error) = self
+                .store
+                .write()
+                .expect("session store lock poisoned")
+                .update_preferences(|prefs| prefs.sidebar_visible = true)
+            {
+                eprintln!("diri: could not remember sidebar visibility: {error}");
+            }
+            cx.emit(SidebarEvent::VisibilityChanged);
+        }
+        self.ui.popover = None;
+        let (mut rows, selected) = self.focus_rows_snapshot();
+        if rows.is_empty()
+            && let Some(selected) = selected.as_ref()
+        {
+            self.store
+                .write()
+                .expect("session store lock poisoned")
+                .reveal_in_sidebar(selected);
+            rows = self.focus_rows_snapshot().0;
+        }
+        let visible = focus_row_ids(&rows);
+        self.ui.reconcile_focus_cursor(&visible, selected.as_ref());
+        self.focus_handle.focus(window, cx);
+        self.scroll_focus_cursor_into_view(window);
+        cx.notify();
+    }
+
+    fn focus_rows_snapshot(&self) -> (Vec<FocusRow>, Option<SessionId>) {
+        let mut store = self.store.write().expect("session store lock poisoned");
+        let expanded_archives = store.preferences().sidebar_expanded_archives.clone();
+        let selected = store.selected_session_id().cloned();
+        let projection = store.sidebar_projection();
+        (focus_rows(&projection, &expanded_archives), selected)
+    }
+
+    fn move_focus_cursor(
+        &mut self,
+        movement: CursorMove,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let (rows, selected) = self.focus_rows_snapshot();
+        let visible = focus_row_ids(&rows);
+        self.ui.reconcile_focus_cursor(&visible, selected.as_ref());
+        self.ui.move_focus_cursor(movement, &visible);
+        self.scroll_focus_cursor_into_view(window);
+        cx.notify();
+        true
+    }
+
+    fn move_focus_horizontally(
+        &mut self,
+        right: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let (rows, selected) = self.focus_rows_snapshot();
+        let visible = focus_row_ids(&rows);
+        self.ui.reconcile_focus_cursor(&visible, selected.as_ref());
+        let action = horizontal_focus_action(&rows, self.ui.focus_cursor.as_ref(), right);
+        match action {
+            HorizontalFocusAction::Collapse(id) | HorizontalFocusAction::Expand(id) => {
+                let _ = self
+                    .store
+                    .write()
+                    .expect("session store lock poisoned")
+                    .toggle_session_collapsed(id);
+            }
+            HorizontalFocusAction::MoveTo(id) => {
+                self.ui.set_focus_cursor(id, &visible);
+            }
+            HorizontalFocusAction::Unchanged => {}
+        }
+        let (next_rows, _) = self.focus_rows_snapshot();
+        self.ui
+            .reconcile_focus_cursor(&focus_row_ids(&next_rows), None);
+        self.scroll_focus_cursor_into_view(window);
+        cx.notify();
+        true
+    }
+
+    fn activate_focus_cursor(&mut self, cx: &mut Context<Self>) -> bool {
+        let Some(id) = self.ui.focus_cursor.clone() else {
+            return true;
+        };
+        let exists = {
+            let mut store = self.store.write().expect("session store lock poisoned");
+            let exists = store.sessions().contains_key(&id);
+            if exists {
+                store.select(id);
+            }
+            exists
+        };
+        if exists {
+            cx.emit(SidebarEvent::SessionActivated);
+            cx.notify();
+        }
+        true
+    }
+
+    fn scroll_focus_cursor_into_view(&self, window: &mut Window) {
+        let Some(id) = self.ui.focus_cursor.clone() else {
+            return;
+        };
+        let scroll = self.list_scroll.clone();
+        let row_bounds = Rc::clone(&self.row_bounds);
+        // Keyboard movement changes the focused styling in the upcoming
+        // frame. A row newly exposed by Right may not have bounds until that
+        // frame has painted, so retry once on the following frame.
+        window.on_next_frame(move |window, _cx| {
+            if !reveal_tracked_row(&scroll, &row_bounds, &id, window) {
+                window.on_next_frame(move |window, _cx| {
+                    reveal_tracked_row(&scroll, &row_bounds, &id, window);
+                });
+            }
+        });
+    }
+
     fn on_key_down(
         &mut self,
         event: &gpui::KeyDownEvent,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.ui.renaming.is_none() {
-            if self.ui.popover.is_some() && event.keystroke.key.as_str() == "escape" {
-                self.ui.popover = None;
-                cx.notify();
-            }
-            return;
-        }
-        match event.keystroke.key.as_str() {
-            "enter" => self.commit_rename(),
-            "escape" => self.ui.cancel_rename(),
-            _ => {
-                let Some(edit) = query_editor::edit_for(&event.keystroke) else {
-                    return;
-                };
-                match edit {
-                    Edit::Local(local) => {
-                        self.ui.rename_draft.apply(local);
-                    }
-                    Edit::Clipboard(ClipboardEdit::Copy) => {
-                        query_editor::copy_selection(&self.ui.rename_draft, cx);
-                    }
-                    Edit::Clipboard(ClipboardEdit::Cut) => {
-                        query_editor::cut_selection(&mut self.ui.rename_draft, cx);
-                    }
-                    Edit::Clipboard(ClipboardEdit::Paste) => {
-                        if let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) {
-                            self.ui.rename_draft.insert(&text);
+        if self.ui.renaming.is_some() {
+            // Rename remains a modal editor for every editing keystroke. A
+            // non-editing application shortcut may continue through GPUI's
+            // action dispatch, matching the existing command behavior.
+            match event.keystroke.key.as_str() {
+                "enter" => self.commit_rename(),
+                "escape" => self.ui.cancel_rename(),
+                _ => {
+                    let Some(edit) = query_editor::edit_for(&event.keystroke) else {
+                        return;
+                    };
+                    match edit {
+                        Edit::Local(local) => {
+                            self.ui.rename_draft.apply(local);
+                        }
+                        Edit::Clipboard(ClipboardEdit::Copy) => {
+                            query_editor::copy_selection(&self.ui.rename_draft, cx);
+                        }
+                        Edit::Clipboard(ClipboardEdit::Cut) => {
+                            query_editor::cut_selection(&mut self.ui.rename_draft, cx);
+                        }
+                        Edit::Clipboard(ClipboardEdit::Paste) => {
+                            if let Some(text) =
+                                cx.read_from_clipboard().and_then(|item| item.text())
+                            {
+                                self.ui.rename_draft.insert(&text);
+                            }
                         }
                     }
                 }
             }
+            cx.stop_propagation();
+            cx.notify();
+            return;
         }
-        cx.notify();
+
+        let key = event.keystroke.key.as_str();
+        if key == "escape" {
+            cx.stop_propagation();
+            if self.ui.popover.take().is_none() {
+                cx.emit(SidebarEvent::FocusTerminal);
+            }
+            cx.notify();
+            return;
+        }
+        let modifiers = event.keystroke.modifiers;
+        if modifiers.platform || modifiers.control || modifiers.alt {
+            return;
+        }
+        let handled = match key {
+            "up" => self.move_focus_cursor(CursorMove::Up, window, cx),
+            "down" => self.move_focus_cursor(CursorMove::Down, window, cx),
+            "home" => self.move_focus_cursor(CursorMove::Home, window, cx),
+            "end" => self.move_focus_cursor(CursorMove::End, window, cx),
+            "left" => self.move_focus_horizontally(false, window, cx),
+            "right" => self.move_focus_horizontally(true, window, cx),
+            "enter" => self.activate_focus_cursor(cx),
+            // Deliberately consumed but unbound. Hold-to-peek owns Space in
+            // the follow-up issue, and activation must remain Enter-only.
+            "space" => true,
+            _ => false,
+        };
+        if handled {
+            cx.stop_propagation();
+        }
     }
 
     fn schedule_hover_card(
@@ -878,7 +1071,7 @@ impl Sidebar {
                             cx.stop_propagation();
                             this.commit_rename();
                             this.ui.hover_card = None;
-                            this.rename_focus.focus(window, cx);
+                            this.focus_handle.focus(window, cx);
                             this.ui.popover = Some(Popover::ProjectActions {
                                 id: id.clone(),
                                 position: Some(event.position),
@@ -1055,12 +1248,28 @@ impl Sidebar {
         // row list here means "collapsed" without asking a second source.
         for row in &group.sessions {
             let shortcut = self.shortcut_for(row.id());
-            section = section.child(self.session_row(row, shortcut, colors, window, cx));
+            let id = row.id().clone();
+            let rendered = self.session_row(row, shortcut, colors, window, cx);
+            section = section.child(self.track_row_bounds(id, rendered));
         }
         if !collapsed && !group.archived.is_empty() {
             section = section.child(self.archived_bucket(group, colors, window, cx));
         }
         section.into_any_element()
+    }
+
+    fn track_row_bounds(&self, id: SessionId, row: AnyElement) -> AnyElement {
+        let bounds = Rc::clone(&self.row_bounds);
+        div()
+            .w_full()
+            .flex_none()
+            .on_children_prepainted(move |children, _, _| {
+                if let Some(row) = children.first().copied() {
+                    bounds.borrow_mut().insert(id.clone(), row);
+                }
+            })
+            .child(row)
+            .into_any_element()
     }
 
     fn session_row(
@@ -1083,6 +1292,9 @@ impl Sidebar {
             )
         };
         let hovered = self.ui.hovered_session.as_ref() == Some(&id);
+        let focused = self.focus_handle.is_focused(window)
+            && self.ui.renaming.is_none()
+            && self.ui.focus_cursor.as_ref() == Some(&id);
         let archived = session.is_archived();
         let hibernated = session.hibernation.is_some();
         let session_is_remote = session.host.is_some();
@@ -1219,6 +1431,12 @@ impl Sidebar {
             .gap(px(8.0))
             .rounded(px(Radius::ROW))
             .bg(fill.color(colors))
+            .border_1()
+            .border_color(if focused {
+                Ink::FRESH.alpha(0.82)
+            } else {
+                colors.primary.alpha(0.0)
+            })
             .opacity(if archived {
                 0.58
             } else if hibernated {
@@ -1235,6 +1453,7 @@ impl Sidebar {
             .on_click(
                 cx.listener(move |this, event: &gpui::ClickEvent, window, cx| {
                     this.commit_rename();
+                    this.ui.focus_cursor = Some(row_session.id.clone());
                     if event.click_count() == 2 {
                         this.begin_rename(&row_session, window, cx);
                         return;
@@ -1269,7 +1488,8 @@ impl Sidebar {
                     cx.stop_propagation();
                     this.commit_rename();
                     this.ui.hover_card = None;
-                    this.rename_focus.focus(window, cx);
+                    this.ui.focus_cursor = Some(rename_session.id.clone());
+                    this.focus_handle.focus(window, cx);
                     this.ui.popover = Some(Popover::SessionActions {
                         id: rename_session.id.clone(),
                         position: event.position,
@@ -1655,7 +1875,9 @@ impl Sidebar {
             );
         if expanded {
             for session in &group.archived {
-                bucket = bucket.child(self.archived_row(session, colors, window, cx));
+                let id = session.id.clone();
+                let rendered = self.archived_row(session, colors, window, cx);
+                bucket = bucket.child(self.track_row_bounds(id, rendered));
             }
         }
         bucket.into_any_element()
@@ -1665,11 +1887,14 @@ impl Sidebar {
         &mut self,
         session: &SessionRecord,
         colors: SemanticColors,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let id = session.id.clone();
         let hovered = self.ui.hovered_session.as_ref() == Some(&id);
+        let focused = self.focus_handle.is_focused(window)
+            && self.ui.renaming.is_none()
+            && self.ui.focus_cursor.as_ref() == Some(&id);
         let selected = self
             .store
             .read()
@@ -1689,13 +1914,19 @@ impl Sidebar {
             .items_center()
             .gap(px(8.0))
             .rounded(px(Radius::ROW))
-            .opacity(0.58)
+            .opacity(if focused { 0.82 } else { 0.58 })
             .bg(if selected {
                 RowFill::Selected.color(colors)
             } else if hovered {
                 RowFill::Hover.color(colors)
             } else {
                 RowFill::Clear.color(colors)
+            })
+            .border_1()
+            .border_color(if focused {
+                Ink::FRESH.alpha(0.82)
+            } else {
+                colors.primary.alpha(0.0)
             })
             .cursor_pointer()
             .on_hover(cx.listener({
@@ -1707,6 +1938,7 @@ impl Sidebar {
             }))
             .on_click(cx.listener(move |this, event: &gpui::ClickEvent, _, cx| {
                 let modifiers = event.modifiers();
+                this.ui.focus_cursor = Some(row_session.id.clone());
                 this.store
                     .write()
                     .expect("session store lock poisoned")
@@ -3716,13 +3948,130 @@ impl Sidebar {
     }
 }
 
+fn focus_rows(
+    projection: &crate::store::SidebarProjection,
+    expanded_archives: &[ProjectId],
+) -> Vec<FocusRow> {
+    let mut result = Vec::new();
+    for group in &projection.projects {
+        let mut ancestors: Vec<SessionId> = Vec::new();
+        for row in &group.sessions {
+            let depth = usize::from(row.depth);
+            ancestors.truncate(depth);
+            let parent = depth
+                .checked_sub(1)
+                .and_then(|index| ancestors.get(index))
+                .cloned();
+            result.push(FocusRow {
+                id: row.id().clone(),
+                parent,
+                has_children: row.has_children,
+                collapsed: row.collapsed,
+            });
+            ancestors.push(row.id().clone());
+        }
+        if expanded_archives.contains(&group.project.id) {
+            result.extend(group.archived.iter().map(|session| FocusRow {
+                id: session.id.clone(),
+                parent: None,
+                has_children: false,
+                collapsed: false,
+            }));
+        }
+    }
+    result
+}
+
+fn focus_row_ids(rows: &[FocusRow]) -> Vec<SessionId> {
+    rows.iter().map(|row| row.id.clone()).collect()
+}
+
+fn horizontal_focus_action(
+    rows: &[FocusRow],
+    cursor: Option<&SessionId>,
+    right: bool,
+) -> HorizontalFocusAction {
+    let Some(row) = cursor.and_then(|cursor| rows.iter().find(|row| &row.id == cursor)) else {
+        return HorizontalFocusAction::Unchanged;
+    };
+    if right {
+        if row.has_children && row.collapsed {
+            HorizontalFocusAction::Expand(row.id.clone())
+        } else if row.has_children {
+            rows.iter()
+                .find(|candidate| candidate.parent.as_ref() == Some(&row.id))
+                .map(|child| HorizontalFocusAction::MoveTo(child.id.clone()))
+                .unwrap_or(HorizontalFocusAction::Unchanged)
+        } else {
+            HorizontalFocusAction::Unchanged
+        }
+    } else if row.has_children && !row.collapsed {
+        HorizontalFocusAction::Collapse(row.id.clone())
+    } else {
+        row.parent
+            .clone()
+            .map(HorizontalFocusAction::MoveTo)
+            .unwrap_or(HorizontalFocusAction::Unchanged)
+    }
+}
+
+fn offset_to_reveal(
+    current: f32,
+    viewport_top: f32,
+    viewport_bottom: f32,
+    row_top: f32,
+    row_bottom: f32,
+) -> f32 {
+    if row_top < viewport_top {
+        current + viewport_top - row_top
+    } else if row_bottom > viewport_bottom {
+        current - (row_bottom - viewport_bottom)
+    } else {
+        current
+    }
+}
+
+fn reveal_tracked_row(
+    scroll: &ScrollHandle,
+    row_bounds: &RefCell<HashMap<SessionId, Bounds<Pixels>>>,
+    id: &SessionId,
+    window: &mut Window,
+) -> bool {
+    let Some(row) = row_bounds.borrow().get(id).copied() else {
+        return false;
+    };
+    let viewport = scroll.bounds();
+    let offset = scroll.offset();
+    let next_y = offset_to_reveal(
+        f32::from(offset.y),
+        f32::from(viewport.top()),
+        f32::from(viewport.bottom()),
+        f32::from(row.top()),
+        f32::from(row.bottom()),
+    );
+    if (next_y - f32::from(offset.y)).abs() > f32::EPSILON {
+        scroll.set_offset(point(offset.x, px(next_y)));
+        window.refresh();
+    }
+    true
+}
+
 impl Render for Sidebar {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let colors = self.colors();
-        let projection = {
+        let (projection, expanded_archives, selected) = {
             let mut store = self.store.write().expect("session store lock poisoned");
-            store.sidebar_projection()
+            let expanded = store.preferences().sidebar_expanded_archives.clone();
+            let selected = store.selected_session_id().cloned();
+            (store.sidebar_projection(), expanded, selected)
         };
+        let focus_rows = focus_rows(&projection, &expanded_archives);
+        let visible = focus_row_ids(&focus_rows);
+        self.ui.reconcile_focus_cursor(&visible, selected.as_ref());
+        let visible_set: HashSet<_> = visible.iter().collect();
+        self.row_bounds
+            .borrow_mut()
+            .retain(|id, _| visible_set.contains(id));
         self.shortcut_ranks.clear();
         let session_count = projection.ordered_sessions.len();
         for (index, session) in projection.ordered_sessions.iter().enumerate() {
@@ -3763,7 +4112,7 @@ impl Render for Sidebar {
             .flex_col()
             .text_color(colors.primary)
             .bg(Self::surface_fill(colors))
-            .track_focus(&self.rename_focus)
+            .track_focus(&self.focus_handle)
             .on_key_down(cx.listener(Self::on_key_down))
             .child(self.top_bar(colors, cx))
             .child(self.new_agent_row(colors, cx));
@@ -4347,6 +4696,57 @@ mod tests {
     }
 
     #[test]
+    fn horizontal_focus_navigation_expands_collapses_and_walks_to_parent() {
+        let parent = SessionId::new("parent");
+        let child = SessionId::new("child");
+        let expanded = vec![
+            FocusRow {
+                id: parent.clone(),
+                parent: None,
+                has_children: true,
+                collapsed: false,
+            },
+            FocusRow {
+                id: child.clone(),
+                parent: Some(parent.clone()),
+                has_children: false,
+                collapsed: false,
+            },
+        ];
+
+        assert_eq!(
+            horizontal_focus_action(&expanded, Some(&parent), false),
+            HorizontalFocusAction::Collapse(parent.clone())
+        );
+        assert_eq!(
+            horizontal_focus_action(&expanded, Some(&parent), true),
+            HorizontalFocusAction::MoveTo(child.clone())
+        );
+        assert_eq!(
+            horizontal_focus_action(&expanded, Some(&child), false),
+            HorizontalFocusAction::MoveTo(parent.clone())
+        );
+
+        let collapsed = [FocusRow {
+            id: parent.clone(),
+            parent: None,
+            has_children: true,
+            collapsed: true,
+        }];
+        assert_eq!(
+            horizontal_focus_action(&collapsed, Some(&parent), true),
+            HorizontalFocusAction::Expand(parent)
+        );
+    }
+
+    #[test]
+    fn scrolling_reveals_only_rows_outside_the_viewport() {
+        assert_eq!(offset_to_reveal(-40.0, 100.0, 300.0, 150.0, 178.0), -40.0);
+        assert_eq!(offset_to_reveal(-40.0, 100.0, 300.0, 80.0, 108.0), -20.0);
+        assert_eq!(offset_to_reveal(-40.0, 100.0, 300.0, 292.0, 320.0), -60.0);
+    }
+
+    #[test]
     fn agent_shortcuts_remain_visible_when_the_execution_host_changes() {
         assert_eq!(
             agent_picker_shortcut(
@@ -4516,6 +4916,82 @@ mod tests {
             sidebar.read_with(cx, |sidebar, _| sidebar.ui.popover.clone()),
             None
         );
+    }
+
+    #[gpui::test]
+    fn rename_mode_swallows_navigation_and_keeps_editing(cx: &mut TestAppContext) {
+        let (view, cx) = cx.add_window_view(|_, cx| {
+            let sidebar = cx.new(|cx| Sidebar::new(None, true, PreviewScenario::Typical, cx));
+            SidebarPopoverHarness { sidebar }
+        });
+        let sidebar = view.read_with(cx, |harness, _| harness.sidebar.clone());
+        let focused = sidebar.read_with(cx, |sidebar, _| {
+            sidebar
+                .ui
+                .focus_cursor
+                .clone()
+                .expect("render seeds the cursor")
+        });
+        sidebar.update_in(cx, |sidebar, window, cx| {
+            sidebar.ui.begin_rename(focused.clone(), "Before");
+            sidebar.focus_handle.focus(window, cx);
+            cx.notify();
+        });
+
+        cx.simulate_keystrokes("down x");
+
+        sidebar.read_with(cx, |sidebar, _| {
+            assert_eq!(sidebar.ui.focus_cursor, Some(focused));
+            assert!(sidebar.ui.renaming.is_some());
+            assert_eq!(sidebar.ui.rename_draft.text(), "x");
+        });
+    }
+
+    #[gpui::test]
+    fn keyboard_cursor_moves_without_activating_until_enter(cx: &mut TestAppContext) {
+        let (view, cx) = cx.add_window_view(|_, cx| {
+            let sidebar = cx.new(|cx| Sidebar::new(None, true, PreviewScenario::Typical, cx));
+            SidebarPopoverHarness { sidebar }
+        });
+        let sidebar = view.read_with(cx, |harness, _| harness.sidebar.clone());
+        sidebar.update_in(cx, |sidebar, window, cx| sidebar.focus(window, cx));
+        let active_before = sidebar.read_with(cx, |sidebar, _| {
+            sidebar
+                .store
+                .read()
+                .expect("session store lock poisoned")
+                .selected_session_id()
+                .cloned()
+        });
+
+        cx.simulate_keystrokes("down space");
+
+        let cursor = sidebar.read_with(cx, |sidebar, _| {
+            assert_eq!(
+                sidebar
+                    .store
+                    .read()
+                    .expect("session store lock poisoned")
+                    .selected_session_id()
+                    .cloned(),
+                active_before
+            );
+            sidebar.ui.focus_cursor.clone().expect("cursor after Down")
+        });
+        assert_ne!(Some(cursor.clone()), active_before);
+
+        cx.simulate_keystrokes("enter");
+
+        sidebar.read_with(cx, |sidebar, _| {
+            assert_eq!(
+                sidebar
+                    .store
+                    .read()
+                    .expect("session store lock poisoned")
+                    .selected_session_id(),
+                Some(&cursor)
+            );
+        });
     }
 
     #[gpui::test]

--- a/diri/crates/diri-app/src/store/mod.rs
+++ b/diri/crates/diri-app/src/store/mod.rs
@@ -2254,6 +2254,18 @@ impl SessionStore {
         changed
     }
 
+    /// Makes a session addressable by an external sidebar-focus request
+    /// without selecting or activating it. Normal selection calls `reveal`
+    /// through `focus_session`; this narrower entry point is for the keyboard
+    /// cursor when every project is currently folded away.
+    pub(crate) fn reveal_in_sidebar(&mut self, id: &SessionId) -> bool {
+        let changed = self.reveal(id);
+        if changed && let Err(error) = self.persist_preferences() {
+            eprintln!("diri: could not remember revealed sidebar row: {error}");
+        }
+        changed
+    }
+
     fn sidebar_visible_order(&mut self) -> Vec<SessionId> {
         let expanded: HashSet<_> = self
             .prefs

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -995,6 +995,12 @@ impl UtilitySurfaces {
         cx.notify();
     }
 
+    pub(crate) fn dismiss(&mut self, cx: &mut Context<Self>) {
+        if self.surface != Surface::None {
+            self.close_surface(cx);
+        }
+    }
+
     pub(crate) fn is_open(&self) -> bool {
         self.surface != Surface::None
     }


### PR DESCRIPTION
## Summary

- add an identity-based sidebar focus cursor with a distinct focus outline that survives reordering and chooses a stable neighboring row after deletion
- implement Up, Down, Home, End, Left, Right, Enter, Escape, and reserved Space behavior across visible session lineage rows
- keep focused rows visible while navigating, including a post-paint retry for newly expanded children
- add a global Shift-Command-B Focus Sidebar command that reveals a hidden sidebar, dismisses competing overlays, and returns focus to the terminal on Escape
- preserve rename editing behavior and prevent sidebar navigation keystrokes from leaking into the live terminal

## Tests

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo clippy -p diri-app --all-targets -- -D warnings
- cargo test -p diri-app sidebar (39 passed)
- cargo test --workspace (all enabled tests passed; opt-in environment/network tests ignored)
- cargo build --workspace --release
- git diff --check

## Tradeoffs

- the keyboard cursor targets actionable session rows, not structural project or archive headings, so Enter always has a consistent activation meaning
- Up and Down clamp at list boundaries instead of wrapping, matching conventional tree navigation
- Space is consumed without activating a row so the follow-up peek interaction can claim it without changing the current session

Closes #70