### PR TITLE
app: add an attention-first Fleet Pulse

### DIFF
--- a/diri/crates/diri-app/src/menu_inbox.rs
+++ b/diri/crates/diri-app/src/menu_inbox.rs
@@ -205,6 +205,7 @@ mod tests {
             projects: vec![group("robite-landing", "robite", Vec::new(), Vec::new())],
             ordered_sessions: Vec::new(),
             display_order: Vec::new(),
+            fleet_pulse: Default::default(),
         };
         let model = build_inbox(&projection, &std::collections::HashSet::new());
         assert!(model.rows.is_empty());
@@ -228,6 +229,7 @@ mod tests {
             )],
             ordered_sessions: Vec::new(),
             display_order: Vec::new(),
+            fleet_pulse: Default::default(),
         };
         let collapsed = std::collections::HashSet::from(["robite".to_owned()]);
         let model = build_inbox(&projection, &collapsed);
@@ -275,6 +277,7 @@ mod tests {
             )],
             ordered_sessions: Vec::new(),
             display_order: Vec::new(),
+            fleet_pulse: Default::default(),
         };
         let model = build_inbox(&projection, &std::collections::HashSet::new());
         let InboxRow::Session(nested) = &model.rows[2] else {
@@ -306,6 +309,7 @@ mod tests {
             )],
             ordered_sessions: Vec::new(),
             display_order: Vec::new(),
+            fleet_pulse: Default::default(),
         };
         let model = build_inbox(&projection, &std::collections::HashSet::new());
         let InboxRow::Session(row) = &model.rows[1] else {
@@ -346,6 +350,7 @@ mod tests {
             )],
             ordered_sessions: Vec::new(),
             display_order: Vec::new(),
+            fleet_pulse: Default::default(),
         };
         let model = build_inbox(&projection, &std::collections::HashSet::new());
         let InboxRow::Session(row) = &model.rows[1] else {

--- a/diri/crates/diri-app/src/sidebar/fixture.rs
+++ b/diri/crates/diri-app/src/sidebar/fixture.rs
@@ -178,6 +178,14 @@ tokio::spawn(async move { clone_repository(request).await });
                 fetched_at: DateMillis(now),
             }]);
         }
+        let (release_summary, release_risk) = if scenario == PreviewScenario::Stress {
+            (
+                "Delete the old release worktree before publishing?",
+                RiskHint::Destructive,
+            )
+        } else {
+            ("Wants to publish the release tag", RiskHint::Network)
+        };
         let claude: SessionRecord = session(
             "preview-claude",
             AgentKind::CLAUDE_CODE,
@@ -191,10 +199,10 @@ tokio::spawn(async move { clone_repository(request).await });
             kind: NeedsInputKind::Permission,
             source: NeedsInputSource::ClaudePermissionHook,
             tool_name: Some("Bash".into()),
-            summary: "Wants to publish the release tag".into(),
+            summary: release_summary.into(),
             prompt_excerpt: None,
             options: None,
-            risk_hint: RiskHint::Network,
+            risk_hint: release_risk,
             occurred_at: DateMillis(now - 45_000.0),
         })
         .into();
@@ -537,6 +545,22 @@ mod tests {
     }
 
     #[test]
