### PR TITLE
Fix spawn_agent prompt delivery acknowledgement

### DIFF
--- a/diri/Cargo.lock
+++ b/diri/Cargo.lock
@@ -1637,6 +1637,7 @@ version = "0.1.0"
 name = "dirijor-mcp"
 version = "0.1.0"
 dependencies = [
+ "diri-engine",
  "diri-proto",
  "libc",
  "serde",

--- a/diri/crates/diri-engine/src/control.rs
+++ b/diri/crates/diri-engine/src/control.rs
@@ -868,24 +868,29 @@ impl ControlServer {
         // raced Claude Code's boot and lost keystrokes into a composer that
         // did not exist yet.
         let prompt = p.initial_prompt.clone().filter(|prompt| !prompt.is_empty());
-        if kind == diri_proto::AgentKind::CLAUDE_CODE_ID || prompt.is_some() {
-            let registry = Arc::clone(&self.registry);
-            let session_id = id.clone();
-            std::thread::spawn(move || {
-                prepare_agent_input(
-                    &registry,
-                    &session_id,
-                    kind == diri_proto::AgentKind::CLAUDE_CODE_ID,
-                    prompt.as_deref(),
-                );
-            });
-        }
-
+        let accept_claude_workspace = kind == diri_proto::AgentKind::CLAUDE_CODE_ID;
         let record = registry
             .records()
             .into_iter()
             .find(|record| record.id.0 == id)
             .ok_or_else(|| ControlError::internal("the new session vanished"))?;
+        drop(registry);
+
+        // A supplied prompt is part of the spawn contract: do not acknowledge
+        // the request until delivery is confirmed. With no prompt, Claude's
+        // workspace-trust convenience remains background work so an ordinary
+        // launch still returns as soon as its session exists.
+        if let Some(prompt) = prompt {
+            prepare_agent_input(&self.registry, &id, accept_claude_workspace, Some(&prompt))
+                .map_err(|error| initial_prompt_control_error(&id, error))?;
+        } else if accept_claude_workspace {
+            let registry = Arc::clone(&self.registry);
+            let session_id = id.clone();
+            std::thread::spawn(move || {
+                let _ = prepare_agent_input(&registry, &session_id, true, None);
+            });
+        }
+
         // SessionSpawnResult is the record itself, as the Swift daemon
         // answers — not wrapped.
         serde_json::to_value(&record).map_err(|error| ControlError::internal(error.to_string()))
@@ -1076,23 +1081,24 @@ impl ControlServer {
         self.publish_updated(&registry, &id);
 
         let prompt = p.initial_prompt.filter(|prompt| !prompt.is_empty());
-        if kind == diri_proto::AgentKind::CLAUDE_CODE_ID || prompt.is_some() {
-            let registry = Arc::clone(&self.registry);
-            let session_id = id.clone();
-            std::thread::spawn(move || {
-                prepare_agent_input(
-                    &registry,
-                    &session_id,
-                    kind == diri_proto::AgentKind::CLAUDE_CODE_ID,
-                    prompt.as_deref(),
-                );
-            });
-        }
+        let accept_claude_workspace = kind == diri_proto::AgentKind::CLAUDE_CODE_ID;
         let record = registry
             .records()
             .into_iter()
             .find(|record| record.id.0 == id)
             .ok_or_else(|| ControlError::internal("the new remote session vanished"))?;
+        drop(registry);
+
+        if let Some(prompt) = prompt {
+            prepare_agent_input(&self.registry, &id, accept_claude_workspace, Some(&prompt))
+                .map_err(|error| initial_prompt_control_error(&id, error))?;
+        } else if accept_claude_workspace {
+            let registry = Arc::clone(&self.registry);
+            let session_id = id.clone();
+            std::thread::spawn(move || {
+                let _ = prepare_agent_input(&registry, &session_id, true, None);
+            });
+        }
         serde_json::to_value(&record).map_err(|error| ControlError::internal(error.to_string()))
     }
 
@@ -1966,16 +1972,15 @@ impl ControlServer {
             .find(|record| record.id.0 == id)
             .ok_or_else(|| ControlError::internal("the resumed session vanished"))?;
         drop(registry);
-        if kind == diri_proto::AgentKind::CLAUDE_CODE_ID || prompt.is_some() {
+        let accept_claude_workspace = kind == diri_proto::AgentKind::CLAUDE_CODE_ID;
+        if let Some(prompt) = prompt {
+            prepare_agent_input(&self.registry, &id, accept_claude_workspace, Some(&prompt))
+                .map_err(|error| initial_prompt_control_error(&id, error))?;
+        } else if accept_claude_workspace {
             let registry = Arc::clone(&self.registry);
             let session_id = id.clone();
             std::thread::spawn(move || {
-                prepare_agent_input(
-                    &registry,
-                    &session_id,
-                    kind == diri_proto::AgentKind::CLAUDE_CODE_ID,
-                    prompt.as_deref(),
-                );
+                let _ = prepare_agent_input(&registry, &session_id, true, None);
             });
         }
         serde_json::to_value(&record).map_err(|error| ControlError::internal(error.to_string()))
@@ -2834,13 +2839,52 @@ fn prepare_agent_input(
     session_id: &str,
     accept_claude_workspace: bool,
     prompt: Option<&str>,
-) {
+) -> Result<(), InitialPromptFailure> {
     if accept_claude_workspace {
         accept_claude_workspace_trust(registry, session_id);
     }
     if let Some(prompt) = prompt {
-        inject_initial_prompt(registry, session_id, prompt);
+        inject_initial_prompt(registry, session_id, prompt)?;
     }
+    Ok(())
+}
+
+pub(crate) fn prepare_agent_input_for_spawn(
+    registry: &Arc<Mutex<Registry>>,
+    session_id: &str,
+    accept_claude_workspace: bool,
+    prompt: Option<&str>,
+) -> Result<(), String> {
+    prepare_agent_input(registry, session_id, accept_claude_workspace, prompt)
+        .map_err(|failure| failure.to_string())
+}
+
+#[derive(Clone, Copy, Debug)]
+enum InitialPromptFailure {
+    SessionEnded,
+    TimedOut,
+    SubmissionUnconfirmed,
+}
+
+impl std::fmt::Display for InitialPromptFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SessionEnded => formatter.write_str("the session ended before accepting it"),
+            Self::TimedOut => formatter.write_str("the agent did not accept it before the timeout"),
+            Self::SubmissionUnconfirmed => {
+                formatter.write_str("the agent never confirmed that it submitted")
+            }
+        }
+    }
+}
+
+fn initial_prompt_control_error(session_id: &str, failure: InitialPromptFailure) -> ControlError {
+    ControlError::new(
+        "initial_prompt_delivery_failed",
+        format!(
+            "session {session_id} was created, but its initial prompt was not delivered: {failure}"
+        ),
+    )
 }
 
 /// Answers Claude Code's "do you trust this folder?" picker on the user's
@@ -2916,28 +2960,31 @@ fn is_claude_workspace_trust_screen(screen: &str) -> bool {
 /// one that lands. Nothing here consults the session's status — Codex reads
 /// as `Working` even at an idle composer, so the echo is the only tell worth
 /// trusting.
-fn inject_initial_prompt(registry: &Arc<Mutex<Registry>>, session_id: &str, prompt: &str) {
+fn inject_initial_prompt(
+    registry: &Arc<Mutex<Registry>>,
+    session_id: &str,
+    prompt: &str,
+) -> Result<(), InitialPromptFailure> {
     if !wait_until_ready(registry, session_id) {
-        return;
+        return Err(InitialPromptFailure::SessionEnded);
     }
     let give_up_at = Instant::now() + PROMPT_INJECTION_WINDOW;
     loop {
         let Some(before) = screen_text(registry, session_id) else {
-            return;
+            return Err(InitialPromptFailure::SessionEnded);
         };
         // A word already on screen (a path in the banner, a word from the
         // tips panel) proves nothing, so the probe is chosen against the
         // pre-typing screen.
         let probe = verification_probe(prompt, &before);
         if with_session(registry, session_id, |session| session.paste_text(prompt)).is_none() {
-            return;
+            return Err(InitialPromptFailure::SessionEnded);
         }
         match wait_for_echo(registry, session_id, probe.as_deref(), &before, ECHO_WINDOW) {
-            EchoOutcome::Gone => return,
+            EchoOutcome::Gone => return Err(InitialPromptFailure::SessionEnded),
             // The composer is holding our text: the Enter is safe.
             EchoOutcome::Visible => {
-                submit_typed_prompt(registry, session_id, probe.as_deref());
-                return;
+                return submit_typed_prompt(registry, session_id, probe.as_deref());
             }
             EchoOutcome::Missing => {}
         }
@@ -2956,7 +3003,7 @@ fn inject_initial_prompt(registry: &Arc<Mutex<Registry>>, session_id: &str, prom
         // the exposure is unchanged; narrowing it would need the holder to
         // report termios.
         if with_session(registry, session_id, |session| session.submit_input()).is_none() {
-            return;
+            return Err(InitialPromptFailure::SessionEnded);
         }
         match wait_for_echo(
             registry,
@@ -2965,14 +3012,15 @@ fn inject_initial_prompt(registry: &Arc<Mutex<Registry>>, session_id: &str, prom
             &before,
             LANDED_WINDOW,
         ) {
-            EchoOutcome::Gone | EchoOutcome::Visible => return,
+            EchoOutcome::Gone => return Err(InitialPromptFailure::SessionEnded),
+            EchoOutcome::Visible => return Ok(()),
             EchoOutcome::Missing => {}
         }
 
         // Truly swallowed. Empty the composer before retyping so a late echo
         // cannot concatenate with the retry.
         if with_session(registry, session_id, |session| session.clear_input_line()).is_none() {
-            return;
+            return Err(InitialPromptFailure::SessionEnded);
         }
         if !sleep_until(give_up_at, PROMPT_RETRY_DELAY) {
             break;
@@ -2983,6 +3031,7 @@ fn inject_initial_prompt(registry: &Arc<Mutex<Registry>>, session_id: &str, prom
          {}s — left untyped rather than submitted blind",
         PROMPT_INJECTION_WINDOW.as_secs()
     );
+    Err(InitialPromptFailure::TimedOut)
 }
 
 /// How long a prompt waits for a composer that will take it. Long enough to
@@ -3052,13 +3101,17 @@ fn wait_for_echo(
 /// confirms the composer let go of it. A prompt still sitting there after the
 /// first Enter gets exactly one more — never a retype, which is what would
 /// double-send.
-fn submit_typed_prompt(registry: &Arc<Mutex<Registry>>, session_id: &str, probe: Option<&str>) {
+fn submit_typed_prompt(
+    registry: &Arc<Mutex<Registry>>,
+    session_id: &str,
+    probe: Option<&str>,
+) -> Result<(), InitialPromptFailure> {
     for _ in 0..2 {
         if with_session(registry, session_id, |session| session.submit_input()).is_none() {
-            return;
+            return Err(InitialPromptFailure::SessionEnded);
         }
         let Some(probe) = probe else {
-            return;
+            return Ok(());
         };
         // Submitting moves the prompt out of the composer and into the
         // transcript above it; either way the agent now owns it. Only a
@@ -3066,16 +3119,17 @@ fn submit_typed_prompt(registry: &Arc<Mutex<Registry>>, session_id: &str, probe:
         for _ in 0..20 {
             std::thread::sleep(Duration::from_millis(100));
             match screen_text(registry, session_id) {
-                None => return,
+                None => return Err(InitialPromptFailure::SessionEnded),
                 Some(now)
                     if !now.contains(probe) || agent_started_working(registry, session_id) =>
                 {
-                    return;
+                    return Ok(());
                 }
                 Some(_) => {}
             }
         }
     }
+    Err(InitialPromptFailure::SubmissionUnconfirmed)
 }
 
 /// True once the session's own status reducer says the agent is doing

--- a/diri/crates/diri-engine/src/mcp/host.rs
+++ b/diri/crates/diri-engine/src/mcp/host.rs
@@ -294,11 +294,10 @@ impl RegistryHost {
     /// The new session records its caller as `parent`, which is what makes the
     /// lineage tools — `list_children`, `wait_for_children` — mean anything.
     ///
-    /// An initial prompt is *not* written here. The agent has not drawn its
-    /// input box yet, and typing into a terminal that is still starting loses
-    /// the text; delivery waits for readiness, which the caller drives with
-    /// `wait_for_agent` then `send_prompt`. The pending prompt is returned so
-    /// the caller knows it still owes it.
+    /// A supplied initial prompt is part of the spawn acknowledgement: this
+    /// call waits for the same readiness-gated, verified delivery as the
+    /// control-backed MCP server and returns an error if the child never
+    /// accepts it.
     fn spawn_agent(&self, arguments: &Value) -> Result<Value, String> {
         let kind = required_str(arguments, "kind")?;
         let cwd = required_str(arguments, "cwd")?;
@@ -355,6 +354,7 @@ impl RegistryHost {
         record.git_branch = branch.clone();
         if let Some(title) = title {
             record.title = title;
+            record.title_source = diri_proto::TitleSource::DirijorAssigned;
         }
 
         let spec = crate::session::SessionSpec {
@@ -371,6 +371,33 @@ impl RegistryHost {
             .spawn(spec, record)
             .map_err(|error| format!("could not start {kind}: {error}"))?;
         let _ = registry.persist();
+        drop(registry);
+
+        let accept_claude_workspace = kind == diri_proto::AgentKind::CLAUDE_CODE_ID;
+        if let Some(prompt) = prompt.as_deref() {
+            crate::control::prepare_agent_input_for_spawn(
+                &self.registry,
+                &id,
+                accept_claude_workspace,
+                Some(prompt),
+            )
+            .map_err(|error| {
+                format!(
+                    "initial_prompt_delivery_failed: session {id} was created, but its initial prompt was not delivered: {error}"
+                )
+            })?;
+        } else if accept_claude_workspace {
+            let registry = Arc::clone(&self.registry);
+            let session_id = id.clone();
+            std::thread::spawn(move || {
+                let _ = crate::control::prepare_agent_input_for_spawn(
+                    &registry,
+                    &session_id,
+                    true,
+                    None,
+                );
+            });
+        }
 
         Ok(json!({
             "id": id,
@@ -379,7 +406,6 @@ impl RegistryHost {
             "worktree": worktree_path,
             "branch": branch,
             "parent": self.caller,
-            "pendingPrompt": prompt,
         }))
     }
 

--- a/diri/crates/diri-engine/tests/inject_prompt.rs
+++ b/diri/crates/diri-engine/tests/inject_prompt.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 use diri_engine::control::ControlServer;
 use diri_engine::detect::ManifestEngine;
 use diri_engine::registry::Registry;
-use diri_proto::ControlMessage;
+use diri_proto::{ControlError, ControlMessage};
 use serde_json::json;
 
 fn engine() -> Arc<ManifestEngine> {
@@ -42,6 +42,15 @@ impl Control {
     }
 
     fn request(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        self.try_request(method, params)
+            .unwrap_or_else(|error| panic!("{method} failed: {error}"))
+    }
+
+    fn try_request(
+        &mut self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, ControlError> {
         let id = self.next_id;
         self.next_id += 1;
         let mut bytes = serde_json::to_vec(&ControlMessage::Request {
@@ -55,9 +64,7 @@ impl Control {
         let mut line = String::new();
         self.reader.read_line(&mut line).expect("read reply");
         match serde_json::from_str::<ControlMessage>(&line).expect("decode") {
-            ControlMessage::Response {
-                result: Ok(result), ..
-            } => result,
+            ControlMessage::Response { result, .. } => result,
             other => panic!("{method} failed: {other:?}"),
         }
     }
@@ -106,6 +113,56 @@ fn screen(control: &mut Control, id: &str) -> String {
 
 fn occurrences(haystack: &str, needle: &str) -> usize {
     haystack.matches(needle).count()
+}
+
+/// A successful spawn with an initial prompt is an acknowledgement that the
+/// prompt reached the child, not merely that prompt delivery was scheduled.
+#[test]
+fn spawn_does_not_return_before_prompt_is_delivered() {
+    let temp = tempfile::tempdir().expect("temp");
+    let server = start_server(temp.path());
+    let mut control = Control::connect(&server);
+
+    let prompt = "acknowledge this prompt";
+    let id = spawn(
+        &mut control,
+        r#"sleep 1.2; stty -echo; printf '\033[?2004h> '; exec cat"#,
+        "/bin/sh",
+        prompt,
+    );
+
+    let text = screen(&mut control, &id);
+    assert!(
+        text.contains(prompt),
+        "session.spawn returned success before delivering its prompt: {text:?}"
+    );
+
+    control.request("session.kill", json!({ "sessionID": id }));
+}
+
+#[test]
+fn spawn_reports_when_the_child_exits_before_accepting_its_prompt() {
+    let temp = tempfile::tempdir().expect("temp");
+    let server = start_server(temp.path());
+    let mut control = Control::connect(&server);
+
+    let error = control
+        .try_request(
+            "session.spawn",
+            json!({
+                "kind": { "shell": {} },
+                "cwd": "/tmp",
+                "argv": ["/bin/sh", "-c", "exit 0"],
+                "initialPrompt": "this cannot be delivered",
+            }),
+        )
+        .expect_err("spawn must not acknowledge an undelivered prompt");
+
+    assert_eq!(error.code, "initial_prompt_delivery_failed");
+    assert!(
+        error.message.contains("session s_") && error.message.contains("was not delivered"),
+        "the error must identify the created session and the delivery failure: {error}"
+    );
 }
 
 /// A TUI that paints nothing for over a second, then brings its composer up

--- a/diri/crates/diri-engine/tests/mcp_tools.rs
+++ b/diri/crates/diri-engine/tests/mcp_tools.rs
@@ -443,7 +443,11 @@ fn a_spawned_session_records_its_parent_and_appears_as_a_child() {
             "id": "sleeper",
             "version": "1",
             "statusModel": "processOnly",
-            "agent": { "binary": "/bin/cat", "statusAuthority": "process" },
+            "agent": {
+                "binary": "/bin/sh",
+                "spawnArgs": ["-c", "stty -echo; printf '\\033[?2004h> '; exec cat"],
+                "statusAuthority": "process"
+            },
             "rules": []
         }"#,
     )
@@ -472,9 +476,9 @@ fn a_spawned_session_records_its_parent_and_appears_as_a_child() {
     let id = spawned["id"].as_str().expect("an id").to_string();
     assert!(id.starts_with("s_"));
     assert_eq!(spawned["parent"], "s_parent");
-    assert_eq!(
-        spawned["pendingPrompt"], "do the thing",
-        "the prompt is returned rather than typed into a terminal that is still starting"
+    assert!(
+        spawned.get("pendingPrompt").is_none(),
+        "a successful spawn has already delivered its prompt"
     );
 
     let children = call(&server, "list_children", json!({})).expect("children");

--- a/diri/crates/dirijor-mcp/Cargo.toml
+++ b/diri/crates/dirijor-mcp/Cargo.toml
@@ -22,4 +22,5 @@ serde_json.workspace = true
 libc = "0.2"
 
 [dev-dependencies]
+diri-engine.workspace = true
 tempfile.workspace = true

--- a/diri/crates/dirijor-mcp/src/bridge.rs
+++ b/diri/crates/dirijor-mcp/src/bridge.rs
@@ -13,6 +13,11 @@ use crate::control::{ControlClient, ControlFailure, default_socket_path};
 use crate::tools::{ToolDefinition, tool_definitions_for};
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(3);
+// The Engine may wait through a first-run trust/login wall before it can
+// confirm an initial prompt. Keep the MCP request alive longer than the
+// Engine's bounded delivery window so callers receive its delivery result,
+// rather than a client-side timeout while the session continues in limbo.
+const SPAWN_TIMEOUT: Duration = Duration::from_secs(300);
 const WRITE_POLICY: &str = "Reads are open across all sessions. Writes to your parent or direct children are delivered verbatim; writes to anyone else are attributed to you. You cannot send_prompt to yourself, and release_agent refuses to kill you or any ancestor.";
 
 #[derive(Clone, Debug)]
@@ -125,7 +130,7 @@ impl Bridge {
             same_repo_as: None,
         };
         let params = serde_json::to_value(params).map_err(|error| error.to_string())?;
-        self.request(Method::SESSION_SPAWN, params, Duration::from_secs(60))
+        self.request(Method::SESSION_SPAWN, params, SPAWN_TIMEOUT)
     }
 
     fn list_agents(&self) -> Result<Value, String> {

--- a/diri/crates/dirijor-mcp/tests/spawn_prompt.rs
+++ b/diri/crates/dirijor-mcp/tests/spawn_prompt.rs
@@ -1,0 +1,246 @@
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use diri_engine::control::ControlServer;
+use diri_engine::detect::ManifestEngine;
+use diri_engine::registry::Registry;
+use dirijor_mcp::Bridge;
+use serde_json::json;
+
+fn git(cwd: &Path, arguments: &[&str]) {
+    let output = Command::new("/usr/bin/git")
+        .args(arguments)
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin")
+        .env("HOME", cwd)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        arguments.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn initialize_repository(path: &Path) {
+    std::fs::create_dir_all(path).expect("create repository");
+    git(path, &["init"]);
+    std::fs::write(path.join("README.md"), "prompt delivery fixture\n").expect("write readme");
+    git(path, &["add", "."]);
+    git(
+        path,
+        &[
+            "-c",
+            "user.name=Diri Tests",
+            "-c",
+            "user.email=diri@example.invalid",
+            "commit",
+            "-m",
+            "fixture",
+        ],
+    );
+}
+
+fn large_markdown_prompt() -> String {
+    let section = "# DeliveryMarker\n\n`x` — y\n\n```text\na\nb\n```\n\n1. do\n2. go\n\n";
+    section.repeat(72)
+}
+
+fn start_server(temp: &Path, fixture: &Path) -> Arc<ControlServer> {
+    let manifests = temp.join("manifests");
+    std::fs::create_dir_all(&manifests).expect("create manifests");
+    std::fs::write(
+        manifests.join("prompt-fixture.json"),
+        serde_json::to_vec_pretty(&json!({
+            "schemaVersion": 1,
+            "id": "prompt-fixture",
+            "version": "1",
+            "statusModel": "processOnly",
+            "agent": {
+                "binary": fixture.to_string_lossy(),
+                "statusAuthority": "process"
+            },
+            "rules": []
+        }))
+        .expect("encode manifest"),
+    )
+    .expect("write manifest");
+    let (engine, failures) = ManifestEngine::load_dir(&manifests).expect("load manifests");
+    assert!(failures.is_empty(), "manifest failures: {failures:?}");
+
+    let registry = Arc::new(Mutex::new(Registry::new(
+        Arc::new(engine),
+        temp.join("state.json"),
+    )));
+    let server = Arc::new(
+        ControlServer::new(registry, temp.join("daemon.sock")).with_logs_dir(temp.join("logs")),
+    );
+    let listener = server.bind().expect("bind control socket");
+    {
+        let server = Arc::clone(&server);
+        std::thread::spawn(move || {
+            while let Ok((stream, _)) = listener.accept() {
+                let server = Arc::clone(&server);
+                std::thread::spawn(move || {
+                    let _ = server.serve(stream);
+                });
+            }
+        });
+    }
+    server
+}
+
+fn call_spawn_agent_through_mcp(socket: &Path, arguments: serde_json::Value) -> serde_json::Value {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_dirijor-mcp"))
+        .env_clear()
+        .env("DIRIJOR_SOCKET", socket)
+        .env("DIRIJOR_SESSION_ID", "s_parent")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("launch MCP server");
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": { "name": "spawn_agent", "arguments": arguments },
+    });
+    {
+        let mut stdin = child.stdin.take().expect("MCP stdin");
+        serde_json::to_writer(&mut stdin, &request).expect("encode MCP call");
+        stdin.write_all(b"\n").expect("write MCP call");
+    }
+
+    let mut line = String::new();
+    BufReader::new(child.stdout.take().expect("MCP stdout"))
+        .read_line(&mut line)
+        .expect("read MCP response");
+    let status = child.wait().expect("wait for MCP server");
+    let mut stderr = String::new();
+    child
+        .stderr
+        .take()
+        .expect("MCP stderr")
+        .read_to_string(&mut stderr)
+        .expect("read MCP stderr");
+    assert!(status.success(), "MCP server failed: {stderr}");
+
+    let response: serde_json::Value = serde_json::from_str(&line).expect("decode MCP response");
+    assert_eq!(
+        response["result"]["isError"], false,
+        "spawn_agent failed: {}",
+        response["result"]["content"][0]["text"]
+    );
+    serde_json::from_str(
+        response["result"]["content"][0]["text"]
+            .as_str()
+            .expect("MCP text content"),
+    )
+    .expect("decode spawn result")
+}
+
+#[test]
+fn spawn_agent_waits_for_a_large_multiline_prompt_in_a_new_worktree() {
+    let temp = tempfile::tempdir().expect("temp");
+    let repo = temp.path().join("repo");
+    let capture = temp.path().join("received.bin");
+    let fixture = temp.path().join("prompt-fixture");
+    initialize_repository(&repo);
+
+    let prompt = large_markdown_prompt();
+    assert!(
+        prompt.len() > 4 * 1024,
+        "fixture must exercise a large prompt"
+    );
+    let framed_prompt_len = prompt.len() + b"\x1b[200~\x1b[201~".len();
+    std::fs::write(
+        &fixture,
+        format!(
+            "#!/bin/sh\nsleep 1.2\nstty raw -echo\nprintf '\\033[?2004h> '\ndd bs=1 count={framed_prompt_len} of='{}' 2>/dev/null\nprintf '\\nDeliveryMarker\\n'\ndd bs=1 count=1 >>'{}' 2>/dev/null\nprintf '\\naccepted\\n'\nsleep 30\n",
+            capture.display(),
+            capture.display(),
+        ),
+    )
+    .expect("write fixture");
+    std::fs::set_permissions(&fixture, std::fs::Permissions::from_mode(0o700))
+        .expect("make fixture executable");
+
+    let server = start_server(temp.path(), &fixture);
+    let bridge = Bridge::new(server.socket_path().to_path_buf(), Some("s_parent".into()));
+    let started = Instant::now();
+    let spawned = call_spawn_agent_through_mcp(
+        server.socket_path(),
+        json!({
+            "kind": "prompt-fixture",
+            "cwd": repo,
+            "worktree": true,
+            "branch": "test/prompt-delivery",
+            "name": "prompt delivery regression",
+            "prompt": prompt,
+        }),
+    );
+    let elapsed = started.elapsed();
+
+    let id = spawned["id"].as_str().expect("session id");
+    let worktree = spawned["worktreePath"]
+        .as_str()
+        .expect("spawned worktree")
+        .to_owned();
+    let expected = format!("\x1b[200~{prompt}\x1b[201~\r").into_bytes();
+    let deadline = Instant::now() + Duration::from_secs(1);
+    let received = loop {
+        let received = std::fs::read(&capture).unwrap_or_default();
+        if received.len() >= expected.len() || Instant::now() >= deadline {
+            break received;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    };
+    let action_deadline = Instant::now() + Duration::from_secs(1);
+    let acted = loop {
+        let output = bridge
+            .call("read_output", &json!({ "session_id": id }))
+            .expect("read fixture output");
+        if output["text"]
+            .as_str()
+            .is_some_and(|text| text.contains("accepted"))
+        {
+            break true;
+        }
+        if Instant::now() >= action_deadline {
+            break false;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    };
+
+    bridge
+        .call("release_agent", &json!({ "session_id": id }))
+        .expect("release fixture agent");
+    bridge
+        .call(
+            "remove_worktree",
+            &json!({ "repo": repo, "path": worktree, "force": true }),
+        )
+        .expect("remove fixture worktree");
+
+    assert!(
+        elapsed >= Duration::from_secs(1),
+        "spawn_agent returned before the delayed composer existed: {elapsed:?}"
+    );
+    assert_eq!(
+        received, expected,
+        "the MCP prompt must arrive exactly once"
+    );
+    assert!(acted, "the spawned agent must act on the submitted prompt");
+}


### PR DESCRIPTION
## Summary

- make `session.spawn` wait for readiness-gated, verified initial-prompt delivery before returning success
- return `initial_prompt_delivery_failed` with the created session id when the child exits, times out, or never confirms submission
- apply the same contract to local spawn, remote spawn, resume-with-prompt, and the adjacent embedded MCP host
- keep promptless Claude workspace-trust handling asynchronous and extend the MCP spawn timeout beyond the bounded delivery window

## Root cause

The prompt was parsed and plumbed correctly. The filed Swift implementation launched `injectInitialPrompt` in an unjoined `Task` and immediately returned the session record. The Rust port preserved that contract with `std::thread::spawn`; it also started the delivery thread while holding the registry mutex the thread needed. As a result, injection could not begin until after the successful spawn response released the lock, and its `void` outcome could never affect that response.

A minimal real-PTY repro with a 22-character single-line prompt, a shell agent, and no worktree returned success with an empty screen in 0.23s. That rules out worktree latency, Claude-specific boot behavior, and Markdown size/content as the root cause.

## Regression coverage

The new stdio integration test launches the shipped `dirijor-mcp` binary, calls `spawn_agent` over JSON-RPC, creates a real git worktree, and sends a greater-than-4-KB multiline Markdown prompt containing headings, fenced code, backticks, an em dash, and numbered lines. A real PTY fixture verifies the exact bracketed-paste bytes arrive once, receives the submitting carriage return, and prints `accepted`; the MCP call must not return before that happens.

Additional tests prove that control-socket spawn waits for delivery and that a child exiting before acceptance returns the structured delivery error.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --workspace --release`

Existing live sessions and persisted formats are unaffected; this changes only acknowledgement and error behavior for new spawns or resumes carrying an initial prompt.