### PR TITLE
fix(agents): fix agent catalog synchronization and settings-driven quick launch

### DIFF
--- a/diri/crates/diri-app/src/agent_catalog.rs
+++ b/diri/crates/diri-app/src/agent_catalog.rs
@@ -34,30 +34,19 @@ impl AgentOption {
     }
 }
 
-/// Complete supported-Agent rows in deterministic product order.
+/// Complete supported-Agent rows in the order supplied by Settings readiness.
 ///
 /// Availability must only come from Engine readiness facts. In particular,
 /// an empty or not-yet-populated response must never be expanded into
 /// optimistic "installed" entries: high-frequency launch surfaces derive
 /// from this collection and must fail closed when detection has no facts.
 pub(crate) fn agent_options(catalog: &AgentReadinessResult) -> Vec<AgentOption> {
-    let mut options: Vec<_> = catalog
+    catalog
         .agents
         .iter()
         .filter(|item| !item.kind.is_terminal())
         .map(option_from_readiness)
-        .collect();
-    options.sort_by(|left, right| {
-        option_order(left)
-            .cmp(&option_order(right))
-            .then_with(|| {
-                left.display_name
-                    .to_lowercase()
-                    .cmp(&right.display_name.to_lowercase())
-            })
-            .then_with(|| left.kind.id().cmp(right.kind.id()))
-    });
-    options
+        .collect()
 }
 
 /// Settings is the complete supported catalog, grouped by readiness rather
@@ -194,7 +183,7 @@ pub(crate) fn display_name(kind: &AgentKind, catalog: &AgentReadinessResult) -> 
         .into_iter()
         .find(|option| option.kind == *kind)
         .map(|option| option.display_name)
-        .unwrap_or_else(|| builtin_name(kind).unwrap_or_else(|| title_case_id(kind.id())))
+        .unwrap_or_else(|| title_case_id(kind.id()))
 }
 
 pub(crate) fn system_image(kind: &AgentKind) -> &'static str {
@@ -248,7 +237,6 @@ fn option_from_readiness(item: &AgentReadinessItem) -> AgentOption {
         .map(|descriptor| descriptor.display_name.trim())
         .filter(|name| !name.is_empty())
         .map(str::to_owned)
-        .or_else(|| builtin_name(&item.kind))
         .unwrap_or_else(|| title_case_id(item.kind.id()));
     let install_hint = setup
         .and_then(|setup| setup.install_hint.as_deref())
@@ -262,8 +250,7 @@ fn option_from_readiness(item: &AgentReadinessItem) -> AgentOption {
         binary: item.binary.clone(),
         available: item.available(),
         show_in_quick_create: item.show_in_quick_create,
-        first_class: descriptor.is_some_and(|descriptor| descriptor.first_class)
-            || is_legacy_first_class(&item.kind),
+        first_class: descriptor.is_some_and(|descriptor| descriptor.first_class),
         setup_url: setup
             .and_then(|setup| setup.url.as_deref())
             .and_then(normal_web_url),
@@ -287,40 +274,6 @@ fn terminal_option() -> AgentOption {
         setup_url: None,
         install_hint: "Uses your login shell.".to_owned(),
         sign_in_hint: None,
-    }
-}
-
-fn option_order(option: &AgentOption) -> (u8, usize) {
-    let pinned = [
-        AgentKind::CLAUDE_CODE_ID,
-        AgentKind::CODEX_ID,
-        AgentKind::CURSOR_ID,
-        AgentKind::GEMINI_ID,
-    ];
-    pinned
-        .iter()
-        .position(|id| *id == option.kind.id())
-        .map_or((1, usize::MAX), |index| (0, index))
-}
-
-fn is_legacy_first_class(kind: &AgentKind) -> bool {
-    matches!(
-        kind.id(),
-        AgentKind::CLAUDE_CODE_ID
-            | AgentKind::CODEX_ID
-            | AgentKind::CURSOR_ID
-            | AgentKind::GEMINI_ID
-    )
-}
-
-fn builtin_name(kind: &AgentKind) -> Option<String> {
-    match kind.id() {
-        AgentKind::CLAUDE_CODE_ID => Some("Claude Code".to_owned()),
-        AgentKind::CODEX_ID => Some("Codex".to_owned()),
-        AgentKind::CURSOR_ID => Some("Cursor".to_owned()),
-        AgentKind::GEMINI_ID => Some("Gemini".to_owned()),
-        AgentKind::SHELL_ID => Some("Terminal".to_owned()),
-        _ => None,
     }
 }
 
@@ -454,6 +407,38 @@ mod tests {
                 AgentKind::new("zebra-missing"),
                 AgentKind::new("alpha-missing"),
             ]
+        );
+    }
+
+    #[test]
+    fn quick_create_choices_come_only_from_settings_and_keep_catalog_order() {
+        let mut zeta = item("zeta-future-agent", true, false);
+        zeta.show_in_quick_create = true;
+        let mut builtin = item("claude-code", true, false);
+        builtin.show_in_quick_create = true;
+        let mut hidden = item("alpha-hidden-agent", true, false);
+        hidden.show_in_quick_create = false;
+        let mut beta = item("beta-future-agent", true, false);
+        beta.show_in_quick_create = true;
+        let catalog = AgentReadinessResult {
+            agents: vec![zeta, builtin, hidden, beta],
+            ..AgentReadinessResult::default()
+        };
+
+        let options = quick_agent_options(Some(&catalog));
+        assert_eq!(
+            options
+                .iter()
+                .map(|option| option.kind.id())
+                .collect::<Vec<_>>(),
+            ["zeta-future-agent", "claude-code", "beta-future-agent"]
+        );
+        assert!(
+            options
+                .iter()
+                .find(|option| option.kind.id() == "claude-code")
+                .is_some_and(|option| !option.first_class),
+            "the client must not override manifest metadata by Agent id"
         );
     }
 

--- a/diri/crates/diri-app/src/agent_catalog.rs
+++ b/diri/crates/diri-app/src/agent_catalog.rs
@@ -1,8 +1,9 @@
 //! The client-side view of the daemon's manifest/readiness catalog.
 //!
 //! Launch surfaces consume this module instead of each rebuilding a partial
-//! four-agent list. It also centralizes unavailable/setup language so the
-//! launcher, sidebar, Settings, and command palette tell the same story.
+//! four-agent list. Quick-create surfaces only ever see installed Agents;
+//! Settings is the one place that lists an unavailable Agent, and it renders
+//! its own setup copy from the readiness item.
 
 use diri_proto::{AgentKind, AgentReadinessItem, AgentReadinessResult};
 
@@ -15,23 +16,6 @@ pub(crate) struct AgentOption {
     pub show_in_quick_create: bool,
     pub first_class: bool,
     pub setup_url: Option<String>,
-    pub install_hint: String,
-    pub sign_in_hint: Option<String>,
-}
-
-impl AgentOption {
-    pub(crate) fn unavailable_label(&self) -> Option<String> {
-        (!self.available).then(|| missing_binary_label(&self.binary))
-    }
-
-    pub(crate) fn unavailable_detail(&self) -> Option<String> {
-        let mut detail = format!("{} · {}", self.unavailable_label()?, self.install_hint);
-        if let Some(sign_in_hint) = &self.sign_in_hint {
-            detail.push_str(" · ");
-            detail.push_str(sign_in_hint);
-        }
-        Some(detail)
-    }
 }
 
 /// Complete supported-Agent rows in the order supplied by Settings readiness.
@@ -79,8 +63,6 @@ pub(crate) fn default_agent_options(catalog: &AgentReadinessResult) -> Vec<Agent
             show_in_quick_create: true,
             first_class: false,
             setup_url: None,
-            install_hint: "Uses your login shell.".to_owned(),
-            sign_in_hint: None,
         });
     }
     options
