### PR TITLE
Peek at sidebar sessions without switching

### DIFF
--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -257,6 +257,13 @@ impl RootView {
                     launcher.update(cx, |launcher, cx| launcher.focus(window, cx));
                 });
             }
+            if let SidebarEvent::PeekChanged(id) = event
+                && let Some(terminal) = &this.terminal
+            {
+                terminal.update(cx, |terminal, cx| {
+                    terminal.set_peeked_session(id.clone(), cx);
+                });
+            }
             if matches!(event, SidebarEvent::SessionActivated) {
                 if this.launcher.read(cx).is_open() {
                     this.launcher
@@ -641,10 +648,38 @@ impl RootView {
     }
 
     fn on_key_down(&mut self, event: &KeyDownEvent, _window: &mut Window, cx: &mut Context<Self>) {
+        let sidebar_focused = self.sidebar.read(cx).is_focused(_window);
+        let peek_in_flight = self.sidebar.read(cx).has_peek_in_flight();
+        // A pointer peek leaves the terminal's focus exactly where it was, so
+        // Root capture is the only safe place to keep typed input out of the
+        // preview. Escape also cancels the delayed pre-peek window.
+        if !sidebar_focused && peek_in_flight {
+            match event.keystroke.key.as_str() {
+                "escape" => {
+                    self.sidebar.update(cx, |sidebar, cx| {
+                        sidebar.cancel_peek(cx);
+                    });
+                    cx.stop_propagation();
+                    return;
+                }
+                "enter" if self.sidebar.read(cx).is_peeking() => {
+                    self.sidebar.update(cx, |sidebar, cx| {
+                        sidebar.commit_peek(cx);
+                    });
+                    cx.stop_propagation();
+                    return;
+                }
+                _ if self.sidebar.read(cx).is_peeking() => {
+                    cx.stop_propagation();
+                    return;
+                }
+                _ => {}
+            }
+        }
         // The sidebar is a real keyboard surface. Let its bubble handler own
         // navigation and rename input instead of mirroring the same keystroke
         // into the live terminal during root capture.
-        if self.sidebar.read(cx).is_focused(_window) {
+        if sidebar_focused {
             return;
         }
         if self.launcher.read(cx).is_open() {
@@ -1082,6 +1117,10 @@ impl RootView {
     }
 
     fn on_key_up(&mut self, event: &KeyUpEvent, window: &mut Window, cx: &mut Context<Self>) {
+        if !self.sidebar.read(cx).is_focused(window) && self.sidebar.read(cx).is_peeking() {
+            cx.stop_propagation();
+            return;
+        }
         if let Some(surfaces) = &self.session_surfaces {
             surfaces.update(cx, |surfaces, cx| {
                 surfaces.handle_key_up(event, window, cx);
@@ -1095,6 +1134,10 @@ impl RootView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if !self.sidebar.read(cx).is_focused(window) && self.sidebar.read(cx).is_peeking() {
+            cx.stop_propagation();
+            return;
+        }
         if let Some(surfaces) = &self.session_surfaces {
             surfaces.update(cx, |surfaces, cx| {
                 surfaces.handle_modifiers_changed(event, window, cx);
@@ -1487,10 +1530,15 @@ impl RootView {
             .expect("session store lock poisoned")
             .selected_session_id()
             .cloned();
-        let split_open = self.auxiliary_terminal.is_some()
-            || selected
-                .as_ref()
-                .is_some_and(|id| self.auxiliary_spawn_parent.as_ref() == Some(id));
+        let peeking = self
+            .terminal
+            .as_ref()
+            .is_some_and(|terminal| terminal.read(cx).is_peeking());
+        let split_open = !peeking
+            && (self.auxiliary_terminal.is_some()
+                || selected
+                    .as_ref()
+                    .is_some_and(|id| self.auxiliary_spawn_parent.as_ref() == Some(id)));
         let mut card = div()
             .relative()
             .flex_1()

--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -40,6 +40,18 @@ use crate::workbench::WorkbenchLayout;
 
 const WINDOW_BOUNDS_SAVE_DELAY: Duration = Duration::from_millis(150);
 
+/// Whether the workbench owns a second vertical pane. Peek presentation is
+/// deliberately absent from this decision: borrowing the primary pane must
+/// not collapse the split and resize the real terminal underneath it.
+fn workbench_split_open(
+    auxiliary_present: bool,
+    selected: Option<&SessionId>,
+    auxiliary_spawn_parent: Option<&SessionId>,
+) -> bool {
+    auxiliary_present
+        || selected.is_some_and(|id| auxiliary_spawn_parent.is_some_and(|parent| parent == id))
+}
+
 pub(crate) fn cached_window_overlay<T: Render>(view: Entity<T>) -> impl IntoElement {
     view.cached(StyleRefinement::default().absolute().inset_0())
 }
@@ -1117,7 +1129,17 @@ impl RootView {
     }
 
     fn on_key_up(&mut self, event: &KeyUpEvent, window: &mut Window, cx: &mut Context<Self>) {
-        if !self.sidebar.read(cx).is_focused(window) && self.sidebar.read(cx).is_peeking() {
+        let sidebar_focused = self.sidebar.read(cx).is_focused(window);
+        if !sidebar_focused && event.keystroke.key.as_str() == "space" {
+            let released = self
+                .sidebar
+                .update(cx, |sidebar, cx| sidebar.release_keyboard_peek(cx));
+            if released {
+                cx.stop_propagation();
+                return;
+            }
+        }
+        if !sidebar_focused && self.sidebar.read(cx).is_peeking() {
             cx.stop_propagation();
             return;
         }
@@ -1530,15 +1552,11 @@ impl RootView {
             .expect("session store lock poisoned")
             .selected_session_id()
             .cloned();
-        let peeking = self
-            .terminal
-            .as_ref()
-            .is_some_and(|terminal| terminal.read(cx).is_peeking());
-        let split_open = !peeking
-            && (self.auxiliary_terminal.is_some()
-                || selected
-                    .as_ref()
-                    .is_some_and(|id| self.auxiliary_spawn_parent.as_ref() == Some(id)));
+        let split_open = workbench_split_open(
+            self.auxiliary_terminal.is_some(),
+            selected.as_ref(),
+            self.auxiliary_spawn_parent.as_ref(),
+        );
         let mut card = div()
             .relative()
             .flex_1()
@@ -2435,4 +2453,21 @@ fn preview_hint(system_image: &str, label: &str, colors: SemanticColors) -> AnyE
                 .child(label.to_owned()),
         )
         .into_any_element()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn peek_presentation_never_collapses_an_existing_or_pending_split() {
+        let selected = SessionId::new("selected");
+        assert!(workbench_split_open(true, Some(&selected), None));
+        assert!(workbench_split_open(
+            false,
+            Some(&selected),
+            Some(&selected)
+        ));
+        assert!(!workbench_split_open(false, Some(&selected), None));
+    }
 }

--- a/diri/crates/diri-app/src/sidebar/mod.rs
+++ b/diri/crates/diri-app/src/sidebar/mod.rs
@@ -5,6 +5,9 @@ mod state;
 mod view;
 
 pub use fixture::{PreviewScenario, SidebarPreviewFixture};
-pub use state::{CursorMove, DragItem, Popover, SidebarUiState, move_before, move_to_end};
+pub use state::{
+    CursorMove, DragItem, PeekSource, Popover, SessionPeek, SidebarUiState, move_before,
+    move_to_end,
+};
 pub use view::Sidebar;
 pub(crate) use view::SidebarEvent;

--- a/diri/crates/diri-app/src/sidebar/state.rs
+++ b/diri/crates/diri-app/src/sidebar/state.rs
@@ -15,6 +15,21 @@ pub enum CursorMove {
     End,
 }
 
+/// The gesture currently borrowing the main pane for a transient session
+/// preview. Keeping this in sidebar-only state is deliberate: a peek must
+/// never masquerade as the Store's durable selection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PeekSource {
+    Pointer,
+    Keyboard,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SessionPeek {
+    pub id: SessionId,
+    pub source: PeekSource,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DragItem {
     Project(ProjectId),
@@ -75,6 +90,17 @@ pub struct SidebarUiState {
     /// previous row at the end) if that session disappears.
     pub focus_cursor: Option<SessionId>,
     focus_order: Vec<SessionId>,
+    /// Transient presentation identity. `SessionStore::selected_session_id`
+    /// remains the sole active identity while this is set.
+    pub peek: Option<SessionPeek>,
+    /// A Space key-down may repeat; only the matching key-up ends the peek.
+    pub space_held: bool,
+    /// A completed pointer hold produces a platform click after mouse-up. The
+    /// click belongs to the release gesture and must not commit the preview.
+    pub suppress_pointer_click: bool,
+    /// Drag-and-drop dispatch may follow capture-phase mouse-up. Remember
+    /// that this gesture was a peek so its release cannot reorder sessions.
+    pub suppress_pointer_drop: bool,
 }
 
 impl SidebarUiState {
@@ -96,7 +122,37 @@ impl SidebarUiState {
             preview_account: false,
             focus_cursor: None,
             focus_order: Vec::new(),
+            peek: None,
+            space_held: false,
+            suppress_pointer_click: false,
+            suppress_pointer_drop: false,
         }
+    }
+
+    pub fn begin_peek(&mut self, id: SessionId, source: PeekSource) -> bool {
+        let next = SessionPeek { id, source };
+        let changed = self.peek.as_ref() != Some(&next);
+        self.peek = Some(next);
+        changed
+    }
+
+    pub fn follow_peek(&mut self, id: SessionId, source: PeekSource) -> bool {
+        if self.peek.as_ref().is_none_or(|peek| peek.source != source) {
+            return false;
+        }
+        self.begin_peek(id, source)
+    }
+
+    pub fn end_peek(&mut self, source: Option<PeekSource>) -> bool {
+        if source.is_some_and(|source| self.peek.as_ref().is_none_or(|peek| peek.source != source))
+        {
+            return false;
+        }
+        self.peek.take().is_some()
+    }
+
+    pub fn take_peek(&mut self) -> Option<SessionPeek> {
+        self.peek.take()
     }
 
     /// Reconciles the identity cursor with the rows the sidebar is actually
@@ -257,6 +313,37 @@ mod tests {
         assert_eq!(state.focus_cursor, Some(rows[2].clone()));
         assert!(state.move_focus_cursor(CursorMove::Home, &rows));
         assert_eq!(state.focus_cursor, Some(rows[0].clone()));
+    }
+
+    #[test]
+    fn peek_follows_by_identity_and_release_restores_no_selection_state() {
+        let one = SessionId::new("one");
+        let two = SessionId::new("two");
+        let mut state = SidebarUiState::new(DEFAULT_SIDEBAR_WIDTH);
+
+        assert!(state.begin_peek(one.clone(), PeekSource::Pointer));
+        assert!(state.follow_peek(two.clone(), PeekSource::Pointer));
+        assert_eq!(
+            state.peek,
+            Some(SessionPeek {
+                id: two,
+                source: PeekSource::Pointer,
+            })
+        );
+        assert!(state.end_peek(Some(PeekSource::Pointer)));
+        assert!(state.peek.is_none());
+    }
+
+    #[test]
+    fn one_gesture_cannot_release_another_gestures_peek() {
+        let mut state = SidebarUiState::new(DEFAULT_SIDEBAR_WIDTH);
+        state.begin_peek(SessionId::new("one"), PeekSource::Keyboard);
+
+        assert!(!state.end_peek(Some(PeekSource::Pointer)));
+        assert_eq!(
+            state.peek.as_ref().map(|peek| peek.source),
+            Some(PeekSource::Keyboard)
+        );
     }
 
     #[test]

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -35,11 +35,14 @@ use crate::updates::{UpdateCommand, UpdatePhase, UpdateState};
 use crate::usage::{UsageFormat, UsageSnapshot};
 
 use super::{
-    CursorMove, DragItem, Popover, PreviewScenario, SidebarPreviewFixture, SidebarUiState,
-    move_before, move_to_end,
+    CursorMove, DragItem, PeekSource, Popover, PreviewScenario, SidebarPreviewFixture,
+    SidebarUiState, move_before, move_to_end,
 };
 
 const PREVIEW_USAGE: f64 = 4.82;
+/// Long enough that a normal click or an intentional reorder wins, short
+/// enough that comparing several sessions still feels like one gesture.
+const SESSION_PEEK_DELAY: Duration = Duration::from_millis(320);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct FocusRow {
@@ -73,6 +76,9 @@ pub(crate) enum SidebarEvent {
     /// Escape left keyboard-navigation mode without changing the active
     /// session. Root owns the terminal entity, so it completes the handoff.
     FocusTerminal,
+    /// Borrow the terminal presentation for a read-only identity, or restore
+    /// the real selected session. This never travels through SessionStore.
+    PeekChanged(Option<SessionId>),
     /// The user acted on the update pill. The sidebar holds no updater of its
     /// own; RootView owns the handle and forwards these.
     Update(UpdateCommand),
@@ -93,11 +99,13 @@ struct DraggedSidebarItem(DragItem);
 struct DragPreview {
     label: SharedString,
     colors: SemanticColors,
+    visible: bool,
 }
 
 impl Render for DragPreview {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
         div()
+            .opacity(if self.visible { 1.0 } else { 0.0 })
             .px(px(10.0))
             .h(px(28.0))
             .flex()
@@ -131,6 +139,11 @@ pub struct Sidebar {
     shortcut_ranks: HashMap<SessionId, usize>,
     focus_handle: FocusHandle,
     hover_generation: u64,
+    /// Invalidates delayed pointer holds without keeping a timer task alive in
+    /// the entity. A moved/released gesture simply advances the generation.
+    peek_generation: u64,
+    pending_pointer_peek: Option<SessionId>,
+    pointer_press: Option<SessionId>,
     usage: Option<UsageSnapshot>,
     update: UpdateState,
     /// When visibility last flipped, so a held ⌘B cannot outrun the slide.
@@ -214,6 +227,9 @@ impl Sidebar {
             shortcut_ranks: HashMap::new(),
             focus_handle: cx.focus_handle(),
             hover_generation: 0,
+            peek_generation: 0,
+            pending_pointer_peek: None,
+            pointer_press: None,
             usage: None,
             update: UpdateState::default(),
             last_toggle: None,
@@ -328,6 +344,7 @@ impl Sidebar {
             return;
         }
         self.last_toggle = Some(now);
+        self.cancel_peek(cx);
         self.ui.toggle();
         let visible = self.ui.visible;
         if let Err(error) = self
@@ -474,6 +491,141 @@ impl Sidebar {
         self.focus_handle.is_focused(window)
     }
 
+    pub fn has_peek_in_flight(&self) -> bool {
+        self.pending_pointer_peek.is_some() || self.ui.peek.is_some()
+    }
+
+    pub fn is_peeking(&self) -> bool {
+        self.ui.peek.is_some()
+    }
+
+    fn emit_peek(&mut self, cx: &mut Context<Self>) {
+        cx.emit(SidebarEvent::PeekChanged(
+            self.ui.peek.as_ref().map(|peek| peek.id.clone()),
+        ));
+        cx.notify();
+    }
+
+    fn begin_peek(&mut self, id: SessionId, source: PeekSource, cx: &mut Context<Self>) {
+        self.pending_pointer_peek = None;
+        self.hover_generation = self.hover_generation.wrapping_add(1);
+        self.ui.hover_card = None;
+        if self.ui.begin_peek(id, source) {
+            self.emit_peek(cx);
+        }
+    }
+
+    fn follow_peek(&mut self, id: SessionId, source: PeekSource, cx: &mut Context<Self>) {
+        if self.ui.follow_peek(id, source) {
+            self.emit_peek(cx);
+        }
+    }
+
+    fn cancel_pending_pointer_peek(&mut self) {
+        self.peek_generation = self.peek_generation.wrapping_add(1);
+        self.pending_pointer_peek = None;
+    }
+
+    fn schedule_pointer_peek(
+        &mut self,
+        id: SessionId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        // A keyboard peek owns Space until key-up. A click during it is a
+        // commit, not the start of a second gesture.
+        if self.ui.peek.is_some() {
+            return;
+        }
+        self.ui.suppress_pointer_click = false;
+        self.ui.suppress_pointer_drop = false;
+        self.cancel_pending_pointer_peek();
+        self.pointer_press = Some(id.clone());
+        self.pending_pointer_peek = Some(id.clone());
+        let generation = self.peek_generation;
+        cx.spawn_in(window, async move |this, cx| {
+            let executor = cx.background_executor();
+            executor.timer(SESSION_PEEK_DELAY).await;
+            let _ = this.update_in(cx, |this, _window, cx| {
+                if this.peek_generation == generation
+                    && this.pending_pointer_peek.as_ref() == Some(&id)
+                {
+                    this.begin_peek(id, PeekSource::Pointer, cx);
+                }
+            });
+        })
+        .detach();
+    }
+
+    fn finish_pointer_gesture(&mut self, released_row: Option<&SessionId>, cx: &mut Context<Self>) {
+        let was_pointer_peek = self
+            .ui
+            .peek
+            .as_ref()
+            .is_some_and(|peek| peek.source == PeekSource::Pointer);
+        let should_suppress_click = released_row.is_some()
+            && released_row == self.pointer_press.as_ref()
+            && was_pointer_peek;
+        self.cancel_pending_pointer_peek();
+        self.pointer_press = None;
+        if self.ui.end_peek(Some(PeekSource::Pointer)) {
+            // Mouse-up is followed by Click on the pressed row. That Click is
+            // part of this release and must not turn restoration into a commit.
+            self.ui.suppress_pointer_click = should_suppress_click;
+            self.ui.suppress_pointer_drop = was_pointer_peek;
+            self.emit_peek(cx);
+        }
+    }
+
+    fn finish_pointer_at(&mut self, position: Point<Pixels>, cx: &mut Context<Self>) {
+        let released_row = self
+            .row_bounds
+            .borrow()
+            .iter()
+            .find(|(_, bounds)| bounds.contains(&position))
+            .map(|(id, _)| id.clone());
+        self.finish_pointer_gesture(released_row.as_ref(), cx);
+    }
+
+    pub fn cancel_peek(&mut self, cx: &mut Context<Self>) -> bool {
+        let pending = self.pending_pointer_peek.is_some();
+        self.cancel_pending_pointer_peek();
+        self.pointer_press = None;
+        self.ui.space_held = false;
+        if self.ui.end_peek(None) {
+            self.emit_peek(cx);
+            true
+        } else {
+            if pending {
+                cx.notify();
+            }
+            pending
+        }
+    }
+
+    pub fn commit_peek(&mut self, cx: &mut Context<Self>) -> bool {
+        self.cancel_pending_pointer_peek();
+        self.pointer_press = None;
+        self.ui.space_held = false;
+        let Some(peek) = self.ui.take_peek() else {
+            return false;
+        };
+        let exists = {
+            let mut store = self.store.write().expect("session store lock poisoned");
+            let exists = store.sessions().contains_key(&peek.id);
+            if exists {
+                store.select(peek.id.clone());
+            }
+            exists
+        };
+        self.emit_peek(cx);
+        if exists {
+            self.ui.focus_cursor = Some(peek.id);
+            cx.emit(SidebarEvent::SessionActivated);
+        }
+        true
+    }
+
     /// Enters keyboard-navigation mode from any other surface. An active row
     /// is the initial landmark, while an existing identity cursor survives
     /// subsequent trips to the terminal.
@@ -527,6 +679,9 @@ impl Sidebar {
         let visible = focus_row_ids(&rows);
         self.ui.reconcile_focus_cursor(&visible, selected.as_ref());
         self.ui.move_focus_cursor(movement, &visible);
+        if let Some(id) = self.ui.focus_cursor.clone() {
+            self.follow_peek(id, PeekSource::Keyboard, cx);
+        }
         self.scroll_focus_cursor_into_view(window);
         cx.notify();
         true
@@ -558,12 +713,18 @@ impl Sidebar {
         let (next_rows, _) = self.focus_rows_snapshot();
         self.ui
             .reconcile_focus_cursor(&focus_row_ids(&next_rows), None);
+        if let Some(id) = self.ui.focus_cursor.clone() {
+            self.follow_peek(id, PeekSource::Keyboard, cx);
+        }
         self.scroll_focus_cursor_into_view(window);
         cx.notify();
         true
     }
 
     fn activate_focus_cursor(&mut self, cx: &mut Context<Self>) -> bool {
+        if self.ui.peek.is_some() {
+            return self.commit_peek(cx);
+        }
         let Some(id) = self.ui.focus_cursor.clone() else {
             return true;
         };
@@ -645,6 +806,9 @@ impl Sidebar {
         let key = event.keystroke.key.as_str();
         if key == "escape" {
             cx.stop_propagation();
+            if self.cancel_peek(cx) {
+                return;
+            }
             if self.ui.popover.take().is_none() {
                 cx.emit(SidebarEvent::FocusTerminal);
             }
@@ -663,14 +827,36 @@ impl Sidebar {
             "left" => self.move_focus_horizontally(false, window, cx),
             "right" => self.move_focus_horizontally(true, window, cx),
             "enter" => self.activate_focus_cursor(cx),
-            // Deliberately consumed but unbound. Hold-to-peek owns Space in
-            // the follow-up issue, and activation must remain Enter-only.
-            "space" => true,
+            "space" => {
+                if !self.ui.space_held {
+                    self.ui.space_held = true;
+                    if let Some(id) = self.ui.focus_cursor.clone() {
+                        self.begin_peek(id, PeekSource::Keyboard, cx);
+                    }
+                }
+                true
+            }
             _ => false,
         };
         if handled {
             cx.stop_propagation();
         }
+    }
+
+    fn on_key_up(
+        &mut self,
+        event: &gpui::KeyUpEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if event.keystroke.key.as_str() != "space" || !self.ui.space_held {
+            return;
+        }
+        self.ui.space_held = false;
+        if self.ui.end_peek(Some(PeekSource::Keyboard)) {
+            self.emit_peek(cx);
+        }
+        cx.stop_propagation();
     }
 
     fn schedule_hover_card(
@@ -682,6 +868,10 @@ impl Sidebar {
     ) {
         self.hover_generation = self.hover_generation.wrapping_add(1);
         let generation = self.hover_generation;
+        if self.ui.peek.is_some() {
+            self.ui.hover_card = None;
+            return;
+        }
         if !hovering {
             if self
                 .ui
@@ -1086,6 +1276,7 @@ impl Sidebar {
                         cx.new(|_| DragPreview {
                             label: drag_label.clone(),
                             colors,
+                            visible: true,
                         })
                     },
                 )
@@ -1295,6 +1486,7 @@ impl Sidebar {
         let focused = self.focus_handle.is_focused(window)
             && self.ui.renaming.is_none()
             && self.ui.focus_cursor.as_ref() == Some(&id);
+        let peeked = self.ui.peek.as_ref().is_some_and(|peek| peek.id == id);
         let archived = session.is_archived();
         let hibernated = session.hibernation.is_some();
         let session_is_remote = session.host.is_some();
@@ -1408,6 +1600,7 @@ impl Sidebar {
         let rename_session = Arc::clone(session);
         let close_id = id.clone();
         let hover_id = id.clone();
+        let press_id = id.clone();
         let drag_item = if multi && let Some(selection) = drag_selection {
             DragItem::Sessions(selection)
         } else {
@@ -1421,6 +1614,7 @@ impl Sidebar {
         let drag_payload = DraggedSidebarItem(drag_item);
         let drag_label: SharedString = title.clone().into();
         let entity = cx.entity();
+        let drag_entity = entity.clone();
         let row = div()
             .id(format!("session:{}", id.0))
             .pl(px(Space::ROW_H))
@@ -1430,9 +1624,15 @@ impl Sidebar {
             .items_center()
             .gap(px(8.0))
             .rounded(px(Radius::ROW))
-            .bg(fill.color(colors))
+            .bg(if peeked {
+                Palette::CLAY.alpha(0.11)
+            } else {
+                fill.color(colors)
+            })
             .border_1()
-            .border_color(if focused {
+            .border_color(if peeked {
+                Palette::CLAY.alpha(0.92)
+            } else if focused {
                 Ink::FRESH.alpha(0.82)
             } else {
                 colors.primary.alpha(0.0)
@@ -1447,13 +1647,30 @@ impl Sidebar {
             .cursor_pointer()
             .on_hover(cx.listener(move |this, is_hovered: &bool, window, cx| {
                 this.ui.hovered_session = is_hovered.then(|| hover_id.clone());
+                if *is_hovered {
+                    this.follow_peek(hover_id.clone(), PeekSource::Pointer, cx);
+                }
                 this.schedule_hover_card(hover_id.clone(), *is_hovered, window, cx);
                 cx.notify();
             }))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |this, _, window, cx| {
+                    this.schedule_pointer_peek(press_id.clone(), window, cx);
+                }),
+            )
             .on_click(
                 cx.listener(move |this, event: &gpui::ClickEvent, window, cx| {
+                    if std::mem::take(&mut this.ui.suppress_pointer_click) {
+                        cx.stop_propagation();
+                        cx.notify();
+                        return;
+                    }
                     this.commit_rename();
                     this.ui.focus_cursor = Some(row_session.id.clone());
+                    // A click made while Space is borrowing the pane is an
+                    // explicit activation of the clicked row.
+                    this.cancel_peek(cx);
                     if event.click_count() == 2 {
                         this.begin_rename(&row_session, window, cx);
                         return;
@@ -1498,9 +1715,22 @@ impl Sidebar {
                 }),
             )
             .on_drag(drag_payload, move |_, _, _, cx| {
+                let visible = drag_entity.update(cx, |this, _| {
+                    let pointer_peek = this
+                        .ui
+                        .peek
+                        .as_ref()
+                        .is_some_and(|peek| peek.source == PeekSource::Pointer);
+                    if !pointer_peek {
+                        this.ui.suppress_pointer_drop = false;
+                        this.cancel_pending_pointer_peek();
+                    }
+                    !pointer_peek
+                });
                 cx.new(|_| DragPreview {
                     label: drag_label.clone(),
                     colors,
+                    visible,
                 })
             })
             .drag_over::<DraggedSidebarItem>({
@@ -1508,6 +1738,22 @@ impl Sidebar {
                 let target_project = session.project_id.clone();
                 let target_parent = session.parent.clone();
                 move |element, dragged, _, cx| {
+                    let peeking = entity.update(cx, |this, cx| {
+                        if this
+                            .ui
+                            .peek
+                            .as_ref()
+                            .is_some_and(|peek| peek.source == PeekSource::Pointer)
+                        {
+                            this.follow_peek(target.clone(), PeekSource::Pointer, cx);
+                            true
+                        } else {
+                            false
+                        }
+                    });
+                    if peeking {
+                        return element.bg(Palette::CLAY.alpha(0.11));
+                    }
                     // Siblings only. A row dropped on a cousin would shuffle
                     // the manual order without moving anything on screen,
                     // because each sibling run is sorted among itself.
@@ -1534,6 +1780,22 @@ impl Sidebar {
             .on_drop(cx.listener({
                 let target_project = session.project_id.clone();
                 move |this, dragged: &DraggedSidebarItem, _, cx| {
+                    let pointer_peek = this
+                        .ui
+                        .peek
+                        .as_ref()
+                        .is_some_and(|peek| peek.source == PeekSource::Pointer);
+                    if std::mem::take(&mut this.ui.suppress_pointer_drop) || pointer_peek {
+                        if pointer_peek {
+                            this.finish_pointer_gesture(None, cx);
+                            // `finish_pointer_gesture` protects a later drop;
+                            // this is that drop, so consume the guard now.
+                            this.ui.suppress_pointer_drop = false;
+                        }
+                        this.finish_drag();
+                        cx.notify();
+                        return;
+                    }
                     if let DragItem::Session {
                         id,
                         project,
@@ -1895,6 +2157,7 @@ impl Sidebar {
         let focused = self.focus_handle.is_focused(window)
             && self.ui.renaming.is_none()
             && self.ui.focus_cursor.as_ref() == Some(&id);
+        let peeked = self.ui.peek.as_ref().is_some_and(|peek| peek.id == id);
         let selected = self
             .store
             .read()
@@ -1903,8 +2166,10 @@ impl Sidebar {
             == Some(&id);
         let row_session = session.clone();
         let revive_id = id.clone();
+        let press_id = id.clone();
         let title = display_title(session);
         let drag_label: SharedString = title.clone().into();
+        let entity = cx.entity();
         div()
             .id(format!("archived-session:{}", id.0))
             .pl(px(Space::ROW_H + Space::INDENT))
@@ -1914,8 +2179,16 @@ impl Sidebar {
             .items_center()
             .gap(px(8.0))
             .rounded(px(Radius::ROW))
-            .opacity(if focused { 0.82 } else { 0.58 })
-            .bg(if selected {
+            .opacity(if peeked {
+                1.0
+            } else if focused {
+                0.82
+            } else {
+                0.58
+            })
+            .bg(if peeked {
+                Palette::CLAY.alpha(0.11)
+            } else if selected {
                 RowFill::Selected.color(colors)
             } else if hovered {
                 RowFill::Hover.color(colors)
@@ -1923,7 +2196,9 @@ impl Sidebar {
                 RowFill::Clear.color(colors)
             })
             .border_1()
-            .border_color(if focused {
+            .border_color(if peeked {
+                Palette::CLAY.alpha(0.92)
+            } else if focused {
                 Ink::FRESH.alpha(0.82)
             } else {
                 colors.primary.alpha(0.0)
@@ -1933,12 +2208,27 @@ impl Sidebar {
                 let id = id.clone();
                 move |this, is_hovered: &bool, _, cx| {
                     this.ui.hovered_session = is_hovered.then(|| id.clone());
+                    if *is_hovered {
+                        this.follow_peek(id.clone(), PeekSource::Pointer, cx);
+                    }
                     cx.notify();
                 }
             }))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |this, _, window, cx| {
+                    this.schedule_pointer_peek(press_id.clone(), window, cx);
+                }),
+            )
             .on_click(cx.listener(move |this, event: &gpui::ClickEvent, _, cx| {
+                if std::mem::take(&mut this.ui.suppress_pointer_click) {
+                    cx.stop_propagation();
+                    cx.notify();
+                    return;
+                }
                 let modifiers = event.modifiers();
                 this.ui.focus_cursor = Some(row_session.id.clone());
+                this.cancel_peek(cx);
                 this.store
                     .write()
                     .expect("session store lock poisoned")
@@ -1962,9 +2252,22 @@ impl Sidebar {
                     archived: true,
                 }),
                 move |_, _, _, cx| {
+                    let visible = entity.update(cx, |this, _| {
+                        let pointer_peek = this
+                            .ui
+                            .peek
+                            .as_ref()
+                            .is_some_and(|peek| peek.source == PeekSource::Pointer);
+                        if !pointer_peek {
+                            this.ui.suppress_pointer_drop = false;
+                            this.cancel_pending_pointer_peek();
+                        }
+                        !pointer_peek
+                    });
                     cx.new(|_| DragPreview {
                         label: drag_label.clone(),
                         colors,
+                        visible,
                     })
                 },
             )
@@ -4114,6 +4417,18 @@ impl Render for Sidebar {
             .bg(Self::surface_fill(colors))
             .track_focus(&self.focus_handle)
             .on_key_down(cx.listener(Self::on_key_down))
+            .on_key_up(cx.listener(Self::on_key_up))
+            .capture_any_mouse_up(cx.listener(|this, event: &gpui::MouseUpEvent, _, cx| {
+                if event.button == MouseButton::Left {
+                    this.finish_pointer_at(event.position, cx);
+                }
+            }))
+            .on_mouse_up_out(
+                MouseButton::Left,
+                cx.listener(|this, event: &gpui::MouseUpEvent, _, cx| {
+                    this.finish_pointer_at(event.position, cx);
+                }),
+            )
             .child(self.top_bar(colors, cx))
             .child(self.new_agent_row(colors, cx));
         if projection.projects.is_empty() {
@@ -4630,7 +4945,10 @@ fn compact_duration(seconds: i64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use gpui::{Modifiers, TestAppContext};
+    use gpui::{
+        KeyDownEvent, KeyUpEvent, Keystroke, Modifiers, MouseButton, MouseDownEvent, MouseUpEvent,
+        TestAppContext,
+    };
 
     use super::*;
 
@@ -4992,6 +5310,208 @@ mod tests {
                 Some(&cursor)
             );
         });
+    }
+
+    #[gpui::test]
+    fn pointer_hold_waits_then_release_restores_without_acknowledging(cx: &mut TestAppContext) {
+        let (view, cx) = cx.add_window_view(|_, cx| {
+            let sidebar = cx.new(|cx| Sidebar::new(None, true, PreviewScenario::Typical, cx));
+            SidebarPopoverHarness { sidebar }
+        });
+        let sidebar = view.read_with(cx, |harness, _| harness.sidebar.clone());
+        sidebar.update(cx, |sidebar, _| {
+            let effects = sidebar
+                ._preview_effects
+                .as_mut()
+                .expect("preview effect queue");
+            while effects.try_recv().is_ok() {}
+        });
+        let (active_before, target, attention_before, residency_before) =
+            sidebar.read_with(cx, |sidebar, _| {
+                let store = sidebar.store.read().expect("session store lock poisoned");
+                let active = store
+                    .selected_session_id()
+                    .cloned()
+                    .expect("preview selection");
+                let target = store
+                    .sessions()
+                    .keys()
+                    .find(|id| *id != &active && id.0 == "preview-claude")
+                    .cloned()
+                    .expect("visible target");
+                let attention = store.sessions()[&target].attention();
+                let residency = store
+                    .terminal_residency()
+                    .resident()
+                    .cloned()
+                    .collect::<Vec<_>>();
+                (active, target, attention, residency)
+            });
+        let row = sidebar.read_with(cx, |sidebar, _| {
+            sidebar
+                .row_bounds
+                .borrow()
+                .get(&target)
+                .copied()
+                .expect("target row")
+        });
+        let down = MouseDownEvent {
+            button: MouseButton::Left,
+            position: row.center(),
+            ..Default::default()
+        };
+        cx.simulate_event(down);
+
+        assert!(!sidebar.read_with(cx, |sidebar, _| sidebar.is_peeking()));
+        cx.executor()
+            .advance_clock(SESSION_PEEK_DELAY - Duration::from_millis(1));
+        cx.run_until_parked();
+        assert!(!sidebar.read_with(cx, |sidebar, _| sidebar.is_peeking()));
+
+        cx.executor().advance_clock(Duration::from_millis(1));
+        cx.run_until_parked();
+        sidebar.read_with(cx, |sidebar, _| {
+            assert_eq!(sidebar.ui.peek.as_ref().map(|peek| &peek.id), Some(&target));
+            let store = sidebar.store.read().expect("session store lock poisoned");
+            assert_eq!(store.selected_session_id(), Some(&active_before));
+            assert_eq!(store.sessions()[&target].attention(), attention_before);
+            assert_eq!(
+                store
+                    .terminal_residency()
+                    .resident()
+                    .cloned()
+                    .collect::<Vec<_>>(),
+                residency_before
+            );
+        });
+        sidebar.update(cx, |sidebar, _| {
+            assert!(
+                matches!(
+                    sidebar
+                        ._preview_effects
+                        .as_mut()
+                        .expect("preview effect queue")
+                        .try_recv(),
+                    Err(mpsc::error::TryRecvError::Empty)
+                ),
+                "peek must emit no Store effect, including MarkSeen or residency changes"
+            );
+        });
+
+        cx.simulate_event(MouseUpEvent {
+            button: MouseButton::Left,
+            position: row.center(),
+            click_count: 1,
+            ..Default::default()
+        });
+        sidebar.read_with(cx, |sidebar, _| {
+            assert!(sidebar.ui.peek.is_none());
+            assert!(
+                sidebar.ui.suppress_pointer_drop,
+                "the release cannot fall through into session reordering"
+            );
+            let store = sidebar.store.read().expect("session store lock poisoned");
+            assert_eq!(store.selected_session_id(), Some(&active_before));
+            assert_eq!(store.sessions()[&target].attention(), attention_before);
+        });
+    }
+
+    #[gpui::test]
+    fn held_space_follows_commits_and_release_or_escape_restore(cx: &mut TestAppContext) {
+        let (view, cx) = cx.add_window_view(|_, cx| {
+            let sidebar = cx.new(|cx| Sidebar::new(None, true, PreviewScenario::Typical, cx));
+            SidebarPopoverHarness { sidebar }
+        });
+        let sidebar = view.read_with(cx, |harness, _| harness.sidebar.clone());
+        sidebar.update_in(cx, |sidebar, window, cx| sidebar.focus(window, cx));
+        let active_before = sidebar.read_with(cx, |sidebar, _| {
+            sidebar
+                .store
+                .read()
+                .expect("session store lock poisoned")
+                .selected_session_id()
+                .cloned()
+                .expect("preview selection")
+        });
+        let key_down = |key: &str| KeyDownEvent {
+            keystroke: Keystroke::parse(key).expect("keystroke"),
+            is_held: false,
+            prefer_character_input: false,
+        };
+
+        cx.simulate_event(key_down("space"));
+        cx.simulate_event(key_down("down"));
+        let followed = sidebar.read_with(cx, |sidebar, _| {
+            let peek = sidebar.ui.peek.as_ref().expect("keyboard peek");
+            assert_eq!(peek.source, PeekSource::Keyboard);
+            assert_eq!(Some(&peek.id), sidebar.ui.focus_cursor.as_ref());
+            assert_ne!(peek.id, active_before);
+            assert_eq!(
+                sidebar
+                    .store
+                    .read()
+                    .expect("session store lock poisoned")
+                    .selected_session_id(),
+                Some(&active_before)
+            );
+            peek.id.clone()
+        });
+        cx.simulate_event(KeyUpEvent {
+            keystroke: Keystroke::parse("space").expect("keystroke"),
+        });
+        sidebar.update_in(cx, |sidebar, window, _| {
+            assert!(sidebar.ui.peek.is_none());
+            assert!(sidebar.is_focused(window));
+            assert_eq!(
+                sidebar
+                    .store
+                    .read()
+                    .expect("session store lock poisoned")
+                    .selected_session_id(),
+                Some(&active_before)
+            );
+        });
+
+        cx.simulate_event(key_down("space"));
+        cx.simulate_event(key_down("escape"));
+        assert!(sidebar.read_with(cx, |sidebar, _| sidebar.ui.peek.is_none()));
+        assert_eq!(
+            sidebar.read_with(cx, |sidebar, _| sidebar
+                .store
+                .read()
+                .expect("session store lock poisoned")
+                .selected_session_id()
+                .cloned()),
+            Some(active_before.clone())
+        );
+
+        cx.simulate_event(key_down("space"));
+        cx.simulate_event(key_down("enter"));
+        sidebar.read_with(cx, |sidebar, _| {
+            assert!(sidebar.ui.peek.is_none());
+            assert_eq!(
+                sidebar
+                    .store
+                    .read()
+                    .expect("session store lock poisoned")
+                    .selected_session_id(),
+                Some(&followed)
+            );
+        });
+        // The key-up belonging to the committed gesture cannot restore the
+        // old identity after Enter made the preview durable.
+        cx.simulate_event(KeyUpEvent {
+            keystroke: Keystroke::parse("space").expect("keystroke"),
+        });
+        assert_eq!(
+            sidebar.read_with(cx, |sidebar, _| sidebar
+                .store
+                .read()
+                .expect("session store lock poisoned")
+                .selected_session_id()
+                .cloned()),
+            Some(followed)
+        );
     }
 
     #[gpui::test]

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -626,6 +626,50 @@ impl Sidebar {
         true
     }
 
+    /// Finishes only a keyboard-owned borrow. Root also calls this when a
+    /// modified shortcut moves focus before the Space key-up reaches us.
+    pub fn release_keyboard_peek(&mut self, cx: &mut Context<Self>) -> bool {
+        if !self.ui.space_held {
+            return false;
+        }
+        self.ui.space_held = false;
+        if self.ui.end_peek(Some(PeekSource::Keyboard)) {
+            self.emit_peek(cx);
+        }
+        true
+    }
+
+    fn guards_pointer_peek_drop(&self) -> bool {
+        self.ui.suppress_pointer_drop
+            || self
+                .ui
+                .peek
+                .as_ref()
+                .is_some_and(|peek| peek.source == PeekSource::Pointer)
+    }
+
+    /// Consumes either ordering of GPUI's release/drop dispatch. If capture
+    /// mouse-up ran first, `suppress_pointer_drop` is set; if drop ran first,
+    /// the live pointer peek is ended here. Neither path may mutate the model.
+    fn consume_pointer_peek_drop(&mut self, cx: &mut Context<Self>) -> bool {
+        let pointer_peek = self
+            .ui
+            .peek
+            .as_ref()
+            .is_some_and(|peek| peek.source == PeekSource::Pointer);
+        if pointer_peek {
+            self.finish_pointer_gesture(None, cx);
+        }
+        if pointer_peek || std::mem::take(&mut self.ui.suppress_pointer_drop) {
+            self.ui.suppress_pointer_drop = false;
+            self.finish_drag();
+            cx.notify();
+            true
+        } else {
+            false
+        }
+    }
+
     /// Enters keyboard-navigation mode from any other surface. An active row
     /// is the initial landmark, while an existing identity cursor survives
     /// subsequent trips to the terminal.
@@ -849,12 +893,8 @@ impl Sidebar {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if event.keystroke.key.as_str() != "space" || !self.ui.space_held {
+        if event.keystroke.key.as_str() != "space" || !self.release_keyboard_peek(cx) {
             return;
-        }
-        self.ui.space_held = false;
-        if self.ui.end_peek(Some(PeekSource::Keyboard)) {
-            self.emit_peek(cx);
         }
         cx.stop_propagation();
     }
@@ -1780,20 +1820,7 @@ impl Sidebar {
             .on_drop(cx.listener({
                 let target_project = session.project_id.clone();
                 move |this, dragged: &DraggedSidebarItem, _, cx| {
-                    let pointer_peek = this
-                        .ui
-                        .peek
-                        .as_ref()
-                        .is_some_and(|peek| peek.source == PeekSource::Pointer);
-                    if std::mem::take(&mut this.ui.suppress_pointer_drop) || pointer_peek {
-                        if pointer_peek {
-                            this.finish_pointer_gesture(None, cx);
-                            // `finish_pointer_gesture` protects a later drop;
-                            // this is that drop, so consume the guard now.
-                            this.ui.suppress_pointer_drop = false;
-                        }
-                        this.finish_drag();
-                        cx.notify();
+                    if this.consume_pointer_peek_drop(cx) {
                         return;
                     }
                     if let DragItem::Session {
@@ -1961,7 +1988,10 @@ impl Sidebar {
         // a sweep down the sidebar; selection changes once per click. An
         // unselected row therefore carries no animation state at all, rather
         // than animating an invisible zero-alpha fill.
-        if !selected && !multi {
+        // Peek owns the row fill while it temporarily borrows the main pane.
+        // Letting the selection animation repaint this background would make
+        // a selected row lose its distinct peek affordance.
+        if peeked || (!selected && !multi) {
             return row.into_any_element();
         }
         row.with_animation(
@@ -2049,6 +2079,9 @@ impl Sidebar {
                 let entity = cx.entity();
                 let project_id = project_id.clone();
                 move |element, dragged, _, cx| {
+                    if entity.read(cx).guards_pointer_peek_drop() {
+                        return element;
+                    }
                     let valid = match &dragged.0 {
                         DragItem::Session {
                             project, archived, ..
@@ -2070,19 +2103,7 @@ impl Sidebar {
             .on_drop(cx.listener({
                 let project_id = project_id.clone();
                 move |this, dragged: &DraggedSidebarItem, _, cx| {
-                    let ids = match &dragged.0 {
-                        DragItem::Session {
-                            id,
-                            project,
-                            archived: false,
-                            ..
-                        } if project == &project_id => vec![id.clone()],
-                        DragItem::Sessions(ids) => ids.clone(),
-                        _ => Vec::new(),
-                    };
-                    this.archive_sessions(ids);
-                    this.finish_drag();
-                    cx.notify();
+                    this.drop_into_archive(&project_id, dragged, cx);
                 }
             }))
             .child(
@@ -2286,6 +2307,7 @@ impl Sidebar {
                     })
                     .text_size(px(if hovered { 9.0 } else { 10.0 }))
                     .text_color(colors.secondary)
+                    .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
                     .child(sf_symbol_weighted(
                         if hovered {
                             "tray.and.arrow.up.fill"
@@ -2303,11 +2325,7 @@ impl Sidebar {
                     .when(hovered, |button| {
                         button.on_click(cx.listener(move |this, _, _, cx| {
                             cx.stop_propagation();
-                            this.store
-                                .write()
-                                .expect("session store lock poisoned")
-                                .revive_sessions(vec![revive_id.clone()]);
-                            cx.notify();
+                            this.revive_from_control(revive_id.clone(), cx);
                         }))
                     }),
             )
@@ -4012,6 +4030,42 @@ impl Sidebar {
             .archive_sessions(ids);
     }
 
+    fn revive_from_control(&mut self, id: SessionId, cx: &mut Context<Self>) {
+        // The nested control stops mouse-down propagation, and this explicit
+        // cancellation is defense in depth for platforms that synthesize the
+        // click after rerendering the hovered row.
+        self.cancel_peek(cx);
+        self.store
+            .write()
+            .expect("session store lock poisoned")
+            .revive_sessions(vec![id]);
+        cx.notify();
+    }
+
+    fn drop_into_archive(
+        &mut self,
+        project_id: &ProjectId,
+        dragged: &DraggedSidebarItem,
+        cx: &mut Context<Self>,
+    ) {
+        if self.consume_pointer_peek_drop(cx) {
+            return;
+        }
+        let ids = match &dragged.0 {
+            DragItem::Session {
+                id,
+                project,
+                archived: false,
+                ..
+            } if project == project_id => vec![id.clone()],
+            DragItem::Sessions(ids) => ids.clone(),
+            _ => Vec::new(),
+        };
+        self.archive_sessions(ids);
+        self.finish_drag();
+        cx.notify();
+    }
+
     fn close_sessions(&mut self, ids: Vec<SessionId>, cx: &mut Context<Self>) {
         let mut store = self.store.write().expect("session store lock poisoned");
         store.request_close(ids.clone());
@@ -5417,6 +5471,99 @@ mod tests {
     }
 
     #[gpui::test]
+    fn pointer_peek_drop_cannot_archive_in_either_release_order(cx: &mut TestAppContext) {
+        let (view, cx) = cx.add_window_view(|_, cx| {
+            let sidebar = cx.new(|cx| Sidebar::new(None, true, PreviewScenario::Typical, cx));
+            SidebarPopoverHarness { sidebar }
+        });
+        let sidebar = view.read_with(cx, |harness, _| harness.sidebar.clone());
+        let session = sidebar.read_with(cx, |sidebar, _| {
+            sidebar
+                .store
+                .read()
+                .expect("session store lock poisoned")
+                .sessions()[&SessionId::new("preview-sleeping")]
+                .as_ref()
+                .clone()
+        });
+        let dragged = DraggedSidebarItem(DragItem::Session {
+            id: session.id.clone(),
+            project: session.project_id.clone(),
+            parent: session.parent.clone(),
+            archived: false,
+        });
+
+        sidebar.update(cx, |sidebar, cx| {
+            // Drop dispatch before capture-phase mouse-up.
+            sidebar.pointer_press = Some(session.id.clone());
+            sidebar.begin_peek(session.id.clone(), PeekSource::Pointer, cx);
+            sidebar.drop_into_archive(&session.project_id, &dragged, cx);
+            assert!(sidebar.ui.peek.is_none());
+            assert!(!sidebar.ui.suppress_pointer_drop);
+            assert!(
+                sidebar
+                    .store
+                    .read()
+                    .expect("session store lock poisoned")
+                    .sessions()[&session.id]
+                    .archived_at
+                    .is_none()
+            );
+
+            // Capture-phase mouse-up before drop dispatch.
+            sidebar.pointer_press = Some(session.id.clone());
+            sidebar.begin_peek(session.id.clone(), PeekSource::Pointer, cx);
+            sidebar.finish_pointer_gesture(Some(&session.id), cx);
+            assert!(sidebar.ui.suppress_pointer_drop);
+            sidebar.drop_into_archive(&session.project_id, &dragged, cx);
+            assert!(!sidebar.ui.suppress_pointer_drop);
+            assert!(
+                sidebar
+                    .store
+                    .read()
+                    .expect("session store lock poisoned")
+                    .sessions()[&session.id]
+                    .archived_at
+                    .is_none()
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn archived_revive_click_cancels_any_bubbled_row_peek(cx: &mut TestAppContext) {
+        let (view, cx) = cx.add_window_view(|_, cx| {
+            let sidebar = cx.new(|cx| Sidebar::new(None, true, PreviewScenario::Typical, cx));
+            SidebarPopoverHarness { sidebar }
+        });
+        let sidebar = view.read_with(cx, |harness, _| harness.sidebar.clone());
+        let archived = SessionId::new("preview-archived");
+        sidebar.update_in(cx, |sidebar, window, cx| {
+            // Model the worst event order: a bubbled row mouse-down managed to
+            // arm the hold immediately before the nested revive click.
+            sidebar.schedule_pointer_peek(archived.clone(), window, cx);
+            assert!(sidebar.pending_pointer_peek.is_some());
+            sidebar.revive_from_control(archived.clone(), cx);
+        });
+
+        sidebar.read_with(cx, |sidebar, _| {
+            assert!(sidebar.pending_pointer_peek.is_none());
+            assert!(sidebar.pointer_press.is_none());
+            assert!(
+                sidebar
+                    .store
+                    .read()
+                    .expect("session store lock poisoned")
+                    .sessions()[&archived]
+                    .archived_at
+                    .is_none()
+            );
+        });
+        cx.executor().advance_clock(SESSION_PEEK_DELAY);
+        cx.run_until_parked();
+        assert!(!sidebar.read_with(cx, |sidebar, _| sidebar.is_peeking()));
+    }
+
+    #[gpui::test]
     fn held_space_follows_commits_and_release_or_escape_restore(cx: &mut TestAppContext) {
         let (view, cx) = cx.add_window_view(|_, cx| {
             let sidebar = cx.new(|cx| Sidebar::new(None, true, PreviewScenario::Typical, cx));
@@ -5512,6 +5659,32 @@ mod tests {
                 .cloned()),
             Some(followed)
         );
+    }
+
+    #[gpui::test]
+    fn keyboard_peek_release_survives_focus_transfer_before_space_up(cx: &mut TestAppContext) {
+        let (view, cx) = cx.add_window_view(|_, cx| {
+            let sidebar = cx.new(|cx| Sidebar::new(None, true, PreviewScenario::Typical, cx));
+            SidebarPopoverHarness { sidebar }
+        });
+        let sidebar = view.read_with(cx, |harness, _| harness.sidebar.clone());
+        sidebar.update_in(cx, |sidebar, window, cx| sidebar.focus(window, cx));
+        cx.simulate_event(KeyDownEvent {
+            keystroke: Keystroke::parse("space").expect("keystroke"),
+            is_held: false,
+            prefer_character_input: false,
+        });
+        assert!(sidebar.read_with(cx, |sidebar, _| sidebar.is_peeking()));
+
+        let transferred_focus = sidebar.update(cx, |_, cx| cx.focus_handle());
+        sidebar.update_in(cx, |sidebar, window, cx| {
+            transferred_focus.focus(window, cx);
+            assert!(!sidebar.is_focused(window));
+            // This is the Root capture route for an unfocused Space key-up.
+            assert!(sidebar.release_keyboard_peek(cx));
+            assert!(!sidebar.ui.space_held);
+            assert!(sidebar.ui.peek.is_none());
+        });
     }
 
     #[gpui::test]

--- a/diri/crates/diri-app/src/terminal_pane.rs
+++ b/diri/crates/diri-app/src/terminal_pane.rs
@@ -24,14 +24,14 @@ use diri_term::metrics::CellMetrics;
 use diri_term::scrollback::{WheelDelta, WheelEvent, WheelRoute};
 use diri_term::theme::TermTheme;
 use diri_ui::{
-    AgentKind as UiAgentKind, Fill, FloatingSurface, Ink, Metrics, Radius, SemanticColors,
-    StatusGlyph, StatusState, Typo,
+    AgentKind as UiAgentKind, AgentLogo, Fill, FloatingSurface, Ink, Metrics, Palette, Radius,
+    SemanticColors, StatusGlyph, StatusState, Typo,
 };
 use gpui::{
     AnyElement, ClickEvent, ClipboardEntry, ClipboardItem, Context, Entity, EventEmitter,
-    FocusHandle, KeyDownEvent, KeyUpEvent, ModifiersChangedEvent, MouseButton, Render, ScrollDelta,
-    ScrollWheelEvent, SharedString, StatefulInteractiveElement, Task, Window, div, font,
-    prelude::*, px, rgba,
+    FocusHandle, FontWeight, KeyDownEvent, KeyUpEvent, ModifiersChangedEvent, MouseButton, Render,
+    ScrollDelta, ScrollWheelEvent, SharedString, StatefulInteractiveElement, Task, Window, div,
+    font, prelude::*, px, rgba,
 };
 use tokio::runtime::Handle;
 use tokio::sync::mpsc;
@@ -509,6 +509,14 @@ enum SessionSource {
     Fixed(SessionId),
 }
 
+/// Read-only presentation borrowed by the sidebar. It owns no attachment and
+/// has no relationship to Store selection/residency; its optional element is
+/// a view over a buffer the primary pane already had in memory.
+struct PeekPresentation {
+    id: SessionId,
+    element: Option<TerminalElement>,
+}
+
 /// Grid frames parked while a column change round-trips through the daemon,
 /// so the re-wrap and the program's repaint reach the screen as one paint
 /// rather than as a jump and a correction. See [`REFLOW_HOLD`].
@@ -586,6 +594,7 @@ pub struct TerminalPane {
     reflow_holds: HashMap<SessionId, ReflowHold>,
     started_at: Instant,
     session_source: SessionSource,
+    peek: Option<PeekPresentation>,
     /// Last selection observed by the primary pane. Spawn responses select the
     /// daemon-created id asynchronously, so this transition is also the
     /// reliable point at which keyboard focus can leave the picker.
@@ -710,6 +719,7 @@ impl TerminalPane {
             reflow_holds: HashMap::new(),
             started_at: Instant::now(),
             session_source,
+            peek: None,
             observed_selected_id,
             viewport: None,
             sidebar_visible: true,
@@ -865,6 +875,44 @@ impl TerminalPane {
         window.focus(&self.focus, cx);
     }
 
+    pub fn is_peeking(&self) -> bool {
+        self.peek.is_some()
+    }
+
+    /// Changes only what this pane paints. In particular, this does not touch
+    /// terminal residency, open an attachment, resize a PTY, select a session,
+    /// acknowledge attention, or auto-resume a hibernated process.
+    pub fn set_peeked_session(&mut self, id: Option<SessionId>, cx: &mut Context<Self>) {
+        if self.peek.as_ref().map(|peek| &peek.id) == id.as_ref() {
+            return;
+        }
+        self.peek = id.map(|id| {
+            let buffer = self
+                .residents
+                .get(&id)
+                .map(|resident| resident.element.buffer())
+                .or_else(|| {
+                    self.parked_grids
+                        .iter()
+                        .find(|(parked, _)| parked == &id)
+                        .map(|(_, buffer)| Arc::clone(buffer))
+                });
+            let element = buffer.map(|buffer| {
+                let mut mono = font(crate::fonts::mono_family());
+                mono.fallbacks = Some(gpui::FontFallbacks::from_fonts(vec![
+                    ".SF NS Mono".to_owned(),
+                    "Menlo".to_owned(),
+                    "Apple Symbols".to_owned(),
+                    "STIX Two Math".to_owned(),
+                    "Apple Color Emoji".to_owned(),
+                ]));
+                TerminalElement::new(buffer).font(mono).focused(false)
+            });
+            PeekPresentation { id, element }
+        });
+        cx.notify();
+    }
+
     pub fn set_viewport(&mut self, viewport: TerminalViewport, cx: &mut Context<Self>) {
         if self.viewport == Some(viewport) {
             return;
@@ -951,7 +999,7 @@ impl TerminalPane {
                 if let Some(resident) = self.residents.get_mut(&id) {
                     resident.attachment_state = state;
                 }
-                if self.selected_id().as_ref() == Some(&id) {
+                if self.visible_id().as_ref() == Some(&id) {
                     cx.notify();
                 }
             }
@@ -989,13 +1037,13 @@ impl TerminalPane {
                 if let Some(resident) = self.residents.get_mut(&id) {
                     resident.element.set_modes(alt_screen, mouse_reporting);
                 }
-                if self.selected_id().as_ref() == Some(&id) {
+                if self.visible_id().as_ref() == Some(&id) {
                     cx.notify();
                 }
             }
             PaneEvent::Chunk(_, TerminalChunk::Pong) => {}
             PaneEvent::FindSnapshot(id, request, snapshot) => {
-                let visible = self.selected_id().as_ref() == Some(&id);
+                let visible = self.visible_id().as_ref() == Some(&id);
                 if let Some(resident) = self.residents.get_mut(&id)
                     && let Some(find) = resident.find.as_mut()
                     && resident
@@ -1015,7 +1063,7 @@ impl TerminalPane {
                         .complete_scrollback_fetch(result, visible_rows);
                 }
                 self.pump_scrollback_fetch(&id, visible_rows);
-                if self.selected_id().as_ref() == Some(&id) {
+                if self.visible_id().as_ref() == Some(&id) {
                     cx.notify();
                 }
             }
@@ -1023,7 +1071,7 @@ impl TerminalPane {
                 if let Some(resident) = self.residents.get_mut(&id) {
                     resident.element.fail_scrollback_fetch();
                 }
-                if self.selected_id().as_ref() == Some(&id) {
+                if self.visible_id().as_ref() == Some(&id) {
                     cx.notify();
                 }
             }
@@ -1049,7 +1097,7 @@ impl TerminalPane {
         cx: &mut Context<Self>,
     ) {
         let now = self.started_at.elapsed();
-        let selected = self.selected_id();
+        let selected = self.visible_id();
         let mut schedule_find = false;
         let mut changed = false;
         let mut applied = false;
@@ -1183,7 +1231,29 @@ impl TerminalPane {
             .map(Arc::clone)
     }
 
+    fn visible_id(&self) -> Option<SessionId> {
+        self.peek
+            .as_ref()
+            .map(|peek| peek.id.clone())
+            .or_else(|| self.selected_id())
+    }
+
+    fn visible_session(&self) -> Option<Arc<SessionRecord>> {
+        let id = self.visible_id()?;
+        self.runtime
+            .store
+            .read()
+            .expect("session store lock poisoned")
+            .sessions()
+            .get(&id)
+            .map(Arc::clone)
+    }
+
     fn open_find(&mut self, _: &OpenFind, window: &mut Window, cx: &mut Context<Self>) {
+        if self.is_peeking() {
+            cx.stop_propagation();
+            return;
+        }
         let Some(id) = self.selected_id() else {
             return;
         };
@@ -1202,6 +1272,10 @@ impl TerminalPane {
     }
 
     fn close_find(&mut self, _: &CloseFind, _window: &mut Window, cx: &mut Context<Self>) {
+        if self.is_peeking() {
+            cx.stop_propagation();
+            return;
+        }
         if self.close_find_for_selected() {
             cx.stop_propagation();
             cx.notify();
@@ -1233,6 +1307,10 @@ impl TerminalPane {
     }
 
     fn navigate_find(&mut self, backwards: bool, cx: &mut Context<Self>) {
+        if self.is_peeking() {
+            cx.stop_propagation();
+            return;
+        }
         let Some(id) = self.selected_id() else {
             return;
         };
@@ -1365,6 +1443,10 @@ impl TerminalPane {
     }
 
     fn copy_selection(&mut self, _: &CopySelection, _window: &mut Window, cx: &mut Context<Self>) {
+        if self.is_peeking() {
+            cx.stop_propagation();
+            return;
+        }
         let Some(id) = self.selected_id() else {
             return;
         };
@@ -1378,6 +1460,10 @@ impl TerminalPane {
     }
 
     fn paste(&mut self, _: &Paste, window: &mut Window, cx: &mut Context<Self>) {
+        if self.is_peeking() {
+            cx.stop_propagation();
+            return;
+        }
         let Some(item) = cx.read_from_clipboard() else {
             return;
         };
@@ -1463,6 +1549,10 @@ impl TerminalPane {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.is_peeking() {
+            cx.stop_propagation();
+            return;
+        }
         if let Some(navigation) = &self.navigation
             && navigation.read(cx).is_open()
         {
@@ -1593,6 +1683,10 @@ impl TerminalPane {
     }
 
     fn handle_key_up(&mut self, event: &KeyUpEvent, _window: &mut Window, cx: &mut Context<Self>) {
+        if self.is_peeking() {
+            cx.stop_propagation();
+            return;
+        }
         if matches!(event.keystroke.key.as_str(), "control" | "ctrl") {
             self.runtime
                 .store
@@ -1609,6 +1703,10 @@ impl TerminalPane {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.is_peeking() {
+            cx.stop_propagation();
+            return;
+        }
         let mut store = self
             .runtime
             .store
@@ -1658,6 +1756,10 @@ impl TerminalPane {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.is_peeking() {
+            cx.stop_propagation();
+            return;
+        }
         let Some(id) = self.selected_id() else {
             return;
         };
@@ -2055,6 +2157,141 @@ impl TerminalPane {
                     cx.open_url(url);
                 }
             }))
+            .into_any_element()
+    }
+
+    fn render_peek_header(&self, session: &SessionRecord, colors: SemanticColors) -> AnyElement {
+        let glyph = self.glyphs.get(&session.id).cloned();
+        let branch = session.git_branch.clone();
+        div()
+            .h(px(Metrics::TITLE_BAR))
+            .flex_none()
+            .px(px(Metrics::TOOLBAR_EDGE_INSET))
+            .flex()
+            .items_center()
+            .gap(px(Metrics::TOOLBAR_ITEM_GAP))
+            .bg(colors.sidebar_surface())
+            .child(
+                div()
+                    .flex_none()
+                    .px(px(6.0))
+                    .py(px(2.0))
+                    .rounded(px(Radius::CHIP))
+                    .bg(Palette::CLAY.alpha(0.14))
+                    .border_1()
+                    .border_color(Palette::CLAY.alpha(0.55))
+                    .text_size(px(Typo::META.size - 1.0))
+                    .font_weight(FontWeight::SEMIBOLD)
+                    .text_color(Palette::CLAY)
+                    .child("PEEK"),
+            )
+            .child(
+                div()
+                    .min_w(px(0.0))
+                    .flex_1()
+                    .overflow_hidden()
+                    .whitespace_nowrap()
+                    .text_size(px(Typo::TITLE.size))
+                    .font_weight(Typo::TITLE.weight)
+                    .text_color(colors.primary)
+                    .child(session.title.clone()),
+            )
+            .when_some(branch, |header, branch| {
+                header.child(
+                    div()
+                        .max_w(px(160.0))
+                        .overflow_hidden()
+                        .text_ellipsis()
+                        .whitespace_nowrap()
+                        .text_size(px(Typo::META.size))
+                        .text_color(colors.tertiary)
+                        .child(branch),
+                )
+            })
+            .child(
+                div()
+                    .flex_none()
+                    .flex()
+                    .items_center()
+                    .gap(px(Metrics::TOOLBAR_ITEM_GAP))
+                    .when_some(glyph, |identity, glyph| identity.child(glyph))
+                    .child(
+                        div()
+                            .text_size(px(Typo::META.size))
+                            .text_color(colors.tertiary)
+                            .child("Release to return · Enter to switch"),
+                    ),
+            )
+            .into_any_element()
+    }
+
+    fn render_peek_surface(
+        &self,
+        session: &SessionRecord,
+        theme: TermTheme,
+        font_size: f32,
+        colors: SemanticColors,
+    ) -> AnyElement {
+        let element = self
+            .peek
+            .as_ref()
+            .filter(|peek| peek.id == session.id)
+            .and_then(|peek| peek.element.clone());
+        let content = element.map_or_else(
+            || {
+                let message = if session.hibernation.is_some() {
+                    "Hibernated · showing the best available session state"
+                } else if session.is_archived() {
+                    "Archived · no resident terminal snapshot"
+                } else {
+                    "No resident terminal snapshot yet"
+                };
+                div()
+                    .size_full()
+                    .flex()
+                    .flex_col()
+                    .items_center()
+                    .justify_center()
+                    .gap(px(12.0))
+                    .bg(theme.background)
+                    .child(
+                        AgentLogo::new(ui_agent_kind(session.effective_kind()), 48.0, colors)
+                            .badged(false),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(Typo::ROW.size))
+                            .text_color(colors.secondary)
+                            .child(message),
+                    )
+                    .into_any_element()
+            },
+            |element| {
+                div()
+                    .size_full()
+                    .pt(px(2.0))
+                    .pb(px(10.0))
+                    .px(px(12.0))
+                    .bg(theme.background)
+                    .child(element.theme(theme).font_size(px(font_size)).focused(false))
+                    .into_any_element()
+            },
+        );
+        div()
+            .debug_selector(|| "TERMINAL_PEEK_SURFACE".into())
+            .relative()
+            .min_h(px(0.0))
+            .flex_1()
+            .overflow_hidden()
+            .rounded_tl(px(Radius::CARD))
+            .rounded_tr(px(Radius::CARD))
+            .border_l_2()
+            .border_color(Palette::CLAY.alpha(0.72))
+            .bg(theme.background)
+            .occlude()
+            .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+            .on_scroll_wheel(|_, _, cx| cx.stop_propagation())
+            .child(content)
             .into_any_element()
     }
 
@@ -2746,57 +2983,75 @@ impl Render for TerminalPane {
         self.sync_status_glyphs(colors, window, cx);
         self.update_selected_geometry(window, cx);
 
-        let selected = self.selected_session();
+        let selected = self.visible_session();
 
         let content = if let Some(session) = selected {
-            let chips = PaneChip::for_session(&session);
-            let visible_chip_count = toolbar_visible_chip_count(
-                &chips,
-                self.viewport.map_or(900.0, |viewport| viewport.width),
-                self.sidebar_visible,
-            );
-            if visible_chip_count >= chips.len() {
-                self.overflow_open = false;
-            }
-            let mut pane = div()
-                .relative()
-                .flex()
-                .flex_col()
-                .flex_1()
-                .h_full()
-                .overflow_hidden()
-                .border_l_1()
-                .border_color(sidebar_colors.primary.alpha(0.08))
-                .bg(sidebar_colors.sidebar_surface())
-                .child(self.render_header(
-                    &session,
+            if self.is_peeking() {
+                div()
+                    .relative()
+                    .flex()
+                    .flex_col()
+                    .flex_1()
+                    .h_full()
+                    .overflow_hidden()
+                    .border_l_1()
+                    .border_color(sidebar_colors.primary.alpha(0.08))
+                    .bg(sidebar_colors.sidebar_surface())
+                    .child(self.render_peek_header(&session, sidebar_colors))
+                    .child(self.render_peek_surface(&session, theme, font_size, colors))
+                    .into_any_element()
+            } else {
+                let chips = PaneChip::for_session(&session);
+                let visible_chip_count = toolbar_visible_chip_count(
                     &chips,
-                    visible_chip_count,
-                    sidebar_colors,
-                    cx,
-                ));
-            let terminal_surface = div()
-                .relative()
-                .min_h(px(0.0))
-                .flex_1()
-                .flex()
-                .flex_col()
-                .rounded_tl(px(Radius::CARD))
-                .rounded_tr(px(Radius::CARD))
-                .overflow_hidden()
-                .bg(theme.background)
-                .child(self.render_grid_and_overlays(&session, theme, font_size, window, cx));
-            pane = pane.child(terminal_surface);
-            if let Some(find) = self.render_find_bar(&session, colors, cx) {
-                pane = pane.child(find);
+                    self.viewport.map_or(900.0, |viewport| viewport.width),
+                    self.sidebar_visible,
+                );
+                if visible_chip_count >= chips.len() {
+                    self.overflow_open = false;
+                }
+                let mut pane = div()
+                    .relative()
+                    .flex()
+                    .flex_col()
+                    .flex_1()
+                    .h_full()
+                    .overflow_hidden()
+                    .border_l_1()
+                    .border_color(sidebar_colors.primary.alpha(0.08))
+                    .bg(sidebar_colors.sidebar_surface())
+                    .child(self.render_header(
+                        &session,
+                        &chips,
+                        visible_chip_count,
+                        sidebar_colors,
+                        cx,
+                    ));
+                let terminal_surface = div()
+                    .relative()
+                    .min_h(px(0.0))
+                    .flex_1()
+                    .flex()
+                    .flex_col()
+                    .rounded_tl(px(Radius::CARD))
+                    .rounded_tr(px(Radius::CARD))
+                    .overflow_hidden()
+                    .bg(theme.background)
+                    .child(self.render_grid_and_overlays(&session, theme, font_size, window, cx));
+                pane = pane.child(terminal_surface);
+                if let Some(find) = self.render_find_bar(&session, colors, cx) {
+                    pane = pane.child(find);
+                }
+                if let Some(popover) = self.render_checks_popover(&session, colors, cx) {
+                    pane = pane.child(popover);
+                }
+                if let Some(overflow) =
+                    self.render_overflow(&session, visible_chip_count, colors, cx)
+                {
+                    pane = pane.child(overflow);
+                }
+                pane.into_any_element()
             }
-            if let Some(popover) = self.render_checks_popover(&session, colors, cx) {
-                pane = pane.child(popover);
-            }
-            if let Some(overflow) = self.render_overflow(&session, visible_chip_count, colors, cx) {
-                pane = pane.child(overflow);
-            }
-            pane.into_any_element()
         } else {
             let show_sidebar = matches!(self.session_source, SessionSource::FollowSelection)
                 && !self.sidebar_visible;
@@ -3367,7 +3622,8 @@ fn exit_description(session: &SessionRecord) -> String {
 mod tests {
     use diri_proto::grid::{ChangedRow, GridCell};
     use diri_proto::{
-        DateMillis, ExitInfo, NeedsInputDetail, NeedsInputKind, NeedsInputSource, SessionListResult,
+        DateMillis, ExitInfo, HibernationInfo, HibernationReason, NeedsInputDetail, NeedsInputKind,
+        NeedsInputSource, SessionListResult,
     };
     use gpui::{Image, ImageFormat, KeyDownEvent, Keystroke, Modifiers, TestAppContext, point};
 
@@ -3755,6 +4011,105 @@ mod tests {
         assert!(
             cx.debug_bounds("show-sidebar").is_some(),
             "collapsing the sidebar must leave a way to reveal it"
+        );
+    }
+
+    #[gpui::test]
+    fn peek_is_read_only_preserves_focus_and_does_not_wake_a_nonresident_session(
+        cx: &mut TestAppContext,
+    ) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        let tokio = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime"),
+        );
+        let active = fixture_session();
+        let mut sleeping = fixture_session();
+        sleeping.id = SessionId::new("sleeping-peek");
+        sleeping.title = "Sleeping preview".to_owned();
+        sleeping.hibernation = Some(HibernationInfo {
+            since: DateMillis(1.0),
+            reason: HibernationReason::Idle,
+            tree_pids: vec![42],
+            tree_start_times: None,
+        });
+        let attention_before = sleeping.attention();
+        {
+            let mut store = runtime.store.write().expect("session store lock poisoned");
+            store.upsert_session(active.clone());
+            store.upsert_session(sleeping.clone());
+            store.select(active.id.clone());
+        }
+
+        let runtime_for_view = Arc::clone(&runtime);
+        let (pane, cx) = cx.add_window_view(move |window, cx| {
+            TerminalPane::new(runtime_for_view, tokio, window, cx)
+        });
+        let (input_tx, mut input_rx) = mpsc::unbounded_channel();
+        let active_offset = pane.update_in(cx, |pane, window, cx| {
+            pane.focus(window, cx);
+            let active_offset = pane.residents[&active.id].element.view_offset();
+            let pane_tx = pane.pane_tx.clone();
+            pane.residents
+                .get_mut(&active.id)
+                .expect("active resident")
+                .attachment = AttachmentControl {
+                tx: input_tx,
+                pane_tx,
+            };
+
+            pane.set_peeked_session(Some(sleeping.id.clone()), cx);
+            assert!(pane.is_peeking());
+            assert!(pane.is_focused(window));
+            assert_eq!(pane.visible_id(), Some(sleeping.id.clone()));
+            assert!(!pane.residents.contains_key(&sleeping.id));
+            assert!(
+                pane.peek
+                    .as_ref()
+                    .is_some_and(|peek| peek.element.is_none())
+            );
+            active_offset
+        });
+        assert!(
+            cx.debug_bounds("TERMINAL_PEEK_SURFACE").is_some(),
+            "a hibernated session without a grid still paints its metadata fallback"
+        );
+
+        pane.update_in(cx, |pane, window, cx| {
+            pane.handle_key_down(
+                &KeyDownEvent {
+                    keystroke: Keystroke::parse("x").expect("keystroke"),
+                    is_held: false,
+                    prefer_character_input: false,
+                },
+                window,
+                cx,
+            );
+            assert!(
+                input_rx.try_recv().is_err(),
+                "peek must deliver no PTY input"
+            );
+
+            pane.set_peeked_session(None, cx);
+            assert!(pane.is_focused(window));
+            assert_eq!(
+                pane.residents[&active.id].element.view_offset(),
+                active_offset
+            );
+        });
+        let store = runtime.store.read().expect("session store lock poisoned");
+        assert_eq!(store.selected_session_id(), Some(&active.id));
+        assert_eq!(store.sessions()[&sleeping.id].attention(), attention_before);
+        assert!(store.sessions()[&sleeping.id].hibernation.is_some());
+        assert_eq!(
+            store
+                .terminal_residency()
+                .resident()
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec![active.id]
         );
     }
 

--- a/diri/crates/diri-app/src/terminal_pane.rs
+++ b/diri/crates/diri-app/src/terminal_pane.rs
@@ -1813,6 +1813,12 @@ impl TerminalPane {
     }
 
     fn update_selected_geometry(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        // Peek borrows presentation only. Even if a surrounding layout sends
+        // a transient viewport while it is active, do not update the selected
+        // terminal's size bookkeeping or send a PTY resize/reflow.
+        if self.is_peeking() {
+            return;
+        }
         let Some(session) = self.selected_session() else {
             return;
         };
@@ -4051,14 +4057,10 @@ mod tests {
         let active_offset = pane.update_in(cx, |pane, window, cx| {
             pane.focus(window, cx);
             let active_offset = pane.residents[&active.id].element.view_offset();
-            let pane_tx = pane.pane_tx.clone();
             pane.residents
                 .get_mut(&active.id)
                 .expect("active resident")
-                .attachment = AttachmentControl {
-                tx: input_tx,
-                pane_tx,
-            };
+                .attachment = AttachmentControl { tx: input_tx };
 
             pane.set_peeked_session(Some(sleeping.id.clone()), cx);
             assert!(pane.is_peeking());
@@ -4069,6 +4071,20 @@ mod tests {
                 pane.peek
                     .as_ref()
                     .is_some_and(|peek| peek.element.is_none())
+            );
+            pane.set_viewport(
+                TerminalViewport {
+                    x: 40.0,
+                    y: 0.0,
+                    width: 520.0,
+                    height: 260.0,
+                },
+                cx,
+            );
+            pane.update_selected_geometry(window, cx);
+            assert!(
+                input_rx.try_recv().is_err(),
+                "a viewport update during peek must not resize the selected PTY"
             );
             active_offset
         });


### PR DESCRIPTION
## Summary

- add a 320 ms press-hold preview that follows pointer movement and restores the active session on release
- add hold-Space keyboard peeking that follows sidebar navigation, commits with Enter, and cancels with Space release or Escape—even if a shortcut transfers focus before key-up
- render a clearly marked, read-only terminal preview without changing store selection, attention, residency, attachment, PTY input, resize, or reflow state
- show the best already-available snapshot for nonresident sessions and a metadata fallback for hibernated sessions without waking them

## Design

Peek identity lives in sidebar UI state and is sent directly to the terminal presentation layer; it never becomes `SessionStore` selection until an explicit commit. The active row therefore retains its selected treatment while the borrowed row receives a restrained Clay outline/fill, and the terminal keeps its geometry with a compact `PEEK` label instead of animating or replacing the workspace structure. Pointer targets swap atomically, so following the pointer cannot flash the original session.

The preview uses only an already resident buffer or parked grid, creates no attachment, and blocks mouse, wheel, keyboard, paste, find, and modifier input. Existing auxiliary splits stay mounted at the same size, while the terminal pane independently refuses geometry mutation during peek. Capture-phase release guards cover both GPUI release/drop orderings across session and archive targets, so a completed hold can neither click-commit nor reorder/archive. Nested revive controls stop row press propagation and defensively cancel any pending hold.

## Dependency

This is stacked on PR #82 (`codex/issue-70-sidebar-focus`) because keyboard peeking builds on that sidebar focus/navigation model. Merge #82 first.

## Tests

- `/Users/giga/.cargo/bin/cargo fmt --all -- --check`
- `/Users/giga/.cargo/bin/cargo check --workspace`
- `/Users/giga/.cargo/bin/cargo clippy --workspace --all-targets -- -D warnings`
- `/Users/giga/.cargo/bin/cargo test -p diri-app` (362 passed, 2 ignored)
- `/Users/giga/.cargo/bin/cargo test -p diri-engine --lib` (267 passed, 3 ignored)
- focused GPUI coverage for pointer delay/release invariants, both archive drop event orderings, nested revive cancellation, keyboard focus-transfer release, split preservation, no-resize viewport changes, and hibernated read-only no-wake behavior

Closes #71