### PR TITLE
Fix unreadable terminal colors in light themes

### DIFF
--- a/diri/crates/diri-term/src/theme.rs
+++ b/diri/crates/diri-term/src/theme.rs
@@ -18,6 +18,72 @@ const fn with_alpha(color: Rgba, alpha: f32) -> Rgba {
     Rgba { a: alpha, ..color }
 }
 
+const MINIMUM_TEXT_CONTRAST: f32 = 4.5;
+
+fn relative_luminance(color: Rgba) -> f32 {
+    fn linear(channel: f32) -> f32 {
+        if channel <= 0.04045 {
+            channel / 12.92
+        } else {
+            ((channel + 0.055) / 1.055).powf(2.4)
+        }
+    }
+
+    0.2126 * linear(color.r) + 0.7152 * linear(color.g) + 0.0722 * linear(color.b)
+}
+
+fn contrast_ratio(left: Rgba, right: Rgba) -> f32 {
+    let left = relative_luminance(left);
+    let right = relative_luminance(right);
+    (left.max(right) + 0.05) / (left.min(right) + 0.05)
+}
+
+fn mix(left: Rgba, right: Rgba, amount: f32) -> Rgba {
+    Rgba {
+        r: left.r + (right.r - left.r) * amount,
+        g: left.g + (right.g - left.g) * amount,
+        b: left.b + (right.b - left.b) * amount,
+        a: left.a + (right.a - left.a) * amount,
+    }
+}
+
+/// Pull an explicit dark-oriented terminal color toward the theme foreground
+/// only as far as needed to remain readable on a light default background.
+///
+/// Programs such as Claude Code emit truecolor syntax palettes chosen by their
+/// own theme. A light Diri theme cannot replace those colors through its ANSI
+/// palette, so white and neon tokens otherwise disappear into the terminal's
+/// light background. Explicit block backgrounds are intentionally excluded by
+/// the caller: a program's own diff/error panels keep their authored colors.
+fn readable_explicit_foreground(foreground: Rgba, background: Rgba, fallback: Rgba) -> Rgba {
+    if contrast_ratio(foreground, background) >= MINIMUM_TEXT_CONTRAST {
+        return foreground;
+    }
+    let fallback = if contrast_ratio(fallback, background) >= MINIMUM_TEXT_CONTRAST {
+        fallback
+    } else {
+        let black = rgba_f32(0.0, 0.0, 0.0, 1.0);
+        let white = rgba_f32(1.0, 1.0, 1.0, 1.0);
+        if contrast_ratio(black, background) >= contrast_ratio(white, background) {
+            black
+        } else {
+            white
+        }
+    };
+
+    let mut unreadable = 0.0;
+    let mut readable = 1.0;
+    for _ in 0..12 {
+        let amount = (unreadable + readable) * 0.5;
+        if contrast_ratio(mix(foreground, fallback, amount), background) >= MINIMUM_TEXT_CONTRAST {
+            readable = amount;
+        } else {
+            unreadable = amount;
+        }
+    }
+    mix(foreground, fallback, readable)
+}
+
 /// Concrete rendering attributes after terminal colors and SGR flags resolve.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ResolvedCellStyle {
@@ -367,6 +433,13 @@ impl TermTheme {
         } else {
             self.resolve_color(cell.bg, true)
         };
+        if self.appearance == ThemeAppearance::Light
+            && !inverse
+            && is_default_background(cell.bg)
+            && !matches!(cell.fg, TermColor::Default | TermColor::DefaultInverted)
+        {
+            foreground = readable_explicit_foreground(foreground, background, self.foreground);
+        }
         let visible = !cell.style.contains(TermStyle::INVISIBLE);
         if cell.style.contains(TermStyle::DIM) {
             foreground = foreground.opacity(0.5);
@@ -593,6 +666,57 @@ mod tests {
             theme.resolve_color(TermColor::Rgb(12, 34, 56), false),
             hex(0x0c2238),
         );
+    }
+
+    #[test]
+    fn light_theme_keeps_dark_oriented_truecolor_readable_on_its_default_background() {
+        for theme in TermTheme::CATALOG
+            .iter()
+            .filter(|theme| theme.appearance == ThemeAppearance::Light)
+        {
+            for foreground in [TermColor::Rgb(255, 255, 255), TermColor::Ansi(15)] {
+                let resolved = theme.resolve_cell(GridCell::new(
+                    u32::from('x'),
+                    foreground,
+                    TermColor::Default,
+                    TermStyle::empty(),
+                ));
+
+                assert!(
+                    contrast_ratio(resolved.foreground, resolved.background) >= 4.5,
+                    "a dark-oriented TUI's bright text must remain readable with {}",
+                    theme.id
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn light_theme_preserves_truecolor_inside_an_explicit_dark_panel() {
+        let theme = TermTheme::DIRIJOR_LIGHT;
+        let foreground = TermColor::Rgb(255, 255, 255);
+        let resolved = theme.resolve_cell(GridCell::new(
+            u32::from('x'),
+            foreground,
+            TermColor::Rgb(64, 0, 0),
+            TermStyle::empty(),
+        ));
+
+        assert_rgba(resolved.foreground, theme.resolve_color(foreground, false));
+    }
+
+    #[test]
+    fn dark_theme_preserves_truecolor_on_its_default_background() {
+        let theme = TermTheme::DIRIJOR_DARK;
+        let foreground = TermColor::Rgb(32, 32, 32);
+        let resolved = theme.resolve_cell(GridCell::new(
+            u32::from('x'),
+            foreground,
+            TermColor::Default,
+            TermStyle::empty(),
+        ));
+
+        assert_rgba(resolved.foreground, theme.resolve_color(foreground, false));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- enforce readable contrast for explicit terminal foreground colors on light default backgrounds
- preserve authored colors inside explicit diff/error panels and leave dark themes unchanged
- cover truecolor and ANSI bright text across every bundled light theme

## Root cause
Dark-oriented TUIs such as Claude Code emit explicit truecolor syntax colors. Those bypass Diri’s theme ANSI palette, so near-white text was painted unchanged on a light terminal background.

## Verification
- PATH=/Users/giga/.cargo/bin:$PATH ./scripts/check.sh
- cargo test -p diri-term