### PR TITLE
engine: persist state durably before shutdown

### DIFF
--- a/diri/crates/diri-engine/src/control.rs
+++ b/diri/crates/diri-engine/src/control.rs
@@ -2570,7 +2570,7 @@ impl ControlServer {
 
     fn daemon_prepare_shutdown(&self) -> Result<JsonValue, ControlError> {
         let mut registry = self.registry.lock().map_err(poisoned)?;
-        let _ = registry.persist();
+        registry.persist_for_shutdown().map_err(io_control_error)?;
         Ok(json!({}))
     }
 
@@ -2583,7 +2583,7 @@ impl ControlServer {
             let mut registry = self.registry.lock().map_err(poisoned)?;
             let live_sessions = registry.live_count();
             if live_sessions == 0 {
-                let _ = registry.persist();
+                registry.persist_for_shutdown().map_err(io_control_error)?;
             }
             live_sessions
         };
@@ -2643,7 +2643,7 @@ impl ControlServer {
     fn daemon_shutdown(&self) -> Result<JsonValue, ControlError> {
         {
             let mut registry = self.registry.lock().map_err(poisoned)?;
-            let _ = registry.persist();
+            registry.persist_for_shutdown().map_err(io_control_error)?;
         }
         let browser = self.browser.get().cloned();
         let socket_path = self.socket_path.clone();
@@ -4571,6 +4571,38 @@ mod tests {
             Some("another control client still requires the Engine")
         );
         assert_eq!(idle_shutdown_refusal(0, 1), None);
+    }
+
+    #[test]
+    fn shutdown_handlers_propagate_persistence_failure_before_scheduling_exit() {
+        let temp = tempfile::tempdir().expect("temp");
+        let blocked_parent = temp.path().join("not-a-directory");
+        std::fs::write(&blocked_parent, b"file").expect("blocking file");
+        let registry = Registry::new(engine(), blocked_parent.join("state.json"));
+        let server = ControlServer::new(
+            Arc::new(Mutex::new(registry)),
+            temp.path().join("daemon.sock"),
+        );
+
+        for error in [
+            server
+                .daemon_prepare_shutdown()
+                .expect_err("prepare must report persistence failure"),
+            server
+                .daemon_shutdown_if_idle()
+                .expect_err("idle shutdown must report persistence failure"),
+            server
+                .daemon_shutdown()
+                .expect_err("forced shutdown must report persistence failure"),
+        ] {
+            assert_eq!(error.code, "internal");
+            assert!(
+                error.message.contains("not-a-directory")
+                    || error.message.contains("Not a directory")
+                    || error.message.contains("File exists"),
+                "unexpected persistence error: {error}"
+            );
+        }
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/registry.rs
+++ b/diri/crates/diri-engine/src/registry.rs
@@ -171,6 +171,17 @@ impl Registry {
         self.persist_now()
     }
 
+    /// Commits the latest state before the daemon acknowledges a shutdown.
+    ///
+    /// Shutdown is a durability boundary, not another debounced mutation: the
+    /// process may exit immediately after the acknowledgement, so neither the
+    /// background flusher nor [`Drop`] is guaranteed to run. Always write the
+    /// current snapshot synchronously, even when a recent persist would
+    /// normally be deferred.
+    pub fn persist_for_shutdown(&mut self) -> std::io::Result<()> {
+        self.persist_now()
+    }
+
     /// Writes out a deferred persist, if one is pending.
     pub fn flush_dirty(&mut self) -> std::io::Result<()> {
         if !self.dirty {
@@ -1163,6 +1174,42 @@ mod tests {
         let mut reloaded = Registry::new(engine(), &state_file);
         assert_eq!(reloaded.load().expect("load"), 1);
         assert_eq!(reloaded.records()[0].id.0, "s_1");
+    }
+
+    #[test]
+    fn shutdown_persistence_commits_a_snapshot_deferred_by_the_debounce() {
+        let temp = tempfile::tempdir().expect("temp");
+        let state_file = temp.path().join("state.json");
+        let mut registry = Registry::new(engine(), &state_file);
+
+        registry.insert_record(record("before"));
+        registry.persist().expect("initial persist");
+        registry.insert_record(record("latest"));
+        registry.persist().expect("debounced persist");
+
+        let deferred: PersistedState =
+            serde_json::from_slice(&std::fs::read(&state_file).expect("read deferred state"))
+                .expect("parse deferred state");
+        assert_eq!(
+            deferred.sessions.len(),
+            1,
+            "the second regular persist should still be waiting for the flusher"
+        );
+
+        registry
+            .persist_for_shutdown()
+            .expect("shutdown persistence");
+        let committed: PersistedState =
+            serde_json::from_slice(&std::fs::read(&state_file).expect("read committed state"))
+                .expect("parse committed state");
+        assert_eq!(
+            committed
+                .sessions
+                .iter()
+                .map(|record| record.id.0.as_str())
+                .collect::<Vec<_>>(),
+            ["before", "latest"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

A registry mutation acknowledged within the 500 ms persistence debounce could be lost when the daemon immediately exited. Forced shutdown also skips Rust drops, so the background flusher was not a durability boundary.

## What changed

- add a narrow `Registry::persist_for_shutdown` interface that synchronously commits the latest atomic snapshot
- use it for prepare, idle, and forced shutdown
- return persistence failures instead of scheduling exit after a failed write
- cover both the debounce regression and every shutdown handler failure path

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p diri-engine --all-targets -- -D warnings`
- `cargo test -p diri-engine shutdown_` (4 passed)
- `cargo test -p diri-engine --lib` (281 passed, 3 ignored)

The wider package suite progressed through all earlier groups before an unrelated existing MCP integration test stalled; this PR does not touch that path.
