### PR TITLE
terminal: respect bracketed paste mode

### DIFF
--- a/diri/PLAN.md
+++ b/diri/PLAN.md
@@ -109,7 +109,7 @@ Everything below is verified against the Swift source; cite these files in code 
 
 **Transport** — one unix socket, role decided by the first line of each connection (`ConnectionHub.swift:223`):
 - Control channel: newline-delimited JSON `ControlMessage` — `request{id,method,params}` / `response{id,ok|err{code,message}}` / `event{event,seq,params}`. Max line 4 MiB.
-- Data channel: first line is NDJSON `AttachRequest{attach: <sessionID>, fromOffset?, token?, role}`, then binary frames both ways: `[type u8][len u32 BE][payload]`, max 16 MiB. Types: `input=2`, `resize=3` (cols u16 + rows u16 BE), `ping=6`/`pong=7`, `grid=8`, `scroll=9` (dir u8, lines u16, col u16, row u16 BE), `modes=10` (bit0 altScreen, bit1 historical any-mouse compatibility, bits2–3 mouse tracking off/1000/1002/1003, bit4 legacy/SGR encoding), `mouse=11` (pre-encoded report bytes on the raw interactive path). Types 1/4/5 are legacy byte-replay — ignore.
+- Data channel: first line is NDJSON `AttachRequest{attach: <sessionID>, fromOffset?, token?, role}`, then binary frames both ways: `[type u8][len u32 BE][payload]`, max 16 MiB. Types: `input=2`, `resize=3` (cols u16 + rows u16 BE), `ping=6`/`pong=7`, `grid=8`, `scroll=9` (dir u8, lines u16, col u16, row u16 BE), `modes=10` (bit0 altScreen, bit1 historical any-mouse compatibility, bits2–3 mouse tracking off/1000/1002/1003, bit4 legacy/SGR encoding, bit5 bracketed paste), `mouse=11` (pre-encoded report bytes on the raw interactive path). Types 1/4/5 are legacy byte-replay — ignore.
 - Port-forward channel exists (`ForwardRequest`) — v1 skip.
 
 **Grid codec** (`Grid.swift:100-234`) — must match bit-for-bit, big-endian throughout:

--- a/diri/crates/diri-app/src/terminal_pane.rs
+++ b/diri/crates/diri-app/src/terminal_pane.rs
@@ -353,6 +353,22 @@ enum AttachmentState {
     Reconnecting,
 }
 
