### PR TITLE
Accept Finder drops in the sidebar

### DIFF
--- a/diri/crates/diri-app/src/composer.rs
+++ b/diri/crates/diri-app/src/composer.rs
@@ -138,6 +138,27 @@ impl PromptComposer {
         self.reveal_caret = true;
     }
 
+    /// Append staged context without replacing a draft the user already
+    /// wrote. A new block starts on its own line unless the draft already
+    /// ends in whitespace, keeping quoted paths visually separate while
+    /// preserving every byte of the existing text.
+    pub fn append_context(&mut self, context: &str) {
+        if context.is_empty() {
+            return;
+        }
+        if !self.editor.is_empty()
+            && !self
+                .editor
+                .text()
+                .chars()
+                .next_back()
+                .is_some_and(char::is_whitespace)
+        {
+            self.insert_multiline("\n");
+        }
+        self.insert_multiline(context);
+    }
+
     pub fn editor_mut(&mut self) -> &mut QueryEditor {
         self.reveal_caret = true;
         self.goal_column = None;
@@ -428,5 +449,30 @@ mod tests {
         assert_eq!(intersect(&(2..9), &(0..5)), Some(2..5));
         assert_eq!(intersect(&(2..9), &(5..12)), Some(5..9));
         assert_eq!(intersect(&(2..9), &(12..14)), None);
+    }
+
+    #[test]
+    fn staged_context_appends_without_replacing_the_existing_draft() {
+        let mut composer = PromptComposer::default();
+        composer.insert_multiline("Review the parser first");
+        composer.append_context("'/tmp/a file.rs' '/tmp/tests'");
+        assert_eq!(
+            composer.text(),
+            "Review the parser first\n'/tmp/a file.rs' '/tmp/tests'"
+        );
+
+        composer.append_context("'/tmp/more.rs'");
+        assert_eq!(
+            composer.text(),
+            "Review the parser first\n'/tmp/a file.rs' '/tmp/tests'\n'/tmp/more.rs'"
+        );
+    }
+
+    #[test]
+    fn staged_context_uses_existing_trailing_whitespace() {
+        let mut composer = PromptComposer::default();
+        composer.insert_multiline("Look here: ");
+        composer.append_context("'/tmp/example.rs'");
+        assert_eq!(composer.text(), "Look here: '/tmp/example.rs'");
     }
 }

