### PR TITLE
Clarify native agent spawning guidance

### DIFF
--- a/diri/crates/diri-engine/src/mcp/tools.rs
+++ b/diri/crates/diri-engine/src/mcp/tools.rs
@@ -43,13 +43,18 @@ pub fn tool_definitions_for(kinds: &[String]) -> Vec<ToolDefinition> {
     vec![
         tool(
             "spawn_agent",
-            "Open a NEW session (tab) in diri running an agent or a shell. USE THIS whenever the \
-             user asks to open, start, spawn or launch another agent, session, or terminal. \
+            "Open a NEW standalone agent session, or an interactive shell in the current \
+             session's Cmd+J pane. USE THIS whenever the user asks to open, start, spawn or \
+             launch another agent, session, or terminal. For an agent, choose its native kind \
+             and pass the task as `prompt`; if no agent is named, reuse your own native kind \
+             when it is offered. Never use `shell` to launch an agent CLI such as \
+             `claude`, `codex`, `cursor`, or `gemini`; a shell prompt is executed as commands. \
+             Use `shell` only when the user explicitly wants a terminal or raw commands. \
              Optionally create a fresh git worktree for it and give it an initial prompt.",
             json!({
                 "type": "object",
                 "properties": {
-                    "kind": { "type": "string", "enum": kind_enum, "description": "Which agent to run." },
+                    "kind": { "type": "string", "enum": kind_enum, "description": "The native agent kind to launch. Use shell only for a terminal or raw commands, never as an agent wrapper." },
                     "cwd": { "type": "string", "description": "Working directory (a repo path when worktree is true)." },
                     "worktree": { "type": "boolean", "description": "Create a fresh git worktree off cwd and run there (local spawns only)." },
                     "prompt": { "type": "string", "description": "Initial prompt to send once the agent is ready." },
@@ -243,6 +248,33 @@ mod tests {
             .filter_map(Value::as_str)
             .collect();
         assert_eq!(enumerated, vec!["opencode", "shell"]);
+    }
+
+    #[test]
+    fn spawning_guidance_reserves_shell_for_terminal_commands() {
+        let tools = tool_definitions();
+        let spawn = tools
+            .iter()
+            .find(|tool| tool.name == "spawn_agent")
+            .expect("spawn_agent");
+        let kind = spawn.input_schema["properties"]["kind"]["description"]
+            .as_str()
+            .expect("kind description");
+
+        assert!(spawn.description.contains("standalone agent session"));
+        assert!(spawn.description.contains("reuse your own native kind"));
+        assert!(
+            spawn
+                .description
+                .contains("Never use `shell` to launch an agent CLI")
+        );
+        assert!(
+            spawn
+                .description
+                .contains("shell prompt is executed as commands")
+        );
+        assert!(kind.contains("native agent kind"));
+        assert!(kind.contains("never as an agent wrapper"));
     }
 
     #[test]

--- a/diri/crates/dirijor-mcp/src/main.rs
+++ b/diri/crates/dirijor-mcp/src/main.rs
@@ -84,7 +84,13 @@ fn initialize(params: &Value) -> Value {
              open/start/spawn/close another agent, session, tab, or terminal (Claude Code, \
              Codex, Cursor, Gemini, or a shell), to check what other sessions are doing, to \
              talk to another session, or to parallelize work across git worktrees — no \
-             extra confirmation of intent needed.\n\nTypical orchestration flow: spawn_agent \
+             extra confirmation of intent needed.\n\nAgent vs terminal rule: when asked to spawn \
+             another agent, select that agent's native kind (for example `claude` or `codex`) \
+             and pass its task as `prompt`. If no agent is named, use your own native kind when \
+             it is available. Never use `shell` to launch an agent CLI such as `claude`, \
+             `codex`, `cursor`, or `gemini`. A child `shell` is an interactive terminal shown \
+             in the parent's Cmd+J pane, and its prompt is executed as shell commands; use it \
+             only when the user explicitly wants a terminal or raw commands.\n\nTypical orchestration flow: spawn_agent \
              (optionally worktree:true and an initial prompt) → wait_for_agent(until:\"done\") \
              → read_output → send_prompt for follow-ups → release_agent when finished. \
              get_artifacts returns PR/Linear/preview URLs and listening ports a session has \
@@ -190,5 +196,15 @@ mod tests {
         .unwrap();
         assert_eq!(called["result"]["isError"], false);
         assert_eq!(called["result"]["content"][0]["text"], "{\"agents\":[]}");
+    }
+
+    #[test]
+    fn instructions_distinguish_agent_sessions_from_shell_panes() {
+        let initialized = initialize(&json!({}));
+        let instructions = initialized["instructions"].as_str().expect("instructions");
+
+        assert!(instructions.contains("native kind"));
+        assert!(instructions.contains("Never use `shell` to launch an agent CLI"));
+        assert!(instructions.contains("Cmd+J"));
     }
 }


### PR DESCRIPTION
## Summary
- tell orchestrating agents to select the requested native agent kind and pass work through `prompt`
- reserve `shell` for explicit terminal or raw-command requests and explain its Cmd+J placement
- add regression tests for the MCP initialization instructions and `spawn_agent` tool schema

## Tests
- `/Users/giga/.cargo/bin/cargo fmt --check --package diri-engine --package dirijor-mcp`
- `/Users/giga/.cargo/bin/cargo test -p dirijor-mcp -p diri-engine`