### PR TITLE
test: wait on a deadline for the spawned daemon marker

### DIFF
--- a/diri/crates/diri-app/src/daemon_launch.rs
+++ b/diri/crates/diri-app/src/daemon_launch.rs
@@ -536,10 +536,12 @@ mod tests {
             server.join().expect("fixture server"),
             vec![Method::HELLO, Method::DAEMON_SHUTDOWN]
         );
-        for _ in 0..50 {
-            if marker.exists() {
-                break;
-            }
+        // Wait on a deadline, not a fixed iteration count. This is a real
+        // spawned process writing a real file, and 50 × 10ms only ever bought
+        // half a second — enough on an idle machine, not enough on a loaded CI
+        // runner, where this failed with the marker simply not written yet.
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        while !marker.exists() && std::time::Instant::now() < deadline {
             std::thread::sleep(Duration::from_millis(10));
         }
         assert_eq!(


### PR DESCRIPTION
CI on `main` has been red about half the time — 4 of the last 8 runs, including a commit titled docs-only, which is what says these are infrastructural rather than code. This is one of the two causes I could pin down.

`an_outdated_live_daemon_is_replaced_by_the_resolved_bundle` spawns a real process and waits for it to write a marker file:

```rust
for _ in 0..50 {
    if marker.exists() { break; }
    std::thread::sleep(Duration::from_millis(10));
}
assert_eq!(std::fs::read_to_string(marker).expect("new daemon marker"), "launched");
```

That is a hard **500 ms** budget for a process launch plus a file write. Fine on an idle machine; not fine on a loaded runner, where it falls out of the loop and fails on the `read_to_string` with `NotFound` — an error about the timeout, not about anything the test is checking.

Swapped for a ten-second deadline. A passing run is no slower, since the loop still exits the moment the marker lands.

## The other one, not fixed here

The failure on #78 was different:

```
control::tests::history_resume_keeps_the_identity_needed_for_another_resume
panicked at crates/diri-engine/src/control.rs:3530:
terminate resumed probe: Os { code: 1, kind: PermissionDenied, message: "Operation not permitted" }
```

The test asserts `registry.terminate(...)` succeeds on a short-lived probe process. EPERM from `kill` usually means the process is already gone or otherwise unsignalable — which the OS does not promise won't happen.

I deliberately left it alone. The obvious patch is to tolerate the error, but `Registry::terminate` is real engine code and `remove()` already swallows its result, so making it lenient could hide a genuine failure rather than fix a flake. I could not reproduce the EPERM to verify any fix, and guessing at engine kill semantics is worse than leaving a known-flaky test visible. Worth a look from someone who knows what states that probe can exit in.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy -p diri-app --all-targets -- -D warnings`
- [x] `cargo test -p diri-app --bin diri daemon_launch` — 9 passed