### PR TITLE
Forward mouse clicks and drags to mouse-reporting programs

### DIFF
--- a/diri/PLAN.md
+++ b/diri/PLAN.md
@@ -109,7 +109,7 @@ Everything below is verified against the Swift source; cite these files in code 
 
 **Transport** — one unix socket, role decided by the first line of each connection (`ConnectionHub.swift:223`):
 - Control channel: newline-delimited JSON `ControlMessage` — `request{id,method,params}` / `response{id,ok|err{code,message}}` / `event{event,seq,params}`. Max line 4 MiB.
-- Data channel: first line is NDJSON `AttachRequest{attach: <sessionID>, fromOffset?, token?, role}`, then binary frames both ways: `[type u8][len u32 BE][payload]`, max 16 MiB. Types: `input=2`, `resize=3` (cols u16 + rows u16 BE), `ping=6`/`pong=7`, `grid=8`, `scroll=9` (dir u8, lines u16, col u16, row u16 BE), `modes=10` (bit0 altScreen, bit1 mouseReporting). Types 1/4/5 are legacy byte-replay — ignore.
+- Data channel: first line is NDJSON `AttachRequest{attach: <sessionID>, fromOffset?, token?, role}`, then binary frames both ways: `[type u8][len u32 BE][payload]`, max 16 MiB. Types: `input=2`, `resize=3` (cols u16 + rows u16 BE), `ping=6`/`pong=7`, `grid=8`, `scroll=9` (dir u8, lines u16, col u16, row u16 BE), `modes=10` (bit0 altScreen, bit1 historical any-mouse compatibility, bits2–3 mouse tracking off/1000/1002/1003, bit4 legacy/SGR encoding), `mouse=11` (pre-encoded report bytes on the raw interactive path). Types 1/4/5 are legacy byte-replay — ignore.
 - Port-forward channel exists (`ForwardRequest`) — v1 skip.
 
 **Grid codec** (`Grid.swift:100-234`) — must match bit-for-bit, big-endian throughout:

--- a/diri/REMOTE_PORT.md
+++ b/diri/REMOTE_PORT.md
@@ -420,7 +420,10 @@ updates. A snapshot contains only the visible grid, cursor, modes, dimensions,
 and sequence. Mouse state preserves the selected tracking regime (off, DECSET
 1000, 1002, or 1003) independently from legacy/SGR coordinate encoding. The
 wire mode byte retains its historical any-mouse bit and uses previously unused
-bits for those details. Scrollback is bounded to 4 MiB and served on demand
+bits for those details. A live protocol 1.3 Holder exposes only the historical
+bit, so the Engine preserves those details as unknown: it does not synthesize
+button or motion reports, while wheel intent remains encoded by that Holder's
+authoritative parser. Scrollback is bounded to 4 MiB and served on demand
 through `Scroll`. Raw output is bounded to 32 MiB.
 
 The PTY reader must never block on a client. The Holder uses bounded queues. It

--- a/diri/REMOTE_PORT.md
+++ b/diri/REMOTE_PORT.md
@@ -417,8 +417,11 @@ PTY bytes -> shared terminal parser -> Grid + Cursor + Modes
 
 On attach, the Holder sends a `FullSnapshot`, followed by sequenced incremental
 updates. A snapshot contains only the visible grid, cursor, modes, dimensions,
-and sequence. Scrollback is bounded to 4 MiB and served on demand through
-`Scroll`. Raw output is bounded to 32 MiB.
+and sequence. Mouse state preserves the selected tracking regime (off, DECSET
+1000, 1002, or 1003) independently from legacy/SGR coordinate encoding. The
+wire mode byte retains its historical any-mouse bit and uses previously unused
+bits for those details. Scrollback is bounded to 4 MiB and served on demand
+through `Scroll`. Raw output is bounded to 32 MiB.
 
 The PTY reader must never block on a client. The Holder uses bounded queues. It
 coalesces background output for no more than 8 ms, while up to two grid
@@ -474,7 +477,9 @@ are a future enhancement and are not part of the completed baseline.
 `diri-proto::remote_pty` is the versioned protocol authority. Protocol 1.3
 declares terminal, session management, environment capture, directory listing,
 batched executable discovery, persistence probing, and atomic activation as
-required capabilities.
+required capabilities. Protocol 1.4 additively preserves granular mouse
+tracking/encoding bits and the raw mouse-input frame while retaining the old
+any-mouse compatibility bit.
 
 The protocol includes:
 
@@ -488,6 +493,7 @@ Grid
 Scroll
 Modes
 Input
+Mouse
 Resize
 Ping
 Pong

--- a/diri/crates/diri-app/src/terminal_pane.rs
+++ b/diri/crates/diri-app/src/terminal_pane.rs
@@ -478,7 +478,6 @@ impl AttachmentControl {
         if bytes.is_empty() {
             return;
         }
-        let _ = self.pane_tx.send(PaneEvent::InteractiveInput);
         let _ = self.tx.send(AttachmentCommand::Mouse(bytes));
     }
 
@@ -1101,10 +1100,7 @@ impl TerminalPane {
                 }
                 self.apply_grid_updates(id, updates, window, cx);
             }
