### PR TITLE
diri: make the motion springs executable and spend them on selection

### DIFF
--- a/diri/crates/diri-app/src/seam.rs
+++ b/diri/crates/diri-app/src/seam.rs
@@ -9,7 +9,7 @@
 
 use std::time::{Duration, Instant};
 
-use diri_ui::Motion;
+use diri_ui::{Motion, motion};
 
 /// How long a panel takes to slide open or shut.
 pub const SEAM_SLIDE: Duration = Duration::from_millis(Motion::SEAM_SLIDE_MS);
@@ -55,22 +55,8 @@ impl SeamSlide {
     }
 
     pub fn seam_at(&self, to: f32, now: Instant) -> f32 {
-        self.from + (to - self.from) * spring_settle(self.progress(now))
+        self.from + (to - self.from) * motion::settle(self.progress(now))
     }
-}
-
-/// The step response of a critically damped spring, normalised to span exactly
-/// 0..1. It leaves fast and settles soft, which is the "spring" part -- but it
-/// never crosses its target, unlike the overshooting curves that usually carry
-/// that name. Overshoot is wrong here specifically: the seam pushes the
-/// terminal card, so a bounce past the target would drag the whole workbench
-/// back and forth rather than reading as elasticity on one small control.
-fn spring_settle(delta: f32) -> f32 {
-    const STIFFNESS: f32 = 7.0;
-    let remaining = |t: f32| (1.0 + STIFFNESS * t) * (-STIFFNESS * t).exp();
-    // The raw response is still ~0.7% short at t = 1. Divide that out, or the
-    // slide ends on a visible one-frame snap onto the settled width.
-    (1.0 - remaining(delta)) / (1.0 - remaining(1.0))
 }
 
 #[cfg(test)]
@@ -78,32 +64,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn the_slide_spans_its_whole_range() {
-        assert_eq!(spring_settle(0.0), 0.0);
-        assert_eq!(spring_settle(1.0), 1.0);
-    }
-
-    #[test]
-    fn the_slide_never_overshoots_or_backs_up() {
-        // Overshoot here would shove the terminal card past its resting edge
-        // and drag it back; a non-monotonic curve would read as a stutter.
-        let mut previous = 0.0;
-        for step in 0..=100 {
-            let value = spring_settle(step as f32 / 100.0);
-            assert!(
-                (0.0..=1.0).contains(&value),
-                "spring_settle({step}/100) left 0..=1 at {value}"
-            );
-            assert!(value >= previous, "spring_settle went backwards at {step}");
-            previous = value;
-        }
-    }
-
-    #[test]
-    fn the_slide_front_loads_its_travel() {
-        // The "spring" read comes from covering most of the distance early and
-        // easing into the target, rather than moving linearly.
-        assert!(spring_settle(0.5) > 0.8, "{}", spring_settle(0.5));
+    fn the_slide_travels_on_the_shared_curve() {
+        // The curve itself is covered in `diri_ui::motion`. What matters here
+        // is that the seam rides that curve rather than a private copy, so a
+        // panel and a row agree on what a transition feels like.
+        let slide = SeamSlide {
+            from: 0.0,
+            started_at: Instant::now() - SEAM_SLIDE / 2,
+        };
+        let now = Instant::now();
+        let expected = 248.0 * motion::settle(slide.progress(now));
+        assert!((slide.seam_at(248.0, now) - expected).abs() < 0.001);
     }
 
     #[test]

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -9,14 +9,14 @@ use diri_proto::{
 };
 use diri_ui::{
     AgentKind, AgentLogo, AlertChip, AttentionDot, AttentionLevel, Fill, FloatingSurface,
-    HairlineDivider, HoverMarquee, Ink, LoadingIndicator, Metrics, Palette, Radius, RowFill,
-    SemanticColors, Space, StateChip, StatusGlyph, StatusState, Typo,
+    HairlineDivider, HoverMarquee, Ink, LoadingIndicator, Metrics, Motion, Palette, Radius,
+    RowFill, SemanticColors, Space, StateChip, StatusGlyph, StatusState, Typo,
 };
 use gpui::{
-    Anchor, AnyElement, App, AppContext as _, Context, Entity, EventEmitter, ExternalPaths,
-    FocusHandle, Focusable, FontWeight, Hsla, IntoElement, MouseButton, Pixels, Point, Render,
-    Rgba, ScrollHandle, SharedString, Task, Window, anchored, deferred, div, linear_color_stop,
-    linear_gradient, point, prelude::*, px,
+    Anchor, Animation, AnimationExt, AnyElement, App, AppContext as _, Context, Entity,
+    EventEmitter, ExternalPaths, FocusHandle, Focusable, FontWeight, Hsla, IntoElement,
+    MouseButton, Pixels, Point, Render, Rgba, ScrollHandle, SharedString, Task, Window, anchored,
+    deferred, div, linear_color_stop, linear_gradient, point, prelude::*, px,
 };
 use tokio::sync::mpsc;
 
@@ -1110,6 +1110,7 @@ impl Sidebar {
         } else {
             RowFill::Clear
         };
+        let fill_color = fill.color(colors);
 
         if self.ui.renaming.as_ref() == Some(&id) {
             return div()
@@ -1199,7 +1200,7 @@ impl Sidebar {
         let drag_payload = DraggedSidebarItem(drag_item);
         let drag_label: SharedString = title.clone().into();
         let entity = cx.entity();
-        div()
+        let row = div()
             .id(format!("session:{}", id.0))
             .pl(px(Space::ROW_H))
             .pr(px(Space::ROW_H))
@@ -1455,8 +1456,34 @@ impl Sidebar {
                             .child(format!("⌘{index}")),
                     )
                 },
-            )
-            .into_any_element()
+            );
+
+        // A selection fill arrives on ROW_SELECT instead of switching between
+        // two frames. Hover deliberately does not animate: hover should feel
+        // like the cursor is touching the row, and a highlight that ramps in
+        // reads as lag rather than as polish.
+        //
+        // Cost drives the same split. A running animation asks for a window
+        // frame per tick, and a window frame repaints everything in it --
+        // live terminal grids included. Hover changes on every row a pointer
+        // crosses, so animating it would schedule repaints for the length of
+        // a sweep down the sidebar; selection changes once per click. An
+        // unselected row therefore carries no animation state at all, rather
+        // than animating an invisible zero-alpha fill.
+        if !selected && !multi {
+            return row.into_any_element();
+        }
+        row.with_animation(
+            SharedString::from(format!("row-fill:{}:{fill:?}", id.0)),
+            Animation::new(Motion::ROW_SELECT_TIME).with_easing(|delta| Motion::SNAP.settle(delta)),
+            move |row, delta| {
+                row.bg(Rgba {
+                    a: fill_color.a * delta,
+                    ..fill_color
+                })
+            },
+        )
+        .into_any_element()
     }
 
     /// The fold control for a row that spawned children, drawn in the same