+    fn typical_fixture_exercises_the_complete_fleet_pulse_hierarchy() {
+        let mut store = SidebarPreviewFixture::make(PreviewScenario::Typical).into_store();
+        let pulse = store.fleet_pulse();
+
+        assert_eq!(pulse.needs_you(), 2);
+        assert_eq!(pulse.destructive(), 0);
+        assert_eq!(pulse.done_unseen(), 1);
+        assert_eq!(pulse.working(), 3);
+        assert_eq!(
+            pulse.next_actionable(),
+            Some(&SessionId::new("preview-claude"))
+        );
+        assert_eq!(pulse.summary(), Some("Wants to publish the release tag"));
+    }
+
+    #[test]
     fn stress_fixture_adds_three_edge_cases() {
         let fixture = SidebarPreviewFixture::make(PreviewScenario::Stress);
         assert_eq!(fixture.list.sessions.len(), 13);
@@ -547,6 +571,20 @@ mod tests {
                 .iter()
                 .any(|session| { session.title.starts_with("Investigate why exceptionally") })
         );
+        let mut store = fixture.into_store();
+        let pulse = store.fleet_pulse();
+        assert_eq!(pulse.destructive(), 1);
+        assert!(pulse.next_is_destructive());
+        assert_eq!(
+            pulse.summary(),
+            Some("Delete the old release worktree before publishing?")
+        );
+    }
+
+    #[test]
+    fn empty_fixture_omits_the_fleet_pulse() {
+        let mut store = SidebarPreviewFixture::make(PreviewScenario::Empty).into_store();
+        assert_eq!(store.fleet_pulse().state(), None);
     }
 
     #[test]

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -17,7 +17,7 @@ use diri_ui::{
 use gpui::{
     Anchor, Animation, AnimationExt, AnyElement, App, AppContext as _, Bounds, Context,
     CursorStyle, Entity, EventEmitter, ExternalPaths, FocusHandle, Focusable, FontWeight, Hsla,
-    IntoElement, MouseButton, Pixels, Point, Render, Rgba, ScrollHandle, SharedString, Task,
+    IntoElement, MouseButton, Pixels, Point, Render, Rgba, Role, ScrollHandle, SharedString, Task,
     Window, anchored, deferred, div, linear_color_stop, linear_gradient, point, prelude::*, px,
 };
 use tokio::sync::mpsc;
@@ -30,7 +30,8 @@ use crate::navigation::query_label;
 use crate::query_editor::{self, ClipboardEdit, Edit};
 use crate::seam::toggle_has_settled;
 use crate::store::{
-    ClickModifiers, DirectoryListingState, SessionStore, SpawnOptions, StoreEffect, StoreRuntime,
+    ClickModifiers, DirectoryListingState, FleetPulse, FleetPulseState, SessionStore, SpawnOptions,
+    StoreEffect, StoreRuntime,
 };
 use crate::updates::{UpdateCommand, UpdatePhase, UpdateState};
 use crate::usage::{UsageFormat, UsageSnapshot};
@@ -838,6 +839,166 @@ impl Sidebar {
                     ),
             )
             .into_any_element()