-            PaneEvent::Chunk(
-                id,
-                TerminalChunk::Modes { alt_screen, mouse },
-            ) => {
+            PaneEvent::Chunk(id, TerminalChunk::Modes { alt_screen, mouse }) => {
                 if let Some(resident) = self.residents.get_mut(&id) {
                     if resident.element.mouse_modes() != mouse {
                         resident.pointer_owner = None;

--- a/diri/crates/diri-app/src/terminal_pane.rs
+++ b/diri/crates/diri-app/src/terminal_pane.rs
@@ -360,29 +360,87 @@ enum PointerOwner {
     Ignored,
 }
 
+#[derive(Debug)]
+struct PendingMouseMotion {
+    cell: (u16, u16),
+    bytes: Vec<u8>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum MotionDispatch {
+    SendNow(Vec<u8>),
+    Schedule { delay: Duration, generation: u64 },
+    None,
+}
+
 #[derive(Default)]
 struct MouseMotionLimiter {
     last_sent_at: Option<Instant>,
     last_cell: Option<(u16, u16)>,
+    pending: Option<PendingMouseMotion>,
+    timer_generation: u64,
+    timer_armed: bool,
 }
 
 impl MouseMotionLimiter {
     fn reset(&mut self) {
         self.last_sent_at = None;
         self.last_cell = None;
+        self.cancel_pending();
     }
 
-    fn should_send(&mut self, now: Instant, cell: (u16, u16)) -> bool {
-        if self.last_cell == Some(cell)
-            || self
-                .last_sent_at
-                .is_some_and(|sent| now.duration_since(sent) < MOUSE_MOTION_CADENCE)
-        {
-            return false;
+    fn push(&mut self, now: Instant, cell: (u16, u16), bytes: Vec<u8>) -> MotionDispatch {
+        if self.last_cell == Some(cell) {
+            // A pending intermediate cell is obsolete if the pointer returned
+            // to the last position the child already observed.
+            self.cancel_pending();
+            return MotionDispatch::None;
         }
+        let Some(elapsed) = self.last_sent_at.map(|sent| now.duration_since(sent)) else {
+            self.last_sent_at = Some(now);
+            self.last_cell = Some(cell);
+            return MotionDispatch::SendNow(bytes);
+        };
+        if elapsed >= MOUSE_MOTION_CADENCE {
+            self.cancel_pending();
+            self.last_sent_at = Some(now);
+            self.last_cell = Some(cell);
+            return MotionDispatch::SendNow(bytes);
+        }
+        self.pending = Some(PendingMouseMotion { cell, bytes });
+        if self.timer_armed {
+            return MotionDispatch::None;
+        }
+        self.timer_armed = true;
+        self.timer_generation = self.timer_generation.wrapping_add(1);
+        MotionDispatch::Schedule {
+            delay: MOUSE_MOTION_CADENCE - elapsed,
+            generation: self.timer_generation,
+        }
+    }
+
+    fn flush(&mut self, generation: u64, now: Instant) -> Option<Vec<u8>> {
+        if !self.timer_armed || generation != self.timer_generation {
+            return None;
+        }
+        self.timer_armed = false;
+        let pending = self.pending.take()?;
         self.last_sent_at = Some(now);
-        self.last_cell = Some(cell);
-        true
+        self.last_cell = Some(pending.cell);
+        Some(pending.bytes)
+    }
+
+    /// Drains the latest held motion before a release, preserving PTY order.
+    fn take_pending(&mut self) -> Option<Vec<u8>> {
+        let pending = self.pending.take().map(|pending| pending.bytes);
+        self.reset();
+        pending
+    }
+
+    fn cancel_pending(&mut self) {
+        self.pending = None;
+        self.timer_armed = false;
+        self.timer_generation = self.timer_generation.wrapping_add(1);
     }
 }
 
@@ -886,6 +944,12 @@ impl TerminalPane {
         self.observed_selected_id = selected_id.clone();
 
         self.reconcile_residency();
+        if selection_changed {
+            for resident in self.residents.values_mut() {
+                resident.pointer_owner = None;
+                resident.mouse_motion.reset();
+            }
+        }
         self.sync_status_glyphs(self.current_colors(), window, cx);
 
         // Explicit sidebar clicks already focus through SessionActivated, but
@@ -1003,6 +1067,10 @@ impl TerminalPane {
         match event {
             PaneEvent::AttachmentState(id, state) => {
                 if let Some(resident) = self.residents.get_mut(&id) {
+                    if resident.attachment_state != state {
+                        resident.pointer_owner = None;
+                        resident.mouse_motion.reset();
+                    }
                     resident.attachment_state = state;
                 }
                 if self.selected_id().as_ref() == Some(&id) {
@@ -1038,6 +1106,10 @@ impl TerminalPane {
                 TerminalChunk::Modes { alt_screen, mouse },
             ) => {
                 if let Some(resident) = self.residents.get_mut(&id) {
+                    if resident.element.mouse_modes() != mouse {
+                        resident.pointer_owner = None;
+                        resident.mouse_motion.reset();
+                    }
                     resident.element.set_modes(alt_screen, mouse);
                 }
                 if self.selected_id().as_ref() == Some(&id) {
@@ -1483,7 +1555,13 @@ impl TerminalPane {
             .map(|(_, owner)| owner);
         resident.pointer_owner = None;
         if owner != Some(PointerOwner::Terminal) {
+            resident.mouse_motion.reset();
             return;
+        }
+        if let Some(bytes) = resident.mouse_motion.take_pending() {
+            // A cadence-held drag must precede its release. Letting the timer
+            // fire afterward would resurrect a button that is already up.
+            resident.attachment.mouse(bytes);
         }
         let Some(button) = terminal_mouse_button(event.button) else {
             return;
@@ -1512,47 +1590,83 @@ impl TerminalPane {
         let Some((col, row)) = self.grid_cell_at(event.position, window) else {
             return;
         };
-        let Some(resident) = self.residents.get_mut(&id) else {
-            return;
+        let (dispatch, attachment) = {
+            let Some(resident) = self.residents.get_mut(&id) else {
+                return;
+            };
+            let owner = event.pressed_button.and_then(|button| {
+                resident
+                    .pointer_owner
+                    .filter(|(owned, _)| *owned == button)
+                    .map(|(_, owner)| owner)
+            });
+            if owner == Some(PointerOwner::LocalSelection) {
+                resident.element.drag_selection(col, row);
+                cx.notify();
+                return;
+            }
+            if event.pressed_button.is_some() && owner != Some(PointerOwner::Terminal) {
+                return;
+            }
+            let button = match event.pressed_button {
+                Some(button) => terminal_mouse_button(button).map(Some),
+                None => Some(None),
+            };
+            let Some(button) = button else {
+                return;
+            };
+            let Some(bytes) = encode_mouse_event(
+                resident.element.mouse_modes(),
+                TerminalMouseEvent::Motion(button),
+                terminal_mouse_modifiers(&event.modifiers),
+                col as u16,
+                row as u16,
+            ) else {
+                return;
+            };
+            (
+                resident
+                    .mouse_motion
+                    .push(Instant::now(), (col as u16, row as u16), bytes),
+                resident.attachment.clone(),
+            )
         };
-        let owner = event.pressed_button.and_then(|button| {
-            resident
-                .pointer_owner
-                .filter(|(owned, _)| *owned == button)
-                .map(|(_, owner)| owner)
-        });
-        if owner == Some(PointerOwner::LocalSelection) {
-            resident.element.drag_selection(col, row);
-            cx.notify();
-            return;
+        match dispatch {
+            MotionDispatch::SendNow(bytes) => attachment.mouse(bytes),
+            MotionDispatch::Schedule { delay, generation } => {
+                self.schedule_mouse_motion_flush(id, delay, generation, cx);
+            }
+            MotionDispatch::None => return,
         }
-        if event.pressed_button.is_some() && owner != Some(PointerOwner::Terminal) {
-            return;
-        }
-        let button = match event.pressed_button {
-            Some(button) => terminal_mouse_button(button).map(Some),
-            None => Some(None),
-        };
-        let Some(button) = button else {
-            return;
-        };
-        let Some(bytes) = encode_mouse_event(
-            resident.element.mouse_modes(),
-            TerminalMouseEvent::Motion(button),
-            terminal_mouse_modifiers(&event.modifiers),
-            col as u16,
-            row as u16,
-        ) else {
-            return;
-        };
-        if !resident
-            .mouse_motion
-            .should_send(Instant::now(), (col as u16, row as u16))
-        {
-            return;
-        }
-        resident.attachment.mouse(bytes);
         cx.stop_propagation();
+    }
+
+    fn schedule_mouse_motion_flush(
+        &mut self,
+        id: SessionId,
+        delay: Duration,
+        generation: u64,
+        cx: &mut Context<Self>,
+    ) {
+        let timer = cx.background_executor().timer(delay);
+        cx.spawn(async move |this, cx| {
+            timer.await;
+            let _ = this.update(cx, |this, _cx| {
+                if this.selected_id().as_ref() != Some(&id) {
+                    if let Some(resident) = this.residents.get_mut(&id) {
+                        resident.mouse_motion.reset();
+                    }
+                    return;
+                }
+                let Some(resident) = this.residents.get_mut(&id) else {
+                    return;
+                };
+                if let Some(bytes) = resident.mouse_motion.flush(generation, Instant::now()) {
+                    resident.attachment.mouse(bytes);
+                }
+            });
+        })
+        .detach();
     }
 
     /// The height the mirrored grid needs when the daemon's screen is taller
@@ -3069,7 +3183,8 @@ fn pointer_owner(
             PointerOwner::Ignored
         };
     }
-    if mouse.is_reporting() && terminal_mouse_button(button).is_some() {
+    if mouse.is_reporting() && mouse.has_known_details() && terminal_mouse_button(button).is_some()
+    {
         PointerOwner::Terminal
     } else if button == MouseButton::Left {
         PointerOwner::LocalSelection
@@ -3747,6 +3862,11 @@ mod tests {
             PointerOwner::Ignored,
             "no Command-modified button is forwarded"
         );
+        assert_eq!(
+            pointer_owner(MouseModes::UNKNOWN, MouseButton::Left, &plain),
+            PointerOwner::LocalSelection,
+            "an old remote Holder must not receive a guessed click encoding"
+        );
     }
 
     #[test]
@@ -3795,18 +3915,67 @@ mod tests {
     }
 
     #[test]
-    fn unrestricted_motion_is_rate_limited_and_cell_deduplicated() {
+    fn unrestricted_motion_coalesces_to_the_latest_cell_at_the_trailing_edge() {
         let started = Instant::now();
         let mut limiter = MouseMotionLimiter::default();
-        assert!(
-            limiter.should_send(started, (1, 1)),
-            "first motion is immediate"
+        assert_eq!(
+            limiter.push(started, (1, 1), b"one".to_vec()),
+            MotionDispatch::SendNow(b"one".to_vec())
         );
-        assert!(!limiter.should_send(started + Duration::from_millis(1), (2, 1)));
-        assert!(!limiter.should_send(started + MOUSE_MOTION_CADENCE, (1, 1)));
-        assert!(limiter.should_send(started + MOUSE_MOTION_CADENCE, (2, 1)));
-        limiter.reset();
-        assert!(limiter.should_send(started + Duration::from_secs(1), (2, 1)));
+        let MotionDispatch::Schedule { generation, .. } =
+            limiter.push(started + Duration::from_millis(1), (2, 1), b"two".to_vec())
+        else {
+            panic!("second cell should arm the trailing edge");
+        };
+        assert_eq!(
+            limiter.push(
+                started + Duration::from_millis(2),
+                (3, 1),
+                b"three".to_vec(),
+            ),
+            MotionDispatch::None,
+            "the armed timer folds newer cells"
+        );
+        assert_eq!(
+            limiter.flush(generation, started + MOUSE_MOTION_CADENCE),
+            Some(b"three".to_vec()),
+            "the destination is not dropped when pointer events stop"
+        );
+        assert_eq!(limiter.flush(generation, started), None);
+        assert_eq!(
+            limiter.push(
+                started + MOUSE_MOTION_CADENCE,
+                (3, 1),
+                b"duplicate".to_vec(),
+            ),
+            MotionDispatch::None
+        );
+    }
+
+    #[test]
+    fn a_pending_drag_is_drained_before_release_and_its_timer_is_cancelled() {
+        let started = Instant::now();
+        let mut limiter = MouseMotionLimiter::default();
+        assert!(matches!(
+            limiter.push(started, (1, 1), b"first".to_vec()),
+            MotionDispatch::SendNow(_)
+        ));
+        let MotionDispatch::Schedule { generation, .. } = limiter.push(
+            started + Duration::from_millis(1),
+            (2, 1),
+            b"pending-before-release".to_vec(),
+        ) else {
+            panic!("pending motion");
+        };
+        assert_eq!(
+            limiter.take_pending(),
+            Some(b"pending-before-release".to_vec())
+        );
+        assert_eq!(
+            limiter.flush(generation, started + MOUSE_MOTION_CADENCE),
+            None,
+            "no motion may be emitted after the release"
+        );
     }
 
     #[test]

--- a/diri/crates/diri-app/src/terminal_pane.rs
+++ b/diri/crates/diri-app/src/terminal_pane.rs
@@ -1543,22 +1543,29 @@ impl TerminalPane {
         let Some(id) = self.selected_id() else {
             return;
         };
-        let Some((col, row)) = self.grid_cell_at(event.position, window) else {
-            return;
-        };
+        // Resolve opportunistically, but clear gesture state even if the grid
+        // disappeared between press and release (session teardown, a zero-size
+        // re-seed). GPUI delivers `on_mouse_up_out` in capture phase, so an
+        // ordinary release outside the pane still reaches this path and clamps.
+        let cell = self.grid_cell_at(event.position, window);
         let Some(resident) = self.residents.get_mut(&id) else {
             return;
         };
-        let owner = resident
-            .pointer_owner
-            .filter(|(button, _)| *button == event.button)
-            .map(|(_, owner)| owner);
-        resident.pointer_owner = None;
+        let (owner, pending) = finish_pointer_state(
+            &mut resident.pointer_owner,
+            &mut resident.mouse_motion,
+            event.button,
+            cell.is_some(),
+        );
         if owner != Some(PointerOwner::Terminal) {
-            resident.mouse_motion.reset();
             return;
         }
-        if let Some(bytes) = resident.mouse_motion.take_pending() {
+        let Some((col, row)) = cell else {
+            // With no authoritative coordinate, a guessed release would be
+            // worse than dropping this now-cancelled gesture.
+            return;
+        };
+        if let Some(bytes) = pending {
             // A cadence-held drag must precede its release. Letting the timer
             // fire afterward would resurrect a button that is already up.
             resident.attachment.mouse(bytes);
@@ -3210,6 +3217,25 @@ fn terminal_mouse_modifiers(modifiers: &gpui::Modifiers) -> TerminalMouseModifie
     }
 }
 
+fn finish_pointer_state(
+    pointer_owner: &mut Option<(MouseButton, PointerOwner)>,
+    mouse_motion: &mut MouseMotionLimiter,
+    button: MouseButton,
+    cell_available: bool,
+) -> (Option<PointerOwner>, Option<Vec<u8>>) {
+    let owner = pointer_owner
+        .take()
+        .filter(|(owned, _)| *owned == button)
+        .map(|(_, owner)| owner);
+    let pending = if owner == Some(PointerOwner::Terminal) && cell_available {
+        mouse_motion.take_pending()
+    } else {
+        mouse_motion.reset();
+        None
+    };
+    (owner, pending)
+}
+
 fn find_icon_button(
     id: &'static str,
     system_image: &'static str,
@@ -3975,6 +4001,34 @@ mod tests {
             limiter.flush(generation, started + MOUSE_MOTION_CADENCE),
             None,
             "no motion may be emitted after the release"
+        );
+    }
+
+    #[test]
+    fn release_without_a_grid_cell_cancels_the_gesture_and_pending_timer() {
+        let started = Instant::now();
+        let mut limiter = MouseMotionLimiter::default();
+        assert!(matches!(
+            limiter.push(started, (1, 1), b"first".to_vec()),
+            MotionDispatch::SendNow(_)
+        ));
+        let MotionDispatch::Schedule { generation, .. } = limiter.push(
+            started + Duration::from_millis(1),
+            (2, 1),
+            b"pending".to_vec(),
+        ) else {
+            panic!("pending motion");
+        };
+        let mut owner = Some((MouseButton::Left, PointerOwner::Terminal));
+        assert_eq!(
+            finish_pointer_state(&mut owner, &mut limiter, MouseButton::Left, false),
+            (Some(PointerOwner::Terminal), None)
+        );
+        assert_eq!(owner, None);
+        assert_eq!(
+            limiter.flush(generation, started + MOUSE_MOTION_CADENCE),
+            None,
+            "a stale timer cannot send motion after the physical release"
         );
     }
 

--- a/diri/crates/diri-app/src/terminal_pane.rs
+++ b/diri/crates/diri-app/src/terminal_pane.rs
@@ -9,6 +9,9 @@ use std::time::{Duration, Instant};
 
 use diri_client::attachment::{SessionAttachment, TerminalChunk};
 use diri_proto::grid::GridUpdate;
+use diri_proto::terminal::{
+    MouseModes, TerminalMouseButton, TerminalMouseEvent, TerminalMouseModifiers, encode_mouse_event,
+};
 use diri_proto::{
     AgentKind as ProtoAgentKind, ArtifactKind, ExitReason, PrCheck, PullRequestStatus,
     Resumability, RiskHint, SessionArtifact, SessionId, SessionRecord, SessionStatus,
@@ -65,6 +68,10 @@ const PANE_EVENT_QUEUE_CAPACITY: usize = 256;
 /// the client can never see, resizing slower makes the drag look like it snaps
 /// at the end instead of reflowing under the cursor.
 const RESIZE_CADENCE: Duration = Duration::from_millis(8);
+/// Cell motion is redundant above display cadence. This bounds DECSET 1003
+/// writes while still allowing one report per rendered frame on high-refresh
+/// displays; repeated moves within one cell are suppressed altogether.
+const MOUSE_MOTION_CADENCE: Duration = Duration::from_millis(8);
 /// Two resizes further apart than this belong to different gestures. A drag
 /// steps faster than this and must keep reflowing live; anything slower is a
 /// discrete change -- a panel toggle, a window snap, a font-size change --
@@ -345,8 +352,43 @@ enum AttachmentState {
     Reconnecting,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PointerOwner {
+    LocalSelection,
+    LocalReference,
+    Terminal,
+    Ignored,
+}
+
+#[derive(Default)]
+struct MouseMotionLimiter {
+    last_sent_at: Option<Instant>,
+    last_cell: Option<(u16, u16)>,
+}
+
+impl MouseMotionLimiter {
+    fn reset(&mut self) {
+        self.last_sent_at = None;
+        self.last_cell = None;
+    }
+
+    fn should_send(&mut self, now: Instant, cell: (u16, u16)) -> bool {
+        if self.last_cell == Some(cell)
+            || self
+                .last_sent_at
+                .is_some_and(|sent| now.duration_since(sent) < MOUSE_MOTION_CADENCE)
+        {
+            return false;
+        }
+        self.last_sent_at = Some(now);
+        self.last_cell = Some(cell);
+        true
+    }
+}
+
 enum AttachmentCommand {
     Input(Vec<u8>),
+    Mouse(Vec<u8>),
     Resize(u16, u16),
     Scroll {
         direction: u8,
@@ -372,6 +414,14 @@ impl AttachmentControl {
 
     fn resize(&self, cols: u16, rows: u16) {
         let _ = self.tx.send(AttachmentCommand::Resize(cols, rows));
+    }
+
+    fn mouse(&self, bytes: Vec<u8>) {
+        if bytes.is_empty() {
+            return;
+        }
+        let _ = self.pane_tx.send(PaneEvent::InteractiveInput);
+        let _ = self.tx.send(AttachmentCommand::Mouse(bytes));
     }
 
     fn scroll(&self, direction: u8, lines: u16, col: u16, row: u16) {
@@ -501,6 +551,8 @@ struct ResidentTerminal {
     /// selection, and readline keys as the other query fields.
     find_query: QueryEditor,
     last_size: (u16, u16),
+    pointer_owner: Option<(MouseButton, PointerOwner)>,
+    mouse_motion: MouseMotionLimiter,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -812,6 +864,8 @@ impl TerminalPane {
                     find: None,
                     find_query: QueryEditor::default(),
                     last_size: (0, 0),
+                    pointer_owner: None,
+                    mouse_motion: MouseMotionLimiter::default(),
                 },
             );
         }
@@ -981,13 +1035,10 @@ impl TerminalPane {
             }
             PaneEvent::Chunk(
                 id,
-                TerminalChunk::Modes {
-                    alt_screen,
-                    mouse_reporting,
-                },
+                TerminalChunk::Modes { alt_screen, mouse },
             ) => {
                 if let Some(resident) = self.residents.get_mut(&id) {
-                    resident.element.set_modes(alt_screen, mouse_reporting);
+                    resident.element.set_modes(alt_screen, mouse);
                 }
                 if self.selected_id().as_ref() == Some(&id) {
                     cx.notify();
@@ -1329,7 +1380,179 @@ impl TerminalPane {
         let row = ((f32::from(position.y) - grid_y) / f32::from(metrics.line_height))
             .floor()
             .max(0.0) as usize;
-        Some((col, row))
+        let resident = self.selected_id().and_then(|id| self.residents.get(&id))?;
+        clamp_grid_cell(
+            col,
+            row,
+            resident.element.grid_cols(),
+            resident.element.grid_rows(),
+        )
+        .map(|(col, row)| (usize::from(col), usize::from(row)))
+    }
+
+    fn handle_pointer_down(
+        &mut self,
+        event: &gpui::MouseDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(id) = self.selected_id() else {
+            return;
+        };
+        let Some((col, row)) = self.grid_cell_at(event.position, window) else {
+            return;
+        };
+        let owner = {
+            let Some(resident) = self.residents.get(&id) else {
+                return;
+            };
+            pointer_owner(
+                resident.element.mouse_modes(),
+                event.button,
+                &event.modifiers,
+            )
+        };
+        let Some(resident) = self.residents.get_mut(&id) else {
+            return;
+        };
+        resident.pointer_owner = Some((event.button, owner));
+        resident.mouse_motion.reset();
+
+        match owner {
+            PointerOwner::LocalSelection => {
+                match event.click_count {
+                    1 => resident.element.begin_selection(col, row),
+                    _ => resident.element.select_word(col, row),
+                }
+                cx.notify();
+            }
+            PointerOwner::LocalReference => {
+                let reference = resident.element.reference_at(col, row);
+                match reference {
+                    Some(TerminalReference::Url(url)) => cx.open_url(&url),
+                    Some(TerminalReference::File(reference)) => {
+                        let Some(session) = self.selected_session() else {
+                            return;
+                        };
+                        cx.emit(TerminalPaneEvent::OpenFileReference {
+                            reference,
+                            cwd: session.cwd.clone(),
+                            session_id: session.id.clone(),
+                        });
+                    }
+                    None => {}
+                }
+            }
+            PointerOwner::Terminal => {
+                let Some(button) = terminal_mouse_button(event.button) else {
+                    return;
+                };
+                if let Some(bytes) = encode_mouse_event(
+                    resident.element.mouse_modes(),
+                    TerminalMouseEvent::Press(button),
+                    terminal_mouse_modifiers(&event.modifiers),
+                    col as u16,
+                    row as u16,
+                ) {
+                    resident.attachment.mouse(bytes);
+                }
+                cx.stop_propagation();
+            }
+            PointerOwner::Ignored => {}
+        }
+    }
+
+    fn handle_pointer_up(
+        &mut self,
+        event: &gpui::MouseUpEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(id) = self.selected_id() else {
+            return;
+        };
+        let Some((col, row)) = self.grid_cell_at(event.position, window) else {
+            return;
+        };
+        let Some(resident) = self.residents.get_mut(&id) else {
+            return;
+        };
+        let owner = resident
+            .pointer_owner
+            .filter(|(button, _)| *button == event.button)
+            .map(|(_, owner)| owner);
+        resident.pointer_owner = None;
+        if owner != Some(PointerOwner::Terminal) {
+            return;
+        }
+        let Some(button) = terminal_mouse_button(event.button) else {
+            return;
+        };
+        if let Some(bytes) = encode_mouse_event(
+            resident.element.mouse_modes(),
+            TerminalMouseEvent::Release(button),
+            terminal_mouse_modifiers(&event.modifiers),
+            col as u16,
+            row as u16,
+        ) {
+            resident.attachment.mouse(bytes);
+        }
+        cx.stop_propagation();
+    }
+
+    fn handle_pointer_move(
+        &mut self,
+        event: &gpui::MouseMoveEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(id) = self.selected_id() else {
+            return;
+        };
+        let Some((col, row)) = self.grid_cell_at(event.position, window) else {
+            return;
+        };
+        let Some(resident) = self.residents.get_mut(&id) else {
+            return;
+        };
+        let owner = event.pressed_button.and_then(|button| {
+            resident
+                .pointer_owner
+                .filter(|(owned, _)| *owned == button)
+                .map(|(_, owner)| owner)
+        });
+        if owner == Some(PointerOwner::LocalSelection) {
+            resident.element.drag_selection(col, row);
+            cx.notify();
+            return;
+        }
+        if event.pressed_button.is_some() && owner != Some(PointerOwner::Terminal) {
+            return;
+        }
+        let button = match event.pressed_button {
+            Some(button) => terminal_mouse_button(button).map(Some),
+            None => Some(None),
+        };
+        let Some(button) = button else {
+            return;
+        };
+        let Some(bytes) = encode_mouse_event(
+            resident.element.mouse_modes(),
+            TerminalMouseEvent::Motion(button),
+            terminal_mouse_modifiers(&event.modifiers),
+            col as u16,
+            row as u16,
+        ) else {
+            return;
+        };
+        if !resident
+            .mouse_motion
+            .should_send(Instant::now(), (col as u16, row as u16))
+        {
+            return;
+        }
+        resident.attachment.mouse(bytes);
+        cx.stop_propagation();
     }
 
     /// The height the mirrored grid needs when the daemon's screen is taller
@@ -2111,67 +2334,20 @@ impl TerminalPane {
                             .expect("session store lock poisoned")
                             .select(id_for_focus.clone());
                     }
-                    let Some(id) = this.selected_id() else {
-                        return;
-                    };
-                    let Some((col, row)) = this.grid_cell_at(event.position, window) else {
-                        return;
-                    };
-                    let Some(resident) = this.residents.get(&id) else {
-                        return;
-                    };
-                    if event.modifiers.platform {
-                        match resident.element.reference_at(col, row) {
-                            Some(TerminalReference::Url(url)) => cx.open_url(&url),
-                            Some(TerminalReference::File(reference)) => {
-                                let Some(session) = this.selected_session() else {
-                                    return;
-                                };
-                                cx.emit(TerminalPaneEvent::OpenFileReference {
-                                    reference,
-                                    cwd: session.cwd.clone(),
-                                    session_id: session.id.clone(),
-                                });
-                            }
-                            None => {}
-                        }
-                        return;
-                    }
-                    // Mouse-reporting programs (Claude Code, vim) would
-                    // normally own the pointer, but clicks are not forwarded
-                    // to the PTY yet -- suppressing local selection here
-                    // bought nothing and made text un-copyable. Revisit when
-                    // click forwarding lands (then: plain drag to the app,
-                    // option-drag for local selection, per terminal
-                    // convention).
-                    match event.click_count {
-                        1 => resident.element.begin_selection(col, row),
-                        _ => resident.element.select_word(col, row),
-                    }
-                    // notify, never window.refresh(): refresh() flags the
-                    // whole frame as caching-disabled, repainting every cached
-                    // view at pointer-event rate.
-                    cx.notify();
+                    this.handle_pointer_down(event, window, cx);
                 }),
             )
-            .on_mouse_move(
-                cx.listener(|this, event: &gpui::MouseMoveEvent, window, cx| {
-                    if event.pressed_button != Some(MouseButton::Left) {
-                        return;
-                    }
-                    let Some(id) = this.selected_id() else {
-                        return;
-                    };
-                    let Some((col, row)) = this.grid_cell_at(event.position, window) else {
-                        return;
-                    };
-                    let Some(resident) = this.residents.get(&id) else {
-                        return;
-                    };
-                    resident.element.drag_selection(col, row);
-                    cx.notify();
-                }),
-            )
+            .on_mouse_down(MouseButton::Middle, cx.listener(Self::handle_pointer_down))
+            .on_mouse_down(MouseButton::Right, cx.listener(Self::handle_pointer_down))
+            .on_mouse_up(MouseButton::Left, cx.listener(Self::handle_pointer_up))
+            .on_mouse_up(MouseButton::Middle, cx.listener(Self::handle_pointer_up))
+            .on_mouse_up(MouseButton::Right, cx.listener(Self::handle_pointer_up))
+            // A release outside the pane still belongs to the child that saw
+            // the press. `grid_cell_at` clamps it to the nearest grid cell.
+            .on_mouse_up_out(MouseButton::Left, cx.listener(Self::handle_pointer_up))
+            .on_mouse_up_out(MouseButton::Middle, cx.listener(Self::handle_pointer_up))
+            .on_mouse_up_out(MouseButton::Right, cx.listener(Self::handle_pointer_up))
+            .on_mouse_move(cx.listener(Self::handle_pointer_move))
             .on_scroll_wheel(cx.listener(Self::handle_scroll))
             .child(match overflow {
                 // Settled: the mirrored screen fits, so the grid fills the pane
@@ -2860,6 +3036,65 @@ impl Render for TerminalPane {
     }
 }
 
+fn clamp_grid_cell(col: usize, row: usize, cols: u16, rows: u16) -> Option<(u16, u16)> {
+    if cols == 0 || rows == 0 {
+        return None;
+    }
+    Some((
+        u16::try_from(col).unwrap_or(u16::MAX).min(cols - 1),
+        u16::try_from(row).unwrap_or(u16::MAX).min(rows - 1),
+    ))
+}
+
+fn pointer_owner(
+    mouse: MouseModes,
+    button: MouseButton,
+    modifiers: &gpui::Modifiers,
+) -> PointerOwner {
+    // `platform` is Command on the supported macOS desktop. Preserve local
+    // reference resolution for that entire gesture, including its release.
+    if modifiers.platform {
+        return if button == MouseButton::Left {
+            PointerOwner::LocalReference
+        } else {
+            PointerOwner::Ignored
+        };
+    }
+    // Option must claim the press, not merely the first move; otherwise the
+    // child would receive an unmatched press before a local selection began.
+    if modifiers.alt {
+        return if button == MouseButton::Left {
+            PointerOwner::LocalSelection
+        } else {
+            PointerOwner::Ignored
+        };
+    }
+    if mouse.is_reporting() && terminal_mouse_button(button).is_some() {
+        PointerOwner::Terminal
+    } else if button == MouseButton::Left {
+        PointerOwner::LocalSelection
+    } else {
+        PointerOwner::Ignored
+    }
+}
+
+fn terminal_mouse_button(button: MouseButton) -> Option<TerminalMouseButton> {
+    match button {
+        MouseButton::Left => Some(TerminalMouseButton::Left),
+        MouseButton::Middle => Some(TerminalMouseButton::Middle),
+        MouseButton::Right => Some(TerminalMouseButton::Right),
+        MouseButton::Navigate(_) => None,
+    }
+}
+
+fn terminal_mouse_modifiers(modifiers: &gpui::Modifiers) -> TerminalMouseModifiers {
+    TerminalMouseModifiers {
+        shift: modifiers.shift,
+        alt: modifiers.alt,
+        control: modifiers.control,
+    }
+}
+
 fn find_icon_button(
     id: &'static str,
     system_image: &'static str,
@@ -3069,6 +3304,9 @@ fn spawn_attachment(
                             Some(AttachmentCommand::Input(bytes)) => {
                                 let _ = writer.send_input(bytes);
                             }
+                            Some(AttachmentCommand::Mouse(bytes)) => {
+                                let _ = writer.send_mouse(bytes);
+                            }
                             Some(AttachmentCommand::Resize(cols, rows)) => {
                                 last_resize = Some((cols, rows));
                                 let _ = writer.resize(cols, rows);
@@ -3109,7 +3347,9 @@ async fn wait_for_retry(
             command = commands.recv() => match command {
                 Some(AttachmentCommand::Resize(cols, rows)) => *last_resize = Some((cols, rows)),
                 Some(AttachmentCommand::Close) | None => return true,
-                Some(AttachmentCommand::Input(_)) | Some(AttachmentCommand::Scroll { .. }) => {}
+                Some(AttachmentCommand::Input(_))
+                | Some(AttachmentCommand::Mouse(_))
+                | Some(AttachmentCommand::Scroll { .. }) => {}
             }
         }
     }
@@ -3461,6 +3701,112 @@ mod tests {
             sent.push(at);
         }
         sent
+    }
+
+    #[test]
+    fn pointer_ownership_preserves_local_escape_hatches_and_reporting_off() {
+        let plain = Modifiers::default();
+        let option = Modifiers {
+            alt: true,
+            ..Modifiers::default()
+        };
+        let command = Modifiers {
+            platform: true,
+            ..Modifiers::default()
+        };
+        let reporting = MouseModes::new(
+            diri_proto::terminal::MouseTrackingMode::AnyMotion,
+            diri_proto::terminal::MouseEncoding::Sgr,
+        );
+
+        assert_eq!(
+            pointer_owner(MouseModes::OFF, MouseButton::Left, &plain),
+            PointerOwner::LocalSelection
+        );
+        assert_eq!(
+            pointer_owner(MouseModes::OFF, MouseButton::Right, &plain),
+            PointerOwner::Ignored,
+            "reporting-off right-click behavior stays unchanged"
+        );
+        assert_eq!(
+            pointer_owner(reporting, MouseButton::Left, &plain),
+            PointerOwner::Terminal
+        );
+        assert_eq!(
+            pointer_owner(reporting, MouseButton::Left, &option),
+            PointerOwner::LocalSelection,
+            "Option claims the whole drag before a press can reach the PTY"
+        );
+        assert_eq!(
+            pointer_owner(reporting, MouseButton::Left, &command),
+            PointerOwner::LocalReference,
+            "Command-click remains local"
+        );
+        assert_eq!(
+            pointer_owner(reporting, MouseButton::Right, &command),
+            PointerOwner::Ignored,
+            "no Command-modified button is forwarded"
+        );
+    }
+
+    #[test]
+    fn option_drag_still_produces_copyable_terminal_text() {
+        let element = TerminalElement::with_buffer(GridBuffer::default());
+        let mut cells: Vec<_> = "copy me"
+            .chars()
+            .map(|character| diri_proto::grid::GridCell {
+                scalar: u32::from(character),
+                ..diri_proto::grid::GridCell::BLANK
+            })
+            .collect();
+        cells.push(diri_proto::grid::GridCell::BLANK);
+        element.apply_damage(GridUpdate {
+            cols: 8,
+            rows: 1,
+            cursor_col: 0,
+            cursor_row: 0,
+            cursor_visible: true,
+            is_full_snapshot: true,
+            changed_rows: vec![diri_proto::grid::ChangedRow::new(0, cells)],
+        });
+        let option = Modifiers {
+            alt: true,
+            ..Modifiers::default()
+        };
+        let reporting = MouseModes::new(
+            diri_proto::terminal::MouseTrackingMode::ButtonMotion,
+            diri_proto::terminal::MouseEncoding::Sgr,
+        );
+        assert_eq!(
+            pointer_owner(reporting, MouseButton::Left, &option),
+            PointerOwner::LocalSelection
+        );
+        element.begin_selection(0, 0);
+        element.drag_selection(7, 0);
+        assert_eq!(element.selected_text(), "copy me");
+    }
+
+    #[test]
+    fn pointer_coordinates_clamp_to_every_grid_edge() {
+        assert_eq!(clamp_grid_cell(5, 7, 80, 24), Some((5, 7)));
+        assert_eq!(clamp_grid_cell(usize::MAX, 100, 80, 24), Some((79, 23)));
+        assert_eq!(clamp_grid_cell(0, 0, 0, 24), None);
+        assert_eq!(clamp_grid_cell(0, 0, 80, 0), None);
+    }
+
+    #[test]
+    fn unrestricted_motion_is_rate_limited_and_cell_deduplicated() {
+        let started = Instant::now();
+        let mut limiter = MouseMotionLimiter::default();
+        assert!(
+            limiter.should_send(started, (1, 1)),
+            "first motion is immediate"
+        );
+        assert!(!limiter.should_send(started + Duration::from_millis(1), (2, 1)));
+        assert!(!limiter.should_send(started + MOUSE_MOTION_CADENCE, (1, 1)));
+        assert!(limiter.should_send(started + MOUSE_MOTION_CADENCE, (2, 1)));
+        limiter.reset();
+        assert!(limiter.should_send(started + Duration::from_secs(1), (2, 1)));
     }
 
     #[test]

--- a/diri/crates/diri-client/src/attachment.rs
+++ b/diri/crates/diri-client/src/attachment.rs
@@ -15,6 +15,7 @@ use diri_proto::frames::{Frame, FrameCodec, FrameType};
 use diri_proto::grid::GridUpdate;
 use diri_proto::methods::{AttachRequest, ClientRole};
 use diri_proto::model::SessionId;
+use diri_proto::terminal::MouseModes;
 use futures_core::Stream;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
@@ -32,10 +33,7 @@ const CHUNK_QUEUE_CAPACITY: usize = 256;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TerminalChunk {
     Grid(GridUpdate),
-    Modes {
-        alt_screen: bool,
-        mouse_reporting: bool,
-    },
+    Modes { alt_screen: bool, mouse: MouseModes },
     Pong,
 }
 
@@ -135,6 +133,10 @@ impl SessionAttachmentHandle {
         self.send(Frame::input(bytes))
     }
 
+    pub fn send_mouse(&self, bytes: impl Into<Vec<u8>>) -> Result<(), AttachmentClosed> {
+        self.send(Frame::mouse(bytes))
+    }
+
     pub fn resize(&self, cols: u16, rows: u16) -> Result<(), AttachmentClosed> {
         self.send(Frame::resize(cols, rows))
     }
@@ -201,6 +203,11 @@ impl SessionAttachment {
     /// Queues raw keystroke bytes for the session PTY.
     pub fn send_input(&self, bytes: impl Into<Vec<u8>>) -> Result<(), AttachmentClosed> {
         self.handle().send_input(bytes)
+    }
+
+    /// Queues a pre-encoded mouse report on the raw interactive path.
+    pub fn send_mouse(&self, bytes: impl Into<Vec<u8>>) -> Result<(), AttachmentClosed> {
+        self.handle().send_mouse(bytes)
     }
 
     /// Queues a PTY resize. Debouncing and first-resize semantics belong to the caller.
@@ -314,12 +321,9 @@ async fn process_incoming(
                 .map_err(|_| ())?;
         }
         FrameType::Modes => {
-            let (alt_screen, mouse_reporting) = frame.modes_payload().ok_or(())?;
+            let (alt_screen, mouse) = frame.modes_payload().ok_or(())?;
             chunks
-                .send(TerminalChunk::Modes {
-                    alt_screen,
-                    mouse_reporting,
-                })
+                .send(TerminalChunk::Modes { alt_screen, mouse })
                 .await
                 .map_err(|_| ())?;
         }
@@ -328,7 +332,7 @@ async fn process_incoming(
         // These byte-replay frames belong to the retired VT-parsing client.
         FrameType::Output | FrameType::ReplayBegin | FrameType::ReplayEnd => {}
         // The daemon does not send client-to-daemon frame types.
-        FrameType::Input | FrameType::Resize | FrameType::Scroll => {}
+        FrameType::Input | FrameType::Resize | FrameType::Scroll | FrameType::Mouse => {}
     }
     Ok(())
 }

--- a/diri/crates/diri-engine/src/attach.rs
+++ b/diri/crates/diri-engine/src/attach.rs
@@ -130,7 +130,7 @@ impl AttachHub {
         let Ok(mut guard) = registry.lock() else {
             return false;
         };
-        if matches!(frame.frame_type, FrameType::Input) {
+        if matches!(frame.frame_type, FrameType::Input | FrameType::Mouse) {
             // Input to a frozen session wakes it; write_input's queue covers
             // the race where the governor froze it mid-keystroke.
             let _ = guard.wake_session(session_id);
@@ -141,6 +141,9 @@ impl AttachHub {
         match frame.frame_type {
             FrameType::Input => {
                 let _ = session.write_input(&frame.payload);
+            }
+            FrameType::Mouse => {
+                let _ = session.write_mouse(&frame.payload);
             }
             FrameType::Resize => {
                 if let Some((cols, rows)) = frame.resize_payload() {

--- a/diri/crates/diri-engine/src/checkpoint.rs
+++ b/diri/crates/diri-engine/src/checkpoint.rs
@@ -73,7 +73,14 @@ impl ScreenCheckpoint {
             return None;
         }
         let mouse = if version == PREVIOUS_VERSION {
-            MouseModes::from_detail_bits(0, dict.get("mouseReporting")?.as_boolean()?)
+            if dict.get("mouseReporting")?.as_boolean()? {
+                // Version 2's restore implementation always synthesized this
+                // exact pair. This is checkpoint compatibility, not a claim
+                // about the unknowable details of an old live wire peer.
+                MouseModes::new(MouseTrackingMode::ButtonEvents, MouseEncoding::Sgr)
+            } else {
+                MouseModes::OFF
+            }
         } else {
             MouseModes::new(
                 MouseTrackingMode::from_wire(

--- a/diri/crates/diri-engine/src/checkpoint.rs
+++ b/diri/crates/diri-engine/src/checkpoint.rs
@@ -1,5 +1,6 @@
-//! Durable screen checkpoints: `<id>.screen.plist`, byte-compatible with
-//! `Sources/DirijorDaemonKit/ScreenCheckpoint.swift`.
+//! Durable screen checkpoints: `<id>.screen.plist`. Version 2 remains
+//! load-compatible with the historical Swift checkpoint; version 3 preserves
+//! granular mouse state.
 //!
 //! A checkpoint pairs an RLE-encoded full grid with the exact raw-log offset
 //! it represents, so a restarted daemon can seed the emulator from a few
@@ -8,19 +9,21 @@
 //!
 //! Checkpoints are an acceleration cache, never authoritative state: a
 //! malformed, stale, or future-version file is ignored and the bounded
-//! raw-log replay runs instead. The on-disk format is a property list
-//! (Swift writes binary; either flavor is read) with the exact keys the
-//! Swift daemon uses, so a Rust daemon adopting a Swift-spawned fleet
-//! restores from Swift's checkpoints, and a rollback reads ours.
+//! raw-log replay runs instead. The on-disk format is a property list (either
+//! binary or XML is read). Version 2's historical keys still load during an
+//! upgrade; a rollback safely treats version 3 as a cache miss and rebuilds
+//! from the authoritative raw log.
 
 use std::path::Path;
 
 use diri_proto::grid::{GridCell, GridRowCodec, GridUpdate};
+use diri_proto::terminal::{MouseEncoding, MouseModes, MouseTrackingMode};
 
 // Version 1 persisted only the visible grid. Restoring it silently collapsed
 // every adopted session to at most one line of history, so it is deliberately
 // treated as a cache miss and rebuilt from the authoritative raw log.
-const CURRENT_VERSION: u64 = 2;
+const PREVIOUS_VERSION: u64 = 2;
+const CURRENT_VERSION: u64 = 3;
 
 /// A decoded checkpoint, grid already validated.
 pub struct ScreenCheckpoint {
@@ -34,7 +37,7 @@ pub struct ScreenCheckpoint {
     pub marker_buffer: Vec<u8>,
     pub alt_screen: bool,
     pub bracketed_paste: bool,
-    pub mouse_reporting: bool,
+    pub mouse: MouseModes,
 }
 
 impl ScreenCheckpoint {
@@ -49,7 +52,8 @@ impl ScreenCheckpoint {
     pub fn load(path: &Path) -> Option<Self> {
         let value = plist::Value::from_file(path).ok()?;
         let dict = value.as_dictionary()?;
-        if dict.get("version")?.as_unsigned_integer()? != CURRENT_VERSION {
+        let version = dict.get("version")?.as_unsigned_integer()?;
+        if !matches!(version, PREVIOUS_VERSION | CURRENT_VERSION) {
             return None;
         }
         let grid = GridUpdate::decode(as_data(dict.get("gridPayload")?)?).ok()?;
@@ -68,6 +72,18 @@ impl ScreenCheckpoint {
         {
             return None;
         }
+        let mouse = if version == PREVIOUS_VERSION {
+            MouseModes::from_detail_bits(0, dict.get("mouseReporting")?.as_boolean()?)
+        } else {
+            MouseModes::new(
+                MouseTrackingMode::from_wire(
+                    u8::try_from(dict.get("mouseTrackingMode")?.as_unsigned_integer()?).ok()?,
+                )?,
+                MouseEncoding::from_wire(
+                    u8::try_from(dict.get("mouseEncoding")?.as_unsigned_integer()?).ok()?,
+                )?,
+            )
+        };
         Some(Self {
             log_offset: dict.get("logOffset")?.as_unsigned_integer()?,
             history,
@@ -75,12 +91,11 @@ impl ScreenCheckpoint {
             marker_buffer: as_data(dict.get("markerBuffer")?)?.to_vec(),
             alt_screen: dict.get("altScreen")?.as_boolean()?,
             bracketed_paste: dict.get("bracketedPaste")?.as_boolean()?,
-            mouse_reporting: dict.get("mouseReporting")?.as_boolean()?,
+            mouse,
         })
     }
 
-    /// Writes atomically (temp file + rename) as a binary plist, the format
-    /// Swift's `PropertyListEncoder` emits.
+    /// Writes atomically (temp file + rename) as a binary plist.
     pub fn write_atomically(&self, path: &Path) -> std::io::Result<()> {
         let mut dict = plist::Dictionary::new();
         dict.insert(
@@ -120,7 +135,15 @@ impl ScreenCheckpoint {
         );
         dict.insert(
             "mouseReporting".into(),
-            plist::Value::Boolean(self.mouse_reporting),
+            plist::Value::Boolean(self.mouse.is_reporting()),
+        );
+        dict.insert(
+            "mouseTrackingMode".into(),
+            plist::Value::Integer(u64::from(self.mouse.tracking as u8).into()),
+        );
+        dict.insert(
+            "mouseEncoding".into(),
+            plist::Value::Integer(u64::from(self.mouse.encoding as u8).into()),
         );
 
         let temp = path.with_extension("plist.tmp");
@@ -160,7 +183,7 @@ mod tests {
             marker_buffer: vec![0x1b, b']'],
             alt_screen: true,
             bracketed_paste: false,
-            mouse_reporting: true,
+            mouse: MouseModes::new(MouseTrackingMode::AnyMotion, MouseEncoding::Sgr),
         }
     }
 
@@ -177,11 +200,11 @@ mod tests {
         assert_eq!(loaded.marker_buffer, vec![0x1b, b']']);
         assert!(loaded.alt_screen);
         assert!(!loaded.bracketed_paste);
-        assert!(loaded.mouse_reporting);
+        assert_eq!(loaded.mouse, sample().mouse);
     }
 
     #[test]
-    fn the_on_disk_format_is_a_binary_plist_with_swifts_keys() {
+    fn the_on_disk_format_is_a_binary_plist_with_versioned_keys() {
         let dir = tempfile::tempdir().expect("temp");
         let path = dir.path().join("s_x.screen.plist");
         sample().write_atomically(&path).expect("write");
@@ -205,6 +228,8 @@ mod tests {
             "altScreen",
             "bracketedPaste",
             "mouseReporting",
+            "mouseTrackingMode",
+            "mouseEncoding",
         ] {
             assert!(keys.contains_key(key), "missing Swift key {key}");
         }
@@ -278,6 +303,34 @@ mod tests {
         assert_eq!(loaded.history, sample().history);
         assert_eq!(loaded.grid, sample().grid);
         assert!(loaded.bracketed_paste);
+        assert_eq!(loaded.mouse, MouseModes::OFF);
+    }
+
+    #[test]
+    fn version_two_enabled_mouse_state_loads_with_its_historical_semantics() {
+        let dir = tempfile::tempdir().expect("temp");
+        let path = dir.path().join("s_v2.screen.plist");
+        sample().write_atomically(&path).expect("write");
+        let mut dict = plist::Value::from_file(&path)
+            .expect("read")
+            .into_dictionary()
+            .expect("dictionary");
+        dict.insert(
+            "version".into(),
+            plist::Value::Integer(PREVIOUS_VERSION.into()),
+        );
+        dict.remove("mouseTrackingMode");
+        dict.remove("mouseEncoding");
+        plist::Value::Dictionary(dict)
+            .to_file_binary(&path)
+            .expect("rewrite v2");
+
+        let loaded = ScreenCheckpoint::load(&path).expect("load v2");
+        assert_eq!(
+            loaded.mouse,
+            MouseModes::new(MouseTrackingMode::ButtonEvents, MouseEncoding::Sgr),
+            "v2 restore used to synthesize DECSET 1000 and DECSET 1006"
+        );
     }
 
     #[test]
@@ -300,7 +353,10 @@ mod tests {
             .expect("read back")
             .into_dictionary()
             .expect("dict");
-        dict.insert("version".into(), plist::Value::Integer(3.into()));
+        dict.insert(
+            "version".into(),
+            plist::Value::Integer((CURRENT_VERSION + 1).into()),
+        );
         plist::Value::Dictionary(dict)
             .to_file_binary(&path)
             .expect("rewrite");

--- a/diri/crates/diri-engine/src/remote/client.rs
+++ b/diri/crates/diri-engine/src/remote/client.rs
@@ -171,6 +171,31 @@ impl RemoteSessionClient {
         self.write_terminal(bytes, true)
     }
 
+    /// Routes wheel intent to the Holder that owns the authoritative parser.
+    /// This remains safe for protocol 1.3 sessions, whose mode byte did not
+    /// expose enough detail for the Engine to encode the report itself.
+    pub fn scroll(&self, direction: u8, lines: u16, col: u16, row: u16) -> io::Result<()> {
+        if lines == 0 {
+            return Ok(());
+        }
+        let mut writer = self.writer.lock().expect("remote writer");
+        if writer.controller_epoch.is_none() || writer.input.is_none() {
+            // Wheel/motion is ephemeral. Replaying it after a reconnect would
+            // target a screen that may already have changed.
+            return Ok(());
+        }
+        if write_message(
+            &mut writer,
+            &RemoteMessage::Terminal(Frame::scroll(direction, lines, col, row)),
+        )
+        .is_err()
+        {
+            terminate_current(&mut writer);
+            writer.controller_epoch = None;
+        }
+        Ok(())
+    }
+
     fn write_terminal(&self, bytes: &[u8], mouse: bool) -> io::Result<()> {
         if bytes.is_empty() {
             return Ok(());

--- a/diri/crates/diri-engine/src/remote/client.rs
+++ b/diri/crates/diri-engine/src/remote/client.rs
@@ -164,6 +164,14 @@ impl RemoteSessionClient {
     }
 
     pub fn write(&self, bytes: &[u8]) -> io::Result<()> {
+        self.write_terminal(bytes, false)
+    }
+
+    pub fn write_mouse(&self, bytes: &[u8]) -> io::Result<()> {
+        self.write_terminal(bytes, true)
+    }
+
+    fn write_terminal(&self, bytes: &[u8], mouse: bool) -> io::Result<()> {
         if bytes.is_empty() {
             return Ok(());
         }
@@ -171,10 +179,8 @@ impl RemoteSessionClient {
         if writer.controller_epoch.is_none() || writer.input.is_none() {
             return queue_input(&mut writer, bytes);
         }
-        if let Err(error) = write_message(
-            &mut writer,
-            &RemoteMessage::Terminal(Frame::input(bytes.to_vec())),
-        ) {
+        let frame = terminal_input_frame(self.helper.protocol, bytes, mouse);
+        if let Err(error) = write_message(&mut writer, &RemoteMessage::Terminal(frame)) {
             queue_input(&mut writer, bytes)?;
             terminate_current(&mut writer);
             writer.controller_epoch = None;
@@ -374,6 +380,18 @@ fn write_message(writer: &mut WriterState, message: &RemoteMessage) -> io::Resul
     input.flush()
 }
 
+fn terminal_input_frame(protocol: ProtocolVersion, bytes: &[u8], mouse: bool) -> Frame {
+    if mouse && protocol.minor >= diri_proto::remote_pty::MOUSE_INPUT_PROTOCOL_MINOR {
+        Frame::mouse(bytes.to_vec())
+    } else {
+        // Protocol 1.3 Holders predate the distinct frame but accept the exact
+        // same bytes as ordinary raw input. Live sessions retain their
+        // creation Build ID, so this compatibility path matters across an
+        // Engine upgrade.
+        Frame::input(bytes.to_vec())
+    }
+}
+
 fn queue_input(writer: &mut WriterState, bytes: &[u8]) -> io::Result<()> {
     if writer.queued_input.len().saturating_add(bytes.len()) > MAX_QUEUED_INPUT {
         return Err(io::Error::new(
@@ -416,5 +434,29 @@ impl Drop for RemoteSessionClient {
             terminate_current(writer);
         }
         self.persist_observed_output_offset();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use diri_proto::frames::FrameType;
+
+    use super::*;
+
+    #[test]
+    fn mouse_input_falls_back_for_live_protocol_1_3_holders() {
+        let old = ProtocolVersion { major: 1, minor: 3 };
+        assert_eq!(
+            terminal_input_frame(old, b"mouse", true).frame_type,
+            FrameType::Input
+        );
+        assert_eq!(
+            terminal_input_frame(ProtocolVersion::CURRENT, b"mouse", true).frame_type,
+            FrameType::Mouse
+        );
+        assert_eq!(
+            terminal_input_frame(ProtocolVersion::CURRENT, b"key", false).frame_type,
+            FrameType::Input
+        );
     }
 }

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -1255,6 +1255,14 @@ impl Session {
     /// asked for mouse reporting, otherwise ignored (the client scrolls its
     /// own scrollback).
     pub fn scroll(&self, up: bool, lines: usize, col: usize, row: usize) -> std::io::Result<()> {
+        if let Transport::Remote(client) = &self.transport {
+            return client.scroll(
+                u8::from(!up),
+                u16::try_from(lines).unwrap_or(u16::MAX),
+                u16::try_from(col).unwrap_or(u16::MAX),
+                u16::try_from(row).unwrap_or(u16::MAX),
+            );
+        }
         let bytes = self
             .shared
             .screen

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -29,6 +29,7 @@ use diri_proto::remote_pty::{
     FullSnapshot, GridDelta, LaunchRequest, ProcessExit, RemoteCodec, RemoteMessage,
     RemoteProcessState,
 };
+use diri_proto::terminal::MouseModes;
 use diri_proto::{NeedsInputDetail, SessionStatus};
 use diri_terminal_state::GridMirror;
 
@@ -300,7 +301,7 @@ pub struct GridSignature {
     pub size: (usize, usize),
     pub cursor: (u16, u16, bool),
     pub alt_screen: bool,
-    pub mouse_reporting: bool,
+    pub mouse: MouseModes,
 }
 
 /// Event source for the attachment writer. PTY readers advance it only after
@@ -406,7 +407,7 @@ fn grid_wake_event(state: &GridWakeState, observed: u64) -> GridWakeEvent {
 
 pub(crate) struct AttachmentSeed {
     pub grid: diri_proto::grid::GridUpdate,
-    pub modes: (bool, bool),
+    pub modes: (bool, MouseModes),
     pub signature: GridSignature,
     pub wake: GridWake,
     pub wake_generation: u64,
@@ -1125,16 +1126,16 @@ impl Session {
                     let grid = remote.mirror.full_update()?;
                     let (cols, rows) = remote.mirror.size();
                     let (cursor_col, cursor_row, cursor_visible) = remote.mirror.cursor();
-                    let (alt_screen, _, mouse_reporting) = remote.mirror.modes();
+                    let (alt_screen, _, mouse) = remote.mirror.modes();
                     Some((
                         grid,
-                        (alt_screen, mouse_reporting),
+                        (alt_screen, mouse),
                         GridSignature {
                             content_seq: remote.revision,
                             size: (usize::from(cols), usize::from(rows)),
                             cursor: (cursor_col, cursor_row, cursor_visible),
                             alt_screen,
-                            mouse_reporting,
+                            mouse,
                         },
                     ))
                 })
@@ -1143,13 +1144,13 @@ impl Session {
                 let screen = self.shared.screen.lock().expect("screen");
                 (
                     screen.full_snapshot(),
-                    (screen.is_alt_screen(), screen.mouse_reporting()),
+                    (screen.is_alt_screen(), screen.mouse_modes()),
                     GridSignature {
                         content_seq: screen.content_seq(),
                         size: screen.size(),
                         cursor: screen.cursor(),
                         alt_screen: screen.is_alt_screen(),
-                        mouse_reporting: screen.mouse_reporting(),
+                        mouse: screen.mouse_modes(),
                     },
                 )
             });
@@ -1181,13 +1182,13 @@ impl Session {
         {
             let (cols, rows) = remote.mirror.size();
             let (cursor_col, cursor_row, cursor_visible) = remote.mirror.cursor();
-            let (alt_screen, _, mouse_reporting) = remote.mirror.modes();
+            let (alt_screen, _, mouse) = remote.mirror.modes();
             let current = GridSignature {
                 content_seq: remote.revision,
                 size: (usize::from(cols), usize::from(rows)),
                 cursor: (cursor_col, cursor_row, cursor_visible),
                 alt_screen,
-                mouse_reporting,
+                mouse,
             };
             if current == *signature {
                 return None;
@@ -1204,7 +1205,7 @@ impl Session {
             size: screen.size(),
             cursor: screen.cursor(),
             alt_screen: screen.is_alt_screen(),
-            mouse_reporting: screen.mouse_reporting(),
+            mouse: screen.mouse_modes(),
         };
         if current == *signature {
             return None;
@@ -1233,8 +1234,8 @@ impl Session {
         self.shared.screen.lock().expect("screen").bracketed_paste()
     }
 
-    /// Current (alt_screen, mouse_reporting).
-    pub fn modes(&self) -> (bool, bool) {
+    /// Current alternate-screen and granular mouse modes.
+    pub fn modes(&self) -> (bool, MouseModes) {
         if let Some(remote) = self
             .shared
             .remote_grid
@@ -1243,11 +1244,11 @@ impl Session {
             .as_ref()
             && remote.mirror.sequence().is_some()
         {
-            let (alt_screen, _, mouse_reporting) = remote.mirror.modes();
-            return (alt_screen, mouse_reporting);
+            let (alt_screen, _, mouse) = remote.mirror.modes();
+            return (alt_screen, mouse);
         }
         let screen = self.shared.screen.lock().expect("screen");
-        (screen.is_alt_screen(), screen.mouse_reporting())
+        (screen.is_alt_screen(), screen.mouse_modes())
     }
 
     /// A wheel event from an attached client: forwarded to the child when it
@@ -1331,6 +1332,10 @@ impl Session {
     }
 
     fn write_raw(&self, bytes: &[u8]) -> std::io::Result<()> {
+        self.write_raw_kind(bytes, false)
+    }
+
+    fn write_raw_kind(&self, bytes: &[u8], mouse: bool) -> std::io::Result<()> {
         // Before the deferred exec there is no PTY: queue for the launch
         // flush, exactly like the Swift daemon's `queuedLaunchInput`.
         if let Some(deferred) = &self.deferred
@@ -1354,8 +1359,20 @@ impl Session {
                 writer.flush()
             }
             Transport::Held(client) => client.write(bytes).map_err(holder_io_error),
+            Transport::Remote(client) if mouse => client.write_mouse(bytes),
             Transport::Remote(client) => client.write(bytes),
         }
+    }
+
+    /// Sends a pre-encoded terminal mouse report without presenting it to the
+    /// prompt/status reducers as typed text.
+    pub fn write_mouse(&self, bytes: &[u8]) -> std::io::Result<()> {
+        if bytes.is_empty() {
+            return Ok(());
+        }
+        self.shared.note_hot();
+        self.shared.grid_wake.prioritize_interactive_changes();
+        self.write_raw_kind(bytes, true)
     }
 
     /// Sends text the way a user would.
@@ -2121,7 +2138,7 @@ fn apply_remote_snapshot(
                 &snapshot.grid,
                 snapshot.alt_screen,
                 snapshot.bracketed_paste,
-                snapshot.mouse_reporting,
+                snapshot.mouse,
             )
             .map_err(std::io::Error::other)?;
         remote.revision = remote.revision.saturating_add(1);
@@ -2141,7 +2158,7 @@ fn apply_remote_snapshot(
             &snapshot.grid,
             snapshot.alt_screen,
             snapshot.bracketed_paste,
-            snapshot.mouse_reporting,
+            snapshot.mouse,
         ) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
@@ -2174,7 +2191,7 @@ fn apply_remote_delta(shared: &Shared, delta: GridDelta) -> std::io::Result<()> 
                 &delta.grid,
                 delta.alt_screen,
                 delta.bracketed_paste,
-                delta.mouse_reporting,
+                delta.mouse,
             )
             .map_err(std::io::Error::other)?;
         remote.revision = remote.revision.saturating_add(1);
@@ -2498,7 +2515,7 @@ fn pump_held(
                     &checkpoint.grid,
                     checkpoint.alt_screen,
                     checkpoint.bracketed_paste,
-                    checkpoint.mouse_reporting,
+                    checkpoint.mouse,
                 )
             });
         match restored {
@@ -2775,7 +2792,7 @@ struct CheckpointKey {
     marker_bytes: usize,
     alt_screen: bool,
     bracketed_paste: bool,
-    mouse_reporting: bool,
+    mouse: MouseModes,
 }
 
 /// Writes the current screen as a durable checkpoint, skipping the write when
@@ -2787,14 +2804,14 @@ fn persist_checkpoint(
     marker_buffer: &[u8],
     last_key: &mut Option<CheckpointKey>,
 ) {
-    let (history, grid, alt_screen, bracketed_paste, mouse_reporting, content_seq) = {
+    let (history, grid, alt_screen, bracketed_paste, mouse, content_seq) = {
         let screen = shared.screen.lock().expect("screen");
         (
             screen.history_snapshot(),
             screen.full_snapshot(),
             screen.is_alt_screen(),
             screen.bracketed_paste(),
-            screen.mouse_reporting(),
+            screen.mouse_modes(),
             screen.content_seq(),
         )
     };
@@ -2804,7 +2821,7 @@ fn persist_checkpoint(
         marker_bytes: marker_buffer.len(),
         alt_screen,
         bracketed_paste,
-        mouse_reporting,
+        mouse,
     };
     if *last_key == Some(key) {
         return;
@@ -2816,7 +2833,7 @@ fn persist_checkpoint(
         marker_buffer: marker_buffer.to_vec(),
         alt_screen,
         bracketed_paste,
-        mouse_reporting,
+        mouse,
     };
     // A failed write must not stop the session; the checkpoint is a cache.
     if checkpoint.write_atomically(path).is_ok() {

--- a/diri/crates/diri-engine/tests/attach.rs
+++ b/diri/crates/diri-engine/tests/attach.rs
@@ -168,6 +168,22 @@ fn an_attach_is_seeded_then_streams_diffs_and_answers_input() {
                 .is_some_and(|update| grid_text(&update).contains("warm-up-pump"))
     });
 
+    // Mouse reports use their own frame kind so the Engine takes the raw
+    // interactive path instead of treating escape bytes as prompt text. The
+    // payload remains ordered with keyboard input and reaches the same PTY.
+    data.write_all(
+        &FrameCodec::encode(&Frame::mouse(b"mouse-over-attach\n".to_vec())).expect("encode"),
+    )
+    .expect("send mouse payload");
+    frames.until("the raw mouse payload echo", |frame| {
+        frame.frame_type == FrameType::Grid
+            && frame
+                .grid_payload()
+                .ok()
+                .flatten()
+                .is_some_and(|update| grid_text(&update).contains("mouse-over-attach"))
+    });
+
     // Typing through the established data channel: cat echoes, and each echo
     // comes back as a grid DIFF (not a full snapshot). Use the median so a
     // single scheduler hiccup cannot fail the test, while a fixed 16 ms frame

--- a/diri/crates/diri-engine/tests/checkpoint.rs
+++ b/diri/crates/diri-engine/tests/checkpoint.rs
@@ -12,6 +12,7 @@ use diri_engine::checkpoint::ScreenCheckpoint;
 use diri_engine::session::HolderConfig;
 use diri_engine::{ManifestEngine, OutputLog, Registry};
 use diri_proto::grid::{ChangedRow, GridCell, GridUpdate, TermColor, TermStyle};
+use diri_proto::terminal::MouseModes;
 
 fn engine() -> Arc<ManifestEngine> {
     let dir = diri_engine::detect::bundled_manifest_dir()
@@ -247,7 +248,7 @@ fn adoption_seeds_from_the_checkpoint_not_the_raw_tail() {
         marker_buffer: Vec::new(),
         alt_screen: false,
         bracketed_paste: false,
-        mouse_reporting: false,
+        mouse: MouseModes::OFF,
     }
     .write_atomically(&checkpoint_path(&logs, "s_ad"))
     .expect("plant checkpoint");
@@ -325,7 +326,7 @@ fn a_stale_checkpoint_falls_back_to_tail_replay() {
         marker_buffer: Vec::new(),
         alt_screen: false,
         bracketed_paste: false,
-        mouse_reporting: false,
+        mouse: MouseModes::OFF,
     }
     .write_atomically(&checkpoint_path(&logs, "s_fb"))
     .expect("plant checkpoint");

--- a/diri/crates/diri-proto/src/frames.rs
+++ b/diri/crates/diri-proto/src/frames.rs
@@ -7,6 +7,7 @@ use std::error::Error;
 use std::fmt;
 
 use crate::grid::{GridCodecError, GridUpdate};
+use crate::terminal::MouseModes;
 
 /// A single frame larger than this indicates a corrupt stream.
 pub const MAX_FRAME_BYTES: usize = 16 * 1024 * 1024;
@@ -24,6 +25,9 @@ pub enum FrameType {
     Grid = 8,
     Scroll = 9,
     Modes = 10,
+    /// Pre-encoded terminal mouse report. Kept distinct from `Input` so
+    /// status/prompt reducers never mistake escape sequences for typed text.
+    Mouse = 11,
 }
 
 impl TryFrom<u8> for FrameType {
@@ -41,6 +45,7 @@ impl TryFrom<u8> for FrameType {
             8 => Ok(Self::Grid),
             9 => Ok(Self::Scroll),
             10 => Ok(Self::Modes),
+            11 => Ok(Self::Mouse),
             other => Err(FrameCodecError::UnknownFrameType(other)),
         }
     }
@@ -72,6 +77,11 @@ impl Frame {
     #[must_use]
     pub fn input(bytes: impl Into<Vec<u8>>) -> Self {
         Self::new(FrameType::Input, bytes.into())
+    }
+
+    #[must_use]
+    pub fn mouse(bytes: impl Into<Vec<u8>>) -> Self {
+        Self::new(FrameType::Mouse, bytes.into())
     }
 
     #[must_use]
@@ -118,8 +128,13 @@ impl Frame {
     }
 
     #[must_use]
-    pub fn modes(alt_screen: bool, mouse_reporting: bool) -> Self {
-        let bits = u8::from(alt_screen) | (u8::from(mouse_reporting) << 1);
+    pub fn modes(alt_screen: bool, mouse: MouseModes) -> Self {
+        // Bit 1 stays the historical "any mouse reporting" flag so older
+        // clients continue to route the pointer to the terminal. Granular
+        // tracking and encoding live in previously unused bits.
+        let bits = u8::from(alt_screen)
+            | (u8::from(mouse.is_reporting()) << 1)
+            | (mouse.detail_bits() << 2);
         Self::new(FrameType::Modes, vec![bits])
     }
 
@@ -175,13 +190,16 @@ impl Frame {
     }
 
     #[must_use]
-    pub fn modes_payload(&self) -> Option<(bool, bool)> {
+    pub fn modes_payload(&self) -> Option<(bool, MouseModes)> {
         if self.frame_type != FrameType::Modes {
             return None;
         }
-        self.payload
-            .first()
-            .map(|bits| (bits & 1 != 0, bits & 2 != 0))
+        self.payload.first().map(|bits| {
+            (
+                bits & 1 != 0,
+                MouseModes::from_detail_bits(bits >> 2, bits & 2 != 0),
+            )
+        })
     }
 
     fn offset_frame(frame_type: FrameType, offset: u64) -> Self {
@@ -324,6 +342,7 @@ mod tests {
             FrameType::Grid,
             FrameType::Scroll,
             FrameType::Modes,
+            FrameType::Mouse,
         ];
         for (index, frame_type) in types.into_iter().enumerate() {
             assert_eq!(frame_type as u8, index as u8 + 1);
@@ -334,8 +353,8 @@ mod tests {
             Err(FrameCodecError::UnknownFrameType(0))
         );
         assert_eq!(
-            FrameType::try_from(11),
-            Err(FrameCodecError::UnknownFrameType(11))
+            FrameType::try_from(12),
+            Err(FrameCodecError::UnknownFrameType(12))
         );
     }
 
@@ -365,14 +384,48 @@ mod tests {
         assert_eq!(scroll.scroll_payload(), Some((1, 0x0203, 0x0405, 0x0607)));
 
         for alt_screen in [false, true] {
-            for mouse_reporting in [false, true] {
-                let modes = Frame::modes(alt_screen, mouse_reporting);
-                assert_eq!(modes.modes_payload(), Some((alt_screen, mouse_reporting)));
+            for mouse in [
+                MouseModes::OFF,
+                MouseModes::new(
+                    crate::terminal::MouseTrackingMode::Off,
+                    crate::terminal::MouseEncoding::Sgr,
+                ),
+                MouseModes::new(
+                    crate::terminal::MouseTrackingMode::ButtonEvents,
+                    crate::terminal::MouseEncoding::Legacy,
+                ),
+                MouseModes::new(
+                    crate::terminal::MouseTrackingMode::ButtonMotion,
+                    crate::terminal::MouseEncoding::Sgr,
+                ),
+                MouseModes::new(
+                    crate::terminal::MouseTrackingMode::AnyMotion,
+                    crate::terminal::MouseEncoding::Sgr,
+                ),
+            ] {
+                let modes = Frame::modes(alt_screen, mouse);
+                assert_eq!(modes.modes_payload(), Some((alt_screen, mouse)));
+                assert_eq!(modes.payload[0] & 0b10 != 0, mouse.is_reporting());
             }
         }
         assert_eq!(Frame::ping().payload, Vec::<u8>::new());
         assert_eq!(Frame::pong().payload, Vec::<u8>::new());
         assert_eq!(Frame::input(b"input".to_vec()).payload, b"input");
+        assert_eq!(Frame::mouse(b"mouse".to_vec()).payload, b"mouse");
+    }
+
+    #[test]
+    fn modes_decode_the_historical_boolean_wire_format() {
+        assert_eq!(
+            Frame::new(FrameType::Modes, vec![0b11]).modes_payload(),
+            Some((
+                true,
+                MouseModes::new(
+                    crate::terminal::MouseTrackingMode::ButtonEvents,
+                    crate::terminal::MouseEncoding::Sgr,
+                )
+            ))
+        );
     }
 
     #[test]

--- a/diri/crates/diri-proto/src/frames.rs
+++ b/diri/crates/diri-proto/src/frames.rs
@@ -386,6 +386,7 @@ mod tests {
         for alt_screen in [false, true] {
             for mouse in [
                 MouseModes::OFF,
+                MouseModes::UNKNOWN,
                 MouseModes::new(
                     crate::terminal::MouseTrackingMode::Off,
                     crate::terminal::MouseEncoding::Sgr,
@@ -418,13 +419,7 @@ mod tests {
     fn modes_decode_the_historical_boolean_wire_format() {
         assert_eq!(
             Frame::new(FrameType::Modes, vec![0b11]).modes_payload(),
-            Some((
-                true,
-                MouseModes::new(
-                    crate::terminal::MouseTrackingMode::ButtonEvents,
-                    crate::terminal::MouseEncoding::Sgr,
-                )
-            ))
+            Some((true, MouseModes::UNKNOWN))
         );
     }
 

--- a/diri/crates/diri-proto/src/lib.rs
+++ b/diri/crates/diri-proto/src/lib.rs
@@ -9,6 +9,7 @@ pub mod model;
 pub mod node;
 pub mod paths;
 pub mod remote_pty;
+pub mod terminal;
 
 pub use control::{ControlError, ControlMessage, JsonValue, WIRE_VERSION};
 pub use hosts::{HostEntry, HostNodeConfig, HostsConfig};

--- a/diri/crates/diri-proto/src/remote_pty.rs
+++ b/diri/crates/diri-proto/src/remote_pty.rs
@@ -1,10 +1,10 @@
 //! Versioned wire protocol between the local Engine and a remote PTY Holder.
 //!
-//! Terminal frame kinds 1 through 10 keep their existing payloads and are not
-//! wrapped in another frame. Remote-only control kinds start at 32. Small,
-//! infrequent control payloads use JSON; a full terminal snapshot keeps the
-//! existing binary grid encoding so reconnect does not serialize every cell
-//! as JSON.
+//! Terminal frame kinds 1 through 10 retain their wire meanings; kind 11 adds
+//! raw mouse input. They are not wrapped in another frame. Remote-only control
+//! kinds start at 32. Small, infrequent control payloads use JSON; a full
+//! terminal snapshot keeps the existing binary grid encoding so reconnect
+//! does not serialize every cell as JSON.
 
 use std::error::Error;
 use std::fmt;
@@ -15,9 +15,11 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::frames::{Frame, FrameType, MAX_FRAME_BYTES};
 use crate::grid::{GridCodecError, GridUpdate};
+use crate::terminal::MouseModes;
 
 pub const PROTOCOL_MAJOR: u16 = 1;
-pub const PROTOCOL_MINOR: u16 = 3;
+pub const PROTOCOL_MINOR: u16 = 4;
+pub const MOUSE_INPUT_PROTOCOL_MINOR: u16 = 4;
 pub const MAX_CONTROL_FRAME_BYTES: usize = 64 * 1024;
 pub const MAX_ARGUMENTS: usize = 512;
 pub const MAX_ENVIRONMENT_VARIABLES: usize = 4096;
@@ -264,7 +266,7 @@ pub struct FullSnapshot {
     pub sequence: u64,
     pub alt_screen: bool,
     pub bracketed_paste: bool,
-    pub mouse_reporting: bool,
+    pub mouse: MouseModes,
     pub grid: GridUpdate,
 }
 
@@ -273,7 +275,7 @@ pub struct GridDelta {
     pub sequence: u64,
     pub alt_screen: bool,
     pub bracketed_paste: bool,
-    pub mouse_reporting: bool,
+    pub mouse: MouseModes,
     pub grid: GridUpdate,
 }
 
@@ -864,7 +866,11 @@ impl RemoteCodec {
                 output.extend_from_slice(&value.sequence.to_be_bytes());
                 let modes = u8::from(value.alt_screen)
                     | (u8::from(value.bracketed_paste) << 1)
-                    | (u8::from(value.mouse_reporting) << 2);
+                    // Keep bit 2 as the historical any-reporting flag so an
+                    // older peer remains compatible with this additive mode
+                    // byte extension.
+                    | (u8::from(value.mouse.is_reporting()) << 2)
+                    | (value.mouse.detail_bits() << 3);
                 output.push(modes);
                 if !value.grid.is_full_snapshot {
                     return rollback(
@@ -884,7 +890,8 @@ impl RemoteCodec {
                 output.extend_from_slice(&value.sequence.to_be_bytes());
                 let modes = u8::from(value.alt_screen)
                     | (u8::from(value.bracketed_paste) << 1)
-                    | (u8::from(value.mouse_reporting) << 2);
+                    | (u8::from(value.mouse.is_reporting()) << 2)
+                    | (value.mouse.detail_bits() << 3);
                 output.push(modes);
                 if value.grid.is_full_snapshot {
                     return rollback(
@@ -1038,7 +1045,7 @@ fn decode_json<T: DeserializeOwned>(kind: u8, payload: &[u8]) -> Result<T, Remot
 }
 
 fn decode_message(kind: u8, payload: &[u8]) -> Result<RemoteMessage, RemoteCodecError> {
-    if kind <= FrameType::Modes as u8 {
+    if kind <= FrameType::Mouse as u8 {
         return Ok(RemoteMessage::Terminal(Frame::new(
             FrameType::try_from(kind).map_err(|_| RemoteCodecError::UnknownMessageType(kind))?,
             payload.to_vec(),
@@ -1075,7 +1082,7 @@ fn decode_message(kind: u8, payload: &[u8]) -> Result<RemoteMessage, RemoteCodec
                 sequence,
                 alt_screen: modes & 1 != 0,
                 bracketed_paste: modes & 2 != 0,
-                mouse_reporting: modes & 4 != 0,
+                mouse: MouseModes::from_detail_bits(modes >> 3, modes & 4 != 0),
                 grid,
             }))
         }
@@ -1099,7 +1106,7 @@ fn decode_message(kind: u8, payload: &[u8]) -> Result<RemoteMessage, RemoteCodec
                 sequence,
                 alt_screen: modes & 1 != 0,
                 bracketed_paste: modes & 2 != 0,
-                mouse_reporting: modes & 4 != 0,
+                mouse: MouseModes::from_detail_bits(modes >> 3, modes & 4 != 0),
                 grid,
             }))
         }
@@ -1127,7 +1134,7 @@ fn decode_message(kind: u8, payload: &[u8]) -> Result<RemoteMessage, RemoteCodec
 }
 
 fn validate_kind(kind: u8) -> Result<(), RemoteCodecError> {
-    if (1..=FrameType::Modes as u8).contains(&kind)
+    if (1..=FrameType::Mouse as u8).contains(&kind)
         || (KIND_HELLO..=KIND_SCROLLBACK_RESPONSE).contains(&kind)
     {
         Ok(())
@@ -1260,7 +1267,10 @@ mod tests {
             sequence: 42,
             alt_screen: true,
             bracketed_paste: true,
-            mouse_reporting: false,
+            mouse: MouseModes::new(
+                crate::terminal::MouseTrackingMode::ButtonMotion,
+                crate::terminal::MouseEncoding::Sgr,
+            ),
             grid: GridUpdate {
                 cols: 2,
                 rows: 1,
@@ -1275,12 +1285,18 @@ mod tests {
 
     #[test]
     fn terminal_frames_keep_their_existing_wire_kind() {
-        let message = RemoteMessage::Terminal(Frame::input(b"abc".to_vec()));
-        let encoded = RemoteCodec::encode(&message).expect("encode");
-        assert_eq!(encoded[0], FrameType::Input as u8);
+        for frame in [
+            Frame::input(b"abc".to_vec()),
+            Frame::mouse(b"mouse".to_vec()),
+        ] {
+            let expected_kind = frame.frame_type as u8;
+            let message = RemoteMessage::Terminal(frame);
+            let encoded = RemoteCodec::encode(&message).expect("encode");
+            assert_eq!(encoded[0], expected_kind);
 
-        let decoded = RemoteCodec::new().feed(&encoded).expect("decode");
-        assert_eq!(decoded, vec![message]);
+            let decoded = RemoteCodec::new().feed(&encoded).expect("decode");
+            assert_eq!(decoded, vec![message]);
+        }
     }
 
     #[test]
@@ -1303,9 +1319,30 @@ mod tests {
         let message = RemoteMessage::FullSnapshot(snapshot());
         let encoded = RemoteCodec::encode(&message).expect("encode");
         assert_eq!(encoded[0], KIND_FULL_SNAPSHOT);
+        assert_ne!(encoded[13] & 0b100, 0, "historical any-mouse bit");
         assert_eq!(
             RemoteCodec::new().feed(&encoded).expect("decode"),
             vec![message]
+        );
+    }
+
+    #[test]
+    fn full_snapshot_decodes_the_historical_mouse_boolean() {
+        let message = RemoteMessage::FullSnapshot(snapshot());
+        let mut encoded = RemoteCodec::encode(&message).expect("encode");
+        // Header (5), sequence (8), then the historical flags byte. Strip
+        // every detailed bit and leave alt/bracketed/any-mouse enabled.
+        encoded[13] = 0b111;
+        let decoded = RemoteCodec::new().feed(&encoded).expect("decode");
+        let RemoteMessage::FullSnapshot(decoded) = &decoded[0] else {
+            panic!("snapshot");
+        };
+        assert_eq!(
+            decoded.mouse,
+            MouseModes::new(
+                crate::terminal::MouseTrackingMode::ButtonEvents,
+                crate::terminal::MouseEncoding::Sgr,
+            )
         );
     }
 
@@ -1318,7 +1355,10 @@ mod tests {
             sequence: 43,
             alt_screen: true,
             bracketed_paste: true,
-            mouse_reporting: false,
+            mouse: MouseModes::new(
+                crate::terminal::MouseTrackingMode::ButtonMotion,
+                crate::terminal::MouseEncoding::Sgr,
+            ),
             grid,
         });
         let encoded = RemoteCodec::encode(&message).expect("encode");

--- a/diri/crates/diri-proto/src/remote_pty.rs
+++ b/diri/crates/diri-proto/src/remote_pty.rs
@@ -1327,7 +1327,7 @@ mod tests {
     }
 
     #[test]
-    fn full_snapshot_decodes_the_historical_mouse_boolean() {
+    fn full_snapshot_keeps_pre_1_4_mouse_details_unknown() {
         let message = RemoteMessage::FullSnapshot(snapshot());
         let mut encoded = RemoteCodec::encode(&message).expect("encode");
         // Header (5), sequence (8), then the historical flags byte. Strip
@@ -1337,13 +1337,24 @@ mod tests {
         let RemoteMessage::FullSnapshot(decoded) = &decoded[0] else {
             panic!("snapshot");
         };
-        assert_eq!(
-            decoded.mouse,
-            MouseModes::new(
-                crate::terminal::MouseTrackingMode::ButtonEvents,
-                crate::terminal::MouseEncoding::Sgr,
-            )
-        );
+        assert_eq!(decoded.mouse, MouseModes::UNKNOWN);
+    }
+
+    #[test]
+    fn each_pre_1_4_mouse_regime_decodes_without_a_false_guess() {
+        // Protocol 1.3 represented all of these states with the same bit. A
+        // new peer must therefore preserve that ambiguity instead of choosing
+        // a tracking mode or coordinate encoding that may be wrong.
+        for legacy_state in ["1000-legacy", "1002-sgr", "1003-legacy"] {
+            let message = RemoteMessage::FullSnapshot(snapshot());
+            let mut encoded = RemoteCodec::encode(&message).expect("encode");
+            encoded[13] = 0b100;
+            let decoded = RemoteCodec::new().feed(&encoded).expect("decode");
+            let RemoteMessage::FullSnapshot(decoded) = &decoded[0] else {
+                panic!("snapshot");
+            };
+            assert_eq!(decoded.mouse, MouseModes::UNKNOWN, "{legacy_state}");
+        }
     }
 
     #[test]

--- a/diri/crates/diri-proto/src/terminal.rs
+++ b/diri/crates/diri-proto/src/terminal.rs
@@ -1,0 +1,362 @@
+//! Shared terminal mode and input-wire types.
+//!
+//! These values cross the Holder, Engine, client, and renderer boundaries, so
+//! keeping one representation prevents a terminal mode from being silently
+//! weakened as it moves through the stack.
+
+use serde::{Deserialize, Serialize};
+
+/// The DEC private mouse tracking mode selected by the foreground program.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+#[repr(u8)]
+pub enum MouseTrackingMode {
+    #[default]
+    Off = 0,
+    /// DECSET 1000: button press/release events only.
+    ButtonEvents = 1,
+    /// DECSET 1002: button events plus motion while a button is held.
+    ButtonMotion = 2,
+    /// DECSET 1003: button events plus all pointer motion.
+    AnyMotion = 3,
+}
+
+impl MouseTrackingMode {
+    #[must_use]
+    pub const fn from_wire(value: u8) -> Option<Self> {
+        match value {
+            0 => Some(Self::Off),
+            1 => Some(Self::ButtonEvents),
+            2 => Some(Self::ButtonMotion),
+            3 => Some(Self::AnyMotion),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub const fn dec_private_mode(self) -> Option<u16> {
+        match self {
+            Self::Off => None,
+            Self::ButtonEvents => Some(1000),
+            Self::ButtonMotion => Some(1002),
+            Self::AnyMotion => Some(1003),
+        }
+    }
+}
+
+/// Coordinate/button encoding selected independently with DECSET 1006.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+#[repr(u8)]
+pub enum MouseEncoding {
+    #[default]
+    Legacy = 0,
+    Sgr = 1,
+}
+
+impl MouseEncoding {
+    #[must_use]
+    pub const fn from_wire(value: u8) -> Option<Self> {
+        match value {
+            0 => Some(Self::Legacy),
+            1 => Some(Self::Sgr),
+            _ => None,
+        }
+    }
+}
+
+/// Complete mouse state: tracking and encoding are independent DEC modes.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MouseModes {
+    pub tracking: MouseTrackingMode,
+    pub encoding: MouseEncoding,
+}
+
+impl MouseModes {
+    pub const OFF: Self = Self {
+        tracking: MouseTrackingMode::Off,
+        encoding: MouseEncoding::Legacy,
+    };
+
+    #[must_use]
+    pub const fn new(tracking: MouseTrackingMode, encoding: MouseEncoding) -> Self {
+        Self { tracking, encoding }
+    }
+
+    #[must_use]
+    pub const fn is_reporting(self) -> bool {
+        !matches!(self.tracking, MouseTrackingMode::Off)
+    }
+
+    /// Packs the granular fields without assigning their position in a wider
+    /// protocol mode byte.
+    #[must_use]
+    pub const fn detail_bits(self) -> u8 {
+        (self.tracking as u8) | ((self.encoding as u8) << 2)
+    }
+
+    /// Decodes detailed bits. A historical enabled-only bit maps to the mode
+    /// the old checkpoint restore path synthesized: DECSET 1000 + 1006.
+    #[must_use]
+    pub const fn from_detail_bits(bits: u8, historical_enabled: bool) -> Self {
+        let tracking = match MouseTrackingMode::from_wire(bits & 0b11) {
+            Some(MouseTrackingMode::Off) if historical_enabled => MouseTrackingMode::ButtonEvents,
+            Some(mode) => mode,
+            None => MouseTrackingMode::Off,
+        };
+        let encoding = if bits & 0b100 != 0 || (bits & 0b11 == 0 && historical_enabled) {
+            MouseEncoding::Sgr
+        } else {
+            MouseEncoding::Legacy
+        };
+        Self { tracking, encoding }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TerminalMouseButton {
+    Left,
+    Middle,
+    Right,
+}
+
+impl TerminalMouseButton {
+    const fn code(self) -> u8 {
+        match self {
+            Self::Left => 0,
+            Self::Middle => 1,
+            Self::Right => 2,
+        }
+    }
+}
+
+/// Only modifiers defined by xterm mouse reporting. Command/Platform is
+/// intentionally absent: the desktop reserves that gesture for local links.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct TerminalMouseModifiers {
+    pub shift: bool,
+    pub alt: bool,
+    pub control: bool,
+}
+
+impl TerminalMouseModifiers {
+    fn bits(self) -> u8 {
+        u8::from(self.shift) * 4 + u8::from(self.alt) * 8 + u8::from(self.control) * 16
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TerminalMouseEvent {
+    Press(TerminalMouseButton),
+    Release(TerminalMouseButton),
+    Motion(Option<TerminalMouseButton>),
+    WheelUp,
+    WheelDown,
+}
+
+impl TerminalMouseEvent {
+    const fn button_code(self) -> u8 {
+        match self {
+            Self::Press(button) | Self::Release(button) => button.code(),
+            Self::Motion(Some(button)) => 32 + button.code(),
+            Self::Motion(None) => 35,
+            Self::WheelUp => 64,
+            Self::WheelDown => 65,
+        }
+    }
+
+    const fn is_release(self) -> bool {
+        matches!(self, Self::Release(_))
+    }
+}
+
+/// Encodes one xterm mouse report at a zero-based grid coordinate.
+///
+/// The caller clamps coordinates to its authoritative grid. Legacy X10
+/// coordinates have no representation beyond the 223rd row/column, so those
+/// reports are omitted instead of lying about which cell was targeted.
+#[must_use]
+pub fn encode_mouse_event(
+    modes: MouseModes,
+    event: TerminalMouseEvent,
+    modifiers: TerminalMouseModifiers,
+    col: u16,
+    row: u16,
+) -> Option<Vec<u8>> {
+    match (modes.tracking, event) {
+        (MouseTrackingMode::Off, _) => return None,
+        (MouseTrackingMode::ButtonEvents, TerminalMouseEvent::Motion(_)) => return None,
+        (MouseTrackingMode::ButtonMotion, TerminalMouseEvent::Motion(None)) => return None,
+        _ => {}
+    }
+
+    let modifiers = modifiers.bits();
+    match modes.encoding {
+        MouseEncoding::Sgr => {
+            let final_byte = if event.is_release() { 'm' } else { 'M' };
+            Some(
+                format!(
+                    "\x1b[<{};{};{}{final_byte}",
+                    event.button_code() + modifiers,
+                    u32::from(col) + 1,
+                    u32::from(row) + 1,
+                )
+                .into_bytes(),
+            )
+        }
+        MouseEncoding::Legacy => {
+            if col >= 223 || row >= 223 {
+                return None;
+            }
+            let button = if event.is_release() {
+                3 + modifiers
+            } else {
+                event.button_code() + modifiers
+            };
+            Some(vec![
+                0x1b,
+                b'[',
+                b'M',
+                32 + button,
+                33 + u8::try_from(col).expect("legacy coordinate checked"),
+                33 + u8::try_from(row).expect("legacy coordinate checked"),
+            ])
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LEGACY_BUTTONS: MouseModes =
+        MouseModes::new(MouseTrackingMode::ButtonEvents, MouseEncoding::Legacy);
+    const SGR_MOTION: MouseModes =
+        MouseModes::new(MouseTrackingMode::AnyMotion, MouseEncoding::Sgr);
+
+    #[test]
+    fn tracking_modes_filter_motion_at_the_requested_granularity() {
+        let held = TerminalMouseEvent::Motion(Some(TerminalMouseButton::Left));
+        let free = TerminalMouseEvent::Motion(None);
+        let modifiers = TerminalMouseModifiers::default();
+
+        assert!(encode_mouse_event(MouseModes::OFF, held, modifiers, 0, 0).is_none());
+        assert!(encode_mouse_event(LEGACY_BUTTONS, held, modifiers, 0, 0).is_none());
+        let drag = MouseModes::new(MouseTrackingMode::ButtonMotion, MouseEncoding::Legacy);
+        assert!(encode_mouse_event(drag, held, modifiers, 0, 0).is_some());
+        assert!(encode_mouse_event(drag, free, modifiers, 0, 0).is_none());
+        assert!(encode_mouse_event(SGR_MOTION, held, modifiers, 0, 0).is_some());
+        assert!(encode_mouse_event(SGR_MOTION, free, modifiers, 0, 0).is_some());
+    }
+
+    #[test]
+    fn legacy_encodes_each_button_release_and_modifier_bit() {
+        let modifiers = TerminalMouseModifiers {
+            shift: true,
+            alt: true,
+            control: true,
+        };
+        for (button, code) in [
+            (TerminalMouseButton::Left, 0),
+            (TerminalMouseButton::Middle, 1),
+            (TerminalMouseButton::Right, 2),
+        ] {
+            assert_eq!(
+                encode_mouse_event(
+                    LEGACY_BUTTONS,
+                    TerminalMouseEvent::Press(button),
+                    modifiers,
+                    4,
+                    7
+                ),
+                Some(vec![0x1b, b'[', b'M', 32 + code + 28, 37, 40])
+            );
+            assert_eq!(
+                encode_mouse_event(
+                    LEGACY_BUTTONS,
+                    TerminalMouseEvent::Release(button),
+                    modifiers,
+                    4,
+                    7
+                ),
+                Some(vec![0x1b, b'[', b'M', 32 + 3 + 28, 37, 40])
+            );
+        }
+    }
+
+    #[test]
+    fn sgr_preserves_large_coordinates_and_release_button_identity() {
+        assert_eq!(
+            encode_mouse_event(
+                SGR_MOTION,
+                TerminalMouseEvent::Press(TerminalMouseButton::Right),
+                TerminalMouseModifiers::default(),
+                500,
+                300,
+            ),
+            Some(b"\x1b[<2;501;301M".to_vec())
+        );
+        assert_eq!(
+            encode_mouse_event(
+                SGR_MOTION,
+                TerminalMouseEvent::Release(TerminalMouseButton::Middle),
+                TerminalMouseModifiers::default(),
+                500,
+                300,
+            ),
+            Some(b"\x1b[<1;501;301m".to_vec())
+        );
+        assert!(
+            encode_mouse_event(
+                LEGACY_BUTTONS,
+                TerminalMouseEvent::Press(TerminalMouseButton::Left),
+                TerminalMouseModifiers::default(),
+                223,
+                0,
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn motion_reports_encode_held_button_no_button_and_sgr_modifiers() {
+        let modifiers = TerminalMouseModifiers {
+            shift: true,
+            alt: false,
+            control: true,
+        };
+        assert_eq!(
+            encode_mouse_event(
+                SGR_MOTION,
+                TerminalMouseEvent::Motion(Some(TerminalMouseButton::Left)),
+                modifiers,
+                9,
+                4,
+            ),
+            Some(b"\x1b[<52;10;5M".to_vec())
+        );
+        assert_eq!(
+            encode_mouse_event(
+                SGR_MOTION,
+                TerminalMouseEvent::Motion(None),
+                TerminalMouseModifiers {
+                    alt: true,
+                    ..TerminalMouseModifiers::default()
+                },
+                9,
+                4,
+            ),
+            Some(b"\x1b[<43;10;5M".to_vec())
+        );
+    }
+
+    #[test]
+    fn legacy_enabled_only_state_migrates_to_the_historical_restore_mode() {
+        assert_eq!(
+            MouseModes::from_detail_bits(0, true),
+            MouseModes::new(MouseTrackingMode::ButtonEvents, MouseEncoding::Sgr)
+        );
+        assert_eq!(MouseModes::from_detail_bits(0, false), MouseModes::OFF);
+    }
+}

--- a/diri/crates/diri-proto/src/terminal.rs
+++ b/diri/crates/diri-proto/src/terminal.rs
@@ -19,6 +19,12 @@ pub enum MouseTrackingMode {
     ButtonMotion = 2,
     /// DECSET 1003: button events plus all pointer motion.
     AnyMotion = 3,
+    /// A pre-1.4 peer reported only that some mouse mode was active.
+    ///
+    /// This is deliberately not assigned a wire-detail value: guessing one
+    /// of 1000/1002/1003 would either drop requested motion or send motion a
+    /// program never requested.
+    Unknown = 4,
 }
 
 impl MouseTrackingMode {
@@ -40,6 +46,7 @@ impl MouseTrackingMode {
             Self::ButtonEvents => Some(1000),
             Self::ButtonMotion => Some(1002),
             Self::AnyMotion => Some(1003),
+            Self::Unknown => None,
         }
     }
 }
@@ -52,6 +59,8 @@ pub enum MouseEncoding {
     #[default]
     Legacy = 0,
     Sgr = 1,
+    /// A pre-1.4 peer did not expose whether DECSET 1006 was active.
+    Unknown = 2,
 }
 
 impl MouseEncoding {
@@ -79,6 +88,13 @@ impl MouseModes {
         encoding: MouseEncoding::Legacy,
     };
 
+    /// Some reporting mode is active, but a legacy peer did not preserve its
+    /// tracking granularity or coordinate encoding.
+    pub const UNKNOWN: Self = Self {
+        tracking: MouseTrackingMode::Unknown,
+        encoding: MouseEncoding::Unknown,
+    };
+
     #[must_use]
     pub const fn new(tracking: MouseTrackingMode, encoding: MouseEncoding) -> Self {
         Self { tracking, encoding }
@@ -89,23 +105,34 @@ impl MouseModes {
         !matches!(self.tracking, MouseTrackingMode::Off)
     }
 
+    /// Whether a desktop can safely synthesize button/motion reports.
+    #[must_use]
+    pub const fn has_known_details(self) -> bool {
+        !matches!(self.tracking, MouseTrackingMode::Unknown)
+            && !matches!(self.encoding, MouseEncoding::Unknown)
+    }
+
     /// Packs the granular fields without assigning their position in a wider
     /// protocol mode byte.
     #[must_use]
     pub const fn detail_bits(self) -> u8 {
-        (self.tracking as u8) | ((self.encoding as u8) << 2)
+        match (self.tracking, self.encoding) {
+            (MouseTrackingMode::Unknown, _) | (_, MouseEncoding::Unknown) => 0,
+            _ => (self.tracking as u8) | ((self.encoding as u8) << 2),
+        }
     }
 
-    /// Decodes detailed bits. A historical enabled-only bit maps to the mode
-    /// the old checkpoint restore path synthesized: DECSET 1000 + 1006.
+    /// Decodes additive wire details. An enabled-only legacy value remains
+    /// explicitly unknown: unlike the old checkpoint restore path, a live
+    /// peer may really be using any tracking mode and either encoding.
     #[must_use]
     pub const fn from_detail_bits(bits: u8, historical_enabled: bool) -> Self {
         let tracking = match MouseTrackingMode::from_wire(bits & 0b11) {
-            Some(MouseTrackingMode::Off) if historical_enabled => MouseTrackingMode::ButtonEvents,
+            Some(MouseTrackingMode::Off) if historical_enabled => return Self::UNKNOWN,
             Some(mode) => mode,
             None => MouseTrackingMode::Off,
         };
-        let encoding = if bits & 0b100 != 0 || (bits & 0b11 == 0 && historical_enabled) {
+        let encoding = if bits & 0b100 != 0 {
             MouseEncoding::Sgr
         } else {
             MouseEncoding::Legacy
@@ -186,6 +213,7 @@ pub fn encode_mouse_event(
 ) -> Option<Vec<u8>> {
     match (modes.tracking, event) {
         (MouseTrackingMode::Off, _) => return None,
+        (MouseTrackingMode::Unknown, _) => return None,
         (MouseTrackingMode::ButtonEvents, TerminalMouseEvent::Motion(_)) => return None,
         (MouseTrackingMode::ButtonMotion, TerminalMouseEvent::Motion(None)) => return None,
         _ => {}
@@ -223,6 +251,7 @@ pub fn encode_mouse_event(
                 33 + u8::try_from(row).expect("legacy coordinate checked"),
             ])
         }
+        MouseEncoding::Unknown => None,
     }
 }
 
@@ -352,10 +381,18 @@ mod tests {
     }
 
     #[test]
-    fn legacy_enabled_only_state_migrates_to_the_historical_restore_mode() {
-        assert_eq!(
-            MouseModes::from_detail_bits(0, true),
-            MouseModes::new(MouseTrackingMode::ButtonEvents, MouseEncoding::Sgr)
+    fn legacy_enabled_only_wire_state_keeps_its_details_unknown() {
+        assert_eq!(MouseModes::from_detail_bits(0, true), MouseModes::UNKNOWN);
+        assert!(
+            encode_mouse_event(
+                MouseModes::UNKNOWN,
+                TerminalMouseEvent::Press(TerminalMouseButton::Left),
+                TerminalMouseModifiers::default(),
+                0,
+                0,
+            )
+            .is_none(),
+            "unknown legacy modes must not be guessed for app-generated input"
         );
         assert_eq!(MouseModes::from_detail_bits(0, false), MouseModes::OFF);
     }

--- a/diri/crates/diri-remote/src/holder.rs
+++ b/diri/crates/diri-remote/src/holder.rs
@@ -783,7 +783,7 @@ impl Holder {
         }
         match message {
             RemoteMessage::Terminal(frame) => match frame.frame_type {
-                FrameType::Input => self.write_input(&frame.payload),
+                FrameType::Input | FrameType::Mouse => self.write_input(&frame.payload),
                 FrameType::Resize => {
                     let Some((cols, rows)) = frame.resize_payload() else {
                         return Err(io::Error::new(
@@ -1021,7 +1021,7 @@ impl Holder {
                 sequence: self.state.snapshot_sequence,
                 alt_screen: self.screen.is_alt_screen(),
                 bracketed_paste: self.screen.bracketed_paste(),
-                mouse_reporting: self.screen.mouse_reporting(),
+                mouse: self.screen.mouse_modes(),
                 grid,
             }))?;
         } else {
@@ -1029,7 +1029,7 @@ impl Holder {
                 sequence: self.state.snapshot_sequence,
                 alt_screen: self.screen.is_alt_screen(),
                 bracketed_paste: self.screen.bracketed_paste(),
-                mouse_reporting: self.screen.mouse_reporting(),
+                mouse: self.screen.mouse_modes(),
                 grid,
             }))?;
         }
@@ -1068,7 +1068,7 @@ impl Holder {
             sequence: self.state.snapshot_sequence,
             alt_screen: self.screen.is_alt_screen(),
             bracketed_paste: self.screen.bracketed_paste(),
-            mouse_reporting: self.screen.mouse_reporting(),
+            mouse: self.screen.mouse_modes(),
             grid: self.screen.full_snapshot(),
         }))
     }

--- a/diri/crates/diri-term/src/element.rs
+++ b/diri/crates/diri-term/src/element.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuar
 use std::time::{Duration, Instant};
 
 use diri_proto::grid::{GridCell, GridUpdate};
+use diri_proto::terminal::MouseModes;
 use gpui::{
     App, Bounds, ContentMask, Element, ElementId, FocusHandle, Font, FontFallbacks, FontId,
     GlobalElementId, InputHandler, InspectorElementId, IntoElement, LayoutId, PaintQuad, Pixels,
@@ -375,6 +376,13 @@ impl TerminalElement {
         read_lock(&self.buffer).rows
     }
 
+    /// Columns in the mirrored screen, used to clamp pointer reports to the
+    /// authoritative grid while a resize is in flight.
+    #[must_use]
+    pub fn grid_cols(&self) -> u16 {
+        read_lock(&self.buffer).cols
+    }
+
     #[must_use]
     pub fn theme(mut self, theme: TermTheme) -> Self {
         self.theme = theme;
@@ -474,21 +482,18 @@ impl TerminalElement {
         mutex_lock(&self.shared.viewport).scroll_to_absolute(absolute_row, anchor, visible_rows)
     }
 
-    pub fn set_modes(&self, alt_screen: bool, mouse_reporting: bool) -> bool {
+    pub fn set_modes(&self, alt_screen: bool, mouse: MouseModes) -> bool {
         let mut modes = mutex_lock(&self.shared.modes);
         let entered_alt = alt_screen && !modes.alt_screen;
-        *modes = TerminalModes {
-            alt_screen,
-            mouse_reporting,
-        };
+        *modes = TerminalModes { alt_screen, mouse };
         drop(modes);
         entered_alt && mutex_lock(&self.shared.viewport).enter_alt_screen()
     }
 
     /// True while the foreground program consumes mouse events, in which case
     /// pointer gestures belong to it rather than local selection.
-    pub fn mouse_reporting(&self) -> bool {
-        mutex_lock(&self.shared.modes).mouse_reporting
+    pub fn mouse_modes(&self) -> MouseModes {
+        mutex_lock(&self.shared.modes).mouse
     }
 
     /// Resolves a wheel event and applies local scrollback movement. Daemon

--- a/diri/crates/diri-term/src/scrollback.rs
+++ b/diri/crates/diri-term/src/scrollback.rs
@@ -14,6 +14,7 @@ use std::pin::Pin;
 use diri_proto::grid::{GridCell, GridCodecError, GridRowCodec};
 use diri_proto::methods::ReadScrollbackCellsResult;
 use diri_proto::model::SessionId;
+use diri_proto::terminal::MouseModes;
 
 use crate::buffer::GridBuffer;
 
@@ -461,7 +462,7 @@ impl ScrollbackViewport {
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct TerminalModes {
     pub alt_screen: bool,
-    pub mouse_reporting: bool,
+    pub mouse: MouseModes,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -504,7 +505,7 @@ impl ScrollRouter {
             WheelDelta::PrecisePoints(delta) => self.precise_steps(delta, event.line_height),
             WheelDelta::Lines(delta) => classic_steps(delta, event.visible_rows),
         }?;
-        if !modes.alt_screen && !modes.mouse_reporting {
+        if !modes.alt_screen && !modes.mouse.is_reporting() {
             return Some(WheelRoute::Local {
                 lines: i64::from(steps),
             });
@@ -941,7 +942,10 @@ mod tests {
             router.route(
                 TerminalModes {
                     alt_screen: false,
-                    mouse_reporting: true,
+                    mouse: MouseModes::new(
+                        diri_proto::terminal::MouseTrackingMode::ButtonEvents,
+                        diri_proto::terminal::MouseEncoding::Legacy,
+                    ),
                 },
                 event(-12.0),
             ),

--- a/diri/crates/diri-terminal-state/src/lib.rs
+++ b/diri/crates/diri-terminal-state/src/lib.rs
@@ -22,6 +22,10 @@ use alacritty_terminal::term::cell::{Cell, Flags};
 use alacritty_terminal::term::{Config, Term, TermMode};
 use alacritty_terminal::vte::ansi::{Color, NamedColor, Processor, Rgb};
 use diri_proto::grid::{ChangedRow, GridCell, GridRowCodec, GridUpdate, TermColor, TermStyle};
+use diri_proto::terminal::{
+    MouseEncoding, MouseModes, MouseTrackingMode, TerminalMouseEvent, TerminalMouseModifiers,
+    encode_mouse_event,
+};
 
 /// Receiver-side authority for a remote terminal stream. A mirror accepts a
 /// full snapshot as a new baseline and then only contiguous sequenced diffs;
@@ -38,7 +42,7 @@ pub struct GridMirror {
     sequence: Option<u64>,
     alt_screen: bool,
     bracketed_paste: bool,
-    mouse_reporting: bool,
+    mouse: MouseModes,
 }
 
 impl GridMirror {
@@ -53,7 +57,7 @@ impl GridMirror {
         grid: &GridUpdate,
         alt_screen: bool,
         bracketed_paste: bool,
-        mouse_reporting: bool,
+        mouse: MouseModes,
     ) -> Result<(), MirrorError> {
         if !grid.is_full_snapshot {
             return Err(MirrorError::SnapshotRequired);
@@ -64,7 +68,7 @@ impl GridMirror {
         self.sequence = Some(sequence);
         self.alt_screen = alt_screen;
         self.bracketed_paste = bracketed_paste;
-        self.mouse_reporting = mouse_reporting;
+        self.mouse = mouse;
         Ok(())
     }
 
@@ -74,7 +78,7 @@ impl GridMirror {
         grid: &GridUpdate,
         alt_screen: bool,
         bracketed_paste: bool,
-        mouse_reporting: bool,
+        mouse: MouseModes,
     ) -> Result<(), MirrorError> {
         let Some(previous) = self.sequence else {
             return Err(MirrorError::SnapshotRequired);
@@ -97,7 +101,7 @@ impl GridMirror {
         self.sequence = Some(sequence);
         self.alt_screen = alt_screen;
         self.bracketed_paste = bracketed_paste;
-        self.mouse_reporting = mouse_reporting;
+        self.mouse = mouse;
         Ok(())
     }
 
@@ -130,8 +134,8 @@ impl GridMirror {
     }
 
     #[must_use]
-    pub const fn modes(&self) -> (bool, bool, bool) {
-        (self.alt_screen, self.bracketed_paste, self.mouse_reporting)
+    pub const fn modes(&self) -> (bool, bool, MouseModes) {
+        (self.alt_screen, self.bracketed_paste, self.mouse)
     }
 
     #[must_use]
@@ -488,9 +492,29 @@ impl HeadlessScreen {
         (self.geometry.cols, self.geometry.rows)
     }
 
-    /// Whether the child asked for mouse reporting (any flavor).
+    /// The independent tracking and encoding modes requested by the child.
+    pub fn mouse_modes(&self) -> MouseModes {
+        let mode = self.term.mode();
+        let tracking = if mode.contains(TermMode::MOUSE_MOTION) {
+            MouseTrackingMode::AnyMotion
+        } else if mode.contains(TermMode::MOUSE_DRAG) {
+            MouseTrackingMode::ButtonMotion
+        } else if mode.contains(TermMode::MOUSE_REPORT_CLICK) {
+            MouseTrackingMode::ButtonEvents
+        } else {
+            MouseTrackingMode::Off
+        };
+        let encoding = if mode.contains(TermMode::SGR_MOUSE) {
+            MouseEncoding::Sgr
+        } else {
+            MouseEncoding::Legacy
+        };
+        MouseModes::new(tracking, encoding)
+    }
+
+    /// Whether any tracking mode is active.
     pub fn mouse_reporting(&self) -> bool {
-        self.term.mode().intersects(TermMode::MOUSE_MODE)
+        self.mouse_modes().is_reporting()
     }
 
     /// Cursor (col, row, visible) without touching cell data.
@@ -621,7 +645,7 @@ impl HeadlessScreen {
         update: &GridUpdate,
         alt_screen: bool,
         bracketed_paste: bool,
-        mouse_reporting: bool,
+        mouse: MouseModes,
     ) -> bool {
         let cols = self.geometry.cols;
         let rows = self.geometry.rows;
@@ -693,8 +717,11 @@ impl HeadlessScreen {
         if bracketed_paste {
             bytes.extend_from_slice(b"\x1b[?2004h");
         }
-        if mouse_reporting {
-            bytes.extend_from_slice(b"\x1b[?1000h\x1b[?1006h");
+        if let Some(mode) = mouse.tracking.dec_private_mode() {
+            bytes.extend_from_slice(format!("\x1b[?{mode}h").as_bytes());
+        }
+        if matches!(mouse.encoding, MouseEncoding::Sgr) {
+            bytes.extend_from_slice(b"\x1b[?1006h");
         }
         bytes.extend_from_slice(if update.cursor_visible {
             b"\x1b[?25h"
@@ -726,19 +753,23 @@ impl HeadlessScreen {
         }
         let x = col.min(self.geometry.cols.saturating_sub(1));
         let y = row.min(self.geometry.rows.saturating_sub(1));
-        let button = if up { 64 } else { 65 }; // X11 wheel buttons 4/5, wheel-flagged
         let mut out = Vec::new();
         for _ in 0..lines {
-            if self.term.mode().contains(TermMode::SGR_MOUSE) {
-                out.extend_from_slice(format!("\x1b[<{button};{};{}M", x + 1, y + 1).as_bytes());
+            let event = if up {
+                TerminalMouseEvent::WheelUp
             } else {
-                // Legacy X10 encoding: 32 + button, 32 + 1-based coordinate.
-                out.push(0x1b);
-                out.extend_from_slice(b"[M");
-                out.push(32 + button as u8);
-                out.push((32 + x + 1).min(255) as u8);
-                out.push((32 + y + 1).min(255) as u8);
-            }
+                TerminalMouseEvent::WheelDown
+            };
+            let Some(report) = encode_mouse_event(
+                self.mouse_modes(),
+                event,
+                TerminalMouseModifiers::default(),
+                x as u16,
+                y as u16,
+            ) else {
+                break;
+            };
+            out.extend_from_slice(&report);
         }
         out
     }
@@ -1267,7 +1298,13 @@ mod tests {
 
         let mut restored = HeadlessScreen::new(40, 10);
         assert!(
-            restored.restore(&[], &snapshot, false, true, true),
+            restored.restore(
+                &[],
+                &snapshot,
+                false,
+                true,
+                MouseModes::new(MouseTrackingMode::ButtonEvents, MouseEncoding::Sgr),
+            ),
             "restorable"
         );
         assert_eq!(restored.lines(), original.lines());
@@ -1287,7 +1324,7 @@ mod tests {
 
         let mut smaller = HeadlessScreen::new(39, 10);
         assert!(
-            !smaller.restore(&[], &snapshot, false, false, false),
+            !smaller.restore(&[], &snapshot, false, false, MouseModes::OFF),
             "a checkpoint from another geometry is a cache miss"
         );
     }
@@ -1305,7 +1342,7 @@ mod tests {
 
         let mut restored = HeadlessScreen::new(12, 2);
         assert!(
-            restored.restore(&history, &snapshot, false, false, false),
+            restored.restore(&history, &snapshot, false, false, MouseModes::OFF),
             "restorable"
         );
         assert_eq!(restored.scrollback(), original.scrollback());
@@ -1333,11 +1370,11 @@ mod tests {
         let snapshot = screen.full_snapshot();
         let mut mirror = GridMirror::new();
         mirror
-            .apply_snapshot(9, &snapshot, false, true, false)
+            .apply_snapshot(9, &snapshot, false, true, MouseModes::OFF)
             .expect("snapshot");
         assert_eq!(mirror.sequence(), Some(9));
         assert_eq!(mirror.size(), (8, 2));
-        assert_eq!(mirror.modes(), (false, true, false));
+        assert_eq!(mirror.modes(), (false, true, MouseModes::OFF));
 
         let mut delta_source = HeadlessScreen::new(8, 2);
         delta_source.feed(b"one");
@@ -1345,15 +1382,56 @@ mod tests {
         delta_source.feed(b" two");
         let delta = delta_source.grid_update(false);
         mirror
-            .apply_delta(10, &delta, true, false, true)
+            .apply_delta(
+                10,
+                &delta,
+                true,
+                false,
+                MouseModes::new(MouseTrackingMode::AnyMotion, MouseEncoding::Sgr),
+            )
             .expect("contiguous delta");
-        assert_eq!(mirror.modes(), (true, false, true));
+        assert_eq!(
+            mirror.modes(),
+            (
+                true,
+                false,
+                MouseModes::new(MouseTrackingMode::AnyMotion, MouseEncoding::Sgr)
+            )
+        );
         assert!(matches!(
-            mirror.apply_delta(12, &delta, false, false, false),
+            mirror.apply_delta(12, &delta, false, false, MouseModes::OFF),
             Err(MirrorError::SequenceGap {
                 expected: 11,
                 actual: 12
             })
         ));
+    }
+
+    #[test]
+    fn parser_preserves_each_tracking_mode_and_encoding_independently() {
+        let mut screen = HeadlessScreen::new(300, 24);
+        assert_eq!(screen.mouse_modes(), MouseModes::OFF);
+
+        screen.feed(b"\x1b[?1000h");
+        assert_eq!(
+            screen.mouse_modes(),
+            MouseModes::new(MouseTrackingMode::ButtonEvents, MouseEncoding::Legacy)
+        );
+        screen.feed(b"\x1b[?1002h\x1b[?1006h");
+        assert_eq!(
+            screen.mouse_modes(),
+            MouseModes::new(MouseTrackingMode::ButtonMotion, MouseEncoding::Sgr)
+        );
+        screen.feed(b"\x1b[?1003h\x1b[?1006l");
+        assert_eq!(
+            screen.mouse_modes(),
+            MouseModes::new(MouseTrackingMode::AnyMotion, MouseEncoding::Legacy)
+        );
+        screen.feed(b"\x1b[?1003l\x1b[?1006h");
+        assert_eq!(
+            screen.mouse_modes(),
+            MouseModes::new(MouseTrackingMode::Off, MouseEncoding::Sgr),
+            "1006 is independent of tracking"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Preserve terminal mouse tracking as off / DECSET 1000 / 1002 / 1003 independently from legacy / SGR encoding across the parser, grid mirrors, local and remote transports, and durable checkpoints.
- Forward primary-button presses, releases, requested drag/motion events, and wheel reports through a dedicated raw mouse frame so terminal status and prompt reducers never interpret mouse escape bytes as typed text.
- Keep pointer coordinates within the mirrored grid, preserve SGR coordinates beyond column 223, and cap motion traffic at 125 Hz with same-cell deduplication and trailing-edge delivery of the latest cell.
- Preserve local macOS gestures: Option-drag remains copyable terminal selection and Command-click remains local URL/file activation; reporting-off behavior is unchanged.

## Compatibility

- Checkpoints advance to v3 and continue loading v2. A v2 enabled-only mouse flag migrates to the exact historical restore behavior, DECSET 1000 plus 1006. Older binaries safely treat v3 as a cache miss and replay the authoritative raw log.
- Local and remote mode bytes retain their historical any-mouse bits and add granular state only in previously unused bits.
- Remote protocol 1.4 adds the Mouse frame. A live protocol 1.3 Holder did not expose tracking granularity or coordinate encoding, so a new Engine represents those details as unknown and does not synthesize potentially incorrect button/motion bytes. Wheel intent remains safe because it is sent as `Scroll` for that Holder to encode from its authoritative parser state.
- New Holders accept both `Input` and `Mouse` frame kinds, and new Engines retain the raw-Input fallback for pre-1.4 peers.
- Legacy mouse reports outside their representable 223-cell coordinate range are omitted instead of reporting a false cell; SGR reports exact large coordinates.
- A pending motion report is replaced by the latest cell and delivered at the trailing edge. Release drains it first on the same attachment channel; mode, session, attachment, and gesture changes invalidate stale timers. A release received after the pointer leaves the grid also clears ownership and cancels pending motion before coordinate lookup, so no held drag can leak past the physical release.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p diri-proto`
- `cargo test -p diri-terminal-state`
- `cargo test -p diri-engine --test attach`
- `cargo test -p diri-engine --test checkpoint -- --test-threads=1`
- Targeted app tests for pointer ownership, Option-drag copying, grid clamping, trailing-edge motion delivery, release ordering, and release without an available grid cell
- Targeted engine tests for protocol-1.3 mouse-frame fallback and checkpoint v2 migration
- `cargo test --workspace`: all suites passed except one timing-sensitive, unrelated remote environment-capture case that timed out once; its exact isolated rerun passed: `cargo test -p diri-remote --test holder_e2e environment_capture_tolerates_startup_noise_and_bounds_timeout_failures -- --exact --nocapture`
- `cargo build --workspace --release`
- `git diff --check`

Closes #76