--- a/diri/crates/diri-ui/src/lib.rs
+++ b/diri/crates/diri-ui/src/lib.rs
@@ -9,6 +9,7 @@
 mod brand;
 mod components;
 mod icon;
+pub mod motion;
 mod status;
 mod svg;
 mod tokens;

--- a/diri/crates/diri-ui/src/motion.rs
+++ b/diri/crates/diri-ui/src/motion.rs
@@ -1,0 +1,143 @@
+//! The one place the motion tokens become executable.
+//!
+//! `Motion` in `tokens` names the curves and durations the product is supposed
+//! to move on, but until this module the springs were four inert pairs of
+//! floats: nothing evaluated them, and the only file that referenced them was
+//! the gallery example, which printed their numbers. This is what turns them
+//! into motion, so a transition in the sidebar and a transition in a panel are
+//! the same motion rather than two hand-rolled approximations that drifted.
+//!
+//! Everything here is transition motion: started by a state change, and it
+//! settles. Nothing in this module loops, and nothing samples a clock. Periodic
+//! motion is a separate decision with its own measured cost -- see the note on
+//! `status::StatusGlyph` -- and is deliberately not reachable from here.
+
+use std::time::Duration;
+
+use crate::{Motion, Spring};
+
+/// The step response of a critically damped spring, normalised to span exactly
+/// 0..1. It leaves fast and settles soft, which is the "spring" part -- but it
+/// never crosses its target, unlike the overshooting curves that usually carry
+/// that name.
+///
+/// Overshoot is deliberately absent. The surfaces this drives are panels and
+/// rows that push their neighbours, so a bounce past the target drags adjacent
+/// layout back and forth rather than reading as elasticity on one small
+/// control. A curve that only ever approaches its target composes safely
+/// anywhere; an overshooting one has to be audited per site.
+#[must_use]
+pub fn settle(delta: f32) -> f32 {
+    settle_with(Spring::SEAM_STIFFNESS, delta)
+}
+
+/// `settle` at an explicit stiffness, for callers that want a tauter or looser
+/// approach than the shared default.
+#[must_use]
+pub fn settle_with(stiffness: f32, delta: f32) -> f32 {
+    let delta = delta.clamp(0.0, 1.0);
+    let remaining = |t: f32| (1.0 + stiffness * t) * (-stiffness * t).exp();
+    // The raw response is still short of 1 at t = 1. Divide that out, or every
+    // transition ends on a visible one-frame snap onto its settled value.
+    (1.0 - remaining(delta)) / (1.0 - remaining(1.0))
+}
+
+impl Spring {
+    /// Stiffness of the shared `settle` curve, in units of "per transition
+    /// duration" rather than per second — the curve is always evaluated over a
+    /// normalised 0..1 progress, so duration is the caller's business.
+    pub const SEAM_STIFFNESS: f32 = 7.0;
+
+    /// This spring's stiffness, derived from its damping fraction. A looser
+    /// damping fraction approaches its target later, which is what separates
+    /// `POP` from `SETTLE` at the same duration.
+    #[must_use]
+    pub fn stiffness(self) -> f32 {
+        Self::SEAM_STIFFNESS * self.damping_fraction / 0.82
+    }
+
+    /// This spring's normalised step response at `delta`.
+    #[must_use]
+    pub fn settle(self, delta: f32) -> f32 {
+        settle_with(self.stiffness(), delta)
+    }
+}
+
+impl Motion {
+    /// Row selection and focus fills, as a `Duration` an animation can take.
+    pub const ROW_SELECT_TIME: Duration = Duration::from_millis((Self::ROW_SELECT * 1000.0) as u64);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_curve_spans_its_whole_range() {
+        assert_eq!(settle(0.0), 0.0);
+        assert_eq!(settle(1.0), 1.0);
+    }
+
+    #[test]
+    fn the_curve_never_overshoots_or_backs_up() {
+        // Overshoot would shove a pushed neighbour past its resting edge and
+        // drag it back; a non-monotonic curve would read as a stutter.
+        let mut previous = 0.0;
+        for step in 0..=100 {
+            let value = settle(step as f32 / 100.0);
+            assert!(
+                (0.0..=1.0).contains(&value),
+                "settle({step}/100) left 0..=1 at {value}"
+            );
+            assert!(value >= previous, "settle went backwards at {step}");
+            previous = value;
+        }
+    }
+
+    #[test]
+    fn the_curve_front_loads_its_travel() {
+        // The "spring" read comes from covering most of the distance early and
+        // easing into the target, rather than moving linearly.
+        assert!(settle(0.5) > 0.8, "{}", settle(0.5));
+    }
+
+    #[test]
+    fn progress_outside_the_animation_is_clamped() {
+        // GPUI clamps its own delta, but the curve is public and is also fed
+        // raw elapsed-over-duration ratios by the seam.
+        assert_eq!(settle(-1.0), 0.0);
+        assert_eq!(settle(2.0), 1.0);
+    }
+
+    #[test]
+    fn every_spring_settles_without_overshooting() {
+        for spring in [
+            Motion::SNAP,
+            Motion::POP,
+            Motion::SETTLE,
+            Motion::FOOTER_PIN,
+        ] {
+            assert_eq!(spring.settle(0.0), 0.0);
+            assert_eq!(spring.settle(1.0), 1.0);
+            let mut previous = 0.0;
+            for step in 0..=50 {
+                let value = spring.settle(step as f32 / 50.0);
+                assert!((0.0..=1.0).contains(&value));
+                assert!(value >= previous);
+                previous = value;
+            }
+        }
+    }
+
+    #[test]
+    fn a_looser_damping_fraction_approaches_its_target_later() {
+        // POP (0.60) stays behind SETTLE (0.82) at the midpoint -- that
+        // difference is the whole reason both tokens exist.
+        assert!(Motion::POP.settle(0.5) < Motion::SETTLE.settle(0.5));
+    }
+
+    #[test]
+    fn the_token_duration_survives_the_conversion_to_time() {
+        assert_eq!(Motion::ROW_SELECT_TIME, Duration::from_millis(160));
+    }
+}