@@ -179,6 +161,12 @@ pub(crate) fn resolved_target_agent(
 }
 
 pub(crate) fn display_name(kind: &AgentKind, catalog: &AgentReadinessResult) -> String {
+    // `agent_options` deliberately drops terminal kinds, so without this the
+    // shell falls through to `title_case_id` and surfaces as "Shell" — a name
+    // no other launch surface uses for it.
+    if kind.is_terminal() {
+        return "Terminal".to_owned();
+    }
     agent_options(catalog)
         .into_iter()
         .find(|option| option.kind == *kind)
@@ -226,10 +214,6 @@ pub(crate) fn normal_web_url(url: &str) -> Option<String> {
     .then(|| url.to_owned())
 }
 
-pub(crate) fn missing_binary_label(binary: &str) -> String {
-    format!("Missing {binary}")
-}
-
 fn option_from_readiness(item: &AgentReadinessItem) -> AgentOption {
     let descriptor = item.descriptor.as_ref();
     let setup = descriptor.and_then(|descriptor| descriptor.setup.as_ref());
@@ -238,12 +222,6 @@ fn option_from_readiness(item: &AgentReadinessItem) -> AgentOption {
         .filter(|name| !name.is_empty())
         .map(str::to_owned)
         .unwrap_or_else(|| title_case_id(item.kind.id()));
-    let install_hint = setup
-        .and_then(|setup| setup.install_hint.as_deref())
-        .map(str::trim)
-        .filter(|hint| !hint.is_empty())
-        .map(str::to_owned)
-        .unwrap_or_else(|| format!("Install {} and add it to PATH.", item.binary));
     AgentOption {
         kind: item.kind.clone(),
         display_name,
@@ -254,12 +232,6 @@ fn option_from_readiness(item: &AgentReadinessItem) -> AgentOption {
         setup_url: setup
             .and_then(|setup| setup.url.as_deref())
             .and_then(normal_web_url),
-        install_hint,
-        sign_in_hint: setup
-            .and_then(|setup| setup.sign_in_hint.as_deref())
-            .map(str::trim)
-            .filter(|hint| !hint.is_empty())
-            .map(str::to_owned),
     }
 }
 
@@ -272,8 +244,6 @@ fn terminal_option() -> AgentOption {
         show_in_quick_create: true,
         first_class: false,
         setup_url: None,
-        install_hint: "Uses your login shell.".to_owned(),
-        sign_in_hint: None,
     }
 }
 
@@ -312,7 +282,7 @@ mod tests {
     }
 
     #[test]
-    fn unavailable_guidance_and_web_url_validation_are_shared() {
+    fn setup_urls_are_carried_through_and_web_url_validation_is_shared() {
         let mut unavailable = item("amp", false, false);
         unavailable.descriptor.as_mut().unwrap().setup = Some(AgentSetup {
             url: Some("https://ampcode.com/manual".into()),
@@ -323,15 +293,6 @@ mod tests {
             agents: vec![unavailable],
             ..AgentReadinessResult::default()
         });
-        assert_eq!(
-            options[0].unavailable_label().as_deref(),
-            Some("Missing amp-bin")
-        );
-        assert_eq!(options[0].install_hint, "Install Amp's CLI.");
-        assert_eq!(
-            options[0].unavailable_detail().as_deref(),
-            Some("Missing amp-bin · Install Amp's CLI. · Sign in at ampcode.com, then run amp.")
-        );
         assert_eq!(
             options[0].setup_url.as_deref(),
             Some("https://ampcode.com/manual")
@@ -486,7 +447,7 @@ mod tests {
     }
 
     #[test]
-    fn old_daemon_entries_without_descriptors_keep_useful_availability_copy() {
+    fn entries_without_descriptors_are_still_named_and_marked_unavailable() {
         let catalog = AgentReadinessResult {
             agents: vec![AgentReadinessItem {
                 kind: AgentKind::CODEX,
@@ -499,11 +460,7 @@ mod tests {
         };
         let options = agent_options(&catalog);
         assert_eq!(options[0].display_name, "Codex");
-        assert_eq!(
-            options[0].unavailable_label().as_deref(),
-            Some("Missing codex")
-        );
-        assert_eq!(options[0].install_hint, "Install codex and add it to PATH.");
+        assert!(!options[0].available);
         assert_eq!(options[0].setup_url, None);
     }
 }

--- a/diri/crates/diri-app/src/agent_catalog.rs
+++ b/diri/crates/diri-app/src/agent_catalog.rs
@@ -34,14 +34,13 @@ impl AgentOption {
     }
 }
 
-/// Catalog rows in deterministic product order. An empty response means an
-/// old daemon that predates descriptors, so retain the original four choices
-/// as optimistic compatibility entries instead of making the app unusable.
+/// Complete supported-Agent rows in deterministic product order.
+///
+/// Availability must only come from Engine readiness facts. In particular,
+/// an empty or not-yet-populated response must never be expanded into
+/// optimistic "installed" entries: high-frequency launch surfaces derive
+/// from this collection and must fail closed when detection has no facts.
 pub(crate) fn agent_options(catalog: &AgentReadinessResult) -> Vec<AgentOption> {
-    if catalog.agents.is_empty() {
-        return legacy_options();
-    }
-
     let mut options: Vec<_> = catalog
         .agents
         .iter()
@@ -59,6 +58,15 @@ pub(crate) fn agent_options(catalog: &AgentReadinessResult) -> Vec<AgentOption> 
             .then_with(|| left.kind.id().cmp(right.kind.id()))
     });
     options
+}
+
+/// Settings is the complete supported catalog, grouped by readiness rather
+/// than by name. The stable sort preserves the Engine/catalog order within
+/// each group, so adding a manifest does not introduce a second alphabetical
+/// policy in the UI.
+pub(crate) fn settings_agent_items(mut items: Vec<AgentReadinessItem>) -> Vec<AgentReadinessItem> {
+    items.sort_by_key(|item| !item.available());
+    items
 }
 
 /// Settings and the launcher must expose the shell whenever default resolution
@@ -117,15 +125,15 @@ pub(crate) fn installed_agent_options(catalog: Option<&AgentReadinessResult>) ->
 /// Whether an explicit spawn (shortcut, menu command, launcher submit) may
 /// dispatch this kind. Installed agents qualify even when hidden from quick
 /// create — menu visibility must not turn a saved default into a dead
-/// shortcut — terminals always qualify, and an unfetched catalog does not
-/// veto: availability is then unknown, and the daemon is the authority at
-/// spawn time.
+/// shortcut — and terminals always qualify. An unfetched catalog fails
+/// closed: launch surfaces must not turn missing readiness facts into a claim
+/// that an Agent is installed.
 pub(crate) fn kind_spawnable(kind: &AgentKind, catalog: Option<&AgentReadinessResult>) -> bool {
     if kind.is_terminal() {
         return true;
     }
     let Some(catalog) = catalog else {
-        return true;
+        return false;
     };
     agent_options(catalog)
         .iter()
@@ -150,6 +158,35 @@ pub(crate) fn resolved_default_agent(
         .iter()
         .find(|option| option.available && option.first_class)
         .map_or(AgentKind::SHELL, |option| option.kind.clone())
+}
+
+/// Resolve the Agent actually used by a target-scoped default shortcut.
+///
+/// A saved, installed default remains valid even when the user hides it from
+/// quick-create menus. If it is unavailable on this target, prefer the first
+/// installed and user-enabled Agent shown by those menus, then Terminal. With
+/// no readiness facts, fail closed to Terminal instead of borrowing another
+/// target's PATH or guessing that a manifest binary exists.
+pub(crate) fn resolved_target_agent(
+    saved: &AgentKind,
+    catalog: Option<&AgentReadinessResult>,
+) -> AgentKind {
+    if saved.is_terminal() {
+        return AgentKind::SHELL;
+    }
+    let Some(catalog) = catalog else {
+        return AgentKind::SHELL;
+    };
+    if agent_options(catalog)
+        .iter()
+        .any(|option| option.available && option.kind == *saved)
+    {
+        return saved.clone();
+    }
+    quick_agent_options(Some(catalog))
+        .into_iter()
+        .find(|option| !option.kind.is_terminal())
+        .map_or(AgentKind::SHELL, |option| option.kind)
 }
 
 pub(crate) fn display_name(kind: &AgentKind, catalog: &AgentReadinessResult) -> String {
@@ -237,28 +274,6 @@ fn option_from_readiness(item: &AgentReadinessItem) -> AgentOption {
             .filter(|hint| !hint.is_empty())
             .map(str::to_owned),
     }
-}
-
-fn legacy_options() -> Vec<AgentOption> {
-    [
-        (AgentKind::CLAUDE_CODE, "Claude Code", "claude"),
-        (AgentKind::CODEX, "Codex", "codex"),
-        (AgentKind::CURSOR, "Cursor", "cursor-agent"),
-        (AgentKind::GEMINI, "Gemini", "gemini"),
-    ]
-    .into_iter()
-    .map(|(kind, display_name, binary)| AgentOption {
-        kind,
-        display_name: display_name.to_owned(),
-        binary: binary.to_owned(),
-        available: true,
-        show_in_quick_create: true,
-        first_class: true,
-        setup_url: None,
-        install_hint: format!("Install {binary} and add it to PATH."),
-        sign_in_hint: None,
-    })
-    .collect()
 }
 
 fn terminal_option() -> AgentOption {
@@ -406,6 +421,69 @@ mod tests {
     }
 
     #[test]
+    fn an_empty_catalog_never_invents_installed_agents() {
+        let catalog = AgentReadinessResult::default();
+
+        assert!(agent_options(&catalog).is_empty());
+        assert_eq!(
+            quick_agent_options(Some(&catalog))
+                .into_iter()
+                .map(|option| option.kind)
+                .collect::<Vec<_>>(),
+            vec![AgentKind::SHELL]
+        );
+    }
+
+    #[test]
+    fn settings_groups_installed_agents_first_without_name_sorting() {
+        let items = vec![
+            item("zebra-missing", false, false),
+            item("zulu-installed", true, false),
+            item("alpha-missing", false, false),
+            item("beta-installed", true, false),
+        ];
+
+        assert_eq!(
+            settings_agent_items(items)
+                .into_iter()
+                .map(|item| item.kind)
+                .collect::<Vec<_>>(),
+            vec![
+                AgentKind::new("zulu-installed"),
+                AgentKind::new("beta-installed"),
+                AgentKind::new("zebra-missing"),
+                AgentKind::new("alpha-missing"),
+            ]
+        );
+    }
+
+    #[test]
+    fn target_default_uses_only_that_targets_readiness() {
+        let mut hidden = item("hidden", true, false);
+        hidden.show_in_quick_create = false;
+        let mut visible = item("visible", true, false);
+        visible.show_in_quick_create = true;
+        let unavailable = item("saved", false, true);
+        let catalog = AgentReadinessResult {
+            agents: vec![unavailable, visible, hidden],
+            ..AgentReadinessResult::default()
+        };
+
+        assert_eq!(
+            resolved_target_agent(&AgentKind::new("saved"), Some(&catalog)),
+            AgentKind::new("visible")
+        );
+        assert_eq!(
+            resolved_target_agent(&AgentKind::new("hidden"), Some(&catalog)),
+            AgentKind::new("hidden")
+        );
+        assert_eq!(
+            resolved_target_agent(&AgentKind::new("saved"), None),
+            AgentKind::SHELL
+        );
+    }
+
+    #[test]
     fn quick_create_visibility_never_vetoes_an_explicit_spawn() {
         // Installed but hidden from quick create: the saved default's ⌘T must
         // still spawn it — menu visibility is not availability.
@@ -417,9 +495,8 @@ mod tests {
         };
         assert!(kind_spawnable(&AgentKind::CODEX, Some(&catalog)));
         assert!(!kind_spawnable(&AgentKind::new("absent"), Some(&catalog)));
-        // An unfetched catalog means unknown, not unavailable: the daemon's
-        // spawn-time check is the authority. Terminals are never vetoed.
-        assert!(kind_spawnable(&AgentKind::CLAUDE_CODE, None));
+        // Missing readiness facts fail closed. Terminals are always safe.
+        assert!(!kind_spawnable(&AgentKind::CLAUDE_CODE, None));
         assert!(kind_spawnable(&AgentKind::SHELL, Some(&catalog)));
     }
 

--- a/diri/crates/diri-app/src/launcher.rs
+++ b/diri/crates/diri-app/src/launcher.rs
@@ -201,13 +201,12 @@ impl LauncherOverlay {
     }
 
     /// Keeps a saved default preference intact while making this invocation
-    /// usable on a target where that Agent is absent. It runs only after a
-    /// catalog exists, so an in-flight remote scan never causes a false
-    /// fallback or visual jump; and it judges by installed state, not quick
-    /// create visibility, so a hidden-but-installed default is not switched
-    /// away from.
+    /// usable on a target where that Agent is absent. Missing readiness facts
+    /// fail closed to the Terminal choice; and installed state, rather than
+    /// quick-create visibility, keeps a hidden-but-installed explicit default
+    /// valid.
     fn reconcile_harness(&mut self) {
-        let spawnable = {
+        let (spawnable, catalog_known) = {
             let store = self
                 .services
                 .store
@@ -215,10 +214,10 @@ impl LauncherOverlay {
                 .read()
                 .expect("session store lock poisoned");
             let catalog = store.agent_catalog(self.selected_host.as_deref());
-            if catalog.is_none() {
-                return;
-            }
-            crate::agent_catalog::kind_spawnable(&self.selected_harness, catalog)
+            (
+                crate::agent_catalog::kind_spawnable(&self.selected_harness, catalog),
+                catalog.is_some(),
+            )
         };
         if spawnable {
             return;
@@ -229,10 +228,12 @@ impl LauncherOverlay {
         };
         let unavailable = title_case_id(self.selected_harness.id());
         self.selected_harness = first.kind.clone();
-        self.fallback_notice = Some(format!(
-            "{unavailable} is unavailable here; using {}",
-            first.display_name
-        ));
+        self.fallback_notice = catalog_known.then(|| {
+            format!(
+                "{unavailable} is unavailable here; using {}",
+                first.display_name
+            )
+        });
     }
 
     fn projects(&self) -> Vec<LauncherProject> {
@@ -317,11 +318,6 @@ impl LauncherOverlay {
                 .read()
                 .expect("session store lock poisoned");
             let catalog = store.agent_catalog(self.selected_host.as_deref());
-            // No catalog means a scan is in flight or failed, not that the
-            // Agent is absent: submitting stays possible and the daemon's
-            // spawn-time check remains the authority. Claiming "not
-            // available" here would block ⌘↵ for the length of an SSH scan —
-            // or forever, when the scan errored.
             crate::agent_catalog::kind_spawnable(&self.selected_harness, catalog)
         };
         if spawnable {

--- a/diri/crates/diri-app/src/launcher.rs
+++ b/diri/crates/diri-app/src/launcher.rs
@@ -201,10 +201,15 @@ impl LauncherOverlay {
     }
 
     /// Keeps a saved default preference intact while making this invocation
-    /// usable on a target where that Agent is absent. Missing readiness facts
-    /// fail closed to the Terminal choice; and installed state, rather than
-    /// quick-create visibility, keeps a hidden-but-installed explicit default
-    /// valid.
+    /// usable on a target where that Agent is absent. It judges by installed
+    /// state, not quick-create visibility, so a hidden-but-installed default is
+    /// not switched away from.
+    ///
+    /// A target with no readiness facts yet is *unknown*, not empty, so the
+    /// selection is left alone: rewriting it to Terminal would silently discard
+    /// the user's Agent for the length of an SSH scan, and — because Terminal
+    /// is always spawnable — this would never run again to put it back.
+    /// `blocker` holds ⌘↵ until the scan answers instead.
     fn reconcile_harness(&mut self) {
         let (spawnable, catalog_known) = {
             let store = self
@@ -219,7 +224,7 @@ impl LauncherOverlay {
                 catalog.is_some(),
             )
         };
-        if spawnable {
+        if spawnable || !catalog_known {
             return;
         }
         let choices = self.harness_choices();
@@ -228,12 +233,10 @@ impl LauncherOverlay {
         };
         let unavailable = title_case_id(self.selected_harness.id());
         self.selected_harness = first.kind.clone();
-        self.fallback_notice = catalog_known.then(|| {
-            format!(
-                "{unavailable} is unavailable here; using {}",
-                first.display_name
-            )
-        });
+        self.fallback_notice = Some(format!(
+            "{unavailable} is unavailable here; using {}",
+            first.display_name
+        ));
     }
 
     fn projects(&self) -> Vec<LauncherProject> {
@@ -310,24 +313,43 @@ impl LauncherOverlay {
         if self.selected_root.is_empty() {
             return Some("Choose a project to start in".to_owned());
         }
-        let spawnable = {
+        let (spawnable, catalog_known, scan_error) = {
             let store = self
                 .services
                 .store
                 .store
                 .read()
                 .expect("session store lock poisoned");
-            let catalog = store.agent_catalog(self.selected_host.as_deref());
-            crate::agent_catalog::kind_spawnable(&self.selected_harness, catalog)
+            let host = self.selected_host.as_deref();
+            let catalog = store.agent_catalog(host);
+            (
+                crate::agent_catalog::kind_spawnable(&self.selected_harness, catalog),
+                catalog.is_some(),
+                store.agent_catalog_error(host).map(str::to_owned),
+            )
         };
         if spawnable {
-            None
-        } else {
-            Some(format!(
+            return None;
+        }
+        if catalog_known {
+            return Some(format!(
                 "{} is not available on this host",
                 self.selected_harness_label()
-            ))
+            ));
         }
+        // Readiness for this target has not answered yet, so submitting would
+        // spawn blind. Name the state rather than claiming absence — and leave
+        // the Agent menu usable, since picking Terminal explicitly stays a
+        // valid escape hatch when a scan cannot answer at all.
+        Some(scan_error.map_or_else(
+            || {
+                format!(
+                    "Checking whether {} is available here…",
+                    self.selected_harness_label()
+                )
+            },
+            |error| format!("Could not check Agents on this host: {error}"),
+        ))
     }
 
     fn can_submit(&self) -> bool {

--- a/diri/crates/diri-app/src/navigation.rs
+++ b/diri/crates/diri-app/src/navigation.rs
@@ -1,4 +1,6 @@
 use std::cmp::Ordering;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
@@ -94,6 +96,10 @@ pub struct NavigationOverlay {
     directory_index: DirectoryIndex,
     quick_snapshot: QuickOpenSnapshot,
     ranked_items: Vec<RankedFolder>,
+    /// Identity of the readiness facts `ranked_actions` was built from, so a
+    /// store change that cannot have altered the Agent rows does not rebuild
+    /// them. See `agent_actions_fingerprint`.
+    agent_actions_fingerprint: u64,
     scroll_handle: ScrollHandle,
     /// Separate slots: the disk-cache load and the filesystem scan both start
     /// at launch, and neither may cancel the other by sharing a `Task` slot.
@@ -139,6 +145,7 @@ impl NavigationOverlay {
             directory_index: DirectoryIndex::default(),
             quick_snapshot: QuickOpenSnapshot::default(),
             ranked_items: Vec::new(),
+            agent_actions_fingerprint: 0,
             scroll_handle: ScrollHandle::new(),
             cache_task: None,
             scan_task: None,
@@ -168,6 +175,7 @@ impl NavigationOverlay {
             directory_index: DirectoryIndex::default(),
             quick_snapshot: QuickOpenSnapshot::default(),
             ranked_items: Vec::new(),
+            agent_actions_fingerprint: 0,
             scroll_handle: ScrollHandle::new(),
             cache_task: None,
             scan_task: None,
@@ -180,11 +188,55 @@ impl NavigationOverlay {
         self.overlay.is_some()
     }
 
+    /// Store changes broadcast on the UI publish tick, so an open palette gets
+    /// one of these several times a second while any session is producing
+    /// output. Rebuilding on each would take a write lock, clone every project
+    /// and session record, and re-rank the whole list — reordering rows under a
+    /// highlight index that is not re-anchored. Only readiness can change the
+    /// Agent rows this handler exists for, so gate on exactly that.
     fn handle_store_change(&mut self, cx: &mut Context<Self>) {
         if self.overlay == Some(Overlay::CommandPalette) {
-            self.refresh_command_items();
+            let fingerprint = {
+                let store = self.store.read().expect("session store lock poisoned");
+                agent_actions_fingerprint(&store)
+            };
+            if fingerprint != self.agent_actions_fingerprint {
+                let highlighted = self.highlighted_command();
+                self.refresh_command_items();
+                self.restore_highlight(highlighted.as_ref());
+            }
         }
         cx.notify();
+    }
+
+    /// The row the user is on, so a rebuild can put the highlight back on it
+    /// rather than on whatever inherits its index.
+    fn highlighted_command(&self) -> Option<CommandSelection> {
+        self.ranked_actions.get(self.highlight).map_or_else(
+            || {
+                self.ranked_sessions
+                    .get(self.highlight.saturating_sub(self.ranked_actions.len()))
+                    .map(|ranked| CommandSelection::Session(ranked.item.id.clone()))
+            },
+            |action| Some(CommandSelection::Action(action.item.command.clone())),
+        )
+    }
+
+    fn restore_highlight(&mut self, previous: Option<&CommandSelection>) {
+        let found = match previous {
+            Some(CommandSelection::Action(command)) => self
+                .ranked_actions
+                .iter()
+                .position(|ranked| ranked.item.command == *command),
+            Some(CommandSelection::Session(id)) => self
+                .ranked_sessions
+                .iter()
+                .position(|ranked| ranked.item.id == *id)
+                .map(|index| index + self.ranked_actions.len()),
+            None => None,
+        };
+        let count = self.ranked_actions.len() + self.ranked_sessions.len();
+        self.highlight = found.unwrap_or(self.highlight).min(count.saturating_sub(1));
     }
 
     pub(crate) fn toggle_command_palette(
@@ -579,11 +631,6 @@ impl NavigationOverlay {
                 }
                 self.close_overlay(cx);
             }
-            PaletteCommand::UnavailableAgent { setup_url } => {
-                if let Some(url) = setup_url {
-                    cx.open_url(&url);
-                }
-            }
             PaletteCommand::MigrateSelected { target_host } => {
                 {
                     let mut store = self.store.write().expect("session store lock poisoned");
@@ -607,7 +654,7 @@ impl NavigationOverlay {
     /// to run on every keystroke — a few hundred candidates against one
     /// matcher — and never run per frame.
     fn refresh_command_items(&mut self) {
-        let (actions, sessions) = {
+        let (actions, sessions, fingerprint) = {
             let mut store = self.store.write().expect("session store lock poisoned");
             let projects: Vec<_> = store
                 .sidebar_projection()
@@ -629,8 +676,10 @@ impl NavigationOverlay {
                 default_host.as_deref(),
                 store.agent_catalogs(),
             );
-            (actions, store.ordered_sessions())
+            let fingerprint = agent_actions_fingerprint(&store);
+            (actions, store.ordered_sessions(), fingerprint)
         };
+        self.agent_actions_fingerprint = fingerprint;
         let query = FuzzyQuery::new(self.query.text());
         self.ranked_actions = palette::rank_actions(actions, &query, &mut self.matcher);
         self.ranked_sessions = palette::rank_sessions(sessions, &query, &mut self.matcher);
@@ -1239,6 +1288,27 @@ fn kind_label(kind: &AgentKind) -> String {
     }
 }
 
+/// Identity of everything the palette's Agent rows are derived from: the saved
+/// default, the target it spawns on, and each target's readiness facts. Session
+/// and project churn is deliberately excluded — it moves on every UI tick and
+/// cannot change which Agents a target can launch.
+fn agent_actions_fingerprint(store: &SessionStore) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    store.preferences().default_agent.id().hash(&mut hasher);
+    store.default_spawn_host().hash(&mut hasher);
+    let mut targets: Vec<_> = store.agent_catalogs().iter().collect();
+    targets.sort_by_key(|(target, _)| *target);
+    for (target, catalog) in targets {
+        target.hash(&mut hasher);
+        for agent in &catalog.agents {
+            agent.kind.id().hash(&mut hasher);
+            agent.available().hash(&mut hasher);
+            agent.show_in_quick_create.hash(&mut hasher);
+        }
+    }
+    hasher.finish()
+}
+
 fn relative_parent(path: &Path) -> String {
     let Some(parent) = path.parent() else {
         return String::new();
@@ -1336,9 +1406,7 @@ mod tests {
     }
 
     #[gpui::test]
-    fn open_palette_rebuilds_terminal_fallback_when_agent_readiness_arrives(
-        cx: &mut TestAppContext,
-    ) {
+    fn an_open_palette_rebuilds_its_agent_rows_when_readiness_arrives(cx: &mut TestAppContext) {
         let runtime = Arc::new(StoreRuntime::inert());
         {
             let mut store = runtime.store.write().expect("session store lock poisoned");
@@ -1358,12 +1426,30 @@ mod tests {
             overlay
         });
 
+        // Forge has not been scanned, so no Agent is advertised as launchable
+        // there — but ⌘T still belongs to the saved preference.
         assert!(overlay.read_with(cx, |overlay, _| {
             overlay.ranked_actions.iter().any(|ranked| {
-                ranked.item.title == "New Terminal on Forge"
+                ranked.item.title == "New Claude Code on Forge"
                     && ranked.item.command == PaletteCommand::Action(CommandId::NewDefaultSession)
             })
         }));
+
+        // A store change that cannot have moved readiness must not rebuild the
+        // list: these arrive on the UI tick, and re-ranking under a fixed
+        // highlight index moves rows out from under the user's selection.
+        let before = overlay.read_with(cx, |overlay, _| overlay.agent_actions_fingerprint);
+        overlay.update(cx, |overlay, cx| {
+            overlay.highlight = 1;
+            overlay.handle_store_change(cx);
+        });
+        assert_eq!(
+            overlay.read_with(cx, |overlay, _| (
+                overlay.agent_actions_fingerprint,
+                overlay.highlight
+            )),
+            (before, 1)
+        );
 
         runtime
             .store

--- a/diri/crates/diri-app/src/navigation.rs
+++ b/diri/crates/diri-app/src/navigation.rs
@@ -101,8 +101,8 @@ pub struct NavigationOverlay {
     scan_task: Option<Task<()>>,
     rank_task: Option<Task<()>>,
     /// This view is `.cached()` in RootView, so ambient window redraws no
-    /// longer reach it: store changes must notify it directly, or an open
-    /// palette's session rows go stale.
+    /// longer reach it: store changes must rebuild an open command palette and
+    /// notify it directly, or its catalog actions and session rows go stale.
     _store_changes: Option<Task<()>>,
 }
 
@@ -115,7 +115,10 @@ impl NavigationOverlay {
             loop {
                 match changes.recv().await {
                     Ok(()) | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
-                        if this.update(cx, |_, cx| cx.notify()).is_err() {
+                        if this
+                            .update(cx, |this, cx| this.handle_store_change(cx))
+                            .is_err()
+                        {
                             return;
                         }
                     }
@@ -175,6 +178,13 @@ impl NavigationOverlay {
 
     pub fn is_open(&self) -> bool {
         self.overlay.is_some()
+    }
+
+    fn handle_store_change(&mut self, cx: &mut Context<Self>) {
+        if self.overlay == Some(Overlay::CommandPalette) {
+            self.refresh_command_items();
+        }
+        cx.notify();
     }
 
     pub(crate) fn toggle_command_palette(
@@ -1254,6 +1264,10 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
+    use crate::commands::CommandId;
+    use diri_proto::{
+        AgentDescriptor, AgentPathSource, AgentReadinessItem, AgentReadinessResult, HostEntry,
+    };
     use gpui::{Entity, ScrollDelta, ScrollWheelEvent, TestAppContext, point};
 
     #[test]
@@ -1319,6 +1333,77 @@ mod tests {
         assert!(cramped.top_inset < px(180.0 / 12.0));
         assert_eq!(cramped.list_height, px(MIN_LIST_HEIGHT));
         assert_eq!(layout(800.0, 150.0).top_inset, px(MIN_TOP_INSET));
+    }
+
+    #[gpui::test]
+    fn open_palette_rebuilds_terminal_fallback_when_agent_readiness_arrives(
+        cx: &mut TestAppContext,
+    ) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        {
+            let mut store = runtime.store.write().expect("session store lock poisoned");
+            store.set_hosts(vec![HostEntry {
+                id: "forge".into(),
+                name: Some("Forge".into()),
+                ssh: "forge.example".into(),
+                default_cwd: None,
+                node: None,
+            }]);
+            store.set_default_spawn_host(Some("forge".into()));
+        }
+        let runtime_for_view = Arc::clone(&runtime);
+        let (overlay, cx) = cx.add_window_view(move |_window, cx| {
+            let mut overlay = NavigationOverlay::opened_for_test(runtime_for_view, cx);
+            overlay.refresh_command_items();
+            overlay
+        });
+
+        assert!(overlay.read_with(cx, |overlay, _| {
+            overlay.ranked_actions.iter().any(|ranked| {
+                ranked.item.title == "New Terminal on Forge"
+                    && ranked.item.command == PaletteCommand::Action(CommandId::NewDefaultSession)
+            })
+        }));
+
+        runtime
+            .store
+            .write()
+            .expect("session store lock poisoned")
+            .set_agent_catalog(AgentReadinessResult {
+                host: Some("forge".into()),
+                agents: vec![AgentReadinessItem {
+                    kind: AgentKind::CODEX,
+                    binary: "codex".into(),
+                    path: Some("/usr/bin/codex".into()),
+                    detected_path: Some("/usr/bin/codex".into()),
+                    path_source: Some(AgentPathSource::SystemPath),
+                    show_in_quick_create: true,
+                    descriptor: Some(AgentDescriptor {
+                        id: AgentKind::CODEX_ID.into(),
+                        display_name: "Codex".into(),
+                        first_class: true,
+                        ..AgentDescriptor::default()
+                    }),
+                    ..AgentReadinessItem::default()
+                }],
+                ..AgentReadinessResult::default()
+            });
+        overlay.update(cx, |overlay, cx| overlay.handle_store_change(cx));
+
+        assert!(overlay.read_with(cx, |overlay, _| {
+            !overlay.ranked_actions.iter().any(|ranked| {
+                ranked.item.title == "New Terminal on Forge"
+                    && ranked.item.command == PaletteCommand::Action(CommandId::NewDefaultSession)
+            }) && overlay.ranked_actions.iter().any(|ranked| {
+                ranked.item.title == "New Codex on Forge"
+                    && ranked.item.command
+                        == PaletteCommand::SpawnAgent {
+                            agent: AgentKind::CODEX,
+                            cwd: None,
+                            host: Some("forge".into()),
+                        }
+            })
+        }));
     }
 
     struct WheelHarness {

--- a/diri/crates/diri-app/src/palette.rs
+++ b/diri/crates/diri-app/src/palette.rs
@@ -11,7 +11,7 @@ use diri_proto::{AgentKind, AgentReadinessResult, HostEntry, Project, SessionRec
 
 use crate::agent_catalog::{
     AgentOption, display_name, quick_agent_options, resolved_default_agent, resolved_target_agent,
-    system_image,
+    system_image, title_case_id,
 };
 use crate::commands::{self, CommandId};
 use crate::fuzzy::{FuzzyMatcher, FuzzyQuery, PreparedText, Score};
@@ -28,9 +28,6 @@ pub enum PaletteCommand {
         /// host's defaultCwd unless overridden).
         host: Option<String>,
     },
-    /// An unavailable local Agent row. A verified HTTP(S) setup URL is opened
-    /// on activation; without one the containing action is disabled.
-    UnavailableAgent { setup_url: Option<String> },
     /// `session.migrate` the SELECTED session; None = back to local.
     MigrateSelected { target_host: Option<String> },
     /// `host.sync_prefs` to one configured host.
@@ -82,11 +79,13 @@ pub fn actions_for_catalogs(
     let default_catalog = catalog(default_host_id);
     let target_default = resolved_target_agent(&default_agent, default_catalog);
     let default_agents = quick_agent_options(default_catalog);
+    let mut default_is_listed = false;
     for agent in default_agents {
         if agent.kind == AgentKind::SHELL {
             continue;
         }
         let is_default = agent.kind == target_default;
+        default_is_listed |= is_default;
         result.push(new_dynamic_agent_action(
             agent.kind,
             agent.display_name,
@@ -99,8 +98,41 @@ pub fn actions_for_catalogs(
         || "New Terminal".to_owned(),
         |host| format!("New Terminal on {}", host.display_name()),
     );
-    if target_default == AgentKind::SHELL {
-        result.push(default_action(terminal_title.clone(), "terminal"));
+    // ⌘T needs exactly one row, and it must describe what ⌘T will actually do.
+    // The quick-create loop above carries the badge whenever it lists the
+    // resolved Agent; it cannot when that Agent is hidden from quick create,
+    // when resolution lands on Terminal, or when this target has no readiness
+    // facts at all. In that last case the shortcut still belongs to the saved
+    // preference — it resolves against real facts, or opens the launcher, at
+    // press time — so labelling the row "Terminal" would promise a session the
+    // user never chose.
+    if !default_is_listed {
+        let pending = default_catalog.is_none();
+        let kind = if pending {
+            default_agent.clone()
+        } else {
+            target_default.clone()
+        };
+        if kind.is_terminal() {
+            result.push(default_action(
+                terminal_title.clone(),
+                "terminal",
+                "shell console zsh bash tty default",
+            ));
+        } else {
+            let name = default_catalog.map_or_else(
+                || title_case_id(kind.id()),
+                |catalog| display_name(&kind, catalog),
+            );
+            result.push(default_action(
+                default_host.map_or_else(
+                    || format!("New {name} Session"),
+                    |host| format!("New {name} on {}", host.display_name()),
+                ),
+                system_image(&kind),
+                &format!("{} agent spawn start create default", kind.id()),
+            ));
+        }
     }
     result.extend([
         registered_action_with_title(CommandId::NewTerminal, terminal_title),
@@ -264,9 +296,25 @@ pub fn actions_for_default_host(
     let options = quick_agent_options(Some(catalog));
     let mut result = Vec::new();
     if default_agent == AgentKind::SHELL {
-        result.push(default_action("New Terminal".into(), "terminal"));
+        result.push(default_action(
+            "New Terminal".into(),
+            "terminal",
+            "shell console zsh bash tty default",
+        ));
     } else if let Some(option) = options.iter().find(|option| option.kind == default_agent) {
         result.push(new_agent_action(option, true, default_host));
+    } else {
+        // Installed, so still what ⌘T launches, but hidden from quick create —
+        // menu visibility must not leave the shortcut without a row.
+        let name = display_name(&default_agent, catalog);
+        result.push(default_action(
+            default_host.map_or_else(
+                || format!("New {name} Session"),
+                |host| format!("New {name} on {}", host.display_name()),
+            ),
+            system_image(&default_agent),
+            &format!("{} agent spawn start create default", default_agent.id()),
+        ));
     }
     result.extend(
         options
@@ -412,7 +460,7 @@ fn registered_action_with_title(id: CommandId, title: String) -> PaletteAction {
     }
 }
 
-fn default_action(title: String, system_image: &'static str) -> PaletteAction {
+fn default_action(title: String, system_image: &'static str, keywords: &str) -> PaletteAction {
     let command = commands::command(CommandId::NewDefaultSession);
     PaletteAction {
         id: command.stable_id.into(),
@@ -422,16 +470,18 @@ fn default_action(title: String, system_image: &'static str) -> PaletteAction {
         detail: None,
         enabled: true,
         command: PaletteCommand::Action(CommandId::NewDefaultSession),
-        keywords: "shell console zsh bash tty default".into(),
+        keywords: keywords.into(),
     }
 }
 
+/// Builds a row for an Agent the target's readiness reports as installed.
+/// Callers pass `quick_agent_options` output, so unavailable Agents never reach
+/// here — Settings is the one surface that lists them, with their setup links.
 fn new_agent_action(
     option: &AgentOption,
     is_default: bool,
     host: Option<&HostEntry>,
 ) -> PaletteAction {
-    let available = host.is_some() || option.available;
     let registered = is_default.then_some(CommandId::NewDefaultSession);
     PaletteAction {
         id: if is_default {
@@ -444,28 +494,21 @@ fn new_agent_action(
             |host| format!("New {} on {}", option.display_name, host.display_name()),
         ),
         system_image: system_image(&option.kind),
-        shortcut: available.then_some(()).and_then(|()| {
-            registered
-                .or((option.kind == AgentKind::CODEX).then_some(CommandId::NewCodexSession))
-                .and_then(|id| commands::command(id).shortcut)
-        }),
-        detail: (!available).then(|| option.unavailable_detail()).flatten(),
-        enabled: available || option.setup_url.is_some(),
-        command: if !available {
-            PaletteCommand::UnavailableAgent {
-                setup_url: option.setup_url.clone(),
-            }
-        } else if let Some(id) = registered {
-            PaletteCommand::Action(id)
-        } else {
-            PaletteCommand::SpawnAgent {
+        shortcut: registered
+            .or((option.kind == AgentKind::CODEX).then_some(CommandId::NewCodexSession))
+            .and_then(|id| commands::command(id).shortcut),
+        detail: None,
+        enabled: true,
+        command: registered.map_or_else(
+            || PaletteCommand::SpawnAgent {
                 agent: option.kind.clone(),
                 cwd: None,
                 host: host.map(|host| host.id.clone()),
-            }
-        },
+            },
+            PaletteCommand::Action,
+        ),
         keywords: format!(
-            "{} {} agent spawn start create tab setup install",
+            "{} {} agent spawn start create tab",
             option.kind.id(),
             option.binary
         ),
@@ -800,7 +843,7 @@ mod tests {
     }
 
     #[test]
-    fn an_unscanned_default_target_exposes_terminal_as_the_safe_default() {
+    fn an_unscanned_default_target_keeps_the_shortcut_on_the_saved_preference() {
         let host = HostEntry {
             id: "forge".into(),
             name: Some("Forge".into()),
@@ -809,7 +852,7 @@ mod tests {
             node: None,
         };
         let actions = actions_for_catalogs(
-            AgentKind::new("unavailable-agent"),
+            AgentKind::new("saved-agent"),
             &[],
             std::slice::from_ref(&host),
             None,
@@ -817,21 +860,49 @@ mod tests {
             &HashMap::new(),
         );
 
+        // Forge has never been scanned, so no Agent may be advertised as
+        // launchable there. ⌘T still belongs to the saved preference — it
+        // resolves against real facts, or opens the launcher, at press time —
+        // so the row must name it rather than promise an unrequested Terminal.
         let default = actions
             .iter()
             .find(|action| action.id == "new-default")
-            .expect("safe default action");
-        assert_eq!(default.title, "New Terminal on Forge");
+            .expect("default action");
+        assert_eq!(default.title, "New Saved Agent on Forge");
         assert_eq!(default.shortcut, Some("⌘T"));
         assert_eq!(
             default.command,
             PaletteCommand::Action(CommandId::NewDefaultSession)
         );
         assert!(
-            !actions
-                .iter()
-                .any(|action| action.id.contains("unavailable-agent"))
+            !actions.iter().any(|action| matches!(
+                &action.command,
+                PaletteCommand::SpawnAgent { agent, .. } if !agent.is_terminal()
+            )),
+            "an unscanned target must not advertise a direct Agent spawn"
         );
+    }
+
+    #[test]
+    fn a_default_hidden_from_quick_create_still_owns_the_shortcut() {
+        // Installed, so ⌘T launches it, but toggled out of the quick-create
+        // menus in Settings. Menu visibility must not leave the shortcut
+        // without any row to sit on.
+        let mut hidden = catalog_item("codex", "Codex", true, None, None);
+        hidden.show_in_quick_create = false;
+        let catalog = AgentReadinessResult {
+            agents: vec![hidden, catalog_item("amp", "Amp", true, None, None)],
+            ..AgentReadinessResult::default()
+        };
+
+        let actions = actions(AgentKind::CODEX, &catalog, &[], &[], None);
+
+        let default = actions
+            .iter()
+            .find(|action| action.id == "new-default")
+            .expect("default action");
+        assert_eq!(default.title, "New Codex Session");
+        assert_eq!(default.shortcut, Some("⌘T"));
     }
 
     #[test]

--- a/diri/crates/diri-app/src/palette.rs
+++ b/diri/crates/diri-app/src/palette.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use diri_proto::{AgentKind, AgentReadinessResult, HostEntry, Project, SessionRecord};
 
 use crate::agent_catalog::{
-    AgentOption, agent_options, display_name, quick_agent_options, resolved_default_agent,
+    AgentOption, display_name, quick_agent_options, resolved_default_agent, resolved_target_agent,
     system_image,
 };
 use crate::commands::{self, CommandId};
@@ -71,28 +71,22 @@ pub fn actions_for_catalogs(
     default_host_id: Option<&str>,
     catalogs: &HashMap<String, AgentReadinessResult>,
 ) -> Vec<PaletteAction> {
-    // Only the default target's catalog is warmed at connect. A host whose
-    // scan has not run yet must not lose its rows to that accident of timing —
-    // fall back to the local catalog as the optimistic guess, the way these
-    // actions were built before per-host catalogs; spawn-time discovery on
-    // the host stays the authority.
-    let catalog = |host: Option<&str>| {
-        catalogs
-            .get(host.unwrap_or("local"))
-            .or_else(|| catalogs.get("local"))
-    };
+    // Readiness is target-specific. Missing remote facts must not inherit the
+    // local machine's PATH: that would advertise Agents the remote cannot
+    // launch. `quick_agent_options(None)` deliberately leaves only Terminal
+    // until that target's scan completes.
+    let catalog = |host: Option<&str>| catalogs.get(host.unwrap_or("local"));
     let default_host = default_host_id.and_then(|id| hosts.iter().find(|host| host.id == id));
     let default_host_id = default_host.map(|host| host.id.as_str());
     let mut result = Vec::new();
-    let default_agents = quick_agent_options(catalog(default_host_id));
-    let has_default = default_agents
-        .iter()
-        .any(|agent| agent.kind == default_agent);
-    for (index, agent) in default_agents.into_iter().enumerate() {
+    let default_catalog = catalog(default_host_id);
+    let target_default = resolved_target_agent(&default_agent, default_catalog);
+    let default_agents = quick_agent_options(default_catalog);
+    for agent in default_agents {
         if agent.kind == AgentKind::SHELL {
             continue;
         }
-        let is_default = agent.kind == default_agent || (index == 0 && !has_default);
+        let is_default = agent.kind == target_default;
         result.push(new_dynamic_agent_action(
             agent.kind,
             agent.display_name,
@@ -105,6 +99,9 @@ pub fn actions_for_catalogs(
         || "New Terminal".to_owned(),
         |host| format!("New Terminal on {}", host.display_name()),
     );
+    if target_default == AgentKind::SHELL {
+        result.push(default_action(terminal_title.clone(), "terminal"));
+    }
     result.extend([
         registered_action_with_title(CommandId::NewTerminal, terminal_title),
         registered_action(CommandId::ToggleQuickOpen),
@@ -264,7 +261,7 @@ pub fn actions_for_default_host(
 ) -> Vec<PaletteAction> {
     let default_host = default_host_id.and_then(|id| hosts.iter().find(|host| host.id == id));
     let default_agent = resolved_default_agent(&default_agent, catalog);
-    let options = agent_options(catalog);
+    let options = quick_agent_options(Some(catalog));
     let mut result = Vec::new();
     if default_agent == AgentKind::SHELL {
         result.push(default_action("New Terminal".into(), "terminal"));
@@ -604,7 +601,15 @@ mod tests {
     use super::*;
 
     fn catalog() -> AgentReadinessResult {
-        AgentReadinessResult::default()
+        AgentReadinessResult {
+            agents: vec![
+                installed_agent("claude-code", "Claude Code", true),
+                installed_agent("codex", "Codex", true),
+                installed_agent("cursor", "Cursor", true),
+                installed_agent("gemini", "Gemini", true),
+            ],
+            ..AgentReadinessResult::default()
+        }
     }
 
     fn catalog_item(
@@ -681,7 +686,7 @@ mod tests {
     }
 
     #[test]
-    fn unavailable_catalog_action_uses_shared_missing_binary_and_safe_setup() {
+    fn unavailable_catalog_agent_is_not_a_quick_palette_action() {
         let catalog = AgentReadinessResult {
             agents: vec![catalog_item(
                 "amp",
@@ -693,43 +698,17 @@ mod tests {
             ..AgentReadinessResult::default()
         };
         let actions = actions(AgentKind::new("amp"), &catalog, &[], &[], None);
-        let amp = actions
-            .iter()
-            .find(|action| action.id == "new-amp")
-            .expect("unavailable Amp row");
-        assert_eq!(
-            amp.detail.as_deref(),
-            Some("Missing amp-bin · Install Amp. · Sign in at ampcode.com, then run amp.")
-        );
-        assert!(amp.enabled);
-        assert_eq!(
-            amp.command,
-            PaletteCommand::UnavailableAgent {
-                setup_url: Some("https://ampcode.com/manual".into())
-            }
-        );
+        assert!(!actions.iter().any(|action| action.id == "new-amp"));
     }
 
     #[test]
-    fn unavailable_action_without_setup_metadata_is_disabled_not_a_noop() {
+    fn unavailable_catalog_agent_without_setup_is_not_a_quick_palette_action() {
         let catalog = AgentReadinessResult {
             agents: vec![catalog_item("private", "Private", false, None, None)],
             ..AgentReadinessResult::default()
         };
         let actions = actions(AgentKind::new("private"), &catalog, &[], &[], None);
-        let private = actions
-            .iter()
-            .find(|action| action.id == "new-private")
-            .expect("unavailable informational row");
-        assert!(!private.enabled);
-        assert_eq!(
-            private.detail.as_deref(),
-            Some("Missing private-bin · Install private-bin and add it to PATH.")
-        );
-        assert_eq!(
-            private.command,
-            PaletteCommand::UnavailableAgent { setup_url: None }
-        );
+        assert!(!actions.iter().any(|action| action.id == "new-private"));
     }
 
     #[test]
@@ -770,7 +749,7 @@ mod tests {
     }
 
     #[test]
-    fn a_host_whose_catalog_has_not_been_fetched_keeps_its_actions() {
+    fn a_host_whose_catalog_has_not_been_fetched_does_not_borrow_local_actions() {
         let host = HostEntry {
             id: "forge".into(),
             name: Some("Forge".into()),
@@ -779,8 +758,8 @@ mod tests {
             node: None,
         };
         // Only the local catalog is warmed at connect; forge has never been
-        // scanned. Its rows fall back to the local catalog instead of
-        // silently vanishing until some surface happens to trigger a scan.
+        // scanned. Local availability says nothing about the remote target,
+        // so Forge must not claim that Codex can be launched there.
         let catalogs = HashMap::from([(
             "local".to_owned(),
             AgentReadinessResult {
@@ -805,7 +784,7 @@ mod tests {
             None,
             &catalogs,
         );
-        assert!(actions.iter().any(|action| {
+        assert!(!actions.iter().any(|action| {
             action.command
                 == PaletteCommand::SpawnAgent {
                     agent: AgentKind::new("codex"),
@@ -816,7 +795,42 @@ mod tests {
         assert!(
             actions
                 .iter()
-                .any(|action| action.title == "New Codex in app on Forge")
+                .all(|action| action.title != "New Codex in app on Forge")
+        );
+    }
+
+    #[test]
+    fn an_unscanned_default_target_exposes_terminal_as_the_safe_default() {
+        let host = HostEntry {
+            id: "forge".into(),
+            name: Some("Forge".into()),
+            ssh: "forge".into(),
+            default_cwd: None,
+            node: None,
+        };
+        let actions = actions_for_catalogs(
+            AgentKind::new("unavailable-agent"),
+            &[],
+            std::slice::from_ref(&host),
+            None,
+            Some("forge"),
+            &HashMap::new(),
+        );
+
+        let default = actions
+            .iter()
+            .find(|action| action.id == "new-default")
+            .expect("safe default action");
+        assert_eq!(default.title, "New Terminal on Forge");
+        assert_eq!(default.shortcut, Some("⌘T"));
+        assert_eq!(
+            default.command,
+            PaletteCommand::Action(CommandId::NewDefaultSession)
+        );
+        assert!(
+            !actions
+                .iter()
+                .any(|action| action.id.contains("unavailable-agent"))
         );
     }
 

--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -797,8 +797,7 @@ impl RootView {
         store.spawn_default(SpawnOptions {
             host,
             ..SpawnOptions::default()
-        });
-        true
+        })
     }
 
     fn open_auxiliary_terminal(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {

--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -794,18 +794,10 @@ impl RootView {
             .write()
             .expect("session store lock poisoned");
         let host = store.default_spawn_host();
-        let kind = store.preferences().default_agent.clone();
-        if !crate::agent_catalog::kind_spawnable(&kind, store.agent_catalog(host.as_deref())) {
-            store.request_agent_catalog(host, false);
-            return false;
-        }
-        store.spawn_kind(
-            kind,
-            SpawnOptions {
-                host,
-                ..SpawnOptions::default()
-            },
-        );
+        store.spawn_default(SpawnOptions {
+            host,
+            ..SpawnOptions::default()
+        });
         true
     }
 

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -514,13 +514,19 @@ impl Sidebar {
             let store = self.store.read().expect("session store lock poisoned");
             let host = store.default_spawn_host();
             let catalog = store.agent_catalog(host.as_deref());
-            let kind = crate::agent_catalog::resolved_target_agent(
-                &store.preferences().default_agent,
-                catalog,
-            );
+            // Without readiness facts the row names the saved preference: that
+            // is what this control will attempt, and resolution happens against
+            // real facts at press time. Naming Terminal here would advertise a
+            // session the user never chose.
             let agent = catalog.map_or_else(
-                || "Terminal".to_owned(),
-                |catalog| crate::agent_catalog::display_name(&kind, catalog),
+                || crate::agent_catalog::title_case_id(store.preferences().default_agent.id()),
+                |catalog| {
+                    let kind = crate::agent_catalog::resolved_target_agent(
+                        &store.preferences().default_agent,
+                        Some(catalog),
+                    );
+                    crate::agent_catalog::display_name(&kind, catalog)
+                },
             );
             let location =
                 host.map_or_else(|| "This Mac".to_owned(), |id| store.host_display_name(&id));

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -512,15 +512,18 @@ impl Sidebar {
         let hovering = self.ui.hovered_control == Some("new-agent");
         let (agent, location) = {
             let store = self.store.read().expect("session store lock poisoned");
-            let agent = store.agent_catalog(None).map_or_else(
-                || crate::agent_catalog::title_case_id(store.preferences().default_agent.id()),
-                |catalog| {
-                    crate::agent_catalog::display_name(&store.preferences().default_agent, catalog)
-                },
+            let host = store.default_spawn_host();
+            let catalog = store.agent_catalog(host.as_deref());
+            let kind = crate::agent_catalog::resolved_target_agent(
+                &store.preferences().default_agent,
+                catalog,
             );
-            let location = store
-                .default_spawn_host()
-                .map_or_else(|| "This Mac".to_owned(), |id| store.host_display_name(&id));
+            let agent = catalog.map_or_else(
+                || "Terminal".to_owned(),
+                |catalog| crate::agent_catalog::display_name(&kind, catalog),
+            );
+            let location =
+                host.map_or_else(|| "This Mac".to_owned(), |id| store.host_display_name(&id));
             (agent, location)
         };
         div()
@@ -1834,7 +1837,10 @@ impl Sidebar {
                 directory
                     .clone()
                     .unwrap_or_else(|| store.default_new_agent_directory()),
-                store.preferences().default_agent.clone(),
+                crate::agent_catalog::resolved_target_agent(
+                    &store.preferences().default_agent,
+                    store.agent_catalog(host.as_deref()),
+                ),
                 store.hosts().to_vec(),
                 store.selected_session().cloned(),
                 store.repo_target(selected_host_id).cloned(),
@@ -2183,7 +2189,7 @@ impl Sidebar {
             let shortcut = shortcut.to_owned();
             let agent_kind = ui_agent_kind(&option.kind);
             let spawn_kind = option.kind.clone();
-            let available = selected_host.is_some() || option.available;
+            let available = option.available;
             let unavailable = (!available).then_some(option.unavailable_detail).flatten();
             let setup_url = (!available).then_some(option.setup_url).flatten();
             content = content.child(

--- a/diri/crates/diri-app/src/store/mod.rs
+++ b/diri/crates/diri-app/src/store/mod.rs
@@ -1928,7 +1928,12 @@ impl SessionStore {
         if options.host.is_none() && options.cwd.is_none() && options.same_repo_as.is_none() {
             options.host = self.default_spawn_host();
         }
-        self.spawn_kind(self.prefs.default_agent.clone(), options);
+        let target_host = options.host.clone();
+        let kind = crate::agent_catalog::resolved_target_agent(
+            &self.prefs.default_agent,
+            self.agent_catalog(target_host.as_deref()),
+        );
+        self.spawn_kind(kind, options);
     }
 
     pub fn spawn_shell(&mut self, mut options: SpawnOptions) {

--- a/diri/crates/diri-app/src/store/mod.rs
+++ b/diri/crates/diri-app/src/store/mod.rs
@@ -1924,16 +1924,49 @@ impl SessionStore {
         self.emit(StoreEffect::ReopenLast);
     }
 
-    pub fn spawn_default(&mut self, mut options: SpawnOptions) {
+    /// Spawns the Agent this target resolves the saved default to. Returns
+    /// whether a session was actually requested.
+    ///
+    /// Missing readiness facts are not a licence to substitute a shell: a
+    /// remote catalog is warmed asynchronously after connect and a failed scan
+    /// is remembered, so resolving `None` to Terminal would silently launch
+    /// something the user never chose — potentially forever. The request is
+    /// declined instead, and the scan is (re)armed so the next press decides on
+    /// real facts. Callers that own a shortcut surface the refusal; `⌘T` opens
+    /// the launcher, where the choice is visible and editable.
+    pub fn spawn_default(&mut self, mut options: SpawnOptions) -> bool {
         if options.host.is_none() && options.cwd.is_none() && options.same_repo_as.is_none() {
             options.host = self.default_spawn_host();
         }
         let target_host = options.host.clone();
+        if self.agent_catalog(target_host.as_deref()).is_none() {
+            let target = target_host
+                .as_deref()
+                .map_or_else(|| "this Mac".to_owned(), |id| self.host_display_name(id));
+            // A recorded failure suppresses passive requests, so a shortcut
+            // press — an explicit user action — retries the way Settings'
+            // Refresh does. Otherwise it just joins the in-flight scan.
+            let failed = self.agent_catalog_error(target_host.as_deref());
+            let detail = failed.map_or_else(
+                || format!("Checking which Agents are installed on {target}."),
+                |error| format!("Could not check which Agents are installed on {target}: {error}"),
+            );
+            let force = failed.is_some();
+            self.last_action_failure = Some(ActionFailure {
+                title: "No Agent to launch yet".to_owned(),
+                detail,
+                retrying: false,
+                retry: None,
+            });
+            self.request_agent_catalog(target_host, force);
+            return false;
+        }
         let kind = crate::agent_catalog::resolved_target_agent(
             &self.prefs.default_agent,
             self.agent_catalog(target_host.as_deref()),
         );
         self.spawn_kind(kind, options);
+        true
     }
 
     pub fn spawn_shell(&mut self, mut options: SpawnOptions) {

--- a/diri/crates/diri-app/src/store/tests.rs
+++ b/diri/crates/diri-app/src/store/tests.rs
@@ -1750,6 +1750,61 @@ fn top_level_shortcuts_spawn_on_the_configured_default_host() {
 }
 
 #[test]
+fn default_shortcut_never_launches_an_agent_unavailable_on_its_target() {
+    let (mut store, mut effects) = SessionStore::headless(Prefs {
+        default_agent: AgentKind::new("saved-agent"),
+        default_spawn_host: Some("forge".into()),
+        ..Prefs::default()
+    });
+    store.set_hosts(vec![diri_proto::HostEntry {
+        id: "forge".into(),
+        name: Some("Forge".into()),
+        ssh: "forge".into(),
+        default_cwd: None,
+        node: None,
+    }]);
+    store.set_agent_catalog(AgentReadinessResult {
+        host: Some("forge".into()),
+        agents: vec![
+            AgentReadinessItem {
+                kind: AgentKind::new("saved-agent"),
+                binary: "saved-agent".into(),
+                path: None,
+                descriptor: Some(AgentDescriptor {
+                    id: "saved-agent".into(),
+                    display_name: "Saved Agent".into(),
+                    ..AgentDescriptor::default()
+                }),
+                ..AgentReadinessItem::default()
+            },
+            AgentReadinessItem {
+                kind: AgentKind::new("installed-agent"),
+                binary: "installed-agent".into(),
+                path: Some("/bin/installed-agent".into()),
+                show_in_quick_create: true,
+                descriptor: Some(AgentDescriptor {
+                    id: "installed-agent".into(),
+                    display_name: "Installed Agent".into(),
+                    ..AgentDescriptor::default()
+                }),
+                ..AgentReadinessItem::default()
+            },
+        ],
+        ..AgentReadinessResult::default()
+    });
+    drain(&mut effects);
+
+    store.spawn_default(super::SpawnOptions::default());
+
+    let params = match effects.try_recv() {
+        Ok(StoreEffect::Spawn(params)) => params,
+        other => panic!("expected spawn effect, got {other:?}"),
+    };
+    assert_eq!(params.kind, AgentKind::new("installed-agent"));
+    assert_eq!(params.host.as_deref(), Some("forge"));
+}
+
+#[test]
 fn selecting_a_default_host_persists_across_store_reloads() {
     let directory = tempdir().unwrap();
     let path = directory.path().join("prefs.json");

--- a/diri/crates/diri-app/src/store/tests.rs
+++ b/diri/crates/diri-app/src/store/tests.rs
@@ -1737,6 +1737,8 @@ fn top_level_shortcuts_spawn_on_the_configured_default_host() {
         default_cwd: None,
         node: None,
     }]);
+    let default_agent = store.preferences().default_agent.clone();
+    store.set_agent_catalog(installed_catalog(Some("forge"), &default_agent));
     drain(&mut effects);
 
     store.spawn_default(super::SpawnOptions::default());
@@ -1747,6 +1749,66 @@ fn top_level_shortcuts_spawn_on_the_configured_default_host() {
     };
     assert_eq!(params.host.as_deref(), Some("forge"));
     assert_eq!(params.cwd, "~");
+}
+
+/// Readiness facts in which `kind` is installed on `host`, so `spawn_default`
+/// has something to resolve against instead of declining.
+fn installed_catalog(host: Option<&str>, kind: &AgentKind) -> AgentReadinessResult {
+    AgentReadinessResult {
+        host: host.map(str::to_owned),
+        agents: vec![AgentReadinessItem {
+            kind: kind.clone(),
+            binary: kind.id().to_owned(),
+            path: Some(format!("/usr/local/bin/{}", kind.id())),
+            show_in_quick_create: true,
+            ..AgentReadinessItem::default()
+        }],
+        ..AgentReadinessResult::default()
+    }
+}
+
+#[test]
+fn the_default_shortcut_declines_and_rescans_when_readiness_is_unknown() {
+    let (mut store, mut effects) = SessionStore::headless(Prefs {
+        default_spawn_host: Some("forge".into()),
+        ..Prefs::default()
+    });
+    store.set_hosts(vec![diri_proto::HostEntry {
+        id: "forge".into(),
+        name: Some("Forge".into()),
+        ssh: "forge".into(),
+        default_cwd: None,
+        node: None,
+    }]);
+    drain(&mut effects);
+
+    // Forge has never been scanned. Resolving that to Terminal would launch a
+    // shell the user never chose — and, because a failed scan is remembered,
+    // would keep doing so for as long as the app runs.
+    assert!(!store.spawn_default(super::SpawnOptions::default()));
+    assert_eq!(
+        effects.try_recv().ok(),
+        Some(StoreEffect::RefreshAgents {
+            host: Some("forge".into()),
+            force: false
+        }),
+        "declining must re-arm the scan so the next press decides on real facts"
+    );
+    assert!(
+        store
+            .action_failure()
+            .is_some_and(|failure| failure.detail.contains("Forge")),
+        "the refusal has to be visible, not a shortcut that does nothing"
+    );
+
+    store.set_agent_catalog(installed_catalog(
+        Some("forge"),
+        &store.preferences().default_agent.clone(),
+    ));
+    drain(&mut effects);
+
+    assert!(store.spawn_default(super::SpawnOptions::default()));
+    assert!(matches!(effects.try_recv(), Ok(StoreEffect::Spawn(_))));
 }
 
 #[test]
@@ -1849,8 +1911,12 @@ fn a_remote_default_host_round_trips_back_to_local() {
 
     assert_eq!(store.default_spawn_host(), None);
     assert_eq!(Prefs::load(&path).unwrap().default_spawn_host, None);
+    store.set_agent_catalog(installed_catalog(
+        None,
+        &store.preferences().default_agent.clone(),
+    ));
     drain(&mut effects);
-    store.spawn_default(super::SpawnOptions::default());
+    assert!(store.spawn_default(super::SpawnOptions::default()));
     let params = match effects.try_recv() {
         Ok(StoreEffect::Spawn(params)) => params,
         other => panic!("expected spawn effect, got {other:?}"),

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -1822,8 +1822,9 @@ impl UtilitySurfaces {
 
         let mut catalog_rows = div().flex().flex_col();
         if let Some(catalog) = catalog {
-            let agent_count = catalog.agents.len();
-            for (index, item) in catalog.agents.into_iter().enumerate() {
+            let agents = crate::agent_catalog::settings_agent_items(catalog.agents);
+            let agent_count = agents.len();
+            for (index, item) in agents.into_iter().enumerate() {
                 catalog_rows = catalog_rows.child(self.agent_settings_row(index, item, colors, cx));
                 if index + 1 < agent_count {
                     catalog_rows = catalog_rows.child(setting_divider(colors));

--- a/diri/crates/diri-engine/Cargo.toml
+++ b/diri/crates/diri-engine/Cargo.toml
@@ -41,6 +41,9 @@ objc2-foundation = { version = "=0.3.2", default-features = false, features = [
     "NSString",
 ] }
 
+[build-dependencies]
+sha2.workspace = true
+
 [dev-dependencies]
 tempfile.workspace = true
 

--- a/diri/crates/diri-engine/build.rs
+++ b/diri/crates/diri-engine/build.rs
@@ -7,8 +7,18 @@ fn main() {
     let manifest_dir = PathBuf::from("manifests");
     println!("cargo:rerun-if-changed={}", manifest_dir.display());
 
-    let mut paths = fs::read_dir(&manifest_dir)
-        .expect("read canonical Agent catalog")
+    // A packaging that ships the crate without its catalog (vendoring, a sparse
+    // checkout) should still build; it just cannot claim a catalog identity.
+    let Ok(entries) = fs::read_dir(&manifest_dir) else {
+        println!(
+            "cargo:warning=no Agent catalog at {}; the Engine build identity will not track manifests",
+            manifest_dir.display()
+        );
+        println!("cargo:rustc-env=DIRI_AGENT_CATALOG_BUILD_ID=unknown");
+        return;
+    };
+
+    let mut paths = entries
         .filter_map(Result::ok)
         .map(|entry| entry.path())
         .filter(|path| {

--- a/diri/crates/diri-engine/build.rs
+++ b/diri/crates/diri-engine/build.rs
@@ -1,0 +1,41 @@
+use std::fs;
+use std::path::PathBuf;
+
+use sha2::{Digest as _, Sha256};
+
+fn main() {
+    let manifest_dir = PathBuf::from("manifests");
+    println!("cargo:rerun-if-changed={}", manifest_dir.display());
+
+    let mut paths = fs::read_dir(&manifest_dir)
+        .expect("read canonical Agent catalog")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.extension()
+                .is_some_and(|extension| extension == "json")
+        })
+        .collect::<Vec<_>>();
+    paths.sort();
+
+    let mut digest = Sha256::new();
+    for path in paths {
+        println!("cargo:rerun-if-changed={}", path.display());
+        let name = path
+            .file_name()
+            .expect("Agent manifest file name")
+            .to_string_lossy();
+        let bytes = fs::read(&path).expect("read Agent manifest");
+        digest.update((name.len() as u64).to_le_bytes());
+        digest.update(name.as_bytes());
+        digest.update((bytes.len() as u64).to_le_bytes());
+        digest.update(bytes);
+    }
+
+    let catalog_id = digest
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    println!("cargo:rustc-env=DIRI_AGENT_CATALOG_BUILD_ID={catalog_id}");
+}

--- a/diri/crates/diri-engine/manifests/antigravity.json
+++ b/diri/crates/diri-engine/manifests/antigravity.json
@@ -15,6 +15,7 @@
       "agy"
     ],
     "firstClass": true,
+    "catalogOrder": 30,
     "setup": {
       "url": "https://antigravity.google/docs/cli-install",
       "installHint": "Install agy with Google's platform installer.",

--- a/diri/crates/diri-engine/manifests/claude-code.json
+++ b/diri/crates/diri-engine/manifests/claude-code.json
@@ -14,6 +14,7 @@
       "cc"
     ],
     "firstClass": true,
+    "catalogOrder": 10,
     "setup": {
       "url": "https://docs.anthropic.com/en/docs/claude-code/getting-started",
       "installHint": "Follow Anthropic's Claude Code installation guide.",

--- a/diri/crates/diri-engine/manifests/codex.json
+++ b/diri/crates/diri-engine/manifests/codex.json
@@ -13,6 +13,7 @@
       "openai-codex"
     ],
     "firstClass": true,
+    "catalogOrder": 20,
     "setup": {
       "url": "https://developers.openai.com/codex/cli/",
       "installHint": "Follow OpenAI's Codex CLI installation guide.",

--- a/diri/crates/diri-engine/manifests/cursor.json
+++ b/diri/crates/diri-engine/manifests/cursor.json
@@ -13,6 +13,7 @@
       "cursor-agent"
     ],
     "firstClass": true,
+    "catalogOrder": 40,
     "setup": {
       "url": "https://docs.cursor.com/en/cli/installation",
       "installHint": "Follow Cursor's CLI installation guide.",

--- a/diri/crates/diri-engine/manifests/gemini.json
+++ b/diri/crates/diri-engine/manifests/gemini.json
@@ -13,6 +13,7 @@
       "gemini-cli"
     ],
     "firstClass": true,
+    "catalogOrder": 50,
     "setup": {
       "url": "https://github.com/google-gemini/gemini-cli",
       "installHint": "Follow Google's Gemini CLI installation guide.",

--- a/diri/crates/diri-engine/src/agent.rs
+++ b/diri/crates/diri-engine/src/agent.rs
@@ -93,6 +93,11 @@ pub struct AgentDescriptor {
     pub aliases: Vec<String>,
     #[serde(default)]
     pub first_class: bool,
+    /// Product default order in Agent catalogs and quick-create surfaces.
+    /// User-defined ordering can override this later without changing the
+    /// manifest; unspecified Agents follow the ordered entries by id.
+    #[serde(default)]
+    pub catalog_order: Option<u16>,
     #[serde(default)]
     pub status_authority: Option<StatusAuthority>,
     /// The executable to run. Absent for `shell` and `generic`, whose command

--- a/diri/crates/diri-engine/src/bin/dirijord-rs.rs
+++ b/diri/crates/diri-engine/src/bin/dirijord-rs.rs
@@ -534,6 +534,7 @@ fn load_manifests(exe_dir: &Path, app_support: &Path) -> (ManifestEngine, Vec<St
     )
 }
 
+#[cfg(unix)]
 fn load_manifests_from(
     exe_dir: &Path,
     app_support: &Path,
@@ -542,14 +543,26 @@ fn load_manifests_from(
 ) -> (ManifestEngine, Vec<String>) {
     let overrides = app_support.join("manifests/overrides");
     let sibling = exe_dir.join("manifests");
-    let base = match configured {
-        Some(configured) => configured.is_dir().then(|| configured.to_path_buf()),
-        None => sibling.is_dir().then_some(sibling).or_else(|| {
+    // A configured directory that does not exist is a misconfiguration, not an
+    // instruction to run without Agents: an empty catalog silently costs every
+    // session its status detection and leaves the client with Terminal only.
+    // Say so and continue down the normal search order.
+    let configured = configured.filter(|configured| {
+        configured.is_dir() || {
+            eprintln!(
+                "dirijord-rs: DIRI_MANIFESTS_DIR={} is not a directory; using the built-in catalog",
+                configured.display()
+            );
+            false
+        }
+    });
+    let base = configured.map(Path::to_path_buf).or_else(|| {
+        sibling.is_dir().then_some(sibling).or_else(|| {
             source_catalog
                 .is_dir()
                 .then(|| source_catalog.to_path_buf())
-        }),
-    };
+        })
+    });
 
     let mut dirs = base.iter().map(PathBuf::as_path).collect::<Vec<_>>();
     if overrides.is_dir() {
@@ -755,8 +768,34 @@ mod tests {
         let (engine, failed) = load_manifests_from(&exe_dir, &app_support, None, &source_catalog);
 
         assert!(failed.is_empty(), "manifests failed to load: {failed:?}");
-        assert!(engine.manifest("pi").is_some());
-        assert!(engine.ids().len() >= 22);
+        for id in ["claude-code", "codex", "cursor", "gemini", "pi", "shell"] {
+            assert!(
+                engine.manifest(id).is_some(),
+                "the source catalog must supply {id}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_configured_catalog_that_does_not_exist_falls_back_to_the_source_catalog() {
+        let temporary = tempfile::tempdir().expect("temp");
+        let exe_dir = temporary.path().join("bin");
+        let app_support = temporary.path().join("support");
+        let missing = temporary.path().join("typo-manifests");
+        let source_catalog = diri_engine::detect::bundled_manifest_dir();
+
+        let (engine, failed) = load_manifests_from(
+            &exe_dir,
+            &app_support,
+            Some(missing.as_path()),
+            &source_catalog,
+        );
+
+        assert!(failed.is_empty(), "manifests failed to load: {failed:?}");
+        assert!(
+            engine.manifest("claude-code").is_some(),
+            "a stale DIRI_MANIFESTS_DIR must not strand the daemon with an empty catalog"
+        );
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/bin/dirijord-rs.rs
+++ b/diri/crates/diri-engine/src/bin/dirijord-rs.rs
@@ -519,23 +519,41 @@ fn set_executable(path: &Path) {
 }
 
 #[cfg(unix)]
-/// Rust-owned base catalog next to the executable, then user overrides, then
-/// the source-tree fallback used by loose development binaries.
+/// Loads the Rust-owned catalog beside the executable and supplements it with
+/// the source-tree catalog available to loose development builds. The latter
+/// is intentionally later: an old `target/{debug,release}/manifests` directory
+/// must not hide Agents added to the canonical source catalog. Packaged builds
+/// have no source tree at that compiled path and use only their count-checked
+/// sibling catalog. User overrides remain last.
 fn load_manifests(exe_dir: &Path, app_support: &Path) -> (ManifestEngine, Vec<String>) {
-    let mut bases: Vec<PathBuf> = Vec::new();
-    if let Ok(configured) = std::env::var("DIRI_MANIFESTS_DIR") {
-        bases.push(PathBuf::from(configured));
-    }
-    bases.push(exe_dir.join("manifests"));
-    bases.push(diri_engine::detect::bundled_manifest_dir());
-    let base = bases.into_iter().find(|dir| dir.is_dir());
-    let overrides = app_support.join("manifests/overrides");
+    let configured = std::env::var_os("DIRI_MANIFESTS_DIR").map(PathBuf::from);
+    load_manifests_from(
+        exe_dir,
+        app_support,
+        configured.as_deref(),
+        &diri_engine::detect::bundled_manifest_dir(),
+    )
+}
 
-    let mut dirs: Vec<&Path> = Vec::new();
-    if let Some(base) = &base {
-        dirs.push(base);
+fn load_manifests_from(
+    exe_dir: &Path,
+    app_support: &Path,
+    configured: Option<&Path>,
+    source_catalog: &Path,
+) -> (ManifestEngine, Vec<String>) {
+    let overrides = app_support.join("manifests/overrides");
+    let sibling = exe_dir.join("manifests");
+    let mut bases = match configured {
+        Some(configured) => vec![configured.to_path_buf()],
+        None => vec![sibling, source_catalog.to_path_buf()],
+    };
+    bases.retain(|path| path.is_dir());
+    bases.dedup();
+
+    let mut dirs = bases.iter().map(PathBuf::as_path).collect::<Vec<_>>();
+    if overrides.is_dir() {
+        dirs.push(&overrides);
     }
-    dirs.push(&overrides);
     ManifestEngine::load_dirs(&dirs).unwrap_or_else(|error| {
         eprintln!("dirijord-rs: manifest load: {error}");
         (ManifestEngine::new(Vec::new()), Vec::new())
@@ -696,6 +714,33 @@ mod tests {
         install_cli_resource_bundle(&source, &bin);
         assert!(!installed.join("cursor.json").exists());
         assert!(installed.join("codex.json").exists());
+    }
+
+    #[test]
+    fn a_stale_sibling_catalog_cannot_hide_new_source_agents() {
+        let temporary = tempfile::tempdir().expect("temp");
+        let exe_dir = temporary.path().join("bin");
+        let stale = exe_dir.join("manifests");
+        let app_support = temporary.path().join("support");
+        std::fs::create_dir_all(&stale).expect("stale catalog");
+        std::fs::copy(
+            diri_engine::detect::bundled_manifest_dir().join("codex.json"),
+            stale.join("codex.json"),
+        )
+        .expect("copy stale manifest");
+
+        let source_catalog = diri_engine::detect::bundled_manifest_dir();
+        let (engine, failed) = load_manifests_from(&exe_dir, &app_support, None, &source_catalog);
+
+        assert!(failed.is_empty(), "manifests failed to load: {failed:?}");
+        assert!(
+            engine.manifest("pi").is_some(),
+            "the canonical source catalog must supplement an older sibling catalog"
+        );
+        assert!(
+            engine.ids().len() >= 22,
+            "the established Agent catalog must not shrink"
+        );
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/bin/dirijord-rs.rs
+++ b/diri/crates/diri-engine/src/bin/dirijord-rs.rs
@@ -519,12 +519,11 @@ fn set_executable(path: &Path) {
 }
 
 #[cfg(unix)]
-/// Loads the Rust-owned catalog beside the executable and supplements it with
-/// the source-tree catalog available to loose development builds. The latter
-/// is intentionally later: an old `target/{debug,release}/manifests` directory
-/// must not hide Agents added to the canonical source catalog. Packaged builds
-/// have no source tree at that compiled path and use only their count-checked
-/// sibling catalog. User overrides remain last.
+/// Selects exactly one Rust-owned base catalog, then applies user overrides.
+/// An explicit development catalog wins; otherwise packaged builds use their
+/// count-checked sibling catalog and loose builds fall back to the source tree.
+/// Base catalogs must never be merged because that could produce a catalog
+/// different from the one identified when this Engine binary was built.
 fn load_manifests(exe_dir: &Path, app_support: &Path) -> (ManifestEngine, Vec<String>) {
     let configured = std::env::var_os("DIRI_MANIFESTS_DIR").map(PathBuf::from);
     load_manifests_from(
@@ -543,14 +542,16 @@ fn load_manifests_from(
 ) -> (ManifestEngine, Vec<String>) {
     let overrides = app_support.join("manifests/overrides");
     let sibling = exe_dir.join("manifests");
-    let mut bases = match configured {
-        Some(configured) => vec![configured.to_path_buf()],
-        None => vec![sibling, source_catalog.to_path_buf()],
+    let base = match configured {
+        Some(configured) => configured.is_dir().then(|| configured.to_path_buf()),
+        None => sibling.is_dir().then_some(sibling).or_else(|| {
+            source_catalog
+                .is_dir()
+                .then(|| source_catalog.to_path_buf())
+        }),
     };
-    bases.retain(|path| path.is_dir());
-    bases.dedup();
 
-    let mut dirs = bases.iter().map(PathBuf::as_path).collect::<Vec<_>>();
+    let mut dirs = base.iter().map(PathBuf::as_path).collect::<Vec<_>>();
     if overrides.is_dir() {
         dirs.push(&overrides);
     }
@@ -717,30 +718,45 @@ mod tests {
     }
 
     #[test]
-    fn a_stale_sibling_catalog_cannot_hide_new_source_agents() {
+    fn adjacent_catalog_is_not_merged_with_the_source_catalog() {
         let temporary = tempfile::tempdir().expect("temp");
         let exe_dir = temporary.path().join("bin");
-        let stale = exe_dir.join("manifests");
+        let adjacent = exe_dir.join("manifests");
         let app_support = temporary.path().join("support");
-        std::fs::create_dir_all(&stale).expect("stale catalog");
+        std::fs::create_dir_all(&adjacent).expect("adjacent catalog");
         std::fs::copy(
             diri_engine::detect::bundled_manifest_dir().join("codex.json"),
-            stale.join("codex.json"),
+            adjacent.join("codex.json"),
         )
-        .expect("copy stale manifest");
+        .expect("copy adjacent manifest");
 
         let source_catalog = diri_engine::detect::bundled_manifest_dir();
         let (engine, failed) = load_manifests_from(&exe_dir, &app_support, None, &source_catalog);
 
         assert!(failed.is_empty(), "manifests failed to load: {failed:?}");
         assert!(
-            engine.manifest("pi").is_some(),
-            "the canonical source catalog must supplement an older sibling catalog"
+            engine.manifest("codex").is_some(),
+            "the adjacent packaged catalog must be selected"
         );
         assert!(
-            engine.ids().len() >= 22,
-            "the established Agent catalog must not shrink"
+            engine.manifest("pi").is_none(),
+            "a source-tree catalog must not be merged into an adjacent packaged catalog"
         );
+        assert_eq!(engine.ids(), ["codex"]);
+    }
+
+    #[test]
+    fn loose_build_uses_source_catalog_when_no_adjacent_catalog_exists() {
+        let temporary = tempfile::tempdir().expect("temp");
+        let exe_dir = temporary.path().join("bin");
+        let app_support = temporary.path().join("support");
+        let source_catalog = diri_engine::detect::bundled_manifest_dir();
+
+        let (engine, failed) = load_manifests_from(&exe_dir, &app_support, None, &source_catalog);
+
+        assert!(failed.is_empty(), "manifests failed to load: {failed:?}");
+        assert!(engine.manifest("pi").is_some());
+        assert!(engine.ids().len() >= 22);
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/control.rs
+++ b/diri/crates/diri-engine/src/control.rs
@@ -2263,17 +2263,23 @@ impl ControlServer {
                 .filter_map(|id| {
                     let descriptor = engine.manifest(id)?.agent.as_ref()?;
                     let binary = descriptor.binary.clone()?;
-                    Some((id.to_owned(), binary, engine.raw_agent(id).cloned()))
+                    Some((
+                        id.to_owned(),
+                        binary,
+                        descriptor.catalog_order.unwrap_or(u16::MAX),
+                        engine.raw_agent(id).cloned(),
+                    ))
                 })
                 .collect::<Vec<_>>();
-            manifests.sort_by(|left, right| left.0.cmp(&right.0));
+            manifests
+                .sort_by(|left, right| left.2.cmp(&right.2).then_with(|| left.0.cmp(&right.0)));
             manifests
         };
         let preferences = {
             let catalog = self.agent_catalog.lock().map_err(poisoned)?;
             manifests
                 .iter()
-                .map(|(id, _, _)| catalog.preference(params.host.as_deref(), id))
+                .map(|(id, _, _, _)| catalog.preference(params.host.as_deref(), id))
                 .collect::<Vec<_>>()
         };
 
@@ -2290,7 +2296,7 @@ impl ControlServer {
                         queries: manifests
                             .iter()
                             .zip(&preferences)
-                            .map(|((id, binary, _), preference)| {
+                            .map(|((id, binary, _, _), preference)| {
                                 diri_proto::remote_pty::ExecutableQuery {
                                     id: id.clone(),
                                     binary: binary.clone(),
@@ -2310,7 +2316,7 @@ impl ControlServer {
                 .collect::<std::collections::HashMap<_, _>>();
             manifests
                 .iter()
-                .map(|(id, _, _)| {
+                .map(|(id, _, _, _)| {
                     let item = by_id.get(id);
                     crate::agent_catalog::ExecutableResolution {
                         detected_path: item.and_then(|item| item.detected_path.clone()),
@@ -2323,7 +2329,7 @@ impl ControlServer {
             manifests
                 .iter()
                 .zip(&preferences)
-                .map(|((_, binary, _), preference)| {
+                .map(|((_, binary, _, _), preference)| {
                     crate::agent_catalog::resolve_local(
                         binary,
                         preference.executable_path.as_deref(),
@@ -2333,7 +2339,7 @@ impl ControlServer {
         };
 
         let mut agents = Vec::with_capacity(manifests.len());
-        for (((id, binary, raw_descriptor), preference), resolution) in
+        for (((id, binary, _, raw_descriptor), preference), resolution) in
             manifests.into_iter().zip(preferences).zip(resolutions)
         {
             let path = resolution
@@ -3824,6 +3830,15 @@ mod tests {
         assert!(
             agents.len() >= 20,
             "readiness must expose the complete supported CLI catalog"
+        );
+        assert_eq!(
+            agents
+                .iter()
+                .take(3)
+                .filter_map(|agent| agent["kind"].as_str())
+                .collect::<Vec<_>>(),
+            ["claude-code", "codex", "antigravity"],
+            "the manifest-owned default catalog order must place Antigravity after Claude Code and Codex"
         );
         let claude = agents
             .iter()

--- a/diri/crates/diri-engine/src/control.rs
+++ b/diri/crates/diri-engine/src/control.rs
@@ -3827,18 +3827,24 @@ mod tests {
         let server = server(temp.path());
         let result = ok_of(call(&server, "agent.readiness", None));
         let agents = result["agents"].as_array().expect("agents");
-        assert!(
-            agents.len() >= 20,
-            "readiness must expose the complete supported CLI catalog"
-        );
+        // Readiness is the whole supported catalog, not just what happens to be
+        // installed. Naming manifests keeps that honest when one is retired; a
+        // count threshold would only ever be quietly loosened.
+        for id in ["claude-code", "codex", "cursor", "gemini", "amp", "pi"] {
+            assert!(
+                agents.iter().any(|agent| agent["kind"] == id),
+                "readiness must expose the supported Agent {id}"
+            );
+        }
         assert_eq!(
             agents
                 .iter()
-                .take(3)
+                .take(5)
                 .filter_map(|agent| agent["kind"].as_str())
                 .collect::<Vec<_>>(),
-            ["claude-code", "codex", "antigravity"],
-            "the manifest-owned default catalog order must place Antigravity after Claude Code and Codex"
+            ["claude-code", "codex", "antigravity", "cursor", "gemini"],
+            "every first-class Agent needs an explicit catalogOrder, or it falls \
+             into the alphabetical tail behind Agents most users never install"
         );
         let claude = agents
             .iter()

--- a/diri/crates/diri-engine/src/control.rs
+++ b/diri/crates/diri-engine/src/control.rs
@@ -27,7 +27,12 @@ use crate::registry::Registry;
 
 /// Identifies this engine in the handshake, so a client can tell which
 /// implementation it reached.
-pub const BUILD: &str = concat!("diri-engine-", env!("CARGO_PKG_VERSION"));
+pub const BUILD: &str = concat!(
+    "diri-engine-",
+    env!("CARGO_PKG_VERSION"),
+    "+catalog.",
+    env!("DIRI_AGENT_CATALOG_BUILD_ID")
+);
 
 pub struct ControlServer {
     registry: Arc<Mutex<Registry>>,
@@ -3318,6 +3323,12 @@ mod tests {
                 .is_some_and(|b| b.contains("diri-engine")),
             "the handshake should say which engine answered: {result}"
         );
+        assert!(
+            result["build"]
+                .as_str()
+                .is_some_and(|build| build.contains("+catalog.")),
+            "manifest changes must alter the daemon identity: {result}"
+        );
         assert!(result["pid"].as_i64().is_some_and(|pid| pid > 0));
         assert_eq!(result["engineKind"], diri_proto::RUST_ENGINE_KIND);
         assert_eq!(
@@ -3810,7 +3821,10 @@ mod tests {
         let server = server(temp.path());
         let result = ok_of(call(&server, "agent.readiness", None));
         let agents = result["agents"].as_array().expect("agents");
-        assert!(!agents.is_empty());
+        assert!(
+            agents.len() >= 20,
+            "readiness must expose the complete supported CLI catalog"
+        );
         let claude = agents
             .iter()
             .find(|agent| agent["kind"] == "claude-code")
@@ -3827,6 +3841,12 @@ mod tests {
                 .unwrap_or(false),
             "the raw manifest descriptor rides along: {claude}"
         );
+        let pi = agents
+            .iter()
+            .find(|agent| agent["kind"] == "pi")
+            .expect("Pi remains in Settings even when its executable is absent");
+        assert_eq!(pi["binary"], "pi");
+        assert_eq!(pi["descriptor"]["displayName"], "Pi");
     }
 
     #[test]

--- a/diri/crates/diri-proto/src/methods.rs
+++ b/diri/crates/diri-proto/src/methods.rs
@@ -238,8 +238,8 @@ pub struct AgentReadinessItem {
     pub error: Option<String>,
     /// The agent's manifest descriptor. This is how the AGENT CATALOG reaches
     /// the client: `agent.readiness` doubles as "what agents exist and what can
-    /// they do". Absent when talking to a daemon that predates it — the client
-    /// then falls back to its built-in knowledge of the original four.
+    /// they do". Absent descriptors are rendered from the manifest id; clients
+    /// must not invent additional supported or installed Agents.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub descriptor: Option<AgentDescriptor>,
 }


### PR DESCRIPTION
## Summary

- Use Engine readiness and Settings preferences as the source of truth for quick-launch Agents.
- Show the complete manifest-backed Agent catalog in Settings while keeping unavailable or disabled Agents out of quick-create surfaces.
- Resolve Agent availability and defaults per execution target without borrowing local readiness for remote hosts.
- Fall back safely to Terminal while readiness is unavailable and refresh open palette actions when readiness arrives.
- Remove the client-side hardcoded Agent ordering and use manifest-defined catalog order, placing Claude Code and Codex before Antigravity.
- Sort installed Agents before unavailable Agents in Settings.
- Include the Agent catalog hash in the Engine build identity.
- Select exactly one base manifest catalog before applying user overrides, preventing packaged and source catalogs from being merged.