+    }
+
+    fn fleet_pulse_strip(
+        &self,
+        pulse: &FleetPulse,
+        colors: SemanticColors,
+        cx: &mut Context<Self>,
+    ) -> Option<AnyElement> {
+        let state = pulse.state()?;
+        let headline = pulse.headline()?;
+        let accessibility_label = pulse.accessibility_label()?;
+        let interactive = pulse.next_actionable().is_some();
+        let (signal, symbol, secondary, base_opacity, hover_opacity) = match state {
+            FleetPulseState::Urgent { destructive } => {
+                let signal = if destructive {
+                    Ink::DANGER
+                } else {
+                    Ink::ATTENTION
+                };
+                (
+                    signal,
+                    "exclamationmark.triangle",
+                    pulse.summary().unwrap_or("Review the next request"),
+                    0.10,
+                    0.15,
+                )
+            }
+            FleetPulseState::Ready => (
+                Ink::FRESH,
+                "checkmark.circle.fill",
+                pulse.summary().unwrap_or("Review completed work"),
+                0.075,
+                0.12,
+            ),
+            FleetPulseState::Quiet => (
+                colors.secondary,
+                "waveform.circle.fill",
+                "Live across your fleet",
+                0.045,
+                0.075,
+            ),
+        };
+        let description = match state {
+            FleetPulseState::Urgent { .. } => {
+                "Open the next request. Destructive requests are prioritized."
+            }
+            FleetPulseState::Ready => "Open the next finished agent.",
+            FleetPulseState::Quiet => "Diri is watching active agents.",
+        };
+        let shortcut = (matches!(state, FleetPulseState::Urgent { .. }))
+            .then(|| {
+                crate::commands::command(CommandId::SelectNextAttentionSession)
+                    .shortcut_label()
+                    .unwrap_or_default()
+            })
+            .unwrap_or_default();
+        let a11y_entity = cx.entity().downgrade();
+
+        Some(
+            div()
+                .id("fleet-pulse")
+                .debug_selector(|| "FLEET_PULSE".into())
+                .mx(px(Space::INSET))
+                .mb(px(6.0))
+                .px(px(Space::ROW_H))
+                .h(px(42.0))
+                .flex_none()
+                .flex()
+                .items_center()
+                .gap(px(8.0))
+                .rounded(px(Radius::ROW))
+                .border_1()
+                .border_color(signal.alpha(if matches!(state, FleetPulseState::Quiet) {
+                    0.10
+                } else {
+                    0.22
+                }))
+                .bg(signal.alpha(base_opacity))
+                .role(if interactive {
+                    Role::Button
+                } else {
+                    Role::Status
+                })
+                .aria_label(accessibility_label)
+                .aria_description(description)
+                .when(interactive, |row| {
+                    row.focusable()
+                        .tab_stop(true)
+                        .cursor_pointer()
+                        .hover(move |row| row.bg(signal.alpha(hover_opacity)))
+                        .active(move |row| row.bg(signal.alpha(hover_opacity + 0.035)))
+                        .focus_visible(move |row| row.border_color(signal.alpha(0.78)))
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            this.activate_fleet_pulse(cx);
+                        }))
+                        .on_key_down(cx.listener(|this, event: &gpui::KeyDownEvent, _, cx| {
+                            if matches!(event.keystroke.key.as_str(), "enter" | "space") {
+                                this.activate_fleet_pulse(cx);
+                                cx.stop_propagation();
+                            }
+                        }))
+                        .on_a11y_action(gpui::accesskit::Action::Click, move |_, _, cx| {
+                            let _ = a11y_entity.update(cx, |this, cx| {
+                                this.activate_fleet_pulse(cx);
+                            });
+                        })
+                })
+                .when(!shortcut.is_empty(), |row| {
+                    row.aria_keyshortcuts("Meta+Shift+J")
+                })
+                .child(
+                    div()
+                        .flex_none()
+                        .size(px(24.0))
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .rounded(px(Radius::BADGE))
+                        .bg(signal.alpha(0.12))
+                        .child(sf_symbol(symbol, 13.0, signal)),
+                )
+                .child(
+                    div()
+                        .min_w(px(0.0))
+                        .flex_1()
+                        .flex()
+                        .flex_col()
+                        .gap(px(1.0))
+                        .child(
+                            div()
+                                .whitespace_nowrap()
+                                .overflow_hidden()
+                                .text_ellipsis()
+                                .text_size(px(Typo::ROW_EMPHASIZED.size))
+                                .font_weight(Typo::ROW_EMPHASIZED.weight)
+                                .text_color(colors.primary)
+                                .child(headline),
+                        )
+                        .child(
+                            div()
+                                .whitespace_nowrap()
+                                .overflow_hidden()
+                                .text_ellipsis()
+                                .text_size(px(Typo::META.size))
+                                .font_weight(Typo::META.weight)
+                                .text_color(colors.secondary)
+                                .child(secondary.to_owned()),
+                        ),
+                )
+                .when(!shortcut.is_empty(), |row| {
+                    row.child(
+                        div()
+                            .flex_none()
+                            .text_size(px(Typo::META.size))
+                            .text_color(signal.alpha(0.86))
+                            .child(shortcut),
+                    )
+                })
+                .into_any_element(),
+        )
     }
 
     fn top_bar(&self, colors: SemanticColors, cx: &mut Context<Self>) -> AnyElement {
@@ -4099,29 +4260,36 @@ impl Sidebar {
         true
     }
 
-    /// ⌘J: select the next session waiting on a human, in sidebar order and
-    /// wrapping past the current row. Returns false when nothing is waiting.
+    fn activate_fleet_pulse(&mut self, cx: &mut Context<Self>) -> bool {
+        self.commit_rename();
+        {
+            let mut store = self.store.write().expect("session store lock poisoned");
+            let pulse = store.fleet_pulse();
+            let Some(next) = pulse.next_actionable().cloned() else {
+                return false;
+            };
+            store.select(next);
+        }
+        cx.emit(SidebarEvent::SessionActivated);
+        cx.notify();
+        true
+    }
+
+    /// ⇧⌘J: select the next session waiting on a human. Destructive requests
+    /// lead, then the user's project/session order wraps past the current row.
+    /// Returns false when nothing is waiting.
     pub fn select_next_needing_input(&mut self, cx: &mut Context<Self>) -> bool {
         self.commit_rename();
         {
             let mut store = self.store.write().expect("session store lock poisoned");
-            let sessions = store.ordered_sessions();
-            if sessions.is_empty() {
+            let pulse = store.fleet_pulse();
+            if pulse.needs_you() == 0 {
                 return false;
             }
-            let current = store
-                .selected_session_id()
-                .and_then(|id| sessions.iter().position(|session| &session.id == id));
-            // Start one past the selection so repeated ⌘J walks the queue
-            // instead of landing on the same row.
-            let start = current.map_or(0, |index| index + 1);
-            let Some(next) = (0..sessions.len())
-                .map(|offset| &sessions[(start + offset) % sessions.len()])
-                .find(|session| session.attention() == ProtoAttentionLevel::NeedsInput)
-            else {
+            let Some(next) = pulse.next_actionable().cloned() else {
                 return false;
             };
-            store.select(next.id.clone());
+            store.select(next);
         }
         cx.emit(SidebarEvent::SessionActivated);
         cx.notify();
@@ -4475,6 +4643,9 @@ impl Render for Sidebar {
             )
             .child(self.top_bar(colors, cx))
             .child(self.new_agent_row(colors, cx));
+        if let Some(pulse) = self.fleet_pulse_strip(&projection.fleet_pulse, colors, cx) {
+            root = root.child(pulse);
+        }
         if projection.projects.is_empty() {
             root = root.child(self.empty_state(colors, cx));
         } else {
@@ -5375,6 +5546,81 @@ mod tests {
                 Some(&cursor)
             );
         });
+    }
+
+    #[gpui::test]
+    fn fleet_pulse_click_walks_the_risk_order_and_reveals_collapsed_sessions(
+        cx: &mut TestAppContext,
+    ) {
+        let (view, cx) = cx.add_window_view(|_, cx| {
+            let sidebar = cx.new(|cx| Sidebar::new(None, true, PreviewScenario::Stress, cx));
+            SidebarPopoverHarness { sidebar }
+        });
+        let pulse = cx.debug_bounds("FLEET_PULSE").expect("fleet pulse");
+        let sidebar = view.read_with(cx, |harness, _| harness.sidebar.clone());
+
+        cx.simulate_click(pulse.center(), Modifiers::default());
+        cx.run_until_parked();
+        sidebar.read_with(cx, |sidebar, _| {
+            assert_eq!(
+                sidebar
+                    .store
+                    .read()
+                    .expect("session store lock poisoned")
+                    .selected_session_id(),
+                Some(&SessionId::new("preview-claude"))
+            );
+        });
+
+        let pulse = cx.debug_bounds("FLEET_PULSE").expect("fleet pulse");
+        cx.simulate_click(pulse.center(), Modifiers::default());
+        cx.run_until_parked();
+        sidebar.read_with(cx, |sidebar, _| {
+            let store = sidebar.store.read().expect("session store lock poisoned");
+            assert_eq!(
+                store.selected_session_id(),
+                Some(&SessionId::new("preview-question"))
+            );
+            assert!(
+                !store
+                    .preferences()
+                    .sidebar_collapsed_projects
+                    .contains(&ProjectId::new("preview-anara"))
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn fleet_pulse_is_a_keyboard_button(cx: &mut TestAppContext) {
+        let (view, cx) = cx.add_window_view(|_, cx| {
+            let sidebar = cx.new(|cx| Sidebar::new(None, true, PreviewScenario::Typical, cx));
+            SidebarPopoverHarness { sidebar }
+        });
+        let sidebar = view.read_with(cx, |harness, _| harness.sidebar.clone());
+        view.update_in(cx, |_, window, cx| window.focus_next(cx));
+
+        cx.simulate_keystrokes("enter");
+
+        sidebar.read_with(cx, |sidebar, _| {
+            assert_eq!(
+                sidebar
+                    .store
+                    .read()
+                    .expect("session store lock poisoned")
+                    .selected_session_id(),
+                Some(&SessionId::new("preview-claude"))
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn resting_fleet_does_not_reserve_sidebar_space(cx: &mut TestAppContext) {
+        let (_view, cx) = cx.add_window_view(|_, cx| {
+            let sidebar = cx.new(|cx| Sidebar::new(None, true, PreviewScenario::Empty, cx));
+            SidebarPopoverHarness { sidebar }
+        });
+
+        assert!(cx.debug_bounds("FLEET_PULSE").is_none());
     }
 
     #[gpui::test]

--- a/diri/crates/diri-app/src/store/fleet_pulse.rs
+++ b/diri/crates/diri-app/src/store/fleet_pulse.rs
@@ -1,0 +1,370 @@
+use diri_proto::{AttentionLevel, NeedsInputKind, RiskHint, SessionId, SessionRecord};
+
+/// One revision-cached answer to “what deserves the human next?”.
+///
+/// The pulse deliberately reads only canonical [`SessionRecord`] state and is
+/// built from the sidebar's active tree order. That keeps folded projects in
+/// the fleet while excluding archived, closing, and workbench-owned terminal
+/// rows before this module sees them. Destructive requests lead the queue, but
+/// otherwise the user's project/session order is preserved.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct FleetPulse {
+    needs_you: usize,
+    destructive: usize,
+    done_unseen: usize,
+    working: usize,
+    next_actionable: Option<SessionId>,
+    next_is_destructive: bool,
+    summary: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FleetPulseState {
+    Urgent { destructive: bool },
+    Ready,
+    Quiet,
+}
+
+impl FleetPulse {
+    pub(super) fn derive<'a>(
+        sessions: impl IntoIterator<Item = &'a SessionRecord>,
+        selected: Option<&SessionId>,
+    ) -> Self {
+        let mut pulse = Self::default();
+        let mut actionable = Vec::new();
+        let mut ready = Vec::new();
+
+        for session in sessions {
+            match session.attention() {
+                AttentionLevel::NeedsInput => {
+                    pulse.needs_you += 1;
+                    if needs_destructive_confirmation(session) {
+                        pulse.destructive += 1;
+                    }
+                    actionable.push(session);
+                }
+                AttentionLevel::DoneUnseen => {
+                    pulse.done_unseen += 1;
+                    ready.push(session);
+                }
+                AttentionLevel::Working
+                    if session.hibernation.is_none() && !session.effective_kind().is_terminal() =>
+                {
+                    pulse.working += 1;
+                }
+                AttentionLevel::None
+                | AttentionLevel::IdleSeen
+                | AttentionLevel::Working
+                | AttentionLevel::Unknown => {}
+            }
+        }
+
+        // `sort_by_key` is stable, so risk changes urgency without destroying
+        // the project/session ordering a human deliberately arranged.
+        actionable.sort_by_key(|session| !needs_destructive_confirmation(session));
+        let queue = if actionable.is_empty() {
+            &ready
+        } else {
+            &actionable
+        };
+        let next = queue
+            .iter()
+            .position(|session| selected == Some(&session.id))
+            .map_or_else(
+                || queue.first().copied(),
+                |index| queue.get((index + 1) % queue.len()).copied(),
+            );
+        if let Some(next) = next {
+            pulse.next_actionable = Some(next.id.clone());
+            pulse.next_is_destructive = needs_destructive_confirmation(next);
+            pulse.summary = Some(if pulse.needs_you > 0 {
+                attention_summary(next)
+            } else {
+                concise(display_title(next), 96)
+            });
+        }
+        pulse
+    }
+
+    pub const fn needs_you(&self) -> usize {
+        self.needs_you
+    }
+
+    pub const fn destructive(&self) -> usize {
+        self.destructive
+    }
+
+    pub const fn done_unseen(&self) -> usize {
+        self.done_unseen
+    }
+
+    pub const fn working(&self) -> usize {
+        self.working
+    }
+
+    pub const fn next_actionable(&self) -> Option<&SessionId> {
+        self.next_actionable.as_ref()
+    }
+
+    pub const fn next_is_destructive(&self) -> bool {
+        self.next_is_destructive
+    }
+
+    pub fn summary(&self) -> Option<&str> {
+        self.summary.as_deref()
+    }
+
+    /// `None` is intentional: a fleet with only seen/ended/asleep sessions has
+    /// no headline worth stealing vertical space from the session tree.
+    pub const fn state(&self) -> Option<FleetPulseState> {
+        if self.needs_you > 0 {
+            Some(FleetPulseState::Urgent {
+                destructive: self.next_is_destructive,
+            })
+        } else if self.done_unseen > 0 {
+            Some(FleetPulseState::Ready)
+        } else if self.working > 0 {
+            Some(FleetPulseState::Quiet)
+        } else {
+            None
+        }
+    }
+
+    pub fn headline(&self) -> Option<String> {
+        match self.state()? {
+            FleetPulseState::Urgent { .. } => Some(if self.needs_you == 1 {
+                "1 needs you".to_owned()
+            } else {
+                format!("{} need you", self.needs_you)
+            }),
+            FleetPulseState::Ready => Some(if self.done_unseen == 1 {
+                "1 agent finished".to_owned()
+            } else {
+                format!("{} agents finished", self.done_unseen)
+            }),
+            FleetPulseState::Quiet => Some(if self.working == 1 {
+                "1 agent working".to_owned()
+            } else {
+                format!("{} agents working", self.working)
+            }),
+        }
+    }
+
+    pub fn accessibility_label(&self) -> Option<String> {
+        let headline = self.headline()?;
+        let mut parts = vec![headline];
+        if self.destructive > 0 {
+            parts.push(if self.destructive == 1 {
+                "1 destructive request".to_owned()
+            } else {
+                format!("{} destructive requests", self.destructive)
+            });
+        }
+        if let Some(summary) = &self.summary {
+            parts.push(summary.clone());
+        }
+        Some(parts.join(". "))
+    }
+}
+
+fn needs_destructive_confirmation(session: &SessionRecord) -> bool {
+    session
+        .needs_input
+        .as_ref()
+        .is_some_and(|detail| detail.risk_hint == RiskHint::Destructive)
+}
+
+fn attention_summary(session: &SessionRecord) -> String {
+    let detail = session.needs_input.as_ref();
+    let summary = detail
+        .map(|detail| detail.summary.trim())
+        .unwrap_or_default();
+    if !summary.is_empty() {
+        return concise(summary, 96);
+    }
+    match detail.map(|detail| &detail.kind).or({
+        if let diri_proto::SessionStatus::NeedsInput(kind) = &session.status {
+            Some(kind)
+        } else {
+            None
+        }
+    }) {
+        Some(NeedsInputKind::Permission) => "Approval requested".to_owned(),
+        Some(NeedsInputKind::Question | NeedsInputKind::Unknown) | None => {
+            "Question waiting".to_owned()
+        }
+    }
+}
+
+fn display_title(session: &SessionRecord) -> &str {
+    if session.title.trim().is_empty() {
+        "Untitled session"
+    } else {
+        session.title.trim()
+    }
+}
+
+fn concise(value: &str, max_chars: usize) -> String {
+    let normalized = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalized.chars().count() <= max_chars {
+        return normalized;
+    }
+    let mut result: String = normalized
+        .chars()
+        .take(max_chars.saturating_sub(1))
+        .collect();
+    result.push('…');
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use diri_proto::{
+        AgentKind, DateMillis, HibernationInfo, HibernationReason, NeedsInputDetail,
+        NeedsInputSource, ProjectId, Resumability, SessionStatus, TitleSource,
+    };
+
+    use super::*;
+
+    fn session(id: &str, status: SessionStatus) -> SessionRecord {
+        SessionRecord {
+            id: SessionId::new(id),
+            kind: AgentKind::CLAUDE_CODE,
+            cwd: "/work/diri".into(),
+            project_id: ProjectId::new("diri"),
+            worktree_path: None,
+            git_branch: None,
+            title: id.into(),
+            title_source: TitleSource::Placeholder,
+            originating_prompt: None,
+            agent_session_id: None,
+            transcript_path: None,
+            status,
+            status_evidence: None,
+            needs_input: None,
+            resumability: Resumability::Live,
+            parent: None,
+            created_at: DateMillis(1.0),
+            updated_at: DateMillis(1.0),
+            last_turn_completed_at: None,
+            last_seen_at: None,
+            pinned: false,
+            archived_at: None,
+            host: None,
+            remote_persistence: None,
+            hibernation: None,
+            memory_bytes: None,
+            artifacts: None,
+            pull_requests: None,
+            listening_ports: None,
+            foreground_agent: None,
+        }
+    }
+
+    fn needs_input(id: &str, summary: &str, risk_hint: RiskHint) -> SessionRecord {
+        let mut session = session(id, SessionStatus::NeedsInput(NeedsInputKind::Permission));
+        session.needs_input = Some(NeedsInputDetail {
+            kind: NeedsInputKind::Permission,
+            source: NeedsInputSource::ClaudePermissionHook,
+            tool_name: Some("Bash".into()),
+            summary: summary.into(),
+            prompt_excerpt: None,
+            options: None,
+            risk_hint,
+            occurred_at: DateMillis(2.0),
+        });
+        session
+    }
+
+    #[test]
+    fn pulse_counts_canonical_attention_and_ignores_sleeping_or_terminal_work() {
+        let mut done = session("done", SessionStatus::Idle);
+        done.last_turn_completed_at = Some(DateMillis(3.0));
+        done.last_seen_at = Some(DateMillis(2.0));
+        let working = session("working", SessionStatus::Working);
+        let mut shell = session("shell", SessionStatus::Working);
+        shell.kind = AgentKind::SHELL;
+        let mut asleep = session("asleep", SessionStatus::Working);
+        asleep.hibernation = Some(HibernationInfo {
+            since: DateMillis(3.0),
+            reason: HibernationReason::Idle,
+            tree_pids: vec![10],
+            tree_start_times: None,
+        });
+        let destructive = needs_input("delete", "Delete the old worktree?", RiskHint::Destructive);
+        let neutral = needs_input("publish", "Publish the preview?", RiskHint::Network);
+
+        let pulse = FleetPulse::derive(
+            [&done, &working, &shell, &asleep, &neutral, &destructive],
+            None,
+        );
+
+        assert_eq!(pulse.needs_you(), 2);
+        assert_eq!(pulse.destructive(), 1);
+        assert_eq!(pulse.done_unseen(), 1);
+        assert_eq!(pulse.working(), 1);
+        assert_eq!(pulse.next_actionable(), Some(&SessionId::new("delete")));
+        assert!(pulse.next_is_destructive());
+        assert_eq!(pulse.summary(), Some("Delete the old worktree?"));
+        assert_eq!(
+            pulse.state(),
+            Some(FleetPulseState::Urgent { destructive: true })
+        );
+    }
+
+    #[test]
+    fn attention_queue_cycles_after_selection_without_losing_risk_priority() {
+        let destructive = needs_input("delete", "Delete it?", RiskHint::Destructive);
+        let first = needs_input("first", "First question", RiskHint::Neutral);
+        let second = needs_input("second", "Second question", RiskHint::Neutral);
+
+        let after_destructive =
+            FleetPulse::derive([&first, &destructive, &second], Some(&destructive.id));
+        assert_eq!(after_destructive.next_actionable(), Some(&first.id));
+
+        let after_first = FleetPulse::derive([&first, &destructive, &second], Some(&first.id));
+        assert_eq!(after_first.next_actionable(), Some(&second.id));
+
+        let wrapped = FleetPulse::derive([&first, &destructive, &second], Some(&second.id));
+        assert_eq!(wrapped.next_actionable(), Some(&destructive.id));
+    }
+
+    #[test]
+    fn pulse_reveals_ready_then_quiet_and_omits_resting_fleets() {
+        let mut done = session("done", SessionStatus::Idle);
+        done.last_turn_completed_at = Some(DateMillis(3.0));
+        let working = session("working", SessionStatus::Starting);
+        let seen = session("seen", SessionStatus::Idle);
+
+        assert_eq!(
+            FleetPulse::derive([&done, &working], None).state(),
+            Some(FleetPulseState::Ready)
+        );
+        assert_eq!(
+            FleetPulse::derive([&working], None).state(),
+            Some(FleetPulseState::Quiet)
+        );
+        assert_eq!(FleetPulse::derive([&seen], None).state(), None);
+        assert_eq!(FleetPulse::derive([], None).state(), None);
+    }
+
+    #[test]
+    fn summaries_are_normalized_bounded_and_have_a_semantic_fallback() {
+        let long = needs_input(
+            "long",
+            "  Approve   this request because it contains a very long explanation that should not own the entire sidebar width forever and ever  ",
+            RiskHint::Neutral,
+        );
+        let pulse = FleetPulse::derive([&long], None);
+        let summary = pulse.summary().expect("summary");
+        assert!(!summary.contains("  "));
+        assert!(summary.chars().count() <= 96);
+        assert!(summary.ends_with('…'));
+
+        let fallback = needs_input("fallback", " ", RiskHint::Neutral);
+        assert_eq!(
+            FleetPulse::derive([&fallback], None).summary(),
+            Some("Approval requested")
+        );
+    }
+}

--- a/diri/crates/diri-app/src/store/mod.rs
+++ b/diri/crates/diri-app/src/store/mod.rs
@@ -1,5 +1,6 @@
 //! Headless application state and the thin asynchronous daemon adapter.
 
+mod fleet_pulse;
 mod prefs;
 mod projection;
 mod residency;
@@ -31,6 +32,7 @@ use crate::switcher::{
     SessionSwitcherState, SwitcherKey, SwitcherOutcome,
 };
 
+pub use fleet_pulse::{FleetPulse, FleetPulseState};
 pub use prefs::{InspectorTab, Prefs, WindowMode, WindowPlacement};
 pub use projection::{SidebarProject, SidebarProjection, SidebarRow};
 pub use residency::{ResidencyUpdate, TerminalResidency};
@@ -1118,6 +1120,11 @@ impl SessionStore {
             .iter()
             .map(|session| session.as_ref().clone())
             .collect()
+    }
+
+    /// Revision-cached attention queue shared by every fleet-level surface.
+    pub fn fleet_pulse(&mut self) -> FleetPulse {
+        self.sidebar_projection().fleet_pulse.clone()
     }
 
     pub fn selected_session(&self) -> Option<&SessionRecord> {

--- a/diri/crates/diri-app/src/store/projection.rs
+++ b/diri/crates/diri-app/src/store/projection.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use diri_proto::{Project, ProjectId, SessionId, SessionRecord};
 
-use super::{Prefs, is_auxiliary_terminal};
+use super::{FleetPulse, Prefs, is_auxiliary_terminal};
 
 /// Rank given to an item the manual order has never seen. Reconciliation
 /// normally appends every live id (see [`super::SessionStore::reconcile_sidebar_order`]),
@@ -63,6 +63,9 @@ pub struct SidebarProjection {
     pub ordered_sessions: Vec<Arc<SessionRecord>>,
     /// Active then archived rows per project, regardless of what is collapsed.
     pub display_order: Vec<SessionId>,
+    /// Fleet-wide attention derived from every active row, including sessions
+    /// hidden behind a folded project or ancestor.
+    pub fleet_pulse: FleetPulse,
 }
 
 impl SidebarProjection {
@@ -195,10 +198,18 @@ pub(super) fn build_projection(
         })
         .collect();
 
+    let fleet_pulse = FleetPulse::derive(
+        result
+            .iter()
+            .flat_map(|group| group.active.iter().map(AsRef::as_ref)),
+        selected,
+    );
+
     SidebarProjection {
         projects: result,
         ordered_sessions,
         display_order,
+        fleet_pulse,
     }
 }
 


### PR DESCRIPTION
## Why

Diri already knows when agents need input, finish work, or keep running, but that truth is distributed across the session tree. Fleet Pulse turns it into one calm, glanceable next-action surface at the top of the sidebar.

This is the first product slice toward an attention-first agent workspace: the user should be able to answer “what needs me now?” without scanning every project.

## What changed

- derive a revision-cached Fleet Pulse projection from canonical session state
- prioritize destructive approvals, then other blocked work, then unseen completed work
- show compact urgent, ready, quiet, and overflow states in the sidebar
- activate the next actionable session by click, Enter, or Space
- expose button/status semantics and useful accessible labels through AccessKit
- add hover, press, focus-visible, and stable color treatment without timers or autonomous repaint loops
- add deterministic fixtures and focused projection/interaction coverage

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p diri-app --all-targets -- -D warnings`
- `cargo test -p diri-app` (426 passed, 2 ignored)
- headless sidebar fixture review at the narrow 248 px width

## Product direction

The strip is intentionally small. It is a doorway into a future Mission Control workbench, not an attempt to compress that entire experience into the sidebar.