### PR DESCRIPTION
## The finding

`Motion` names four springs — `SNAP`, `POP`, `SETTLE`, `FOOTER_PIN` — and until this PR nothing evaluated any of them. The only file in the repository that referenced a spring was `examples/gallery.rs`, which printed their numbers. They were four inert pairs of floats.

Meanwhile the one place that actually moved on a spring, `seam.rs`, carried its own private critically damped curve, unrelated to the tokens.

## What changed

**`diri-ui/src/motion.rs` (new) — the springs become executable.**
`Spring` gains `stiffness()` and `settle()`, which is what finally makes `POP` and `SETTLE` behave differently rather than merely being named differently. The critically damped curve moves out of `seam.rs` and becomes the shared one, so a panel and a row agree on what a transition feels like. Seven tests cover range, monotonicity, clamping, per-spring ordering, and the token-to-`Duration` conversion.

**`seam.rs` — one curve in the product, not two.**
Drops its private `spring_settle` for the shared curve. The three tests that covered the curve now live with the curve; what stays behind is a test asserting the seam *rides* it, which is the part that can regress.

**Sidebar selection fill — `ROW_SELECT` finally does something.**
A selection fill arrives over 160ms on `Motion::SNAP` instead of switching between two frames. Selection is the sidebar's highest-traffic state change, and a fill that cuts makes a list look like it reshuffled when only one row changed.

