### PR TITLE
Fix light themes in Review and Code tabs

### DIFF
--- a/diri/crates/diri-app/src/code_viewer.rs
+++ b/diri/crates/diri-app/src/code_viewer.rs
@@ -19,7 +19,7 @@ use crate::code_intelligence::{
 };
 use crate::macos::sf_symbols::{SymbolWeight, sf_symbol, sf_symbol_weighted};
 use crate::query_editor::{self, ClipboardEdit, Edit, QueryEditor};
-use diri_ui::{FloatingSurface, Radius, SemanticColors, Typo};
+use diri_ui::{Appearance, FloatingSurface, Radius, SemanticColors, Typo};
 
 #[cfg(test)]
 use crate::code_intelligence::SourceTarget;
@@ -38,6 +38,7 @@ enum ViewerState {
 pub struct CodeViewer {
     tokio: tokio::runtime::Handle,
     focus: FocusHandle,
+    colors: SemanticColors,
     workspace_cwd: Option<PathBuf>,
     intelligence: Option<Arc<CodeIntelligence>>,
     state: ViewerState,
@@ -55,10 +56,15 @@ pub struct CodeViewer {
 }
 
 impl CodeViewer {
-    pub fn new(tokio: tokio::runtime::Handle, cx: &mut Context<Self>) -> Self {
+    pub fn new(
+        tokio: tokio::runtime::Handle,
+        colors: SemanticColors,
+        cx: &mut Context<Self>,
+    ) -> Self {
         Self {
             tokio,
             focus: cx.focus_handle(),
+            colors,
             workspace_cwd: None,
             intelligence: None,
             state: ViewerState::Empty,
@@ -74,6 +80,19 @@ impl CodeViewer {
             history: Vec::new(),
             history_index: 0,
         }
+    }
+
+    pub fn set_colors(&mut self, colors: SemanticColors, cx: &mut Context<Self>) {
+        if self.colors == colors {
+            return;
+        }
+        self.colors = colors;
+        cx.notify();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn appearance(&self) -> diri_ui::Appearance {
+        self.colors.appearance
     }
 
     fn toggle_picker(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -571,7 +590,7 @@ impl CodeViewer {
                             if symbol { "curlybraces" } else { "doc.text" },
                             11.5,
                             if symbol {
-                                rgba(0xc792eaff)
+                                code_palette(colors).keyword
                             } else {
                                 colors.secondary
                             },
@@ -712,7 +731,7 @@ impl Focusable for CodeViewer {
 
 impl Render for CodeViewer {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let colors = SemanticColors::dark();
+        let colors = self.colors;
         let snapshot = match &self.state {
             ViewerState::Ready(snapshot) => Some(Arc::clone(snapshot)),
             _ => None,
@@ -762,11 +781,12 @@ fn source_row(
     content_width: f32,
     colors: SemanticColors,
 ) -> AnyElement {
+    let palette = code_palette(colors);
     let line = &snapshot.lines[index];
     let source = snapshot.text[line.range.clone()]
         .trim_end_matches(['\r', '\n'])
         .to_owned();
-    let styled = highlighted_source(source, extension);
+    let styled = highlighted_source(source, extension, palette);
     div()
         .id(index)
         .h(px(SOURCE_ROW_HEIGHT))
@@ -811,14 +831,39 @@ fn source_row(
                 .items_center()
                 .font_family(crate::fonts::mono_family())
                 .text_size(px(11.5))
-                .text_color(rgba(0xd8dee9ff))
+                .text_color(palette.foreground)
                 .child(styled),
         )
         .into_any_element()
 }
 
-fn highlighted_source(source: String, extension: &str) -> AnyElement {
-    let ranges = lexical_highlights(&source, extension);
+#[derive(Clone, Copy)]
+struct CodePalette {
+    foreground: gpui::Rgba,
+    comment: gpui::Rgba,
+    string: gpui::Rgba,
+    keyword: gpui::Rgba,
+}
+
+fn code_palette(colors: SemanticColors) -> CodePalette {
+    match colors.appearance {
+        Appearance::Dark => CodePalette {
+            foreground: rgba(0xd8dee9ff),
+            comment: rgba(0x718096ff),
+            string: rgba(0xd7ba7dff),
+            keyword: rgba(0xc792eaff),
+        },
+        Appearance::Light => CodePalette {
+            foreground: rgba(0x2f3337ff),
+            comment: rgba(0x5f6368ff),
+            string: rgba(0x7a4d00ff),
+            keyword: rgba(0x6f42c1ff),
+        },
+    }
+}
+
+fn highlighted_source(source: String, extension: &str, palette: CodePalette) -> AnyElement {
+    let ranges = lexical_highlights(&source, extension, palette);
     if ranges.is_empty() {
         return div().child(source).into_any_element();
     }
@@ -827,7 +872,11 @@ fn highlighted_source(source: String, extension: &str) -> AnyElement {
         .into_any_element()
 }
 
-fn lexical_highlights(source: &str, extension: &str) -> Vec<(Range<usize>, HighlightStyle)> {
+fn lexical_highlights(
+    source: &str,
+    extension: &str,
+    palette: CodePalette,
+) -> Vec<(Range<usize>, HighlightStyle)> {
     let mut ranges = Vec::new();
     let comment_start = match extension {
         "py" | "rb" | "sh" | "bash" | "zsh" | "fish" | "toml" | "yaml" | "yml" => source.find('#'),
@@ -839,7 +888,7 @@ fn lexical_highlights(source: &str, extension: &str) -> Vec<(Range<usize>, Highl
         ranges.push((
             start..source.len(),
             HighlightStyle {
-                color: Some(rgba(0x718096ff).into()),
+                color: Some(palette.comment.into()),
                 font_style: Some(gpui::FontStyle::Italic),
                 ..HighlightStyle::default()
             },
@@ -869,7 +918,7 @@ fn lexical_highlights(source: &str, extension: &str) -> Vec<(Range<usize>, Highl
         ranges.push((
             start..cursor,
             HighlightStyle {
-                color: Some(rgba(0xd7ba7dff).into()),
+                color: Some(palette.string.into()),
                 ..HighlightStyle::default()
             },
         ));
@@ -891,7 +940,7 @@ fn lexical_highlights(source: &str, extension: &str) -> Vec<(Range<usize>, Highl
                 ranges.push((
                     start..end,
                     HighlightStyle {
-                        color: Some(rgba(0xc792eaff).into()),
+                        color: Some(palette.keyword.into()),
                         font_weight: Some(FontWeight::MEDIUM),
                         ..HighlightStyle::default()
                     },
@@ -1002,10 +1051,27 @@ const COMMON_KEYWORDS: &[&str] = &[
 mod tests {
     use super::*;
 
+    fn relative_luminance(color: gpui::Rgba) -> f32 {
+        fn linear(channel: f32) -> f32 {
+            if channel <= 0.03928 {
+                channel / 12.92
+            } else {
+                ((channel + 0.055) / 1.055).powf(2.4)
+            }
+        }
+        0.2126 * linear(color.r) + 0.7152 * linear(color.g) + 0.0722 * linear(color.b)
+    }
+
+    fn contrast(left: gpui::Rgba, right: gpui::Rgba) -> f32 {
+        let left = relative_luminance(left);
+        let right = relative_luminance(right);
+        (left.max(right) + 0.05) / (left.min(right) + 0.05)
+    }
+
     #[test]
     fn highlights_keywords_strings_and_comments_without_overlapping() {
         let source = "pub fn main() { let value = \"hello\"; // note";
-        let ranges = lexical_highlights(source, "rs");
+        let ranges = lexical_highlights(source, "rs", code_palette(SemanticColors::dark()));
         assert!(
             ranges
                 .iter()
@@ -1031,12 +1097,32 @@ mod tests {
     #[test]
     fn keyword_boundaries_do_not_color_identifiers() {
         let source = "format for before";
-        let ranges = lexical_highlights(source, "rs");
+        let ranges = lexical_highlights(source, "rs", code_palette(SemanticColors::dark()));
         let words: Vec<_> = ranges
             .iter()
             .map(|(range, _)| &source[range.clone()])
             .collect();
         assert_eq!(words, vec!["for"]);
+    }
+
+    #[test]
+    fn light_code_palette_keeps_source_tokens_readable() {
+        for theme in ["dirijor-light", "solarized-light", "github-light"] {
+            let colors = crate::app_theme::colors(theme);
+            let palette = code_palette(colors);
+
+            for (role, foreground) in [
+                ("source", palette.foreground),
+                ("comment", palette.comment),
+                ("string", palette.string),
+                ("keyword", palette.keyword),
+            ] {
+                assert!(
+                    contrast(foreground, colors.background) >= 4.5,
+                    "{role} contrast must remain readable with {theme}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/diri/crates/diri-app/src/inspector.rs
+++ b/diri/crates/diri-app/src/inspector.rs
@@ -15,8 +15,8 @@ use diri_proto::{
     SessionArtifact, SessionDiffBase, SessionId, SessionRecord, SessionStatus,
 };
 use diri_ui::{
-    AgentKind, AgentLogo, Fill, FloatingSurface, Ink, LoadingIndicator, Metrics, Radius,
-    SemanticColors, Typo,
+    AgentKind, AgentLogo, Appearance, Fill, FloatingSurface, Ink, LoadingIndicator, Metrics,
+    Radius, SemanticColors, Typo,
 };
 use gpui::{
     Animation, AnimationExt, AnyElement, App, Context, DragMoveEvent, Entity, EventEmitter,
@@ -204,7 +204,14 @@ impl WorkbenchInspector {
         cx: &mut Context<Self>,
     ) -> Self {
         let tokio = tokio_owner.handle().clone();
-        let code_viewer = cx.new(|cx| CodeViewer::new(tokio.clone(), cx));
+        let (selected_tab, code_colors) = {
+            let store = runtime.store.read().expect("session store lock poisoned");
+            (
+                store.preferences().inspector_tab,
+                crate::app_theme::sidebar_colors(&store.preferences().terminal_theme),
+            )
+        };
+        let code_viewer = cx.new(|cx| CodeViewer::new(tokio.clone(), code_colors, cx));
         let focus = cx.focus_handle();
         let mut changes = runtime.changes();
         let store_changes = cx.spawn(async move |this, cx| {
@@ -222,12 +229,6 @@ impl WorkbenchInspector {
                 }
             }
         });
-        let selected_tab = runtime
-            .store
-            .read()
-            .expect("session store lock poisoned")
-            .preferences()
-            .inspector_tab;
         Self {
             runtime,
             _tokio_owner: tokio_owner,
@@ -354,6 +355,16 @@ impl WorkbenchInspector {
     }
 
     fn refresh_if_context_changed(&mut self, cx: &mut Context<Self>) {
+        let colors = {
+            let store = self
+                .runtime
+                .store
+                .read()
+                .expect("session store lock poisoned");
+            crate::app_theme::sidebar_colors(&store.preferences().terminal_theme)
+        };
+        self.code_viewer
+            .update(cx, |viewer, cx| viewer.set_colors(colors, cx));
         if !self.visible {
             return;
         }
@@ -4191,14 +4202,11 @@ fn render_row(
     let repo_root = &context.repo_root;
     let layer = context.layer;
     let armed_hunk = context.armed_hunk;
-    let (background, foreground, marker) = match row.kind {
-        DiffRowKind::Addition => (rgba(0x2f7d4a24), rgba(0xc7ebd2ff), "+"),
-        DiffRowKind::Deletion => (rgba(0x9f3a4424), rgba(0xf0c4c8ff), "−"),
-        DiffRowKind::Hunk => (rgba(0x4675a31c), rgba(0x9bbde0ff), ""),
-        DiffRowKind::File => (rgba(0xffffff09), colors.primary, ""),
-        DiffRowKind::Context => (rgba(0x00000000), rgba(0xffffffb8), ""),
-        DiffRowKind::Meta => (rgba(0x00000000), rgba(0xffffff66), ""),
-    };
+    let DiffRowStyle {
+        background,
+        foreground,
+        marker,
+    } = diff_row_style(row.kind, colors);
     let line_number = |line: Option<u32>| line.map_or_else(String::new, |line| line.to_string());
     let text = if row.kind == DiffRowKind::File {
         SharedString::from(row.text.clone())
@@ -4533,6 +4541,35 @@ fn render_row(
         .into_any_element()
 }
 
+#[derive(Clone, Copy)]
+struct DiffRowStyle {
+    background: gpui::Rgba,
+    foreground: gpui::Rgba,
+    marker: &'static str,
+}
+
+fn diff_row_style(kind: DiffRowKind, colors: SemanticColors) -> DiffRowStyle {
+    let (background, foreground, marker) = match (colors.appearance, kind) {
+        (Appearance::Dark, DiffRowKind::Addition) => (rgba(0x2f7d4a24), rgba(0xc7ebd2ff), "+"),
+        (Appearance::Dark, DiffRowKind::Deletion) => (rgba(0x9f3a4424), rgba(0xf0c4c8ff), "−"),
+        (Appearance::Dark, DiffRowKind::Hunk) => (rgba(0x4675a31c), rgba(0x9bbde0ff), ""),
+        (Appearance::Dark, DiffRowKind::File) => (rgba(0xffffff09), colors.primary, ""),
+        (Appearance::Dark, DiffRowKind::Context) => (rgba(0x00000000), rgba(0xffffffb8), ""),
+        (Appearance::Dark, DiffRowKind::Meta) => (rgba(0x00000000), rgba(0xffffff66), ""),
+        (Appearance::Light, DiffRowKind::Addition) => (rgba(0x2f7d4a18), rgba(0x24522eff), "+"),
+        (Appearance::Light, DiffRowKind::Deletion) => (rgba(0x9f3a4418), rgba(0x812c32ff), "−"),
+        (Appearance::Light, DiffRowKind::Hunk) => (rgba(0x4675a316), rgba(0x285b85ff), ""),
+        (Appearance::Light, DiffRowKind::File) => (rgba(0x00000008), rgba(0x34312dff), ""),
+        (Appearance::Light, DiffRowKind::Context) => (rgba(0x00000000), rgba(0x34312dff), ""),
+        (Appearance::Light, DiffRowKind::Meta) => (rgba(0x00000000), rgba(0x5a5650ff), ""),
+    };
+    DiffRowStyle {
+        background,
+        foreground,
+        marker,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4542,6 +4579,39 @@ mod tests {
 
     struct InspectorHarness {
         inspector: Entity<WorkbenchInspector>,
+    }
+
+    fn composite(foreground: gpui::Rgba, background: gpui::Rgba) -> gpui::Rgba {
+        let alpha = foreground.a + background.a * (1.0 - foreground.a);
+        if alpha == 0.0 {
+            return rgba(0x00000000);
+        }
+        gpui::Rgba {
+            r: (foreground.r * foreground.a + background.r * background.a * (1.0 - foreground.a))
+                / alpha,
+            g: (foreground.g * foreground.a + background.g * background.a * (1.0 - foreground.a))
+                / alpha,
+            b: (foreground.b * foreground.a + background.b * background.a * (1.0 - foreground.a))
+                / alpha,
+            a: alpha,
+        }
+    }
+
+    fn relative_luminance(color: gpui::Rgba) -> f32 {
+        fn linear(channel: f32) -> f32 {
+            if channel <= 0.03928 {
+                channel / 12.92
+            } else {
+                ((channel + 0.055) / 1.055).powf(2.4)
+            }
+        }
+        0.2126 * linear(color.r) + 0.7152 * linear(color.g) + 0.0722 * linear(color.b)
+    }
+
+    fn contrast(left: gpui::Rgba, right: gpui::Rgba) -> f32 {
+        let left = relative_luminance(left);
+        let right = relative_luminance(right);
+        (left.max(right) + 0.05) / (left.min(right) + 0.05)
     }
 
     impl Render for InspectorHarness {
@@ -4559,6 +4629,104 @@ mod tests {
         assert!(InspectorTab::Info.index() < InspectorTab::Changes.index());
         assert!(InspectorTab::Changes.index() < InspectorTab::Code.index());
         assert!(InspectorTab::Code.index() < InspectorTab::Artifacts.index());
+    }
+
+    #[gpui::test]
+    fn light_theme_reaches_the_code_tab(cx: &mut TestAppContext) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        runtime
+            .store
+            .write()
+            .expect("session store lock poisoned")
+            .update_preferences(|preferences| {
+                preferences.terminal_theme = "dirijor-light".to_owned();
+                preferences.inspector_tab = InspectorTab::Code;
+            })
+            .expect("inert preferences update");
+        let tokio = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime"),
+        );
+        let inspector_runtime = Arc::clone(&runtime);
+        let (harness, cx) = cx.add_window_view(move |_window, cx| {
+            let inspector = cx.new(|cx| WorkbenchInspector::new(inspector_runtime, tokio, cx));
+            InspectorHarness { inspector }
+        });
+        let code_viewer = harness.read_with(cx, |harness, cx| {
+            harness
+                .inspector
+                .read_with(cx, |inspector, _| inspector.code_viewer.clone())
+        });
+
+        assert_eq!(
+            code_viewer.read_with(cx, |viewer, _| viewer.appearance()),
+            diri_ui::Appearance::Light
+        );
+    }
+
+    #[gpui::test]
+    fn code_tab_tracks_live_light_theme_changes(cx: &mut TestAppContext) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        let tokio = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime"),
+        );
+        let inspector_runtime = Arc::clone(&runtime);
+        let (harness, cx) = cx.add_window_view(move |_window, cx| {
+            let inspector = cx.new(|cx| WorkbenchInspector::new(inspector_runtime, tokio, cx));
+            InspectorHarness { inspector }
+        });
+        let inspector = harness.read_with(cx, |harness, _| harness.inspector.clone());
+        let code_viewer = inspector.read_with(cx, |inspector, _| inspector.code_viewer.clone());
+        assert_eq!(
+            code_viewer.read_with(cx, |viewer, _| viewer.appearance()),
+            diri_ui::Appearance::Dark
+        );
+
+        runtime
+            .store
+            .write()
+            .expect("session store lock poisoned")
+            .update_preferences(|preferences| {
+                preferences.terminal_theme = "dirijor-light".to_owned();
+            })
+            .expect("inert preferences update");
+        runtime.publish_local_change();
+        cx.run_until_parked();
+
+        assert_eq!(
+            code_viewer.read_with(cx, |viewer, _| viewer.appearance()),
+            diri_ui::Appearance::Light
+        );
+    }
+
+    #[test]
+    fn light_review_rows_keep_readable_contrast() {
+        for theme in ["dirijor-light", "solarized-light", "github-light"] {
+            let colors = crate::app_theme::sidebar_colors(theme);
+            let inspector_surface = composite(colors.sidebar_surface(), colors.background);
+
+            for kind in [
+                DiffRowKind::Addition,
+                DiffRowKind::Deletion,
+                DiffRowKind::Hunk,
+                DiffRowKind::File,
+                DiffRowKind::Context,
+                DiffRowKind::Meta,
+            ] {
+                let style = diff_row_style(kind, colors);
+                let row_surface = composite(style.background, inspector_surface);
+                let text = composite(style.foreground, row_surface);
+                assert!(
+                    contrast(text, row_surface) >= 4.5,
+                    "{kind:?} contrast must remain readable with {theme}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/diri/crates/diri-app/src/store/mod.rs
+++ b/diri/crates/diri-app/src/store/mod.rs
@@ -2581,6 +2581,13 @@ impl StoreRuntime {
         self.change_tx.subscribe()
     }
 
+    /// Publishes a synchronous local store mutation to views that subscribe to
+    /// the runtime's invalidation stream. Daemon events already do this in the
+    /// coalescing task; settings saves use this path after updating preferences.
+    pub fn publish_local_change(&self) {
+        let _ = self.change_tx.send(());
+    }
+
     pub fn client(&self) -> &Arc<DaemonClient> {
         &self.client
     }

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -549,6 +549,7 @@ impl UtilitySurfaces {
         {
             self.activity = format!("Could not save settings: {error}");
         } else {
+            self.store_runtime.publish_local_change();
             self.activity = "Settings saved for diri".to_owned();
         }
     }


### PR DESCRIPTION
## Summary
- make the Code viewer consume the selected application theme instead of forcing the dark palette
- add contrast-tested light syntax and diff-row palettes while preserving the existing dark colors
- publish local settings changes so an open Review or Code tab updates immediately when the theme changes

## Root cause
The Code viewer constructed its own dark semantic palette, and Review diff rows overrode semantic colors with dark-only foregrounds. Theme preference saves also did not publish the view invalidation stream, so child surfaces could retain stale colors until another store event.

## Verification
- cargo test -p diri-app — 350 passed, 2 ignored
- cargo clippy -p diri-app --all-targets -- -D warnings
- cargo fmt --all -- --check
- regression coverage verifies 4.5:1 composited contrast for Dirijor Light, Solarized Light, and GitHub Light, plus initial and live Code theme propagation