--- a/diri/crates/diri-app/src/external_drop.rs
+++ b/diri/crates/diri-app/src/external_drop.rs
@@ -1,0 +1,550 @@
+//! Validation and staging for paths entering Diri from the desktop.
+//!
+//! Keep this module independent of GPUI and the sidebar. A desktop drop is
+//! untrusted, transient input: Finder may hand us a vanished file, a cloud
+//! placeholder, or a path the process cannot read. Callers receive a complete
+//! plan and may update UI state from it, but this module never opens a session,
+//! sends input, starts a download, or executes a path.
+
+use std::fs::{self, File};
+use std::io;
+use std::path::{Path, PathBuf};
+
+use diri_proto::SessionId;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ExternalPathKind {
+    File,
+    Directory,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct StagedExternalPath {
+    pub path: PathBuf,
+    pub kind: ExternalPathKind,
+    quoted: String,
+}
+
+impl StagedExternalPath {
+    pub fn quoted(&self) -> &str {
+        &self.quoted
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ExternalPathRejection {
+    Missing,
+    Unreadable,
+    NotMaterialized,
+    NotFileOrDirectory,
+    NotUnicode,
+    RequiresDirectory,
+    AdditionalPath,
+    RemoteTarget,
+}
+
+impl ExternalPathRejection {
+    fn explanation(&self) -> &'static str {
+        match self {
+            Self::Missing => "does not exist",
+            Self::Unreadable => "is not readable",
+            Self::NotMaterialized => "is not downloaded to this Mac",
+            Self::NotFileOrDirectory => "is not a file or directory",
+            Self::NotUnicode => "cannot be represented in a prompt",
+            Self::RequiresDirectory => "is not a directory",
+            Self::AdditionalPath => "only the first directory starts the session",
+            Self::RemoteTarget => "is local, but the target runs on another host",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RejectedExternalPath {
+    pub path: PathBuf,
+    pub reason: ExternalPathRejection,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ExternalDropTarget {
+    EmptySpace,
+    Project { remote: bool },
+    Session { id: SessionId, remote: bool },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ExternalDropAction {
+    OpenLauncher {
+        root: String,
+    },
+    OpenSessionComposer {
+        session_id: SessionId,
+        insertion: String,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ExternalDropPlan {
+    pub action: Option<ExternalDropAction>,
+    pub rejected: Vec<RejectedExternalPath>,
+}
+
+impl ExternalDropPlan {
+    pub fn accepts_drop(&self) -> bool {
+        self.action.is_some()
+    }
+
+    /// Short, visible copy for the inline sidebar/composer feedback surface.
+    pub fn feedback(&self) -> Option<String> {
+        if self.rejected.is_empty() {
+            return None;
+        }
+        let prefix = if self.action.is_some() {
+            "Ignored"
+        } else {
+            "Couldn't use"
+        };
+        let details = self
+            .rejected
+            .iter()
+            .take(3)
+            .map(|rejection| {
+                format!(
+                    "“{}” {}",
+                    rejection.path.to_string_lossy(),
+                    rejection.reason.explanation()
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+        let remaining = self.rejected.len().saturating_sub(3);
+        Some(if remaining == 0 {
+            format!("{prefix}: {details}.")
+        } else {
+            format!("{prefix}: {details}; and {remaining} more.")
+        })
+    }
+}
+
+/// Validate and route a Finder payload for one sidebar target.
+///
+/// This function is intentionally safe to call for drag highlighting as well
+/// as release: inspection is read-only, no contents are consumed, and dataless
+/// files are rejected before `open` could ask the provider to materialize one.
+pub(crate) fn plan_external_drop(
+    paths: &[PathBuf],
+    target: ExternalDropTarget,
+) -> ExternalDropPlan {
+    if let Some(plan) = remote_refusal(paths, &target) {
+        return plan;
+    }
+    plan_staged_drop(target, stage_external_paths(paths))
+}
+
+#[cfg(test)]
+fn plan_external_drop_with(
+    paths: &[PathBuf],
+    target: ExternalDropTarget,
+    probe: &impl PathProbe,
+) -> ExternalDropPlan {
+    if paths.is_empty() {
+        return ExternalDropPlan {
+            action: None,
+            rejected: Vec::new(),
+        };
+    }
+
+    if let Some(plan) = remote_refusal(paths, &target) {
+        return plan;
+    }
+    let staged = stage_external_paths_with(paths, probe);
+    plan_staged_drop(target, staged)
+}
+
+fn remote_refusal(paths: &[PathBuf], target: &ExternalDropTarget) -> Option<ExternalDropPlan> {
+    let remote = match target {
+        ExternalDropTarget::EmptySpace => false,
+        ExternalDropTarget::Project { remote } | ExternalDropTarget::Session { remote, .. } => {
+            *remote
+        }
+    };
+    remote.then(|| ExternalDropPlan {
+        action: None,
+        rejected: paths
+            .iter()
+            .cloned()
+            .map(|path| RejectedExternalPath {
+                path,
+                reason: ExternalPathRejection::RemoteTarget,
+            })
+            .collect(),
+    })
+}
+
+fn plan_staged_drop(
+    target: ExternalDropTarget,
+    staged: Vec<Result<StagedExternalPath, RejectedExternalPath>>,
+) -> ExternalDropPlan {
+    match target {
+        ExternalDropTarget::Session { id, remote: false } => {
+            let mut accepted = Vec::new();
+            let mut rejected = Vec::new();
+            for result in staged {
+                match result {
+                    Ok(path) => accepted.push(path),
+                    Err(error) => rejected.push(error),
+                }
+            }
+            let insertion = accepted
+                .iter()
+                .map(StagedExternalPath::quoted)
+                .collect::<Vec<_>>()
+                .join(" ");
+            ExternalDropPlan {
+                action: (!insertion.is_empty()).then_some(
+                    ExternalDropAction::OpenSessionComposer {
+                        session_id: id,
+                        insertion,
+                    },
+                ),
+                rejected,
+            }
+        }
+        ExternalDropTarget::EmptySpace | ExternalDropTarget::Project { remote: false } => {
+            launcher_plan(staged)
+        }
+        ExternalDropTarget::Project { remote: true }
+        | ExternalDropTarget::Session { remote: true, .. } => {
+            unreachable!("refused before staging")
+        }
+    }
+}
+
+fn launcher_plan(
+    staged: Vec<Result<StagedExternalPath, RejectedExternalPath>>,
+) -> ExternalDropPlan {
+    let chosen = staged.iter().position(|result| {
+        matches!(
+            result,
+            Ok(StagedExternalPath {
+                kind: ExternalPathKind::Directory,
+                ..
+            })
+        )
+    });
+    let mut rejected = Vec::new();
+    let mut root = None;
+    for (index, result) in staged.into_iter().enumerate() {
+        match result {
+            Err(error) => rejected.push(error),
+            Ok(path) if Some(index) == chosen => {
+                root = path.path.to_str().map(str::to_owned);
+                if root.is_none() {
+                    rejected.push(RejectedExternalPath {
+                        path: path.path,
+                        reason: ExternalPathRejection::NotUnicode,
+                    });
+                }
+            }
+            Ok(path) => rejected.push(RejectedExternalPath {
+                reason: if path.kind == ExternalPathKind::Directory && chosen.is_some() {
+                    ExternalPathRejection::AdditionalPath
+                } else {
+                    ExternalPathRejection::RequiresDirectory
+                },
+                path: path.path,
+            }),
+        }
+    }
+    ExternalDropPlan {
+        action: root.map(|root| ExternalDropAction::OpenLauncher { root }),
+        rejected,
+    }
+}
+
+fn stage_path(
+    path: &Path,
+    probe: &impl PathProbe,
+) -> Result<StagedExternalPath, RejectedExternalPath> {
+    let reject = |reason| RejectedExternalPath {
+        path: path.to_path_buf(),
+        reason,
+    };
+    let inspected = probe.inspect(path).map_err(reject)?;
+    if !inspected.materialized {
+        return Err(reject(ExternalPathRejection::NotMaterialized));
+    }
+    if !probe.readable(path, inspected.kind) {
+        return Err(reject(ExternalPathRejection::Unreadable));
+    }
+    let Some(text) = path.to_str() else {
+        return Err(reject(ExternalPathRejection::NotUnicode));
+    };
+    Ok(StagedExternalPath {
+        path: path.to_path_buf(),
+        kind: inspected.kind,
+        quoted: quote_path(text),
+    })
+}
+
+/// Reusable desktop-ingress gate for future attachment types. Consumers can
+/// apply their own file-kind policy after this has established existence,
+/// local materialization, readability, and lossless prompt representation.
+pub(crate) fn stage_external_paths(
+    paths: &[PathBuf],
+) -> Vec<Result<StagedExternalPath, RejectedExternalPath>> {
+    stage_external_paths_with(paths, &FileSystemProbe)
+}
+
+fn stage_external_paths_with(
+    paths: &[PathBuf],
+    probe: &impl PathProbe,
+) -> Vec<Result<StagedExternalPath, RejectedExternalPath>> {
+    paths.iter().map(|path| stage_path(path, probe)).collect()
+}
+
+/// POSIX single-quote a path. A literal quote closes the quoted span, emits an
+/// escaped quote, and reopens it (`'` -> `'\''`). Nothing in the resulting
+/// text can become shell syntax if an Agent chooses to pass it to a shell.
+pub(crate) fn quote_path(path: &str) -> String {
+    format!("'{}'", path.replace('\'', "'\\''"))
+}
+
+#[derive(Clone, Copy)]
+struct InspectedPath {
+    kind: ExternalPathKind,
+    materialized: bool,
+}
+
+trait PathProbe {
+    fn inspect(&self, path: &Path) -> Result<InspectedPath, ExternalPathRejection>;
+    fn readable(&self, path: &Path, kind: ExternalPathKind) -> bool;
+}
+
+struct FileSystemProbe;
+
+impl PathProbe for FileSystemProbe {
+    fn inspect(&self, path: &Path) -> Result<InspectedPath, ExternalPathRejection> {
+        let metadata = fs::metadata(path).map_err(|error| match error.kind() {
+            io::ErrorKind::NotFound => ExternalPathRejection::Missing,
+            io::ErrorKind::PermissionDenied => ExternalPathRejection::Unreadable,
+            _ => ExternalPathRejection::Unreadable,
+        })?;
+        let kind = if metadata.is_file() {
+            ExternalPathKind::File
+        } else if metadata.is_dir() {
+            ExternalPathKind::Directory
+        } else {
+            return Err(ExternalPathRejection::NotFileOrDirectory);
+        };
+        Ok(InspectedPath {
+            kind,
+            materialized: is_materialized(&metadata),
+        })
+    }
+
+    fn readable(&self, path: &Path, kind: ExternalPathKind) -> bool {
+        match kind {
+            ExternalPathKind::File => File::open(path).is_ok(),
+            ExternalPathKind::Directory => fs::read_dir(path).is_ok(),
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn is_materialized(metadata: &fs::Metadata) -> bool {
+    use std::os::macos::fs::MetadataExt as _;
+
+    // `SF_DATALESS` is the kernel's filesystem-level marker for an object
+    // whose contents are owned by a File Provider and absent locally. Checking
+    // it before `File::open` avoids implicitly starting a cloud download.
+    const SF_DATALESS: u32 = 0x4000_0000;
+    metadata.st_flags() & SF_DATALESS == 0
+}
+
+#[cfg(not(target_os = "macos"))]
+fn is_materialized(_metadata: &fs::Metadata) -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct FakeProbe {
+        paths: HashMap<PathBuf, Result<InspectedPath, ExternalPathRejection>>,
+        unreadable: Vec<PathBuf>,
+    }
+
+    impl FakeProbe {
+        fn file(mut self, path: &str) -> Self {
+            self.paths.insert(
+                path.into(),
+                Ok(InspectedPath {
+                    kind: ExternalPathKind::File,
+                    materialized: true,
+                }),
+            );
+            self
+        }
+
+        fn directory(mut self, path: &str) -> Self {
+            self.paths.insert(
+                path.into(),
+                Ok(InspectedPath {
+                    kind: ExternalPathKind::Directory,
+                    materialized: true,
+                }),
+            );
+            self
+        }
+
+        fn dataless(mut self, path: &str) -> Self {
+            self.paths.insert(
+                path.into(),
+                Ok(InspectedPath {
+                    kind: ExternalPathKind::File,
+                    materialized: false,
+                }),
+            );
+            self
+        }
+
+        fn unreadable(mut self, path: &str) -> Self {
+            self = self.file(path);
+            self.unreadable.push(path.into());
+            self
+        }
+    }
+
+    impl PathProbe for FakeProbe {
+        fn inspect(&self, path: &Path) -> Result<InspectedPath, ExternalPathRejection> {
+            self.paths
+                .get(path)
+                .cloned()
+                .unwrap_or(Err(ExternalPathRejection::Missing))
+        }
+
+        fn readable(&self, path: &Path, _kind: ExternalPathKind) -> bool {
+            !self.unreadable.iter().any(|candidate| candidate == path)
+        }
+    }
+
+    fn paths(values: &[&str]) -> Vec<PathBuf> {
+        values.iter().map(PathBuf::from).collect()
+    }
+
+    #[test]
+    fn empty_space_and_project_targets_choose_the_first_directory() {
+        let probe = FakeProbe::default()
+            .file("/tmp/notes.md")
+            .directory("/tmp/first")
+            .directory("/tmp/second");
+        for target in [
+            ExternalDropTarget::EmptySpace,
+            ExternalDropTarget::Project { remote: false },
+        ] {
+            let plan = plan_external_drop_with(
+                &paths(&["/tmp/notes.md", "/tmp/first", "/tmp/second"]),
+                target,
+                &probe,
+            );
+            assert_eq!(
+                plan.action,
+                Some(ExternalDropAction::OpenLauncher {
+                    root: "/tmp/first".into()
+                })
+            );
+            assert_eq!(plan.rejected.len(), 2);
+            assert_eq!(
+                plan.rejected[0].reason,
+                ExternalPathRejection::RequiresDirectory
+            );
+            assert_eq!(
+                plan.rejected[1].reason,
+                ExternalPathRejection::AdditionalPath
+            );
+            assert!(plan.feedback().unwrap().starts_with("Ignored:"));
+        }
+    }
+
+    #[test]
+    fn session_target_attaches_every_valid_path_and_keeps_input_order() {
+        let probe = FakeProbe::default()
+            .directory("/tmp/a folder")
+            .file("/tmp/$HOME; rm -rf nope");
+        let plan = plan_external_drop_with(
+            &paths(&["/tmp/a folder", "/tmp/$HOME; rm -rf nope"]),
+            ExternalDropTarget::Session {
+                id: SessionId("session-1".into()),
+                remote: false,
+            },
+            &probe,
+        );
+        assert_eq!(
+            plan.action,
+            Some(ExternalDropAction::OpenSessionComposer {
+                session_id: SessionId("session-1".into()),
+                insertion: "'/tmp/a folder' '/tmp/$HOME; rm -rf nope'".into(),
+            })
+        );
+        assert!(plan.rejected.is_empty());
+    }
+
+    #[test]
+    fn invalid_unreadable_and_unmaterialized_paths_are_visible_rejections() {
+        let probe = FakeProbe::default()
+            .unreadable("/tmp/private")
+            .dataless("/tmp/cloud.txt");
+        let plan = plan_external_drop_with(
+            &paths(&["/tmp/missing", "/tmp/private", "/tmp/cloud.txt"]),
+            ExternalDropTarget::Session {
+                id: SessionId("session-1".into()),
+                remote: false,
+            },
+            &probe,
+        );
+        assert!(plan.action.is_none());
+        assert_eq!(
+            plan.rejected
+                .iter()
+                .map(|rejection| &rejection.reason)
+                .collect::<Vec<_>>(),
+            vec![
+                &ExternalPathRejection::Missing,
+                &ExternalPathRejection::Unreadable,
+                &ExternalPathRejection::NotMaterialized,
+            ]
+        );
+        let feedback = plan.feedback().unwrap();
+        assert!(feedback.contains("does not exist"));
+        assert!(feedback.contains("not readable"));
+        assert!(feedback.contains("not downloaded"));
+    }
+
+    #[test]
+    fn a_local_drop_on_a_remote_session_is_refused_before_filesystem_access() {
+        let plan = plan_external_drop_with(
+            &paths(&["/path/that/does/not/need/to/exist"]),
+            ExternalDropTarget::Session {
+                id: SessionId("remote".into()),
+                remote: true,
+            },
+            &FakeProbe::default(),
+        );
+        assert!(plan.action.is_none());
+        assert_eq!(plan.rejected[0].reason, ExternalPathRejection::RemoteTarget);
+        assert!(plan.feedback().unwrap().contains("another host"));
+    }
+
+    #[test]
+    fn quoting_neutralizes_spaces_quotes_and_shell_metacharacters() {
+        assert_eq!(
+            quote_path("/tmp/a b/$HOME;$(touch nope)"),
+            "'/tmp/a b/$HOME;$(touch nope)'"
+        );
+        assert_eq!(quote_path("/tmp/it's here"), "'/tmp/it'\\''s here'");
+    }
+}

--- a/diri/crates/diri-app/src/launcher.rs
+++ b/diri/crates/diri-app/src/launcher.rs
@@ -1,11 +1,13 @@
 //! Compact new-session destination opened in the main pane by Command-N.
 
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
-use diri_proto::{AgentKind, Project};
+use diri_proto::{AgentKind, Project, SessionId};
 use diri_ui::{
-    AgentKind as UiAgentKind, AgentLogo, Fill, FloatingSurface, Palette, Radius, SemanticColors,
+    AgentKind as UiAgentKind, AgentLogo, Fill, FloatingSurface, Ink, Palette, Radius,
+    SemanticColors,
 };
 use gpui::{
     AnyElement, App, Context, EventEmitter, FocusHandle, Focusable, FontWeight, HighlightStyle,
@@ -17,6 +19,7 @@ use crate::agent_catalog::{AgentOption, quick_agent_options, title_case_id};
 use crate::composer::PromptComposer;
 use crate::macos::sf_symbols::{SymbolWeight, sf_symbol, sf_symbol_weighted};
 use crate::navigation::CARET;
+use crate::notifications::SendTextCommand;
 use crate::query_editor::{self, ClipboardEdit, Edit};
 use crate::store::SpawnOptions;
 
@@ -73,10 +76,17 @@ pub(crate) struct LauncherOverlay {
     services: Arc<AppServices>,
     focus: FocusHandle,
     prompt: PromptComposer,
+    target: LauncherTarget,
+    new_session_draft: String,
+    session_drafts: HashMap<SessionId, String>,
     selected_harness: AgentKind,
     selected_root: String,
     selected_host: Option<String>,
     fallback_notice: Option<String>,
+    /// Finder drops may partially succeed. Keep their ignored-path detail
+    /// inline with the staged draft until the user sends or replaces it; a
+    /// toast would separate the reason from its action.
+    drop_notice: Option<String>,
     /// Which picker, if any, is open — and where its keyboard highlight sits,
     /// so both are reachable without the mouse.
     picker: Option<Picker>,
@@ -90,6 +100,12 @@ pub(crate) struct LauncherOverlay {
 enum Picker {
     Harness,
     Project,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum LauncherTarget {
+    NewSession,
+    Session(SessionId),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -111,7 +127,7 @@ impl LauncherOverlay {
                     Ok(()) | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
                         if this
                             .update(cx, |this, cx| {
-                                if this.open {
+                                if this.open && matches!(this.target, LauncherTarget::NewSession) {
                                     this.reconcile_harness();
                                 }
                                 cx.notify();
@@ -130,10 +146,14 @@ impl LauncherOverlay {
             services,
             focus,
             prompt: PromptComposer::default(),
+            target: LauncherTarget::NewSession,
+            new_session_draft: String::new(),
+            session_drafts: HashMap::new(),
             selected_harness,
             selected_root,
             selected_host,
             fallback_notice: None,
+            drop_notice: None,
             picker: None,
             highlight: 0,
             open: false,
@@ -147,6 +167,8 @@ impl LauncherOverlay {
     }
 
     pub(crate) fn open(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.switch_target(LauncherTarget::NewSession);
+        self.drop_notice = None;
         // A half-written prompt survives Escape. This used to clear on every
         // open, so closing the launcher by reflex — or bouncing off it to
         // check something — threw the prompt away with no way back. It is
@@ -158,6 +180,48 @@ impl LauncherOverlay {
             self.selected_host = host;
             self.fallback_notice = None;
         }
+        self.activate_new_session(window, cx);
+    }
+
+    /// Open Command-N at a validated local directory. The Finder gesture only
+    /// prepares the form: the existing draft remains, focus lands in its
+    /// prompt, and no spawn occurs before explicit submission.
+    pub(crate) fn open_at_directory(
+        &mut self,
+        root: String,
+        notice: Option<String>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.switch_target(LauncherTarget::NewSession);
+        self.selected_root = root;
+        self.selected_host = None;
+        self.fallback_notice = None;
+        self.drop_notice = notice;
+        self.activate_new_session(window, cx);
+    }
+
+    /// Open the native composer for one existing local session and append the
+    /// staged paths to that session's own draft. Merely opening this surface
+    /// neither attaches to the PTY nor wakes a hibernated process.
+    pub(crate) fn open_for_session(
+        &mut self,
+        session_id: SessionId,
+        insertion: &str,
+        notice: Option<String>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.switch_target(LauncherTarget::Session(session_id.clone()));
+        self.prompt.append_context(insertion);
+        self.drop_notice = notice;
+        self.picker = None;
+        self.open = true;
+        window.focus(&self.focus, cx);
+        cx.notify();
+    }
+
+    fn activate_new_session(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.services
             .store
             .store
@@ -169,6 +233,25 @@ impl LauncherOverlay {
         self.open = true;
         window.focus(&self.focus, cx);
         cx.notify();
+    }
+
+    fn switch_target(&mut self, target: LauncherTarget) {
+        if self.target == target {
+            return;
+        }
+        let saved = transition_draft(
+            &self.target,
+            &target,
+            self.prompt.text(),
+            &mut self.new_session_draft,
+            &mut self.session_drafts,
+        );
+        self.prompt.clear();
+        if !saved.is_empty() {
+            self.prompt.insert_multiline(&saved);
+        }
+        self.target = target;
+        self.picker = None;
     }
 
     pub(crate) fn focus(&self, window: &mut Window, cx: &mut Context<Self>) {
@@ -306,6 +389,21 @@ impl LauncherOverlay {
     /// `None` means it can. The submit button used to just sit there dimmed
     /// with no explanation, which reads as "broken" rather than "not yet".
     fn blocker(&self) -> Option<String> {
+        if let LauncherTarget::Session(id) = &self.target {
+            let store = self
+                .services
+                .store
+                .store
+                .read()
+                .expect("session store lock poisoned");
+            let Some(session) = store.sessions().get(id) else {
+                return Some("This session is no longer available".to_owned());
+            };
+            return session
+                .host
+                .is_some()
+                .then(|| "Local paths cannot be used on a remote session".to_owned());
+        }
         if self.selected_root.is_empty() {
             return Some("Choose a project to start in".to_owned());
         }
@@ -343,21 +441,48 @@ impl LauncherOverlay {
             return false;
         }
         let prompt = self.prompt.text().trim().to_owned();
-        self.services
-            .store
-            .store
-            .write()
-            .expect("session store lock poisoned")
-            .spawn_kind(
-                self.selected_harness.clone(),
-                SpawnOptions {
-                    cwd: Some(self.selected_root.clone()),
-                    initial_prompt: Some(prompt),
-                    host: self.selected_host.clone(),
-                    ..SpawnOptions::default()
-                },
-            );
+        match &self.target {
+            LauncherTarget::NewSession => {
+                self.services
+                    .store
+                    .store
+                    .write()
+                    .expect("session store lock poisoned")
+                    .spawn_kind(
+                        self.selected_harness.clone(),
+                        SpawnOptions {
+                            cwd: Some(self.selected_root.clone()),
+                            initial_prompt: Some(prompt),
+                            host: self.selected_host.clone(),
+                            ..SpawnOptions::default()
+                        },
+                    );
+                self.new_session_draft.clear();
+            }
+            LauncherTarget::Session(id) => {
+                // Selection can attach or resume terminal state, so it belongs
+                // to explicit confirmation—not the Finder release that merely
+                // opened this draft.
+                self.services
+                    .store
+                    .store
+                    .write()
+                    .expect("session store lock poisoned")
+                    .select(id.clone());
+                let _ = self
+                    .services
+                    .store
+                    .notification_action_sender()
+                    .send(SendTextCommand {
+                        session_id: id.clone(),
+                        text: prompt,
+                        submit: true,
+                    });
+                self.session_drafts.remove(id);
+            }
+        }
         self.prompt.clear();
+        self.drop_notice = None;
         self.close(cx);
         true
     }
@@ -386,7 +511,7 @@ impl LauncherOverlay {
             // Cycling the agent from the keyboard: the picker was mouse-only,
             // which is a strange thing to require of a surface you reached
             // with ⌘N and are about to leave with ↵.
-            "tab" => {
+            "tab" if matches!(self.target, LauncherTarget::NewSession) => {
                 self.cycle_harness(if shift { -1 } else { 1 });
                 cx.notify();
                 true
@@ -757,6 +882,9 @@ impl LauncherOverlay {
         focused: bool,
         cx: &mut Context<Self>,
     ) -> AnyElement {
+        if matches!(self.target, LauncherTarget::Session(_)) {
+            return self.render_session_panel(colors, focused, cx);
+        }
         let can_submit = self.can_submit();
         let harness_open = self.picker == Some(Picker::Harness);
         let project_open = self.picker == Some(Picker::Project);
@@ -1069,9 +1197,282 @@ impl LauncherOverlay {
                         .left(px(COMPOSER_INSET))
                         .child(self.render_project_picker(colors, cx)),
                 )
+            })
+            .when_some(self.drop_notice.clone(), |panel, notice| {
+                panel.child(
+                    div()
+                        .id("launcher-drop-notice")
+                        .mt(px(9.0))
+                        .mx(px(COMPOSER_INSET))
+                        .px(px(9.0))
+                        .py(px(7.0))
+                        .flex()
+                        .items_start()
+                        .gap(px(7.0))
+                        .rounded(px(Radius::ROW))
+                        .bg(Ink::ATTENTION.alpha(0.08))
+                        .border_1()
+                        .border_color(Ink::ATTENTION.alpha(0.20))
+                        .child(sf_symbol(
+                            "exclamationmark.circle.fill",
+                            11.0,
+                            Ink::ATTENTION,
+                        ))
+                        .child(
+                            div()
+                                .flex_1()
+                                .text_size(px(10.0))
+                                .line_height(px(14.0))
+                                .text_color(colors.secondary)
+                                .child(notice),
+                        ),
+                )
             });
 
         panel.into_any_element()
+    }
+
+    fn render_session_panel(
+        &self,
+        colors: SemanticColors,
+        focused: bool,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let session = match &self.target {
+            LauncherTarget::Session(id) => self
+                .services
+                .store
+                .store
+                .read()
+                .expect("session store lock poisoned")
+                .sessions()
+                .get(id)
+                .cloned(),
+            LauncherTarget::NewSession => None,
+        };
+        let title = session.as_ref().map_or_else(
+            || "Unavailable session".to_owned(),
+            |session| session.title.clone(),
+        );
+        let cwd = session.as_ref().map_or_else(
+            || "Session no longer available".to_owned(),
+            |session| session.cwd.clone(),
+        );
+        let logo = session.as_ref().map_or(UiAgentKind::Generic, |session| {
+            ui_agent_kind(session.effective_kind())
+        });
+        let can_submit = self.can_submit();
+        let text_height = composer_text_height(self.prompt.line_count());
+        let composer_height = text_height + COMPOSER_CONTROLS_HEIGHT;
+        let composer_fill = if colors.appearance == diri_ui::Appearance::Dark {
+            rgba(0x26282dff)
+        } else {
+            rgba(0xf2f1efff)
+        };
+        let shelf_fill = if colors.appearance == diri_ui::Appearance::Dark {
+            rgba(0x1d1f23ff)
+        } else {
+            rgba(0xe8e7e4ff)
+        };
+        let prompt = if self.prompt.is_empty() {
+            div()
+                .h(px(COMPOSER_LINE_HEIGHT))
+                .flex()
+                .items_center()
+                .when(focused, |line| {
+                    line.child(div().text_color(colors.primary.alpha(0.92)).child(CARET))
+                })
+                .child(
+                    div()
+                        .text_color(colors.tertiary)
+                        .child("Add context or instructions…"),
+                )
+                .into_any_element()
+        } else {
+            div()
+                .id("session-composer-prompt-lines")
+                .size_full()
+                .flex()
+                .flex_col()
+                .overflow_y_scroll()
+                .track_scroll(self.prompt.scroll_handle())
+                .children(self.prompt.render_lines(
+                    px(COMPOSER_LINE_HEIGHT),
+                    focused.then_some(CARET),
+                    HighlightStyle {
+                        background_color: Some(Palette::GEMINI_BLUE.alpha(0.30).into()),
+                        ..HighlightStyle::default()
+                    },
+                ))
+                .into_any_element()
+        };
+
+        div()
+            .relative()
+            .w(px(PANEL_WIDTH))
+            .child(
+                div()
+                    .h(px(TITLE_HEIGHT))
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .gap(px(8.0))
+                    .child(sf_symbol("paperclip", 16.0, Palette::GEMINI_BLUE))
+                    .child(
+                        div()
+                            .max_w(px(PANEL_WIDTH - 52.0))
+                            .whitespace_nowrap()
+                            .overflow_hidden()
+                            .text_ellipsis()
+                            .text_size(px(20.0))
+                            .font_weight(FontWeight::NORMAL)
+                            .text_color(colors.primary.alpha(0.94))
+                            .child(format!("Add context to {title}")),
+                    ),
+            )
+            .child(
+                div()
+                    .relative()
+                    .mt(px(TITLE_GAP))
+                    .mx(px(COMPOSER_INSET))
+                    .h(px(composer_height))
+                    .rounded(px(Radius::PANEL))
+                    .bg(composer_fill)
+                    .border_1()
+                    .border_color(if focused {
+                        Palette::GEMINI_BLUE.alpha(0.46)
+                    } else {
+                        colors.primary.alpha(0.09)
+                    })
+                    .cursor_text()
+                    .on_mouse_down(MouseButton::Left, {
+                        let focus = self.focus.clone();
+                        move |_, window, cx| window.focus(&focus, cx)
+                    })
+                    .child(
+                        div()
+                            .h(px(text_height))
+                            .px(px(COMPOSER_PADDING))
+                            .pt(px(COMPOSER_PAD_TOP))
+                            .pb(px(COMPOSER_PAD_BOTTOM))
+                            .text_size(px(COMPOSER_FONT_SIZE))
+                            .line_height(px(COMPOSER_LINE_HEIGHT))
+                            .text_color(colors.primary)
+                            .child(prompt),
+                    )
+                    .child(
+                        div()
+                            .h(px(COMPOSER_CONTROLS_HEIGHT))
+                            .px(px(10.0))
+                            .pb(px(8.0))
+                            .flex()
+                            .items_end()
+                            .justify_between()
+                            .child(div().text_size(px(10.0)).text_color(colors.tertiary).child(
+                                self.blocker().unwrap_or_else(|| {
+                                    "Review first — dropping sent nothing".to_owned()
+                                }),
+                            ))
+                            .child(
+                                div()
+                                    .id("session-composer-submit")
+                                    .size(px(CONTROL_SIZE))
+                                    .flex()
+                                    .items_center()
+                                    .justify_center()
+                                    .rounded(px(CONTROL_RADIUS))
+                                    .bg(if can_submit {
+                                        colors.primary
+                                    } else {
+                                        Fill::subtle(colors)
+                                    })
+                                    .when(can_submit, |button| {
+                                        button
+                                            .cursor_pointer()
+                                            .hover(move |button| button.opacity(0.86))
+                                            .active(move |button| button.opacity(0.72))
+                                            .on_click(cx.listener(|this, _, _, cx| {
+                                                this.submit(cx);
+                                            }))
+                                    })
+                                    .child(sf_symbol_weighted(
+                                        "arrow.up",
+                                        10.0,
+                                        SymbolWeight::Bold,
+                                        if can_submit {
+                                            colors.background
+                                        } else {
+                                            colors.tertiary
+                                        },
+                                    )),
+                            ),
+                    ),
+            )
+            .child(
+                div()
+                    .relative()
+                    .mx(px(16.0))
+                    .h(px(SHELF_HEIGHT))
+                    .px(px(12.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(8.0))
+                    .rounded_bl(px(Radius::PANEL))
+                    .rounded_br(px(Radius::PANEL))
+                    .bg(shelf_fill)
+                    .border_1()
+                    .border_color(colors.primary.alpha(0.055))
+                    .child(AgentLogo::new(logo, 17.0, colors).badged(false))
+                    .child(
+                        div()
+                            .min_w(px(0.0))
+                            .flex_1()
+                            .whitespace_nowrap()
+                            .overflow_hidden()
+                            .text_ellipsis()
+                            .text_size(px(11.0))
+                            .text_color(colors.secondary)
+                            .child(cwd),
+                    )
+                    .child(
+                        div()
+                            .flex_none()
+                            .text_size(px(10.0))
+                            .text_color(colors.tertiary)
+                            .child("Local draft"),
+                    ),
+            )
+            .when_some(self.drop_notice.clone(), |panel, notice| {
+                panel.child(
+                    div()
+                        .id("session-composer-drop-notice")
+                        .mt(px(9.0))
+                        .mx(px(COMPOSER_INSET))
+                        .px(px(9.0))
+                        .py(px(7.0))
+                        .flex()
+                        .items_start()
+                        .gap(px(7.0))
+                        .rounded(px(Radius::ROW))
+                        .bg(Ink::ATTENTION.alpha(0.08))
+                        .border_1()
+                        .border_color(Ink::ATTENTION.alpha(0.20))
+                        .child(sf_symbol(
+                            "exclamationmark.circle.fill",
+                            11.0,
+                            Ink::ATTENTION,
+                        ))
+                        .child(
+                            div()
+                                .flex_1()
+                                .text_size(px(10.0))
+                                .line_height(px(14.0))
+                                .text_color(colors.secondary)
+                                .child(notice),
+                        ),
+                )
+            })
+            .into_any_element()
     }
 
     /// Wrapper for a picker popover. It swallows its own mouse-down so the
@@ -1181,6 +1582,28 @@ fn initial_target(services: &AppServices) -> (AgentKind, String, Option<String>)
     )
 }
 
+fn transition_draft(
+    current: &LauncherTarget,
+    next: &LauncherTarget,
+    current_text: &str,
+    new_session_draft: &mut String,
+    session_drafts: &mut HashMap<SessionId, String>,
+) -> String {
+    match current {
+        LauncherTarget::NewSession => current_text.clone_into(new_session_draft),
+        LauncherTarget::Session(id) if current_text.is_empty() => {
+            session_drafts.remove(id);
+        }
+        LauncherTarget::Session(id) => {
+            session_drafts.insert(id.clone(), current_text.to_owned());
+        }
+    }
+    match next {
+        LauncherTarget::NewSession => new_session_draft.clone(),
+        LauncherTarget::Session(id) => session_drafts.get(id).cloned().unwrap_or_default(),
+    }
+}
+
 fn ui_agent_kind(kind: &AgentKind) -> UiAgentKind {
     match kind.id() {
         AgentKind::CLAUDE_CODE_ID => UiAgentKind::ClaudeCode,
@@ -1249,5 +1672,55 @@ mod tests {
         ));
         assert_eq!(selected, "/work/chosen");
         assert_eq!(prompt.text(), "keep this\nunfinished prompt");
+    }
+
+    #[test]
+    fn each_session_and_the_new_session_launcher_keep_an_independent_draft() {
+        let new = LauncherTarget::NewSession;
+        let first = LauncherTarget::Session(SessionId("first".into()));
+        let second = LauncherTarget::Session(SessionId("second".into()));
+        let mut new_draft = String::new();
+        let mut sessions = HashMap::new();
+
+        assert_eq!(
+            transition_draft(
+                &new,
+                &first,
+                "unfinished new session",
+                &mut new_draft,
+                &mut sessions,
+            ),
+            ""
+        );
+        assert_eq!(
+            transition_draft(
+                &first,
+                &second,
+                "review this\n'/tmp/one.rs'",
+                &mut new_draft,
+                &mut sessions,
+            ),
+            ""
+        );
+        assert_eq!(
+            transition_draft(
+                &second,
+                &first,
+                "compare '/tmp/two.rs'",
+                &mut new_draft,
+                &mut sessions,
+            ),
+            "review this\n'/tmp/one.rs'"
+        );
+        assert_eq!(
+            transition_draft(
+                &first,
+                &new,
+                "review this\n'/tmp/one.rs'",
+                &mut new_draft,
+                &mut sessions,
+            ),
+            "unfinished new session"
+        );
     }
 }

--- a/diri/crates/diri-app/src/main.rs
+++ b/diri/crates/diri-app/src/main.rs
@@ -10,6 +10,7 @@ mod daemon_launch;
 mod dev_build;
 mod diagnostics;
 pub mod diff;
+mod external_drop;
 pub mod fonts;
 pub mod fuzzy;
 mod git_review;

--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -21,6 +21,7 @@ use crate::commands::{
     ToggleCommandPalette, ToggleHistory, ToggleInspector, ToggleOverview, ToggleQuickOpen,
     ToggleSidebar,
 };
+use crate::external_drop::ExternalDropAction;
 use crate::inspector::{InspectorEvent, WorkbenchInspector};
 use crate::launcher::{LauncherEvent, LauncherOverlay};
 use crate::macos::sf_symbols::{SymbolWeight, sf_symbol, sf_symbol_weighted};
@@ -223,6 +224,39 @@ impl RootView {
             .detach();
         }
         cx.subscribe_in(&sidebar, window, |this, _, event, window, cx| {
+            if let SidebarEvent::ExternalDrop(plan) = event
+                && let Some(action) = &plan.action
+            {
+                let notice = plan.feedback();
+                match action {
+                    ExternalDropAction::OpenLauncher { root } => {
+                        this.launcher.update(cx, |launcher, cx| {
+                            launcher.open_at_directory(root.clone(), notice, window, cx);
+                        });
+                    }
+                    ExternalDropAction::OpenSessionComposer {
+                        session_id,
+                        insertion,
+                    } => {
+                        this.launcher.update(cx, |launcher, cx| {
+                            launcher.open_for_session(
+                                session_id.clone(),
+                                insertion,
+                                notice,
+                                window,
+                                cx,
+                            );
+                        });
+                    }
+                }
+                // Like Command-N, a drop swaps the main-pane branch. Focus
+                // once more after GPUI mounts the composer so the insertion
+                // caret is ready without a click.
+                let launcher = this.launcher.clone();
+                cx.defer_in(window, move |_, window, cx| {
+                    launcher.update(cx, |launcher, cx| launcher.focus(window, cx));
+                });
+            }
             if matches!(event, SidebarEvent::SessionActivated) {
                 if this.launcher.read(cx).is_open() {
                     this.launcher

--- a/diri/crates/diri-app/src/sidebar/mod.rs
+++ b/diri/crates/diri-app/src/sidebar/mod.rs
@@ -6,4 +6,5 @@ mod view;
 
 pub use fixture::{PreviewScenario, SidebarPreviewFixture};
 pub use state::{DragItem, Popover, SidebarUiState, move_before, move_to_end};
-pub use view::{Sidebar, SidebarEvent};
+pub use view::Sidebar;
+pub(crate) use view::SidebarEvent;

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -9,18 +9,19 @@ use diri_proto::{
 };
 use diri_ui::{
     AgentKind, AgentLogo, AlertChip, AttentionDot, AttentionLevel, Fill, FloatingSurface,
-    HairlineDivider, HoverMarquee, Ink, LoadingIndicator, Metrics, Radius, RowFill, SemanticColors,
-    Space, StateChip, StatusGlyph, StatusState, Typo,
+    HairlineDivider, HoverMarquee, Ink, LoadingIndicator, Metrics, Palette, Radius, RowFill,
+    SemanticColors, Space, StateChip, StatusGlyph, StatusState, Typo,
 };
 use gpui::{
-    Anchor, AnyElement, App, AppContext as _, Context, Entity, EventEmitter, FocusHandle,
-    Focusable, FontWeight, Hsla, IntoElement, MouseButton, Pixels, Point, Render, Rgba,
-    ScrollHandle, SharedString, Task, Window, anchored, deferred, div, linear_color_stop,
+    Anchor, AnyElement, App, AppContext as _, Context, Entity, EventEmitter, ExternalPaths,
+    FocusHandle, Focusable, FontWeight, Hsla, IntoElement, MouseButton, Pixels, Point, Render,
+    Rgba, ScrollHandle, SharedString, Task, Window, anchored, deferred, div, linear_color_stop,
     linear_gradient, point, prelude::*, px,
 };
 use tokio::sync::mpsc;
 
 use crate::commands::OpenSettings;
+use crate::external_drop::{ExternalDropPlan, ExternalDropTarget, plan_external_drop};
 use crate::macos::sf_symbols::{SymbolWeight, sf_symbol, sf_symbol_weighted};
 use crate::navigation::query_label;
 use crate::query_editor::{self, ClipboardEdit, Edit};
@@ -39,7 +40,7 @@ use super::{
 const PREVIEW_USAGE: f64 = 4.82;
 
 #[derive(Clone, Debug)]
-pub enum SidebarEvent {
+pub(crate) enum SidebarEvent {
     VisibilityChanged,
     WidthChanged,
     /// The Agents page of Settings, for one target host. Plain Settings goes
@@ -59,6 +60,10 @@ pub enum SidebarEvent {
     /// keeps showing a stale frame until some unrelated update wakes it, which
     /// reads as "the ✕ did nothing".
     ConfirmationChanged,
+    /// Finder input has been fully validated and reduced to a UI-only staged
+    /// action. RootView owns both composer destinations, so the sidebar never
+    /// sends daemon input or spawns a session itself.
+    ExternalDrop(ExternalDropPlan),
 }
 
 #[derive(Clone)]
@@ -111,6 +116,10 @@ pub struct Sidebar {
     /// one-level directory browser. The listing payload itself lives in the
     /// Store so the daemon adapter can complete it asynchronously.
     directory_picker_open: bool,
+    /// Inline, contextual feedback for rejected or partially accepted Finder
+    /// drops. It remains until dismissed or replaced by the next drop so an
+    /// error can never disappear between mouse-up and the next frame.
+    external_drop_feedback: Option<String>,
 }
 
 impl EventEmitter<SidebarEvent> for Sidebar {}
@@ -185,6 +194,7 @@ impl Sidebar {
             last_toggle: None,
             preview,
             directory_picker_open: false,
+            external_drop_feedback: None,
         };
         sidebar.ui.preview_account = preview;
         // Preview-only hook so headless screenshots can verify popover layout.
@@ -625,14 +635,125 @@ impl Sidebar {
             .into_any_element()
     }
 
+    fn external_drop(
+        &mut self,
+        paths: &ExternalPaths,
+        target: ExternalDropTarget,
+        cx: &mut Context<Self>,
+    ) {
+        let plan = plan_external_drop(paths.paths(), target);
+        self.external_drop_feedback = plan.feedback();
+        if plan.action.is_some() {
+            cx.emit(SidebarEvent::ExternalDrop(plan));
+        }
+        cx.notify();
+    }
+
+    fn can_accept_external_drop(paths: &ExternalPaths, target: ExternalDropTarget) -> bool {
+        plan_external_drop(paths.paths(), target).accepts_drop()
+    }
+
+    fn external_drop_feedback(
+        &self,
+        colors: SemanticColors,
+        cx: &mut Context<Self>,
+    ) -> Option<AnyElement> {
+        let message = self.external_drop_feedback.clone()?;
+        Some(
+            div()
+                .id("external-drop-feedback")
+                .mx(px(Space::INSET))
+                .mb(px(6.0))
+                .p(px(8.0))
+                .flex()
+                .items_start()
+                .gap(px(7.0))
+                .rounded(px(Radius::ROW))
+                .bg(Ink::ATTENTION.alpha(0.08))
+                .border_1()
+                .border_color(Ink::ATTENTION.alpha(0.22))
+                .child(sf_symbol(
+                    "exclamationmark.circle.fill",
+                    11.0,
+                    Ink::ATTENTION,
+                ))
+                .child(
+                    div()
+                        .min_w(px(0.0))
+                        .flex_1()
+                        .text_size(px(Typo::META.size))
+                        .line_height(px(15.0))
+                        .text_color(colors.secondary)
+                        .child(message),
+                )
+                .child(
+                    div()
+                        .id("dismiss-external-drop-feedback")
+                        .size(px(18.0))
+                        .flex_none()
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .rounded(px(Radius::CHIP))
+                        .cursor_pointer()
+                        .hover(move |button| button.bg(colors.primary.alpha(0.07)))
+                        .child(sf_symbol("xmark", 8.0, colors.tertiary))
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            this.external_drop_feedback = None;
+                            cx.notify();
+                        })),
+                )
+                .into_any_element(),
+        )
+    }
+
+    fn empty_space_drop_target(&self, cx: &mut Context<Self>) -> AnyElement {
+        div()
+            .id("sidebar-empty-space-drop-target")
+            .flex_1()
+            .min_h(px(52.0))
+            .rounded(px(Radius::ROW))
+            .drag_over::<ExternalPaths>(move |element, paths, _, _| {
+                if Self::can_accept_external_drop(paths, ExternalDropTarget::EmptySpace) {
+                    element
+                        .bg(Ink::FRESH.alpha(0.07))
+                        .border_1()
+                        .border_color(Ink::FRESH.alpha(0.32))
+                } else {
+                    element
+                }
+            })
+            .on_drop(cx.listener(|this, paths: &ExternalPaths, _, cx| {
+                cx.stop_propagation();
+                this.external_drop(paths, ExternalDropTarget::EmptySpace, cx);
+            }))
+            .into_any_element()
+    }
+
     fn empty_state(&self, colors: SemanticColors, cx: &mut Context<Self>) -> AnyElement {
         div()
+            .id("sidebar-empty-state")
             .flex_1()
             .flex()
             .flex_col()
             .items_center()
             .justify_center()
             .gap(px(12.0))
+            .rounded(px(Radius::PANEL))
+            .drag_over::<ExternalPaths>(move |element, paths, _, _| {
+                if Self::can_accept_external_drop(paths, ExternalDropTarget::EmptySpace) {
+                    element
+                        .bg(Ink::FRESH.alpha(0.07))
+                        .border_1()
+                        .border_color(Ink::FRESH.alpha(0.32))
+                } else {
+                    element
+                }
+            })
+            .on_drop(cx.listener(|this, paths: &ExternalPaths, _, cx| {
+                cx.stop_propagation();
+                this.external_drop(paths, ExternalDropTarget::EmptySpace, cx);
+            }))
             .child(AgentLogo::new(AgentKind::ClaudeCode, 44.0, colors).badged(false))
             .child(
                 div()
@@ -695,6 +816,7 @@ impl Sidebar {
         let project_for_click = group.project.clone();
         let project_root = group.project.root.clone();
         let project_host = group.host.clone();
+        let project_is_remote = project_host.is_some();
         let project_host_label = group.host.as_deref().map(|host| {
             self.store
                 .read()
@@ -783,6 +905,31 @@ impl Sidebar {
                 .on_drop(cx.listener(|this, _: &DraggedSidebarItem, _, cx| {
                     this.finish_drag();
                     cx.notify();
+                }))
+                .drag_over::<ExternalPaths>(move |element, paths, _, _| {
+                    if Self::can_accept_external_drop(
+                        paths,
+                        ExternalDropTarget::Project {
+                            remote: project_is_remote,
+                        },
+                    ) {
+                        element
+                            .bg(Ink::FRESH.alpha(0.10))
+                            .border_1()
+                            .border_color(Ink::FRESH.alpha(0.38))
+                    } else {
+                        element
+                    }
+                })
+                .on_drop(cx.listener(move |this, paths: &ExternalPaths, _, cx| {
+                    cx.stop_propagation();
+                    this.external_drop(
+                        paths,
+                        ExternalDropTarget::Project {
+                            remote: project_is_remote,
+                        },
+                        cx,
+                    );
                 }))
                 .child(project_badge(colors))
                 .child(
@@ -929,6 +1076,7 @@ impl Sidebar {
         let hovered = self.ui.hovered_session.as_ref() == Some(&id);
         let archived = session.is_archived();
         let hibernated = session.hibernation.is_some();
+        let session_is_remote = session.host.is_some();
         let ended = matches!(session.status, diri_proto::SessionStatus::Exited(_)) && !archived;
         let host_label = session.host.as_ref().map(|host| {
             self.store
@@ -974,6 +1122,40 @@ impl Sidebar {
                 .gap(px(8.0))
                 .rounded(px(Radius::ROW))
                 .bg(RowFill::Selected.color(colors))
+                .drag_over::<ExternalPaths>({
+                    let id = id.clone();
+                    move |element, paths, _, _| {
+                        if Self::can_accept_external_drop(
+                            paths,
+                            ExternalDropTarget::Session {
+                                id: id.clone(),
+                                remote: session_is_remote,
+                            },
+                        ) {
+                            element
+                                .bg(Palette::GEMINI_BLUE.alpha(0.12))
+                                .border_1()
+                                .border_color(Palette::GEMINI_BLUE.alpha(0.42))
+                        } else {
+                            element
+                        }
+                    }
+                })
+                .on_drop(cx.listener({
+                    let id = id.clone();
+                    move |this, paths: &ExternalPaths, _, cx| {
+                        cx.stop_propagation();
+                        this.commit_rename();
+                        this.external_drop(
+                            paths,
+                            ExternalDropTarget::Session {
+                                id: id.clone(),
+                                remote: session_is_remote,
+                            },
+                            cx,
+                        );
+                    }
+                }))
                 .children(indent_rails(row, colors))
                 // The fold control is inert mid-rename, but its column stays so
                 // the text does not slide sideways the moment editing starts.
@@ -1137,6 +1319,39 @@ impl Sidebar {
                     }
                     this.finish_drag();
                     cx.notify();
+                }
+            }))
+            .drag_over::<ExternalPaths>({
+                let id = id.clone();
+                move |element, paths, _, _| {
+                    if Self::can_accept_external_drop(
+                        paths,
+                        ExternalDropTarget::Session {
+                            id: id.clone(),
+                            remote: session_is_remote,
+                        },
+                    ) {
+                        element
+                            .bg(Palette::GEMINI_BLUE.alpha(0.12))
+                            .border_1()
+                            .border_color(Palette::GEMINI_BLUE.alpha(0.42))
+                    } else {
+                        element
+                    }
+                }
+            })
+            .on_drop(cx.listener({
+                let id = id.clone();
+                move |this, paths: &ExternalPaths, _, cx| {
+                    cx.stop_propagation();
+                    this.external_drop(
+                        paths,
+                        ExternalDropTarget::Session {
+                            id: id.clone(),
+                            remote: session_is_remote,
+                        },
+                        cx,
+                    );
                 }
             }))
             .children(indent_rails(row, colors))
@@ -3499,6 +3714,7 @@ impl Render for Sidebar {
         for group in &projection.projects {
             list = list.child(self.project_section(group, colors, window, cx));
         }
+        list = list.child(self.empty_space_drop_target(cx));
 
         let mut root = div()
             .id("sidebar")
@@ -3527,6 +3743,9 @@ impl Render for Sidebar {
                     .child(list)
                     .children(self.scroll_fades(colors)),
             );
+        }
+        if let Some(feedback) = self.external_drop_feedback(colors, cx) {
+            root = root.child(feedback);
         }
         root = root.child(self.account_footer(colors, cx));
         if let Some(popover) = self.popover(colors, window, cx) {


### PR DESCRIPTION
## Summary

- add a pure, testable ingress layer that validates Finder paths without executing them or materializing cloud placeholders
- route directory drops on empty/project space into a preselected new-session launcher, and row drops into a session-targeted composer
- preserve drafts, append shell-safe quoted paths, support multi-path staging, and surface partial/complete rejection reasons
- keep remote targets fail-closed because local paths cannot resolve on another host

## Safety and UX

- dropping only prepares an editable confirmation surface; it never spawns, sends, wakes a hibernated session, or executes a path
- internal sidebar reordering continues to use its existing drag payload, while external paths use GPUI's `ExternalPaths`
- valid new-session and attach targets use distinct drag affordances
- unreadable, missing, dataless, non-file/directory, extra, and remote-target paths receive visible feedback

## Validation

- `cargo fmt --all -- --check`
- strict workspace clippy (`-D warnings`)
- full workspace test suite
- focused external-drop, composer draft, and launcher transition tests
- `git diff --check`

Closes #73