## Cost

Checked against the vendored GPUI rather than assumed (`crates/gpui/src/elements/animation.rs`):

- **Nothing animates forever.** The element ends in `if !done { window.request_animation_frame(); }`, and a oneshot animation sets `done` once its delta passes 1.0. The one animation added here is oneshot and never calls `.repeat()`.
- **Reduce Motion is automatic.** When `cx.reduce_motion()` is set, GPUI forces the end state and marks the animation done, scheduling no frames at all.
- **The unit of cost is a whole window repaint** — live terminal grids included — for the animation's duration. That is what shaped the next decision.

**Hover is deliberately not animated.** Hover changes on every row a pointer crosses, so animating it would schedule window repaints for the length of a sweep down the sidebar; selection changes once per click. An unselected row carries no animation state at all rather than animating an invisible zero-alpha fill. It is also the better feel — a hover highlight that ramps in reads as lag.

Worst case is one 160ms window animation per selection change. An idle window schedules zero frames.

## Two things I cut after `main` moved

This branch was written against an older `main`, and two of its five original changes were superseded by work that landed in the meantime. Both are dropped rather than merged, because in each case `main`'s version is the better one:

- **`StatusGlyph` cross-fade — dropped.** `main` now documents, with measurements, that a 10 Hz status ticker cost ~3% idle CPU and held ~240 MB of GPU memory an idle window otherwise returns, and adds `status_marks_never_sample_a_clock_while_rendering` to keep marks clock-free. My version sampled an `Instant` during render to retire a finished cross-fade. A one-shot transition is not the perpetual ticker that was measured, but the invariant is deliberate and backed by numbers, and a fleet changing status frequently approximates the thing it rules out. Not worth overriding a measured decision for a 220ms fade.
- **`FloatingSurface` entrance — dropped.** `main` rewrote it with an explicit `floating_surface_motion` policy and a tested opacity ramp (`floating_surface_opacity(false, 0.0) == 0.76`). That structure is better than what I had, and deepening the ramp would have overridden a tested choice.

## What this still does not do

- **No ambient motion.** The dormant periodic machinery in `AnimationPhase` stays dormant; `main`'s measurements are the reason, and turning it on deserves its own argument.
- **No reorder travel.** Rows that change rank still teleport. Making them travel needs per-row layout interpolation — a real piece of work, and the highest-value motion left, now that there is a shared curve to do it with.
- **No velocity-preserving seam reversal.** `seam.rs` still drops toggles arriving mid-slide. Its comment defends this on the grounds that reversal reads as a stutter, which holds for a duration lerp but not for a spring — changing it is a behavior change, not polish.

## Verification

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p diri-ui` — 28 passed.
- `cargo test -p diri-app` — 359 passed, 0 failed.

Run against a private `CARGO_TARGET_DIR`. Sharing one with a dirty main checkout produced a compile error attributed to this branch that came from the other tree entirely.

Motion is something you have to look at. These tests cover the curve's mathematical properties and the no-perpetual-frames contract, not how the fill feels arriving — that part wants eyes on a running build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