+/// A reconnect has no trustworthy child modes until its fresh seed arrives.
+/// Keeping bracketed paste across that gap can send control framing to a shell
+/// that never requested it, so every non-live transition returns to the wire
+/// protocol's backward-compatible raw-paste default.
+fn bracketed_paste_after_attachment_state(current: bool, state: AttachmentState) -> bool {
+    if state == AttachmentState::Live {
+        current
+    } else {
+        false
+    }
+}
+
+fn terminal_paste(text: &str, bracketed_paste: bool) -> Vec<u8> {
+    paste(text, bracketed_paste)
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum PointerOwner {
     LocalSelection,
@@ -621,6 +637,9 @@ struct ResidentTerminal {
     /// predecessor was detached.
     attachment_generation: AttachmentGeneration,
     attachment_state: AttachmentState,
+    /// Last mode advertised by this attachment generation. Reset while the
+    /// transport is not live so paste never trusts state from a dead child.
+    bracketed_paste: bool,
     find: Option<TerminalFindModel>,
     /// The editable text behind `find`'s query, so ⌘F gets the same caret,
     /// selection, and readline keys as the other query fields.
@@ -937,6 +956,7 @@ impl TerminalPane {
                     attachment,
                     attachment_generation: generation,
                     attachment_state: AttachmentState::Attaching,
+                    bracketed_paste: false,
                     find: None,
                     find_query: QueryEditor::default(),
                     last_size: (0, 0),
@@ -1093,6 +1113,8 @@ impl TerminalPane {
                     return;
                 }
                 if let Some(resident) = self.residents.get_mut(&id) {
+                    resident.bracketed_paste =
+                        bracketed_paste_after_attachment_state(resident.bracketed_paste, state);
                     if resident.attachment_state != state {
                         resident.pointer_owner = None;
                         resident.mouse_motion.reset();
@@ -1133,7 +1155,15 @@ impl TerminalPane {
                 }
                 self.apply_grid_updates(id, updates, window, cx);
             }
-            PaneEvent::Chunk(id, generation, TerminalChunk::Modes { alt_screen, mouse }) => {
+            PaneEvent::Chunk(
+                id,
+                generation,
+                TerminalChunk::Modes {
+                    alt_screen,
+                    bracketed_paste,
+                    mouse,
+                },
+            ) => {
                 if !self.attachment_is_current(&id, generation) {
                     return;
                 }
@@ -1142,6 +1172,7 @@ impl TerminalPane {
                         resident.pointer_owner = None;
                         resident.mouse_motion.reset();
                     }
+                    resident.bracketed_paste = bracketed_paste;
                     resident.element.set_modes(alt_screen, mouse);
                 }
                 if self.selected_id().as_ref() == Some(&id) {
@@ -1185,7 +1216,9 @@ impl TerminalPane {
             PaneEvent::ClipboardUploadFinished(id, result) => match result {
                 Ok(remote_path) => {
                     if let Some(resident) = self.residents.get(&id) {
-                        resident.attachment.input(paste(&remote_path, false));
+                        resident
+                            .attachment
+                            .input(terminal_paste(&remote_path, resident.bracketed_paste));
                     }
                 }
                 Err(error) => eprintln!("diri: clipboard image upload failed: {error}"),
@@ -1817,7 +1850,9 @@ impl TerminalPane {
             } else {
                 let local_path = staged.path().to_string_lossy().into_owned();
                 if let Some(resident) = self.residents.get(&id) {
-                    resident.attachment.input(paste(&local_path, false));
+                    resident
+                        .attachment
+                        .input(terminal_paste(&local_path, resident.bracketed_paste));
                 }
                 self.local_clipboard_images.push(staged);
                 if self.local_clipboard_images.len() > 32 {
@@ -1842,7 +1877,9 @@ impl TerminalPane {
             find.set_query(query, now);
             self.schedule_find(id, Duration::from_millis(200), window, cx);
         } else {
-            resident.attachment.input(paste(&text, false));
+            resident
+                .attachment
+                .input(terminal_paste(&text, resident.bracketed_paste));
         }
         cx.stop_propagation();
         cx.notify();
@@ -4759,6 +4796,33 @@ mod tests {
         assert_eq!(bytes, b"clipboard png");
         assert_eq!(extension, "png");
         assert_eq!(item.text(), None);
+    }
+
+    #[test]
+    fn clipboard_paste_respects_the_childs_bracketed_paste_mode() {
+        let text = "first command\nsecond command";
+
+        assert_eq!(terminal_paste(text, false), text.as_bytes());
+        assert_eq!(
+            terminal_paste(text, true),
+            b"\x1b[200~first command\nsecond command\x1b[201~"
+        );
+    }
+
+    #[test]
+    fn reattachment_drops_stale_bracketed_paste_until_fresh_modes_arrive() {
+        assert!(bracketed_paste_after_attachment_state(
+            true,
+            AttachmentState::Live
+        ));
+        assert!(!bracketed_paste_after_attachment_state(
+            true,
+            AttachmentState::Reconnecting
+        ));
+        assert!(!bracketed_paste_after_attachment_state(
+            true,
+            AttachmentState::Attaching
+        ));
     }
 
     #[test]

--- a/diri/crates/diri-client/src/attachment.rs
+++ b/diri/crates/diri-client/src/attachment.rs
@@ -33,7 +33,11 @@ const CHUNK_QUEUE_CAPACITY: usize = 256;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TerminalChunk {
     Grid(GridUpdate),
-    Modes { alt_screen: bool, mouse: MouseModes },
+    Modes {
+        alt_screen: bool,
+        bracketed_paste: bool,
+        mouse: MouseModes,
+    },
     Pong,
 }
 
@@ -321,9 +325,13 @@ async fn process_incoming(
                 .map_err(|_| ())?;
         }
         FrameType::Modes => {
-            let (alt_screen, mouse) = frame.modes_payload().ok_or(())?;
+            let (alt_screen, bracketed_paste, mouse) = frame.terminal_modes_payload().ok_or(())?;
             chunks
-                .send(TerminalChunk::Modes { alt_screen, mouse })
+                .send(TerminalChunk::Modes {
+                    alt_screen,
+                    bracketed_paste,
+                    mouse,
+                })
                 .await
                 .map_err(|_| ())?;
         }
@@ -350,12 +358,14 @@ mod tests {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use diri_proto::control::{ControlMessage, decode_line, encode_line};
+    use diri_proto::frames::Frame;
     use diri_proto::grid::GridCell;
     use diri_proto::methods::{
         HelloParams, HelloResult, Method, SessionIdParams, SessionSpawnParams,
     };
     use diri_proto::model::{AgentKind, SessionId, SessionRecord};
     use diri_proto::paths::{DirijorEnv, DirijorPaths};
+    use diri_proto::terminal::{MouseEncoding, MouseModes, MouseTrackingMode};
     use serde::Serialize;
     use serde::de::DeserializeOwned;
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -363,7 +373,31 @@ mod tests {
     use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
     use tokio::time::timeout;
 
-    use super::{SessionAttachment, TerminalChunk};
+    use super::{SessionAttachment, TerminalChunk, process_incoming};
+
+    #[tokio::test]
+    async fn mode_frames_keep_bracketed_paste_state() {
+        let (mut stream, _peer) = UnixStream::pair().expect("unix stream pair");
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let mouse = MouseModes::new(MouseTrackingMode::ButtonMotion, MouseEncoding::Sgr);
+
+        process_incoming(
+            Frame::modes_with_bracketed_paste(true, true, mouse),
+            &mut stream,
+            &tx,
+        )
+        .await
+        .expect("valid modes frame");
+
+        assert_eq!(
+            rx.recv().await,
+            Some(TerminalChunk::Modes {
+                alt_screen: true,
+                bracketed_paste: true,
+                mouse,
+            })
+        );
+    }
 
     struct TestControl {
         reader: BufReader<OwnedReadHalf>,

--- a/diri/crates/diri-engine/src/attach.rs
+++ b/diri/crates/diri-engine/src/attach.rs
@@ -90,7 +90,10 @@ impl AttachHub {
             if write_frame(&writer, &grid_frame).is_err() {
                 return;
             }
-            let _ = write_frame(&writer, &Frame::modes(seed.modes.0, seed.modes.1));
+            let _ = write_frame(
+                &writer,
+                &Frame::modes_with_bracketed_paste(seed.modes.0, seed.modes.1, seed.modes.2),
+            );
             seed
         };
 
@@ -282,7 +285,7 @@ impl AttachHub {
                 if let Some(previous) = last_modes
                     && previous != modes
                 {
-                    frames.push(Frame::modes(modes.0, modes.1));
+                    frames.push(Frame::modes_with_bracketed_paste(modes.0, modes.1, modes.2));
                 }
                 last_modes = Some(modes);
             }

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -407,7 +407,7 @@ fn grid_wake_event(state: &GridWakeState, observed: u64) -> GridWakeEvent {
 
 pub(crate) struct AttachmentSeed {
     pub grid: diri_proto::grid::GridUpdate,
-    pub modes: (bool, MouseModes),
+    pub modes: (bool, bool, MouseModes),
     pub signature: GridSignature,
     pub wake: GridWake,
     pub wake_generation: u64,
@@ -1126,10 +1126,10 @@ impl Session {
                     let grid = remote.mirror.full_update()?;
                     let (cols, rows) = remote.mirror.size();
                     let (cursor_col, cursor_row, cursor_visible) = remote.mirror.cursor();
-                    let (alt_screen, _, mouse) = remote.mirror.modes();
+                    let (alt_screen, bracketed_paste, mouse) = remote.mirror.modes();
                     Some((
                         grid,
-                        (alt_screen, mouse),
+                        (alt_screen, bracketed_paste, mouse),
                         GridSignature {
                             content_seq: remote.revision,
                             size: (usize::from(cols), usize::from(rows)),
@@ -1144,7 +1144,11 @@ impl Session {
                 let screen = self.shared.screen.lock().expect("screen");
                 (
                     screen.full_snapshot(),
-                    (screen.is_alt_screen(), screen.mouse_modes()),
+                    (
+                        screen.is_alt_screen(),
+                        screen.bracketed_paste(),
+                        screen.mouse_modes(),
+                    ),
                     GridSignature {
                         content_seq: screen.content_seq(),
                         size: screen.size(),
@@ -1234,8 +1238,8 @@ impl Session {
         self.shared.screen.lock().expect("screen").bracketed_paste()
     }
 
-    /// Current alternate-screen and granular mouse modes.
-    pub fn modes(&self) -> (bool, MouseModes) {
+    /// Current alternate-screen, bracketed-paste, and granular mouse modes.
+    pub fn modes(&self) -> (bool, bool, MouseModes) {
         if let Some(remote) = self
             .shared
             .remote_grid
@@ -1244,11 +1248,14 @@ impl Session {
             .as_ref()
             && remote.mirror.sequence().is_some()
         {
-            let (alt_screen, _, mouse) = remote.mirror.modes();
-            return (alt_screen, mouse);
+            return remote.mirror.modes();
         }
         let screen = self.shared.screen.lock().expect("screen");
-        (screen.is_alt_screen(), screen.mouse_modes())
+        (
+            screen.is_alt_screen(),
+            screen.bracketed_paste(),
+            screen.mouse_modes(),
+        )
     }
 
     /// A wheel event from an attached client: forwarded to the child when it

--- a/diri/crates/diri-engine/tests/attach.rs
+++ b/diri/crates/diri-engine/tests/attach.rs
@@ -14,6 +14,7 @@ use diri_engine::registry::Registry;
 use diri_proto::ControlMessage;
 use diri_proto::frames::{Frame, FrameCodec, FrameType};
 use diri_proto::grid::GridUpdate;
+use diri_proto::terminal::MouseModes;
 use serde_json::json;
 
 fn engine() -> Arc<ManifestEngine> {
@@ -111,7 +112,11 @@ fn an_attach_is_seeded_then_streams_diffs_and_answers_input() {
         params: Some(json!({
             "kind": { "shell": {} },
             "cwd": "/tmp",
-            "argv": ["/bin/sh", "-c", "printf 'seeded-screen\\n'; exec cat"],
+            "argv": [
+                "/bin/sh",
+                "-c",
+                "stty -echo; printf '\\033[?2004hseeded-screen\\n'; IFS= read -r _; printf '\\033[?2004l'; stty echo; exec cat"
+            ],
         })),
     });
     let mut reader = std::io::BufReader::new(control.try_clone().expect("clone"));
@@ -149,9 +154,28 @@ fn an_attach_is_seeded_then_streams_diffs_and_answers_input() {
         "the seed carries what the child already painted"
     );
 
-    let _modes = frames.until("initial modes", |frame| {
+    let modes = frames.until("initial modes", |frame| {
         frame.frame_type == FrameType::Modes
     });
+    assert_eq!(
+        modes.terminal_modes_payload(),
+        Some((false, true, MouseModes::OFF)),
+        "the attachment seed carries the child's current paste mode"
+    );
+
+    // The setup shell drops bracketed paste after its first input. A mode-only
+    // terminal change must wake the attachment pump even when no visible cell
+    // changes with it.
+    data.write_all(&FrameCodec::encode(&Frame::input(b"finish-setup\n".to_vec())).expect("encode"))
+        .expect("finish child setup");
+    let modes = frames.until("updated modes", |frame| {
+        frame.frame_type == FrameType::Modes
+    });
+    assert_eq!(
+        modes.terminal_modes_payload(),
+        Some((false, false, MouseModes::OFF)),
+        "live mode changes propagate independently of grid damage"
+    );
 
     // Let the per-session pump establish its shared diff baseline. Its first
     // sample is allowed to be a FullSnapshot: if input beats that first tick,

--- a/diri/crates/diri-proto/src/frames.rs
+++ b/diri/crates/diri-proto/src/frames.rs
@@ -129,12 +129,27 @@ impl Frame {
 
     #[must_use]
     pub fn modes(alt_screen: bool, mouse: MouseModes) -> Self {
+        Self::modes_with_bracketed_paste(alt_screen, false, mouse)
+    }
+
+    /// Builds the additive terminal-mode payload. [`Self::modes`] remains the
+    /// source-compatible constructor for peers that only know screen and
+    /// mouse state.
+    #[must_use]
+    pub fn modes_with_bracketed_paste(
+        alt_screen: bool,
+        bracketed_paste: bool,
+        mouse: MouseModes,
+    ) -> Self {
         // Bit 1 stays the historical "any mouse reporting" flag so older
         // clients continue to route the pointer to the terminal. Granular
-        // tracking and encoding live in previously unused bits.
+        // tracking, encoding, and bracketed paste live in previously unused
+        // bits. Old clients ignore bit 5; new clients decode it as false from
+        // every frame emitted before this extension.
         let bits = u8::from(alt_screen)
             | (u8::from(mouse.is_reporting()) << 1)
-            | (mouse.detail_bits() << 2);
+            | (mouse.detail_bits() << 2)
+            | (u8::from(bracketed_paste) << 5);
         Self::new(FrameType::Modes, vec![bits])
     }
 
@@ -191,12 +206,21 @@ impl Frame {
 
     #[must_use]
     pub fn modes_payload(&self) -> Option<(bool, MouseModes)> {
+        self.terminal_modes_payload()
+            .map(|(alt_screen, _, mouse)| (alt_screen, mouse))
+    }
+
+    /// Decodes all currently defined mode bits. [`Self::modes_payload`]
+    /// retains its original two-field API for existing consumers.
+    #[must_use]
+    pub fn terminal_modes_payload(&self) -> Option<(bool, bool, MouseModes)> {
         if self.frame_type != FrameType::Modes {
             return None;
         }
         self.payload.first().map(|bits| {
             (
                 bits & 1 != 0,
+                bits & (1 << 5) != 0,
                 MouseModes::from_detail_bits(bits >> 2, bits & 2 != 0),
             )
         })
@@ -384,31 +408,43 @@ mod tests {
         assert_eq!(scroll.scroll_payload(), Some((1, 0x0203, 0x0405, 0x0607)));
 
         for alt_screen in [false, true] {
-            for mouse in [
-                MouseModes::OFF,
-                MouseModes::UNKNOWN,
-                MouseModes::new(
-                    crate::terminal::MouseTrackingMode::Off,
-                    crate::terminal::MouseEncoding::Sgr,
-                ),
-                MouseModes::new(
-                    crate::terminal::MouseTrackingMode::ButtonEvents,
-                    crate::terminal::MouseEncoding::Legacy,
-                ),
-                MouseModes::new(
-                    crate::terminal::MouseTrackingMode::ButtonMotion,
-                    crate::terminal::MouseEncoding::Sgr,
-                ),
-                MouseModes::new(
-                    crate::terminal::MouseTrackingMode::AnyMotion,
-                    crate::terminal::MouseEncoding::Sgr,
-                ),
-            ] {
-                let modes = Frame::modes(alt_screen, mouse);
-                assert_eq!(modes.modes_payload(), Some((alt_screen, mouse)));
-                assert_eq!(modes.payload[0] & 0b10 != 0, mouse.is_reporting());
+            for bracketed_paste in [false, true] {
+                for mouse in [
+                    MouseModes::OFF,
+                    MouseModes::UNKNOWN,
+                    MouseModes::new(
+                        crate::terminal::MouseTrackingMode::Off,
+                        crate::terminal::MouseEncoding::Sgr,
+                    ),
+                    MouseModes::new(
+                        crate::terminal::MouseTrackingMode::ButtonEvents,
+                        crate::terminal::MouseEncoding::Legacy,
+                    ),
+                    MouseModes::new(
+                        crate::terminal::MouseTrackingMode::ButtonMotion,
+                        crate::terminal::MouseEncoding::Sgr,
+                    ),
+                    MouseModes::new(
+                        crate::terminal::MouseTrackingMode::AnyMotion,
+                        crate::terminal::MouseEncoding::Sgr,
+                    ),
+                ] {
+                    let modes =
+                        Frame::modes_with_bracketed_paste(alt_screen, bracketed_paste, mouse);
+                    assert_eq!(
+                        modes.terminal_modes_payload(),
+                        Some((alt_screen, bracketed_paste, mouse))
+                    );
+                    assert_eq!(modes.modes_payload(), Some((alt_screen, mouse)));
+                    assert_eq!(modes.payload[0] & 0b10 != 0, mouse.is_reporting());
+                    assert_eq!(modes.payload[0] & 0b10_0000 != 0, bracketed_paste);
+                }
             }
         }
+        assert_eq!(
+            Frame::modes(true, MouseModes::OFF).terminal_modes_payload(),
+            Some((true, false, MouseModes::OFF))
+        );
         assert_eq!(Frame::ping().payload, Vec::<u8>::new());
         assert_eq!(Frame::pong().payload, Vec::<u8>::new());
         assert_eq!(Frame::input(b"input".to_vec()).payload, b"input");
@@ -418,8 +454,8 @@ mod tests {
     #[test]
     fn modes_decode_the_historical_boolean_wire_format() {
         assert_eq!(
-            Frame::new(FrameType::Modes, vec![0b11]).modes_payload(),
-            Some((true, MouseModes::UNKNOWN))
+            Frame::new(FrameType::Modes, vec![0b11]).terminal_modes_payload(),
+            Some((true, false, MouseModes::UNKNOWN))
         );
     }
 
@@ -503,6 +539,10 @@ mod tests {
         );
         assert_eq!(
             Frame::new(FrameType::Modes, Vec::new()).modes_payload(),
+            None
+        );
+        assert_eq!(
+            Frame::new(FrameType::Modes, Vec::new()).terminal_modes_payload(),
             None
         );
         assert_eq!(


### PR DESCRIPTION
## Why

Diri’s terminal emulator already knew when a child enabled DEC bracketed-paste mode, but that state stopped at the engine. Desktop paste always sent raw bytes, so a multiline clipboard could become several immediately executed shell commands instead of one protected paste.

## What changed

- extend the additive modes frame with a backward-compatible bracketed-paste bit
- propagate initial and live mode changes through local and remote attachment paths
- expose bracketed-paste state in the client attachment stream
- keep mode state per resident terminal generation and clear it during attach/reconnect gaps
- use the live mode for text paste and staged local/remote image paths
- preserve the existing public mode constructors/decoders for older consumers

## Verification

- `cargo fmt --all -- --check`
- strict Clippy across `diri-proto`, `diri-client`, `diri-engine`, and `diri-app`
- complete proto and client suites (64 tests including integration)
- real-PTY attachment seed and live mode-toggle integration tests
- app paste-framing and reconnect-reset tests

The wire change is additive: older clients ignore bit 5 and new clients decode its absence as raw paste.
