### PR TITLE
terminal: polish find, selection, and semantic overlays

### DIFF
--- a/diri/crates/diri-app/src/terminal_pane.rs
+++ b/diri/crates/diri-app/src/terminal_pane.rs
@@ -18,7 +18,10 @@ use diri_proto::{
 };
 use diri_term::buffer::GridBuffer;
 use diri_term::element::{SharedGridBuffer, TerminalElement, TerminalReference};
-use diri_term::find::{FindSnapshot, SearchRequest, TerminalFindModel};
+use diri_term::find::{
+    FindSearchScheduler, FindSnapshot, ReadCompletion, SearchRequest, SearchResult,
+    TerminalFindModel,
+};
 use diri_term::keys::{
     Key as TermKey, KeyEvent as TermKeyEvent, Modifiers as TermModifiers, NamedKey, TermInputModes,
     encode_key, paste,
@@ -500,7 +503,13 @@ enum PaneEvent {
     AttachmentState(SessionId, AttachmentGeneration, AttachmentState),
     Chunk(SessionId, AttachmentGeneration, TerminalChunk),
     GridBatch(SessionId, AttachmentGeneration, Vec<GridUpdate>),
-    FindSnapshot(SessionId, SearchRequest, FindSnapshot),
+    FindSnapshot(
+        SessionId,
+        AttachmentGeneration,
+        SearchRequest,
+        Option<FindSnapshot>,
+    ),
+    FindResult(SessionId, AttachmentGeneration, SearchRequest, SearchResult),
     ScrollbackCells(SessionId, diri_proto::ReadScrollbackCellsResult, usize),
     ScrollbackFailed(SessionId),
     ClipboardUploadFinished(SessionId, Result<String, String>),
@@ -524,6 +533,45 @@ struct PaneEventReceiver {
     wake: mpsc::Receiver<()>,
 }
 
+/// The one completion a resident's single-flight find pipeline can be waiting
+/// to deliver. It has a mailbox class of its own: semantic queue pressure must
+/// never strand the scheduler in Reading or Scanning forever.
+enum FindCompletion {
+    Snapshot {
+        generation: AttachmentGeneration,
+        request: SearchRequest,
+        snapshot: Option<FindSnapshot>,
+    },
+    Result {
+        generation: AttachmentGeneration,
+        request: SearchRequest,
+        result: SearchResult,
+    },
+}
+
+impl FindCompletion {
+    const fn generation(&self) -> AttachmentGeneration {
+        match self {
+            Self::Snapshot { generation, .. } | Self::Result { generation, .. } => *generation,
+        }
+    }
+
+    fn into_event(self, id: SessionId) -> PaneEvent {
+        match self {
+            Self::Snapshot {
+                generation,
+                request,
+                snapshot,
+            } => PaneEvent::FindSnapshot(id, generation, request, snapshot),
+            Self::Result {
+                generation,
+                request,
+                result,
+            } => PaneEvent::FindResult(id, generation, request, result),
+        }
+    }
+}
+
 #[derive(Default)]
 struct PaneMailboxState {
     events: VecDeque<PaneEvent>,
@@ -532,6 +580,10 @@ struct PaneMailboxState {
     /// must not be erased.
     grids: HashMap<SessionId, (AttachmentGeneration, Vec<GridUpdate>)>,
     grid_order: VecDeque<SessionId>,
+    /// Exactly one completion per session. Terminal residency bounds the
+    /// producer set, and replacement generations overwrite detached work.
+    find_completions: HashMap<SessionId, FindCompletion>,
+    find_order: VecDeque<SessionId>,
 }
 
 fn pane_event_channel() -> (PaneEventSender, PaneEventReceiver) {
@@ -584,6 +636,26 @@ impl PaneEventSender {
                     state.grids.insert(id, (generation, vec![update]));
                 }
             }
+            PaneEvent::FindSnapshot(id, generation, request, snapshot) => {
+                state.queue_find_completion(
+                    id,
+                    FindCompletion::Snapshot {
+                        generation,
+                        request,
+                        snapshot,
+                    },
+                );
+            }
+            PaneEvent::FindResult(id, generation, request, result) => {
+                state.queue_find_completion(
+                    id,
+                    FindCompletion::Result {
+                        generation,
+                        request,
+                        result,
+                    },
+                );
+            }
             event => {
                 if state.events.len() >= PANE_EVENT_QUEUE_CAPACITY {
                     return Err(());
@@ -604,13 +676,36 @@ impl PaneEventReceiver {
             return false;
         }
         let mut state = self.state.lock().expect("pane event mailbox");
+        // Preserve ordinary semantic ordering, then apply every queued grid
+        // before find completions. Grid damage increments the find content
+        // generation, so a scan of the preceding screen can never flash stale
+        // highlights for one rescan interval.
         batch.extend(state.events.drain(..));
         while let Some(id) = state.grid_order.pop_front() {
             if let Some((generation, updates)) = state.grids.remove(&id) {
                 batch.push(PaneEvent::GridBatch(id, generation, updates));
             }
         }
+        while let Some(id) = state.find_order.pop_front() {
+            if let Some(completion) = state.find_completions.remove(&id) {
+                batch.push(completion.into_event(id));
+            }
+        }
         true
+    }
+}
+
+impl PaneMailboxState {
+    fn queue_find_completion(&mut self, id: SessionId, completion: FindCompletion) {
+        if let Some(queued) = self.find_completions.get(&id)
+            && completion.generation() < queued.generation()
+        {
+            return;
+        }
+        if !self.find_completions.contains_key(&id) {
+            self.find_order.push_back(id.clone());
+        }
+        self.find_completions.insert(id, completion);
     }
 }
 
@@ -622,6 +717,10 @@ struct ResidentTerminal {
     attachment_generation: AttachmentGeneration,
     attachment_state: AttachmentState,
     find: Option<TerminalFindModel>,
+    /// Single flight across both the daemon history read and blocking scan.
+    /// One newer request may replace the dirty follow-up; snapshots never
+    /// queue behind CPU work.
+    find_scheduler: FindSearchScheduler,
     /// The editable text behind `find`'s query, so ⌘F gets the same caret,
     /// selection, and readline keys as the other query fields.
     find_query: QueryEditor,
@@ -938,6 +1037,7 @@ impl TerminalPane {
                     attachment_generation: generation,
                     attachment_state: AttachmentState::Attaching,
                     find: None,
+                    find_scheduler: FindSearchScheduler::default(),
                     find_query: QueryEditor::default(),
                     last_size: (0, 0),
                     pointer_owner: None,
@@ -1149,18 +1249,76 @@ impl TerminalPane {
                 }
             }
             PaneEvent::Chunk(_, _, TerminalChunk::Pong) => {}
-            PaneEvent::FindSnapshot(id, request, snapshot) => {
-                let visible = self.selected_id().as_ref() == Some(&id);
-                if let Some(resident) = self.residents.get_mut(&id)
-                    && let Some(find) = resident.find.as_mut()
-                    && resident
-                        .element
-                        .apply_find_snapshot(find, &request, snapshot)
-                {
-                    resident.element.sync_find_highlights(find);
-                    if visible {
-                        cx.notify();
+            PaneEvent::FindSnapshot(id, generation, request, snapshot) => {
+                if !self.attachment_is_current(&id, generation) {
+                    return;
+                }
+                let read_completion = self
+                    .residents
+                    .get_mut(&id)
+                    .map(|resident| {
+                        resident
+                            .find_scheduler
+                            .finish_read(&request, snapshot.is_some())
+                    })
+                    .unwrap_or(ReadCompletion::Ignore);
+                match read_completion {
+                    ReadCompletion::Ignore | ReadCompletion::Idle => {}
+                    ReadCompletion::Read(next) => {
+                        self.launch_find_read(id, generation, next);
                     }
+                    ReadCompletion::Scan => {
+                        let job = snapshot.and_then(|snapshot| {
+                            self.residents.get(&id).and_then(|resident| {
+                                resident.find.as_ref().and_then(|find| {
+                                    resident
+                                        .element
+                                        .prepare_find_search(find, &request, snapshot)
+                                })
+                            })
+                        });
+                        if let Some(job) = job {
+                            let pane_tx = self.pane_tx.clone();
+                            self.tokio.spawn_blocking(move || {
+                                let result = job.run();
+                                let _ = pane_tx
+                                    .send(PaneEvent::FindResult(id, generation, request, result));
+                            });
+                        } else {
+                            let next = self
+                                .residents
+                                .get_mut(&id)
+                                .and_then(|resident| resident.find_scheduler.finish_scan(&request))
+                                .and_then(|completion| completion.into_next_request());
+                            if let Some(next) = next {
+                                self.launch_find_read(id, generation, next);
+                            }
+                        }
+                    }
+                }
+            }
+            PaneEvent::FindResult(id, generation, request, result) => {
+                if !self.attachment_is_current(&id, generation) {
+                    return;
+                }
+                let visible = self.selected_id().as_ref() == Some(&id);
+                let mut next = None;
+                if let Some(resident) = self.residents.get_mut(&id)
+                    && let Some(completion) = resident.find_scheduler.finish_scan(&request)
+                {
+                    if completion.should_apply_result()
+                        && let Some(find) = resident.find.as_mut()
+                        && resident.element.apply_find_result(find, result)
+                    {
+                        resident.element.sync_find_highlights(find);
+                        if visible {
+                            cx.notify();
+                        }
+                    }
+                    next = completion.into_next_request();
+                }
+                if let Some(next) = next {
+                    self.launch_find_read(id, generation, next);
                 }
             }
             PaneEvent::ScrollbackCells(id, result, visible_rows) => {
@@ -1302,21 +1460,27 @@ impl TerminalPane {
 
     fn start_due_find(&mut self, id: &SessionId) {
         let now = self.started_at.elapsed();
-        let Some(request) = self
-            .residents
-            .get_mut(id)
-            .and_then(|resident| resident.find.as_mut())
-            .and_then(|find| find.take_due_search(now))
-        else {
+        let Some((generation, request)) = self.residents.get_mut(id).and_then(|resident| {
+            let request = resident.find.as_mut()?.take_due_search(now)?;
+            let request = resident.find_scheduler.schedule(request)?;
+            Some((resident.attachment_generation, request))
+        }) else {
             return;
         };
+        self.launch_find_read(id.clone(), generation, request);
+    }
+
+    fn launch_find_read(
+        &self,
+        id: SessionId,
+        generation: AttachmentGeneration,
+        request: SearchRequest,
+    ) {
         let client = Arc::clone(self.runtime.client());
         let pane_tx = self.pane_tx.clone();
-        let id = id.clone();
         self.tokio.spawn(async move {
-            if let Ok(snapshot) = client.read_scrollback(&id).await {
-                let _ = pane_tx.send(PaneEvent::FindSnapshot(id, request, snapshot.into()));
-            }
+            let snapshot = client.read_scrollback(&id).await.ok().map(Into::into);
+            let _ = pane_tx.send(PaneEvent::FindSnapshot(id, generation, request, snapshot));
         });
     }
 
@@ -1381,6 +1545,7 @@ impl TerminalPane {
         if resident.find.take().is_none() {
             return false;
         }
+        resident.find_scheduler.cancel();
         resident.element.set_find_highlights(Vec::new());
         true
     }
@@ -1913,6 +2078,7 @@ impl TerminalPane {
             match event.keystroke.key.as_str() {
                 "escape" => {
                     resident.find = None;
+                    resident.find_scheduler.cancel();
                     resident.element.set_find_highlights(Vec::new());
                     cx.notify();
                 }
@@ -3821,6 +3987,55 @@ mod tests {
 
     use super::*;
 
+    fn due_find_request(
+        model: &mut TerminalFindModel,
+        query: &str,
+        now: Duration,
+    ) -> SearchRequest {
+        model.set_query(query, now);
+        model
+            .take_due_search(now + diri_term::find::SEARCH_DEBOUNCE)
+            .expect("find request should be due")
+    }
+
+    fn find_snapshot(content_seq: u64) -> FindSnapshot {
+        FindSnapshot {
+            lines: Vec::new(),
+            first_row: 0,
+            visible_start_row: 0,
+            cols: 8,
+            rows: 1,
+            content_seq,
+            is_alt_screen: false,
+        }
+    }
+
+    fn find_result(model: &TerminalFindModel, request: &SearchRequest) -> SearchResult {
+        let mut live = GridBuffer::new(8, 1);
+        for (index, ch) in "needle".chars().enumerate() {
+            live.cells[index] = GridCell::new(
+                u32::from(ch),
+                TermColor::Default,
+                TermColor::DefaultInverted,
+                TermStyle::empty(),
+            );
+        }
+        model
+            .prepare_search(request, find_snapshot(1), &live)
+            .expect("search job")
+            .run()
+    }
+
+    fn fill_semantic_mailbox(sender: &PaneEventSender) {
+        for _ in 0..PANE_EVENT_QUEUE_CAPACITY {
+            assert!(
+                sender
+                    .send(PaneEvent::ScrollbackFailed(SessionId::new("pressure")))
+                    .is_ok()
+            );
+        }
+    }
+
     #[tokio::test]
     async fn pane_mailbox_retains_one_exact_final_grid_per_session() {
         let (sender, mut receiver) = pane_event_channel();
@@ -3916,6 +4131,144 @@ mod tests {
         assert_eq!(generation, 4);
         assert_eq!(updates.len(), 1);
         assert_eq!(updates[0].changed_rows[0].cells[0].scalar, u32::from('n'));
+    }
+
+    #[tokio::test]
+    async fn full_semantic_mailbox_cannot_strand_a_find_read() {
+        let (sender, mut receiver) = pane_event_channel();
+        let id = SessionId::new("find-read-pressure");
+        let generation = 7;
+        let mut model = TerminalFindModel::default();
+        let first = due_find_request(&mut model, "first", Duration::ZERO);
+        let latest = due_find_request(&mut model, "latest", Duration::from_secs(1));
+        let mut scheduler = FindSearchScheduler::default();
+        assert_eq!(scheduler.schedule(first.clone()), Some(first.clone()));
+        assert_eq!(scheduler.schedule(latest.clone()), None);
+
+        fill_semantic_mailbox(&sender);
+        assert!(
+            sender
+                .send(PaneEvent::FindSnapshot(
+                    id,
+                    generation,
+                    first.clone(),
+                    Some(find_snapshot(1)),
+                ))
+                .is_ok(),
+            "find completion must not share rejectable semantic capacity"
+        );
+
+        let mut batch = Vec::new();
+        assert!(receiver.recv_batch(&mut batch).await);
+        let delivered = batch.into_iter().find_map(|event| match event {
+            PaneEvent::FindSnapshot(_, _, request, snapshot) => Some((request, snapshot)),
+            _ => None,
+        });
+        let (delivered_request, snapshot) = delivered.expect("guaranteed read completion");
+        assert!(snapshot.is_some());
+        assert_eq!(delivered_request, first);
+        assert_eq!(
+            scheduler.finish_read(&delivered_request, true),
+            ReadCompletion::Read(latest),
+            "the latest search must run after the pressured read completes"
+        );
+    }
+
+    #[tokio::test]
+    async fn full_semantic_mailbox_cannot_strand_a_find_scan() {
+        let (sender, mut receiver) = pane_event_channel();
+        let id = SessionId::new("find-scan-pressure");
+        let generation = 9;
+        let mut model = TerminalFindModel::default();
+        let first = due_find_request(&mut model, "needle", Duration::ZERO);
+        let result = find_result(&model, &first);
+        let latest = due_find_request(&mut model, "latest", Duration::from_secs(1));
+        let mut scheduler = FindSearchScheduler::default();
+        assert_eq!(scheduler.schedule(first.clone()), Some(first.clone()));
+        assert_eq!(scheduler.finish_read(&first, true), ReadCompletion::Scan);
+        assert_eq!(scheduler.schedule(latest.clone()), None);
+
+        fill_semantic_mailbox(&sender);
+        assert!(
+            sender
+                .send(PaneEvent::FindResult(id, generation, first.clone(), result))
+                .is_ok(),
+            "find result must not share rejectable semantic capacity"
+        );
+
+        let mut batch = Vec::new();
+        assert!(receiver.recv_batch(&mut batch).await);
+        let delivered_request = batch.into_iter().find_map(|event| match event {
+            PaneEvent::FindResult(_, _, request, _) => Some(request),
+            _ => None,
+        });
+        let delivered_request = delivered_request.expect("guaranteed scan completion");
+        let completion = scheduler
+            .finish_scan(&delivered_request)
+            .expect("active scan completion");
+        assert_eq!(
+            completion.into_next_request(),
+            Some(latest),
+            "the latest search must run after the pressured scan completes"
+        );
+    }
+
+    #[tokio::test]
+    async fn pane_mailbox_delivers_grid_damage_before_an_older_find_result() {
+        let (sender, mut receiver) = pane_event_channel();
+        let id = SessionId::new("grid-before-find");
+        let generation = 11;
+        let mut model = TerminalFindModel::default();
+        let request = due_find_request(&mut model, "needle", Duration::ZERO);
+        let result = find_result(&model, &request);
+        let mut scheduler = FindSearchScheduler::default();
+        assert_eq!(scheduler.schedule(request.clone()), Some(request.clone()));
+        assert_eq!(scheduler.finish_read(&request, true), ReadCompletion::Scan);
+
+        // The result reaches the mailbox first, but the grid is newer content
+        // already waiting in the same GPUI wake.
+        assert!(
+            sender
+                .send(PaneEvent::FindResult(
+                    id.clone(),
+                    generation,
+                    request.clone(),
+                    result,
+                ))
+                .is_ok()
+        );
+        assert!(
+            sender
+                .send(PaneEvent::Chunk(
+                    id,
+                    generation,
+                    TerminalChunk::Grid(filled_grid('n')),
+                ))
+                .is_ok()
+        );
+
+        let mut batch = Vec::new();
+        assert!(receiver.recv_batch(&mut batch).await);
+        assert!(matches!(batch.first(), Some(PaneEvent::GridBatch(..))));
+        assert!(matches!(batch.last(), Some(PaneEvent::FindResult(..))));
+
+        let mut viewport = diri_term::scrollback::ScrollbackViewport::default();
+        for event in batch {
+            match event {
+                PaneEvent::GridBatch(..) => {
+                    assert!(model.on_output(Duration::from_secs(1)));
+                }
+                PaneEvent::FindResult(_, _, delivered, result) => {
+                    assert!(scheduler.finish_scan(&delivered).is_some());
+                    assert!(
+                        !model.apply_result(result, &mut viewport),
+                        "queued newer grid must invalidate the older result before apply"
+                    );
+                }
+                _ => {}
+            }
+        }
+        assert!(model.matches().is_empty());
     }
 
     /// Replays a drag as the render loop sees it -- a geometry change every
@@ -4533,7 +4886,9 @@ mod tests {
     }
 
     #[gpui::test]
-    fn stale_detached_attachment_cannot_overwrite_a_reselected_session(cx: &mut TestAppContext) {
+    fn stale_detached_attachment_events_cannot_overwrite_a_reselected_session(
+        cx: &mut TestAppContext,
+    ) {
         let runtime = Arc::new(StoreRuntime::inert());
         let tokio = Arc::new(
             tokio::runtime::Builder::new_current_thread()
@@ -4621,6 +4976,89 @@ mod tests {
                 buffer.cells[0].scalar,
                 u32::from('n'),
                 "a detached attachment repainted the newly selected terminal"
+            );
+        });
+
+        // Find crosses two additional async handoffs. Exercise both with a
+        // request that would otherwise be valid for the new resident: only the
+        // attachment generation distinguishes the old producer.
+        let mut find = TerminalFindModel::default();
+        find.set_query("needle", Duration::ZERO);
+        let request = find
+            .take_due_search(Duration::from_millis(200))
+            .expect("find request");
+        let snapshot = FindSnapshot {
+            lines: Vec::new(),
+            first_row: 0,
+            visible_start_row: 0,
+            cols: 8,
+            rows: 1,
+            content_seq: 1,
+            is_alt_screen: false,
+        };
+        let mut live = GridBuffer::new(8, 1);
+        for (index, ch) in "needle".chars().enumerate() {
+            live.cells[index] = GridCell::new(
+                u32::from(ch),
+                TermColor::Default,
+                TermColor::DefaultInverted,
+                TermStyle::empty(),
+            );
+        }
+        let result = find
+            .prepare_search(&request, snapshot.clone(), &live)
+            .expect("search job")
+            .run();
+
+        pane.update_in(cx, move |pane, window, cx| {
+            let resident = pane
+                .residents
+                .get_mut(&reselected.id)
+                .expect("reselected resident");
+            resident.find = Some(find);
+            assert_eq!(
+                resident.find_scheduler.schedule(request.clone()),
+                Some(request.clone())
+            );
+
+            pane.handle_pane_event(
+                PaneEvent::FindSnapshot(
+                    reselected.id.clone(),
+                    old_generation,
+                    request.clone(),
+                    Some(snapshot.clone()),
+                ),
+                window,
+                cx,
+            );
+            let resident = pane
+                .residents
+                .get_mut(&reselected.id)
+                .expect("reselected resident");
+            assert_eq!(
+                resident.find_scheduler.finish_read(&request, true),
+                ReadCompletion::Scan,
+                "stale snapshot advanced the new resident's scheduler"
+            );
+
+            pane.handle_pane_event(
+                PaneEvent::FindResult(
+                    reselected.id.clone(),
+                    old_generation,
+                    request.clone(),
+                    result,
+                ),
+                window,
+                cx,
+            );
+            let resident = pane
+                .residents
+                .get_mut(&reselected.id)
+                .expect("reselected resident");
+            assert!(resident.find.as_ref().unwrap().matches().is_empty());
+            assert!(
+                resident.find_scheduler.finish_scan(&request).is_some(),
+                "stale result completed the new resident's active scan"
             );
         });
     }

--- a/diri/crates/diri-app/src/terminal_pane.rs
+++ b/diri/crates/diri-app/src/terminal_pane.rs
@@ -35,9 +35,9 @@ use diri_ui::{
 };
 use gpui::{
     AnyElement, ClickEvent, ClipboardEntry, ClipboardItem, Context, Entity, EventEmitter,
-    FocusHandle, KeyDownEvent, KeyUpEvent, ModifiersChangedEvent, MouseButton, Render, ScrollDelta,
-    ScrollWheelEvent, SharedString, StatefulInteractiveElement, Task, Window, div, font,
-    prelude::*, px, rgba,
+    FocusHandle, KeyDownEvent, KeyUpEvent, ModifiersChangedEvent, MouseButton, Render, Role,
+    ScrollDelta, ScrollWheelEvent, SharedString, StatefulInteractiveElement, Task, Window, div,
+    font, prelude::*, px, rgba,
 };
 use tokio::runtime::Handle;
 use tokio::sync::mpsc;
@@ -1697,7 +1697,8 @@ impl TerminalPane {
             PointerOwner::LocalSelection => {
                 match event.click_count {
                     1 => resident.element.begin_selection(col, row),
-                    _ => resident.element.select_word(col, row),
+                    2 => resident.element.select_word(col, row),
+                    _ => resident.element.select_line(row),
                 }
                 cx.notify();
             }
@@ -2619,22 +2620,23 @@ impl TerminalPane {
         &mut self,
         session: &SessionRecord,
         theme: TermTheme,
+        colors: SemanticColors,
         font_size: f32,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> AnyElement {
         if session.is_archived() {
-            return self.render_archived_overlay(session, cx);
+            return self.render_archived_overlay(session, colors, cx);
         }
         let exited = matches!(session.status, SessionStatus::Exited(_));
         // An exited agent leaves its last screen behind in the daemon, and that
         // output is exactly what people want to read after closing an agent --
         // so only take the pane over when there is no terminal left to show.
-        if exited && let Some(takeover) = self.render_exited_takeover(session, cx) {
+        if exited && let Some(takeover) = self.render_exited_takeover(session, colors, cx) {
             return takeover;
         }
         let Some(resident) = self.residents.get(&session.id) else {
-            return centered_message("Preparing terminal…", "").into_any_element();
+            return centered_message("Preparing terminal…", "", colors).into_any_element();
         };
         let element = resident
             .element
@@ -2718,14 +2720,16 @@ impl TerminalPane {
                     .rounded(px(999.0))
                     .px(px(12.0))
                     .py(px(6.0))
-                    .bg(rgba(0x303238e8))
+                    .bg(colors.floating_surface())
+                    .border_1()
+                    .border_color(colors.floating_stroke())
                     .text_size(px(11.5))
-                    .text_color(rgba(0xffffff99))
+                    .text_color(colors.secondary)
                     .cursor_pointer()
                     .flex()
                     .items_center()
                     .gap(px(5.0))
-                    .child(sf_symbol("arrow.down", 11.5, rgba(0xffffff99)))
+                    .child(sf_symbol("arrow.down", 11.5, colors.secondary))
                     .child(format!("{view_offset} lines · Return to live"))
                     .on_click(cx.listener(move |this, _, _window, cx| {
                         if let Some(resident) = this.residents.get_mut(&return_id) {
@@ -2752,21 +2756,28 @@ impl TerminalPane {
                     .rounded(px(999.0))
                     .px(px(12.0))
                     .py(px(6.0))
-                    .bg(rgba(0x303238e8))
+                    .bg(colors.floating_surface())
+                    .border_1()
+                    .border_color(colors.floating_stroke())
                     .text_size(px(11.5))
-                    .text_color(rgba(0xffffff99))
+                    .text_color(colors.secondary)
                     .child(message),
             );
         }
         if exited {
-            body = body.child(self.render_exit_pill(session, cx));
+            body = body.child(self.render_exit_pill(session, colors, cx));
         }
         body.into_any_element()
     }
 
     /// Slim status pill over an exited session's last screen: says what happened
     /// and offers the resume that the pane-filling card used to.
-    fn render_exit_pill(&self, session: &SessionRecord, cx: &mut Context<Self>) -> AnyElement {
+    fn render_exit_pill(
+        &self,
+        session: &SessionRecord,
+        colors: SemanticColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
         let id = session.id.clone();
         let resumable = session.resumability == Resumability::Resumable;
         let mut pill = div()
@@ -2775,13 +2786,15 @@ impl TerminalPane {
             .pl(px(12.0))
             .pr(if resumable { px(4.0) } else { px(12.0) })
             .py(px(4.0))
-            .bg(rgba(0x303238e8))
+            .bg(colors.floating_surface())
+            .border_1()
+            .border_color(colors.floating_stroke())
             .flex()
             .items_center()
             .gap(px(8.0))
             .text_size(px(11.5))
-            .text_color(rgba(0xffffff99))
-            .child(sf_symbol("power", 11.0, rgba(0xffffff66)))
+            .text_color(colors.secondary)
+            .child(sf_symbol("power", 11.0, colors.tertiary))
             .child(exit_description(session));
         if resumable {
             pill = pill.child(
@@ -2790,10 +2803,10 @@ impl TerminalPane {
                     .rounded(px(999.0))
                     .px(px(9.0))
                     .py(px(3.0))
-                    .bg(rgba(0xffffff1a))
-                    .hover(|style| style.bg(rgba(0xffffff2e)))
+                    .bg(colors.primary.alpha(0.08))
+                    .hover(move |style| style.bg(colors.primary.alpha(0.14)))
                     .cursor_pointer()
-                    .text_color(rgba(0xffffffe6))
+                    .text_color(colors.primary)
                     .child("Resume")
                     .on_click(cx.listener(move |this, _, _, cx| {
                         this.runtime
@@ -2805,11 +2818,7 @@ impl TerminalPane {
                     })),
             );
         } else if session.resumability == Resumability::TranscriptMissing {
-            pill = pill.child(
-                div()
-                    .text_color(rgba(0xffffff4d))
-                    .child("· transcript gone"),
-            );
+            pill = pill.child(div().text_color(colors.tertiary).child("· transcript gone"));
         }
         // Centered by a full-width row rather than a guessed half-width offset,
         // since the description's length varies with the exit reason.
@@ -2832,7 +2841,8 @@ impl TerminalPane {
     ) -> Option<AnyElement> {
         let resident = self.residents.get(&session.id)?;
         let find = resident.find.as_ref()?;
-        let count = if find.matches().is_empty() {
+        let has_matches = !find.matches().is_empty();
+        let count = if !has_matches {
             if find.query().is_empty() {
                 String::new()
             } else {
@@ -2868,35 +2878,53 @@ impl TerminalPane {
                                 .items_center()
                                 .gap(px(8.0))
                                 .text_size(px(Typo::ROW.size))
-                                .text_color(rgba(0xffffffd9))
-                                .child(sf_symbol("magnifyingglass", 12.0, rgba(0xffffff66)))
+                                .text_color(colors.primary)
+                                .child(sf_symbol("magnifyingglass", 12.0, colors.tertiary))
                                 .child(div().flex_1().child(query))
                                 .child(
                                     div()
                                         .text_size(px(Typo::META.size))
-                                        .text_color(rgba(0xffffff4d))
+                                        .text_color(colors.tertiary)
                                         .child(count),
                                 )
-                                .child(div().w(px(1.0)).h(px(16.0)).bg(rgba(0xffffff1a)))
+                                .child(div().w(px(1.0)).h(px(16.0)).bg(colors.primary.alpha(0.10)))
                                 .child(find_icon_button(
-                                    "find-previous",
-                                    "chevron.up",
+                                    FindButtonSpec {
+                                        id: "find-previous",
+                                        system_image: "chevron.up",
+                                        label: "Previous match",
+                                        shortcut: "Shift+Enter",
+                                    },
+                                    colors,
+                                    has_matches,
                                     cx,
                                     |this, _w, cx| {
                                         this.navigate_find(true, cx);
                                     },
                                 ))
                                 .child(find_icon_button(
-                                    "find-next",
-                                    "chevron.down",
+                                    FindButtonSpec {
+                                        id: "find-next",
+                                        system_image: "chevron.down",
+                                        label: "Next match",
+                                        shortcut: "Enter",
+                                    },
+                                    colors,
+                                    has_matches,
                                     cx,
                                     |this, _w, cx| {
                                         this.navigate_find(false, cx);
                                     },
                                 ))
                                 .child(find_icon_button(
-                                    "find-close",
-                                    "xmark",
+                                    FindButtonSpec {
+                                        id: "find-close",
+                                        system_image: "xmark",
+                                        label: "Close find",
+                                        shortcut: "Escape",
+                                    },
+                                    colors,
+                                    true,
                                     cx,
                                     |this, _w, cx| {
                                         this.close_find_for_selected();
@@ -2909,7 +2937,7 @@ impl TerminalPane {
                                 div()
                                     .pl(px(20.0))
                                     .text_size(px(Typo::META.size))
-                                    .text_color(rgba(0xffffff4d))
+                                    .text_color(colors.tertiary)
                                     .child("full-screen app — screen only"),
                             )
                         }),
@@ -2923,6 +2951,7 @@ impl TerminalPane {
     fn render_exited_takeover(
         &self,
         session: &SessionRecord,
+        colors: SemanticColors,
         cx: &mut Context<Self>,
     ) -> Option<AnyElement> {
         let (auto_resuming, migrating) = {
@@ -2939,10 +2968,12 @@ impl TerminalPane {
         // Mid-migration the source agent is briefly down; show the busy state
         // instead of an exit card with a doomed Resume button.
         if migrating {
-            return Some(centered_message("◌", "Moving session…").into_any_element());
+            return Some(centered_message("◌", "Moving session…", colors).into_any_element());
         }
         if auto_resuming {
-            return Some(centered_message("◌", "Resuming conversation…").into_any_element());
+            return Some(
+                centered_message("◌", "Resuming conversation…", colors).into_any_element(),
+            );
         }
         if self
             .residents
@@ -2951,17 +2982,23 @@ impl TerminalPane {
         {
             return None;
         }
-        Some(self.render_exited_card(session, cx))
+        Some(self.render_exited_card(session, colors, cx))
     }
 
-    fn render_exited_card(&self, session: &SessionRecord, cx: &mut Context<Self>) -> AnyElement {
+    fn render_exited_card(
+        &self,
+        session: &SessionRecord,
+        colors: SemanticColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
         let id = session.id.clone();
-        let content = centered_message("", &exit_description(session));
+        let content = centered_message("", &exit_description(session), colors);
         if session.resumability == Resumability::Resumable {
             content
                 .child(primary_button(
                     "resume-conversation",
                     "Resume Conversation",
+                    colors,
                     cx,
                     move |this, cx| {
                         this.runtime
@@ -2978,7 +3015,7 @@ impl TerminalPane {
                 .child(
                     div()
                         .text_size(px(11.5))
-                        .text_color(rgba(0xffffff4d))
+                        .text_color(colors.tertiary)
                         .child("Transcript is gone — start a fresh session in the same folder."),
                 )
                 .into_any_element()
@@ -2990,21 +3027,23 @@ impl TerminalPane {
     fn render_archived_overlay(
         &self,
         session: &SessionRecord,
+        colors: SemanticColors,
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let id = session.id.clone();
-        let mut content = centered_symbol_message("archivebox", 30.0, &session.title).child(
-            div()
-                .text_size(px(13.0))
-                .text_color(rgba(0xffffff99))
-                .child("Archived"),
-        );
+        let mut content = centered_symbol_message("archivebox", 30.0, &session.title, colors)
+            .child(
+                div()
+                    .text_size(px(13.0))
+                    .text_color(colors.secondary)
+                    .child("Archived"),
+            );
         if session.resumability == Resumability::NotResumable {
             content = content.child(
                 div()
                     .max_w(px(320.0))
                     .text_size(px(11.5))
-                    .text_color(rgba(0xffffff4d))
+                    .text_color(colors.tertiary)
                     .child(
                         "This session can't resume its conversation; revive restores it as ended.",
                     ),
@@ -3014,6 +3053,7 @@ impl TerminalPane {
             .child(primary_button(
                 "revive-session",
                 "Revive Session",
+                colors,
                 cx,
                 move |this, cx| {
                     this.runtime
@@ -3070,7 +3110,7 @@ impl TerminalPane {
                     .items_center()
                     .gap(px(8.0))
                     .px(px(8.0))
-                    .hover(|style| style.bg(rgba(0xffffff0f)))
+                    .hover(move |style| style.bg(colors.primary.alpha(0.06)))
                     .when(url.is_some(), |row| row.cursor_pointer())
                     .child(div().size(px(6.0)).rounded(px(3.0)).bg(color))
                     .child(
@@ -3079,7 +3119,7 @@ impl TerminalPane {
                             .overflow_hidden()
                             .whitespace_nowrap()
                             .text_size(px(Typo::ROW.size))
-                            .text_color(rgba(0xffffffd9))
+                            .text_color(colors.primary)
                             .child(check.name),
                     )
                     .child(
@@ -3133,18 +3173,18 @@ impl TerminalPane {
                                         .py(px(8.0))
                                         .text_size(px(Typo::ROW_EMPHASIZED.size))
                                         .font_weight(Typo::ROW_EMPHASIZED.weight)
-                                        .text_color(rgba(0xffffffff))
+                                        .text_color(colors.primary)
                                         .child(headline),
                                 )
-                                .child(div().h(px(1.0)).bg(rgba(0xffffff14)))
+                                .child(div().h(px(1.0)).bg(colors.primary.alpha(0.08)))
                                 .child(div().max_h(px(246.0)).overflow_hidden().child(rows))
-                                .child(div().h(px(1.0)).bg(rgba(0xffffff14)))
+                                .child(div().h(px(1.0)).bg(colors.primary.alpha(0.08)))
                                 .child(
                                     div()
                                         .px(px(12.0))
                                         .py(px(7.0))
                                         .text_size(px(Typo::META.size))
-                                        .text_color(rgba(0xffffff99))
+                                        .text_color(colors.secondary)
                                         .child(footer),
                                 ),
                         )),
@@ -3180,13 +3220,13 @@ impl TerminalPane {
                     .gap(px(7.0))
                     .px(px(8.0))
                     .text_size(px(Typo::ROW.size))
-                    .text_color(rgba(0xffffffd9))
-                    .hover(|style| style.bg(rgba(0xffffff0f)))
+                    .text_color(colors.primary)
+                    .hover(move |style| style.bg(colors.primary.alpha(0.06)))
                     .cursor_pointer()
                     .child(sf_symbol(
                         chip.system_image,
                         11.0,
-                        tint.unwrap_or(rgba(0xffffff99)),
+                        tint.unwrap_or(colors.secondary),
                     ))
                     .child(div().min_w(px(0.0)).flex_1().truncate().child(chip.label))
                     .on_click(cx.listener(move |this, _, _, cx| {
@@ -3307,7 +3347,9 @@ impl Render for TerminalPane {
                 .rounded_tr(px(Radius::CARD))
                 .overflow_hidden()
                 .bg(theme.background)
-                .child(self.render_grid_and_overlays(&session, theme, font_size, window, cx));
+                .child(
+                    self.render_grid_and_overlays(&session, theme, colors, font_size, window, cx),
+                );
             pane = pane.child(terminal_surface);
             if let Some(find) = self.render_find_bar(&session, colors, cx) {
                 pane = pane.child(find);
@@ -3461,36 +3503,66 @@ fn finish_pointer_state(
     (owner, pending)
 }
 
-fn find_icon_button(
+#[derive(Clone, Copy)]
+struct FindButtonSpec {
     id: &'static str,
     system_image: &'static str,
+    label: &'static str,
+    shortcut: &'static str,
+}
+
+fn find_icon_button(
+    spec: FindButtonSpec,
+    colors: SemanticColors,
+    enabled: bool,
     cx: &mut Context<TerminalPane>,
     handler: impl Fn(&mut TerminalPane, &mut Window, &mut Context<TerminalPane>) + 'static,
 ) -> AnyElement {
     div()
-        .id(id)
-        .size(px(20.0))
-        .rounded(px(4.0))
+        .id(spec.id)
+        .size(px(28.0))
+        .rounded(px(Radius::CHIP))
         .flex()
         .items_center()
         .justify_center()
+        .role(Role::Button)
+        .aria_label(spec.label)
+        .aria_keyshortcuts(spec.shortcut)
+        .aria_description(if enabled {
+            "Activate this terminal find action"
+        } else {
+            "Unavailable because there are no matches"
+        })
         .text_size(px(11.0))
-        .text_color(rgba(0xffffff99))
-        .hover(|style| style.bg(rgba(0xffffff0f)))
-        .cursor_pointer()
+        .text_color(if enabled {
+            colors.secondary
+        } else {
+            colors.tertiary
+        })
+        .when(enabled, |button| {
+            button
+                .hover(move |style| style.bg(colors.primary.alpha(0.08)))
+                .active(move |style| style.bg(colors.primary.alpha(0.12)))
+                .cursor_pointer()
+                .on_click(cx.listener(move |this, _, window, cx| handler(this, window, cx)))
+        })
         .child(sf_symbol_weighted(
-            system_image,
+            spec.system_image,
             11.0,
             SymbolWeight::Semibold,
-            rgba(0xffffff99),
+            if enabled {
+                colors.secondary
+            } else {
+                colors.tertiary
+            },
         ))
-        .on_click(cx.listener(move |this, _, window, cx| handler(this, window, cx)))
         .into_any_element()
 }
 
 fn primary_button(
     id: &'static str,
     label: &'static str,
+    colors: SemanticColors,
     cx: &mut Context<TerminalPane>,
     handler: impl Fn(&mut TerminalPane, &mut Context<TerminalPane>) + 'static,
 ) -> AnyElement {
@@ -3500,18 +3572,19 @@ fn primary_button(
         .rounded(px(7.0))
         .px(px(14.0))
         .py(px(7.0))
-        .bg(rgba(0xffffffeb))
+        .bg(colors.primary)
         .text_size(px(13.0))
         .font_weight(Typo::ROW_EMPHASIZED.weight)
-        .text_color(rgba(0x121318ff))
-        .hover(|style| style.bg(rgba(0xffffffff)))
+        .text_color(colors.background)
+        .hover(move |style| style.opacity(0.86))
+        .active(move |style| style.opacity(0.72))
         .cursor_pointer()
         .child(label)
         .on_click(cx.listener(move |this, _, _, cx| handler(this, cx)))
         .into_any_element()
 }
 
-fn centered_message(icon: &str, message: &str) -> gpui::Div {
+fn centered_message(icon: &str, message: &str, colors: SemanticColors) -> gpui::Div {
     div()
         .flex_1()
         .size_full()
@@ -3524,7 +3597,7 @@ fn centered_message(icon: &str, message: &str) -> gpui::Div {
             content.child(
                 div()
                     .text_size(px(30.0))
-                    .text_color(rgba(0xffffff4d))
+                    .text_color(colors.tertiary)
                     .child(icon.to_owned()),
             )
         })
@@ -3532,13 +3605,18 @@ fn centered_message(icon: &str, message: &str) -> gpui::Div {
             content.child(
                 div()
                     .text_size(px(13.0))
-                    .text_color(rgba(0xffffff99))
+                    .text_color(colors.secondary)
                     .child(message.to_owned()),
             )
         })
 }
 
-fn centered_symbol_message(system_image: &str, size: f32, message: &str) -> gpui::Div {
+fn centered_symbol_message(
+    system_image: &str,
+    size: f32,
+    message: &str,
+    colors: SemanticColors,
+) -> gpui::Div {
     div()
         .flex_1()
         .size_full()
@@ -3551,13 +3629,13 @@ fn centered_symbol_message(system_image: &str, size: f32, message: &str) -> gpui
             system_image,
             size,
             SymbolWeight::Regular,
-            rgba(0xffffff4d),
+            colors.tertiary,
         ))
         .when(!message.is_empty(), |content| {
             content.child(
                 div()
                     .text_size(px(13.0))
-                    .text_color(rgba(0xffffff99))
+                    .text_color(colors.secondary)
                     .child(message.to_owned()),
             )
         })

--- a/diri/crates/diri-app/src/terminal_pane.rs
+++ b/diri/crates/diri-app/src/terminal_pane.rs
@@ -2005,7 +2005,9 @@ impl TerminalPane {
         if let Some(find) = resident.find.as_mut() {
             resident.find_query.insert(&text);
             let query = resident.find_query.text().to_owned();
-            find.set_query(query, now);
+            if find.set_query(query, now) {
+                resident.element.set_find_highlights(Vec::new());
+            }
             self.schedule_find(id, Duration::from_millis(200), window, cx);
         } else {
             resident.attachment.input(paste(&text, false));
@@ -2117,7 +2119,9 @@ impl TerminalPane {
                     };
                     if changed {
                         let query = resident.find_query.text().to_owned();
-                        find.set_query(query, now);
+                        if find.set_query(query, now) {
+                            resident.element.set_find_highlights(Vec::new());
+                        }
                         self.schedule_find(id, Duration::from_millis(200), window, cx);
                     }
                 }

--- a/diri/crates/diri-term/src/element.rs
+++ b/diri/crates/diri-term/src/element.rs
@@ -13,7 +13,10 @@ use gpui::{
 };
 
 use crate::buffer::{ApplySummary, GridBuffer};
-use crate::find::{FindSnapshot, FindSpan, NavigationTarget, SearchRequest, TerminalFindModel};
+use crate::find::{
+    FindSnapshot, FindSpan, NavigationTarget, SearchJob, SearchRequest, SearchResult,
+    TerminalFindModel,
+};
 use crate::metrics::CellMetrics;
 use crate::scrollback::{
     ScrollRouter, ScrollbackApplyError, ScrollbackRequest, ScrollbackViewport, ScrolledState,
@@ -648,19 +651,21 @@ impl TerminalElement {
         *mutex_lock(&self.shared.find_spans) = spans;
     }
 
-    pub fn apply_find_snapshot(
+    /// Captures the small live grid and packages it with daemon history for a
+    /// lock-free background scan. No history matching happens on the GPUI
+    /// thread.
+    pub fn prepare_find_search(
         &self,
-        model: &mut TerminalFindModel,
+        model: &TerminalFindModel,
         request: &SearchRequest,
         snapshot: FindSnapshot,
-    ) -> bool {
+    ) -> Option<SearchJob> {
         let buffer = read_lock(&self.buffer);
-        model.apply_snapshot(
-            request,
-            snapshot,
-            &buffer,
-            &mut mutex_lock(&self.shared.viewport),
-        )
+        model.prepare_search(request, snapshot, &buffer)
+    }
+
+    pub fn apply_find_result(&self, model: &mut TerminalFindModel, result: SearchResult) -> bool {
+        model.apply_result(result, &mut mutex_lock(&self.shared.viewport))
     }
 
     pub fn find_next(&self, model: &mut TerminalFindModel) -> Option<NavigationTarget> {

--- a/diri/crates/diri-term/src/element.rs
+++ b/diri/crates/diri-term/src/element.rs
@@ -581,9 +581,15 @@ impl TerminalElement {
     }
 
     pub fn select_word(&self, col: usize, window_row: usize) {
-        let viewport = mutex_lock(&self.shared.viewport).clone();
+        let viewport = mutex_lock(&self.shared.viewport);
         let buffer = read_lock(&self.buffer);
         mutex_lock(&self.shared.selection).select_word(&viewport, &buffer, window_row, col);
+    }
+
+    pub fn select_line(&self, window_row: usize) {
+        let viewport = mutex_lock(&self.shared.viewport);
+        let buffer = read_lock(&self.buffer);
+        mutex_lock(&self.shared.selection).select_line(&viewport, &buffer, window_row);
     }
 
     pub fn clear_selection(&self) {
@@ -607,7 +613,7 @@ impl TerminalElement {
     /// the path itself. Multi-row references are deliberately out of scope.
     #[must_use]
     pub fn reference_at(&self, col: usize, window_row: usize) -> Option<TerminalReference> {
-        let viewport = mutex_lock(&self.shared.viewport).clone();
+        let viewport = mutex_lock(&self.shared.viewport);
         let buffer = read_lock(&self.buffer);
         let absolute_row = viewport.absolute_row(window_row);
         let row = viewport.row_at_absolute(&buffer, absolute_row);
@@ -637,7 +643,7 @@ impl TerminalElement {
 
     #[must_use]
     pub fn selected_text(&self) -> String {
-        let viewport = mutex_lock(&self.shared.viewport).clone();
+        let viewport = mutex_lock(&self.shared.viewport);
         let buffer = read_lock(&self.buffer);
         mutex_lock(&self.shared.selection).selected_text(&viewport, &buffer)
     }

--- a/diri/crates/diri-term/src/find.rs
+++ b/diri/crates/diri-term/src/find.rs
@@ -107,21 +107,27 @@ impl TerminalFindModel {
         self.is_alt_screen
     }
 
-    pub fn set_query(&mut self, query: impl Into<String>, now: Duration) {
+    /// Replaces the query and invalidates results that belong to the previous
+    /// text. Same-query output rescans deliberately bypass this path, so their
+    /// useful matches remain visible until the refreshed snapshot arrives.
+    ///
+    /// Returns whether the query actually changed.
+    pub fn set_query(&mut self, query: impl Into<String>, now: Duration) -> bool {
         let query = query.into();
         if query == self.query {
-            return;
+            return false;
         }
         self.query = query;
         self.generation = self.generation.wrapping_add(1);
         self.rescan_due = None;
+        self.matches.clear();
+        self.current_index = 0;
         if self.query.is_empty() {
-            self.matches.clear();
-            self.current_index = 0;
             self.search_due = None;
         } else {
             self.search_due = Some(now.saturating_add(SEARCH_DEBOUNCE));
         }
+        true
     }
 
     /// Coalesces a busy output stream to at most one pending 100 ms rescan.
@@ -354,6 +360,33 @@ mod tests {
                 .is_rescan
         );
         assert!(model.take_due_search(Duration::from_secs(1)).is_none());
+    }
+
+    #[test]
+    fn query_change_clears_stale_matches_but_output_rescan_retains_them() {
+        let mut viewport = ScrollbackViewport::default();
+        let live = live_buffer(&["needle", "", ""], 12);
+        let mut model = TerminalFindModel::default();
+        search(
+            &mut model,
+            "needle",
+            snapshot(Vec::new(), false),
+            &live,
+            &mut viewport,
+        );
+        assert_eq!(model.matches().len(), 1);
+
+        assert!(model.on_output(Duration::from_secs(1)));
+        assert_eq!(
+            model.matches().len(),
+            1,
+            "same-query rescan keeps useful results"
+        );
+
+        assert!(model.set_query("absent", Duration::from_secs(2)));
+        assert!(model.matches().is_empty());
+        assert_eq!(model.current_index(), 0);
+        assert!(!model.set_query("absent", Duration::from_secs(3)));
     }
 
     #[test]

--- a/diri/crates/diri-term/src/find.rs
+++ b/diri/crates/diri-term/src/find.rs
@@ -7,6 +7,12 @@ use diri_proto::methods::ReadScrollbackResult;
 use crate::buffer::GridBuffer;
 use crate::scrollback::ScrollbackViewport;
 
+mod scheduler;
+mod search;
+
+pub use scheduler::{FindSearchScheduler, ReadCompletion, ScanCompletion};
+pub use search::{SearchJob, SearchResult};
+
 pub const SEARCH_DEBOUNCE: Duration = Duration::from_millis(200);
 pub const OUTPUT_RESCAN_DELAY: Duration = Duration::from_millis(100);
 pub const MATCH_CAP: usize = 500;
@@ -17,7 +23,6 @@ pub struct FindMatch {
     pub absolute_row: i64,
     pub start_col: usize,
     pub end_col_exclusive: usize,
-    pub text: String,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -123,7 +128,16 @@ impl TerminalFindModel {
     /// Returns true only when this call armed the rescan, so the host schedules
     /// exactly one follow-up timer per burst.
     pub fn on_output(&mut self, now: Duration) -> bool {
-        if self.query.is_empty() || self.rescan_due.is_some() {
+        if self.query.is_empty() {
+            return false;
+        }
+        // Content is part of a search generation. Any job that captured the
+        // previous live grid must not overwrite a newer screen when it returns.
+        self.generation = self.generation.wrapping_add(1);
+        // A not-yet-started debounced query search will capture the newest
+        // generation, so arming a second earlier rescan would only defeat the
+        // query debounce and duplicate its work.
+        if self.search_due.is_some() || self.rescan_due.is_some() {
             return false;
         }
         self.rescan_due = Some(now.saturating_add(OUTPUT_RESCAN_DELAY));
@@ -131,7 +145,7 @@ impl TerminalFindModel {
     }
 
     /// Pulls one due request. The app asynchronously reads a scrollback text
-    /// snapshot, then returns it through [`Self::apply_snapshot`].
+    /// snapshot and submits it through [`Self::prepare_search`].
     pub fn take_due_search(&mut self, now: Duration) -> Option<SearchRequest> {
         let is_rescan = if self.search_due.is_some_and(|due| due <= now) {
             self.search_due = None;
@@ -149,37 +163,49 @@ impl TerminalFindModel {
         })
     }
 
-    /// Discards stale async responses, builds sorted matches, and preserves the
-    /// current index only for a same-geometry/content rescan.
-    pub fn apply_snapshot(
-        &mut self,
+    /// Validates an asynchronously-read history snapshot and captures the live
+    /// grid with a short clone. [`SearchJob::run`] owns the expensive scan and
+    /// must be dispatched to a background executor.
+    #[must_use]
+    pub fn prepare_search(
+        &self,
         request: &SearchRequest,
         snapshot: FindSnapshot,
         live: &GridBuffer,
+    ) -> Option<SearchJob> {
+        self.is_current(request)
+            .then(|| SearchJob::new(request.clone(), snapshot, live.clone()))
+    }
+
+    /// Discards stale background results and preserves the current index only
+    /// for a same-geometry/content rescan.
+    pub fn apply_result(
+        &mut self,
+        result: SearchResult,
         viewport: &mut ScrollbackViewport,
     ) -> bool {
-        if request.generation != self.generation || request.query != self.query {
+        if !self.is_current(&result.request) {
             return false;
         }
-        let sequence_changed = self.cached_content_seq != Some(snapshot.content_seq)
-            || self.cached_cols != Some(snapshot.cols);
-        self.matches = build_matches(&request.query, &snapshot, live);
-        self.is_alt_screen = snapshot.is_alt_screen;
-        self.cached_visible_start_row = Some(snapshot.visible_start_row);
-        self.cached_rows = usize::try_from(snapshot.rows.max(0)).unwrap_or(usize::MAX);
-        self.cached_content_seq = Some(snapshot.content_seq);
-        self.cached_cols = Some(snapshot.cols);
+        let sequence_changed = self.cached_content_seq != Some(result.content_seq)
+            || self.cached_cols != Some(result.cols);
+        self.matches = result.matches;
+        self.is_alt_screen = result.is_alt_screen;
+        self.cached_visible_start_row = Some(result.visible_start_row);
+        self.cached_rows = usize::try_from(result.rows.max(0)).unwrap_or(usize::MAX);
+        self.cached_content_seq = Some(result.content_seq);
+        self.cached_cols = Some(result.cols);
         viewport.apply_geometry(
-            snapshot.visible_start_row,
-            snapshot.visible_start_row.max(0),
-            snapshot.content_seq,
+            result.visible_start_row,
+            result.visible_start_row.max(0),
+            result.content_seq,
             self.cached_rows,
         );
 
-        if request.is_rescan && !sequence_changed {
+        if result.request.is_rescan && !sequence_changed {
             self.current_index = self.current_index.min(self.matches.len().saturating_sub(1));
         } else {
-            let window_top = snapshot
+            let window_top = result
                 .visible_start_row
                 .saturating_sub(viewport.view_offset());
             self.current_index = self
@@ -189,6 +215,10 @@ impl TerminalFindModel {
                 .unwrap_or(0);
         }
         true
+    }
+
+    fn is_current(&self, request: &SearchRequest) -> bool {
+        request.generation == self.generation && request.query == self.query
     }
 
     #[must_use]
@@ -252,120 +282,6 @@ impl TerminalFindModel {
     }
 }
 
-fn build_matches(query: &str, snapshot: &FindSnapshot, live: &GridBuffer) -> Vec<FindMatch> {
-    let needle: Vec<char> = query.chars().collect();
-    if needle.is_empty() {
-        return Vec::new();
-    }
-    let mut matches = Vec::new();
-    // One char scratch reused across every scanned line: a rescan walks the
-    // whole scrollback, and a fresh Vec per line dominated the scan.
-    let mut scratch: Vec<char> = Vec::new();
-
-    if !snapshot.is_alt_screen {
-        for (index, line) in snapshot.lines.iter().enumerate() {
-            let absolute_row = snapshot
-                .first_row
-                .saturating_add(i64::try_from(index).unwrap_or(i64::MAX));
-            if absolute_row >= snapshot.visible_start_row {
-                continue;
-            }
-            append_matches(
-                line,
-                None,
-                absolute_row,
-                &needle,
-                &mut scratch,
-                &mut matches,
-            );
-            if matches.len() >= MATCH_CAP {
-                matches.truncate(MATCH_CAP);
-                return matches;
-            }
-        }
-    }
-
-    let live_rows = usize::try_from(snapshot.rows.max(0))
-        .unwrap_or(usize::MAX)
-        .min(usize::from(live.rows));
-    for row in 0..live_rows {
-        let Some((line, columns)) = live.row_text_with_columns(row) else {
-            continue;
-        };
-        append_matches(
-            &line,
-            Some(&columns),
-            snapshot
-                .visible_start_row
-                .saturating_add(i64::try_from(row).unwrap_or(i64::MAX)),
-            &needle,
-            &mut scratch,
-            &mut matches,
-        );
-        if matches.len() >= MATCH_CAP {
-            matches.truncate(MATCH_CAP);
-            return matches;
-        }
-    }
-    matches.sort_by_key(|item| (item.absolute_row, item.start_col));
-    matches.truncate(MATCH_CAP);
-    matches
-}
-
-fn append_matches(
-    line: &str,
-    columns: Option<&[usize]>,
-    absolute_row: i64,
-    needle: &[char],
-    scratch: &mut Vec<char>,
-    output: &mut Vec<FindMatch>,
-) {
-    scratch.clear();
-    scratch.extend(line.chars());
-    let haystack: &[char] = scratch;
-    if haystack.len() < needle.len() {
-        return;
-    }
-    let mut index = 0;
-    while index + needle.len() <= haystack.len() && output.len() < MATCH_CAP {
-        if chars_equal_ci(&haystack[index..index + needle.len()], needle) {
-            let start_col = column_for(index, columns);
-            let end_col_exclusive = column_past_end(index + needle.len(), columns);
-            output.push(FindMatch {
-                absolute_row,
-                start_col,
-                end_col_exclusive,
-                text: line.to_owned(),
-            });
-            index += needle.len();
-        } else {
-            index += 1;
-        }
-    }
-}
-
-fn chars_equal_ci(haystack: &[char], needle: &[char]) -> bool {
-    haystack.iter().zip(needle).all(|(left, right)| {
-        // Exact match first: it skips the case-fold on the overwhelmingly
-        // common path, including every mismatching position the scan visits.
-        left == right || left.to_lowercase().eq(right.to_lowercase())
-    })
-}
-
-fn column_for(index: usize, columns: Option<&[usize]>) -> usize {
-    columns.map_or(index, |columns| {
-        columns
-            .get(index)
-            .copied()
-            .or_else(|| columns.last().map(|last| last + 1))
-            .unwrap_or(index)
-    })
-}
-
-fn column_past_end(index: usize, columns: Option<&[usize]>) -> usize {
-    column_for(index, columns)
-}
-
 #[cfg(test)]
 mod tests {
     use diri_proto::grid::{GridCell, TermColor, TermStyle};
@@ -412,7 +328,8 @@ mod tests {
     ) {
         model.set_query(query, Duration::ZERO);
         let request = model.take_due_search(SEARCH_DEBOUNCE).unwrap();
-        assert!(model.apply_snapshot(&request, snapshot, live, viewport));
+        let job = model.prepare_search(&request, snapshot, live).unwrap();
+        assert!(model.apply_result(job.run(), viewport));
     }
 
     #[test]
@@ -516,6 +433,8 @@ mod tests {
             &mut viewport,
         );
         assert_eq!(model.matches().len(), MATCH_CAP);
+        assert_eq!(model.matches().first().unwrap().absolute_row, 101);
+        assert_eq!(model.matches().last().unwrap().absolute_row, 600);
 
         model.set_query("", Duration::from_secs(1));
         search(
@@ -533,13 +452,13 @@ mod tests {
     }
 
     #[test]
-    fn matching_is_case_insensitive_and_non_overlapping() {
+    fn matching_is_utf8_case_insensitive_and_non_overlapping() {
         let mut viewport = ScrollbackViewport::default();
-        let live = live_buffer(&["BaNaNa", "", ""], 8);
+        let live = live_buffer(&["CAFÉ BaNaNa", "", ""], 16);
         let mut model = TerminalFindModel::default();
         search(
             &mut model,
-            "ana",
+            "café",
             snapshot(Vec::new(), false),
             &live,
             &mut viewport,
@@ -550,7 +469,77 @@ mod tests {
                 model.matches()[0].start_col,
                 model.matches()[0].end_col_exclusive
             ),
-            (1, 4)
+            (0, 4)
         );
+
+        model.set_query("", Duration::from_secs(1));
+        search(
+            &mut model,
+            "ana",
+            snapshot(Vec::new(), false),
+            &live,
+            &mut viewport,
+        );
+        assert_eq!(model.matches().len(), 1);
+        assert_eq!(model.matches()[0].start_col, 6);
+    }
+
+    #[test]
+    fn output_invalidates_an_in_flight_search() {
+        let mut model = TerminalFindModel::default();
+        model.set_query("needle", Duration::ZERO);
+        let request = model.take_due_search(SEARCH_DEBOUNCE).unwrap();
+        let old_live = live_buffer(&["old needle", "", ""], 20);
+        let old_job = model
+            .prepare_search(&request, snapshot(Vec::new(), false), &old_live)
+            .unwrap();
+        assert!(model.on_output(Duration::from_secs(1)));
+
+        let new_request = model
+            .take_due_search(Duration::from_secs(1) + OUTPUT_RESCAN_DELAY)
+            .unwrap();
+        let new_live = live_buffer(&["needle", "", ""], 20);
+        let new_job = model
+            .prepare_search(
+                &new_request,
+                FindSnapshot {
+                    content_seq: 2,
+                    ..snapshot(Vec::new(), false)
+                },
+                &new_live,
+            )
+            .unwrap();
+        let mut viewport = ScrollbackViewport::default();
+        assert!(model.apply_result(new_job.run(), &mut viewport));
+        assert_eq!(model.matches()[0].start_col, 0);
+
+        assert!(!model.apply_result(old_job.run(), &mut viewport));
+        assert_eq!(model.matches()[0].start_col, 0);
+    }
+
+    #[test]
+    fn stale_query_result_cannot_overwrite_the_current_result() {
+        let mut model = TerminalFindModel::default();
+        let live = live_buffer(&["old fresh", "", ""], 20);
+
+        model.set_query("old", Duration::ZERO);
+        let old_request = model.take_due_search(SEARCH_DEBOUNCE).unwrap();
+        let old_job = model
+            .prepare_search(&old_request, snapshot(Vec::new(), false), &live)
+            .unwrap();
+
+        model.set_query("fresh", Duration::from_secs(1));
+        let fresh_request = model
+            .take_due_search(Duration::from_secs(1) + SEARCH_DEBOUNCE)
+            .unwrap();
+        let fresh_job = model
+            .prepare_search(&fresh_request, snapshot(Vec::new(), false), &live)
+            .unwrap();
+        let mut viewport = ScrollbackViewport::default();
+        assert!(model.apply_result(fresh_job.run(), &mut viewport));
+        assert_eq!(model.matches()[0].start_col, 4);
+
+        assert!(!model.apply_result(old_job.run(), &mut viewport));
+        assert_eq!(model.matches()[0].start_col, 4);
     }
 }

--- a/diri/crates/diri-term/src/find/scheduler.rs
+++ b/diri/crates/diri-term/src/find/scheduler.rs
@@ -1,0 +1,220 @@
+//! Single-flight scheduling for asynchronous terminal searches.
+//!
+//! A search crosses two asynchronous seams: reading daemon history and then
+//! scanning it on a blocking executor. [`FindSearchScheduler`] admits one
+//! pipeline at a time and retains only the newest pending request. Callers do
+//! not need queues, task cancellation, or knowledge of which intermediate
+//! snapshots are still useful.
+
+use super::SearchRequest;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SearchPhase {
+    Reading,
+    Scanning,
+}
+
+#[derive(Clone, Debug)]
+struct ActiveSearch {
+    request: SearchRequest,
+    phase: SearchPhase,
+    cancelled: bool,
+}
+
+/// What to do when an asynchronous history read completes.
+#[must_use]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ReadCompletion {
+    /// The completion did not belong to the active read.
+    Ignore,
+    /// No usable snapshot or pending request remains.
+    Idle,
+    /// Scan the snapshot that just completed.
+    Scan,
+    /// Discard that snapshot and read again for this newer request.
+    Read(SearchRequest),
+}
+
+/// A recognized scan completion and the single next read, if one was dirtied
+/// while the scan was active.
+#[must_use]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ScanCompletion {
+    apply_result: bool,
+    next_request: Option<SearchRequest>,
+}
+
+impl ScanCompletion {
+    #[must_use]
+    pub const fn should_apply_result(&self) -> bool {
+        self.apply_result
+    }
+
+    pub fn into_next_request(self) -> Option<SearchRequest> {
+        self.next_request
+    }
+}
+
+/// Per-terminal single-flight state for the history-read and blocking-scan
+/// pipeline.
+#[derive(Clone, Debug, Default)]
+pub struct FindSearchScheduler {
+    active: Option<ActiveSearch>,
+    pending: Option<SearchRequest>,
+}
+
+impl FindSearchScheduler {
+    /// Schedules the newest due request. Returns a request only when the caller
+    /// should start a history read now; otherwise it replaces the one pending
+    /// follow-up without growing a queue.
+    pub fn schedule(&mut self, request: SearchRequest) -> Option<SearchRequest> {
+        if self.active.is_some() {
+            self.pending = Some(request);
+            return None;
+        }
+        self.start_read(request.clone());
+        Some(request)
+    }
+
+    /// Advances a matching read. A newer pending request makes the completed
+    /// snapshot stale before it ever consumes blocking-pool capacity.
+    pub fn finish_read(
+        &mut self,
+        request: &SearchRequest,
+        snapshot_available: bool,
+    ) -> ReadCompletion {
+        let Some(active) = self.active.as_ref() else {
+            return ReadCompletion::Ignore;
+        };
+        if active.phase != SearchPhase::Reading || active.request != *request {
+            return ReadCompletion::Ignore;
+        }
+
+        if let Some(next) = self.pending.take() {
+            self.start_read(next.clone());
+            return ReadCompletion::Read(next);
+        }
+        if active.cancelled || !snapshot_available {
+            self.active = None;
+            return ReadCompletion::Idle;
+        }
+        if let Some(active) = self.active.as_mut() {
+            active.phase = SearchPhase::Scanning;
+        }
+        ReadCompletion::Scan
+    }
+
+    /// Completes the matching blocking scan and atomically promotes only the
+    /// newest pending request. `None` means the result was not the active scan.
+    pub fn finish_scan(&mut self, request: &SearchRequest) -> Option<ScanCompletion> {
+        let active = self.active.as_ref()?;
+        if active.phase != SearchPhase::Scanning || active.request != *request {
+            return None;
+        }
+        let apply_result = !active.cancelled;
+        let next_request = self.pending.take();
+        if let Some(next) = next_request.as_ref() {
+            self.start_read(next.clone());
+        } else {
+            self.active = None;
+        }
+        Some(ScanCompletion {
+            apply_result,
+            next_request,
+        })
+    }
+
+    /// Stops pending work and suppresses the active result without pretending
+    /// a blocking task was cancelled. A later schedule remains single-flight
+    /// behind that task and starts as soon as it really completes.
+    pub fn cancel(&mut self) {
+        self.pending = None;
+        if let Some(active) = self.active.as_mut() {
+            active.cancelled = true;
+        }
+    }
+
+    fn start_read(&mut self, request: SearchRequest) {
+        self.active = Some(ActiveSearch {
+            request,
+            phase: SearchPhase::Reading,
+            cancelled: false,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+    use crate::find::{SEARCH_DEBOUNCE, TerminalFindModel};
+
+    fn next_request(model: &mut TerminalFindModel, query: &str, at: Duration) -> SearchRequest {
+        model.set_query(query, at);
+        model
+            .take_due_search(at.saturating_add(SEARCH_DEBOUNCE))
+            .expect("query search should be due")
+    }
+
+    #[test]
+    fn one_active_scan_coalesces_many_invalidations_into_one_latest_follow_up() {
+        let mut model = TerminalFindModel::default();
+        let first = next_request(&mut model, "first", Duration::ZERO);
+        let second = next_request(&mut model, "second", Duration::from_secs(1));
+        let latest = next_request(&mut model, "latest", Duration::from_secs(2));
+        let mut scheduler = FindSearchScheduler::default();
+
+        assert_eq!(scheduler.schedule(first.clone()), Some(first.clone()));
+        assert_eq!(scheduler.finish_read(&first, true), ReadCompletion::Scan);
+
+        // Hold the first blocking job while multiple query/output generations
+        // arrive. There is still exactly one active scan and one replaceable
+        // dirty slot, never a queue of snapshots or blocking jobs.
+        assert_eq!(scheduler.schedule(second), None);
+        assert_eq!(scheduler.schedule(latest.clone()), None);
+
+        let completion = scheduler
+            .finish_scan(&first)
+            .expect("first scan should be active");
+        assert!(completion.should_apply_result());
+        assert_eq!(completion.into_next_request(), Some(latest.clone()));
+        assert_eq!(scheduler.finish_read(&latest, true), ReadCompletion::Scan);
+        assert!(scheduler.finish_scan(&latest).is_some());
+    }
+
+    #[test]
+    fn newer_request_discards_a_completed_snapshot_before_it_can_scan() {
+        let mut model = TerminalFindModel::default();
+        let first = next_request(&mut model, "first", Duration::ZERO);
+        let latest = next_request(&mut model, "latest", Duration::from_secs(1));
+        let mut scheduler = FindSearchScheduler::default();
+
+        assert_eq!(scheduler.schedule(first.clone()), Some(first.clone()));
+        assert_eq!(scheduler.schedule(latest.clone()), None);
+        assert_eq!(
+            scheduler.finish_read(&first, true),
+            ReadCompletion::Read(latest.clone())
+        );
+        assert_eq!(scheduler.finish_read(&latest, true), ReadCompletion::Scan);
+    }
+
+    #[test]
+    fn cancelled_active_result_is_suppressed_but_later_work_stays_single_flight() {
+        let mut model = TerminalFindModel::default();
+        let first = next_request(&mut model, "first", Duration::ZERO);
+        let reopened = next_request(&mut model, "reopened", Duration::from_secs(1));
+        let mut scheduler = FindSearchScheduler::default();
+
+        assert_eq!(scheduler.schedule(first.clone()), Some(first.clone()));
+        assert_eq!(scheduler.finish_read(&first, true), ReadCompletion::Scan);
+        scheduler.cancel();
+        assert_eq!(scheduler.schedule(reopened.clone()), None);
+
+        let completion = scheduler
+            .finish_scan(&first)
+            .expect("cancelled scan is active");
+        assert!(!completion.should_apply_result());
+        assert_eq!(completion.into_next_request(), Some(reopened));
+    }
+}

--- a/diri/crates/diri-term/src/find/search.rs
+++ b/diri/crates/diri-term/src/find/search.rs
@@ -1,0 +1,169 @@
+//! Pure, blocking terminal-history search.
+//!
+//! [`SearchJob`] owns an immutable history/grid snapshot, so callers can move
+//! the whole scan onto a background executor without locks or callbacks. The
+//! result is capped while retaining the newest matches; presentation state and
+//! stale-generation decisions stay in the parent find model.
+
+use std::collections::VecDeque;
+
+use crate::buffer::GridBuffer;
+
+use super::{FindMatch, FindSnapshot, MATCH_CAP, SearchRequest};
+
+/// An immutable search input prepared with a short clone of the live grid.
+///
+/// `run` is deliberately the only operation: all scanning and Unicode case
+/// comparison lives behind this seam. It is CPU-bound and must be called from
+/// a background executor.
+pub struct SearchJob {
+    request: SearchRequest,
+    snapshot: FindSnapshot,
+    live: GridBuffer,
+}
+
+/// A completed pure search plus the geometry it was computed against.
+pub struct SearchResult {
+    pub(super) request: SearchRequest,
+    pub(super) matches: Vec<FindMatch>,
+    pub(super) visible_start_row: i64,
+    pub(super) rows: i64,
+    pub(super) cols: i64,
+    pub(super) content_seq: u64,
+    pub(super) is_alt_screen: bool,
+}
+
+impl SearchJob {
+    pub(super) fn new(request: SearchRequest, snapshot: FindSnapshot, live: GridBuffer) -> Self {
+        Self {
+            request,
+            snapshot,
+            live,
+        }
+    }
+
+    #[must_use]
+    pub fn run(self) -> SearchResult {
+        let matches = build_matches(&self.request.query, &self.snapshot, &self.live);
+        SearchResult {
+            request: self.request,
+            matches,
+            visible_start_row: self.snapshot.visible_start_row,
+            rows: self.snapshot.rows,
+            cols: self.snapshot.cols,
+            content_seq: self.snapshot.content_seq,
+            is_alt_screen: self.snapshot.is_alt_screen,
+        }
+    }
+}
+
+fn build_matches(query: &str, snapshot: &FindSnapshot, live: &GridBuffer) -> Vec<FindMatch> {
+    let needle: Vec<char> = query.chars().collect();
+    if needle.is_empty() {
+        return Vec::new();
+    }
+
+    // Search still walks every retained line, but memory stays bounded and
+    // each newer hit displaces the oldest. This keeps the live screen and the
+    // newest history discoverable even when old output alone exceeds the cap.
+    let mut matches = VecDeque::with_capacity(MATCH_CAP);
+    // One char scratch reused across every scanned line: a fresh Vec per line
+    // measurably dominates scans of large histories.
+    let mut scratch = Vec::new();
+
+    if !snapshot.is_alt_screen {
+        for (index, line) in snapshot.lines.iter().enumerate() {
+            let absolute_row = snapshot
+                .first_row
+                .saturating_add(i64::try_from(index).unwrap_or(i64::MAX));
+            if absolute_row >= snapshot.visible_start_row {
+                continue;
+            }
+            append_matches(
+                line,
+                None,
+                absolute_row,
+                &needle,
+                &mut scratch,
+                &mut matches,
+            );
+        }
+    }
+
+    let live_rows = usize::try_from(snapshot.rows.max(0))
+        .unwrap_or(usize::MAX)
+        .min(usize::from(live.rows));
+    for row in 0..live_rows {
+        let Some((line, columns)) = live.row_text_with_columns(row) else {
+            continue;
+        };
+        append_matches(
+            &line,
+            Some(&columns),
+            snapshot
+                .visible_start_row
+                .saturating_add(i64::try_from(row).unwrap_or(i64::MAX)),
+            &needle,
+            &mut scratch,
+            &mut matches,
+        );
+    }
+
+    matches.into()
+}
+
+fn append_matches(
+    line: &str,
+    columns: Option<&[usize]>,
+    absolute_row: i64,
+    needle: &[char],
+    scratch: &mut Vec<char>,
+    output: &mut VecDeque<FindMatch>,
+) {
+    scratch.clear();
+    scratch.extend(line.chars());
+    let haystack: &[char] = scratch;
+    if haystack.len() < needle.len() {
+        return;
+    }
+
+    let mut index = 0;
+    while index + needle.len() <= haystack.len() {
+        if chars_equal_ci(&haystack[index..index + needle.len()], needle) {
+            if output.len() == MATCH_CAP {
+                output.pop_front();
+            }
+            output.push_back(FindMatch {
+                absolute_row,
+                start_col: column_for(index, columns),
+                end_col_exclusive: column_past_end(index + needle.len(), columns),
+            });
+            // Preserve the existing non-overlapping navigation semantics.
+            index += needle.len();
+        } else {
+            index += 1;
+        }
+    }
+}
+
+fn chars_equal_ci(haystack: &[char], needle: &[char]) -> bool {
+    haystack.iter().zip(needle).all(|(left, right)| {
+        // Exact match first skips allocation on the overwhelmingly common
+        // path, including every mismatching position the scan visits.
+        left == right || left.to_lowercase().eq(right.to_lowercase())
+    })
+}
+
+fn column_for(index: usize, columns: Option<&[usize]>) -> usize {
+    columns.map_or(index, |columns| {
+        columns
+            .get(index)
+            .copied()
+            .or_else(|| columns.last().map(|last| last + 1))
+            .unwrap_or(index)
+    })
+}
+
+fn column_past_end(index: usize, columns: Option<&[usize]>) -> usize {
+    column_for(index, columns)
+}

--- a/diri/crates/diri-term/src/selection.rs
+++ b/diri/crates/diri-term/src/selection.rs
@@ -118,6 +118,31 @@ impl TerminalSelection {
         });
     }
 
+    /// Expands a triple-click to the complete visual row. Terminal padding is
+    /// retained in the range so dragging can continue naturally, while copy
+    /// still trims the padding through [`Self::selected_text`].
+    pub fn select_line(
+        &mut self,
+        viewport: &ScrollbackViewport,
+        buffer: &GridBuffer,
+        window_row: usize,
+    ) {
+        let row = viewport.window_row(buffer, window_row);
+        if row.is_empty() {
+            self.clear();
+            return;
+        }
+        let absolute_row = viewport.absolute_row(window_row);
+        self.anchor = Some(SelectionPoint {
+            row: absolute_row,
+            col: 0,
+        });
+        self.head = Some(SelectionPoint {
+            row: absolute_row,
+            col: row.len(),
+        });
+    }
+
     #[must_use]
     pub fn range(&self) -> Option<SelectionRange> {
         let anchor = self.anchor?;
@@ -225,13 +250,23 @@ fn columns_for_row(range: SelectionRange, row: i64, cols: usize) -> (usize, usiz
 
 fn word_class(cell: GridCell) -> WordClass {
     let ch = cell_char(cell);
-    if ch.is_alphanumeric() || ch == '_' {
+    if ch.is_alphanumeric() || is_terminal_word_punctuation(ch) {
         WordClass::Word
     } else if ch.is_whitespace() {
         WordClass::Whitespace
     } else {
         WordClass::Punctuation
     }
+}
+
+/// Punctuation people expect to travel with paths, URLs, flags, and common
+/// identifiers when double-clicking in a terminal. Shell separators and quote
+/// delimiters deliberately remain punctuation boundaries.
+fn is_terminal_word_punctuation(ch: char) -> bool {
+    matches!(
+        ch,
+        '_' | '-' | '.' | '/' | '~' | ':' | '@' | '%' | '+' | '=' | '?' | '&' | '#'
+    )
 }
 
 pub(crate) fn cell_char(cell: GridCell) -> char {
@@ -325,6 +360,52 @@ mod tests {
         selection.select_word(&viewport, &buffer, 0, 6);
 
         assert_eq!(selection.selected_text(&viewport, &buffer), "two_three");
+    }
+
+    #[test]
+    fn double_click_keeps_paths_urls_and_flags_together() {
+        let viewport = ScrollbackViewport::default();
+        let text = "open ./crates/diri-app:42 https://diri.dev/a?q=1&v=2, --all | next";
+        let mut buffer = GridBuffer::new(text.len() as u16, 1);
+        buffer.cells = row(text, text.len());
+        let mut selection = TerminalSelection::default();
+
+        selection.select_word(&viewport, &buffer, 0, text.find("diri-app").expect("path"));
+        assert_eq!(
+            selection.selected_text(&viewport, &buffer),
+            "./crates/diri-app:42"
+        );
+
+        selection.select_word(&viewport, &buffer, 0, text.find("diri.dev").expect("url"));
+        assert_eq!(
+            selection.selected_text(&viewport, &buffer),
+            "https://diri.dev/a?q=1&v=2"
+        );
+
+        selection.select_word(&viewport, &buffer, 0, text.find("--all").expect("flag"));
+        assert_eq!(selection.selected_text(&viewport, &buffer), "--all");
+
+        selection.select_word(&viewport, &buffer, 0, text.find('|').expect("pipe"));
+        assert_eq!(selection.selected_text(&viewport, &buffer), "|");
+    }
+
+    #[test]
+    fn triple_click_selects_the_visual_line_without_terminal_padding() {
+        let viewport = ScrollbackViewport::default();
+        let mut buffer = GridBuffer::new(16, 2);
+        buffer.cells = [row("first", 16), row("whole line", 16)].concat();
+        let mut selection = TerminalSelection::default();
+
+        selection.select_line(&viewport, &buffer, 1);
+
+        assert_eq!(selection.selected_text(&viewport, &buffer), "whole line");
+        assert_eq!(
+            selection.range(),
+            Some(SelectionRange {
+                start: SelectionPoint { row: 1, col: 0 },
+                end: SelectionPoint { row: 1, col: 16 },
+            })
+        );
     }
 
     #[test]

--- a/diri/crates/diri-term/src/selection.rs
+++ b/diri/crates/diri-term/src/selection.rs
@@ -98,6 +98,18 @@ impl TerminalSelection {
             return;
         }
         let col = col.min(row.len() - 1);
+        if let Some((start, end)) = url_span_at(&row, col) {
+            let absolute_row = viewport.absolute_row(window_row);
+            self.anchor = Some(SelectionPoint {
+                row: absolute_row,
+                col: start,
+            });
+            self.head = Some(SelectionPoint {
+                row: absolute_row,
+                col: end,
+            });
+            return;
+        }
         let class = word_class(row[col]);
         let mut start = col;
         while start > 0 && word_class(row[start - 1]) == class {
@@ -265,8 +277,49 @@ fn word_class(cell: GridCell) -> WordClass {
 fn is_terminal_word_punctuation(ch: char) -> bool {
     matches!(
         ch,
-        '_' | '-' | '.' | '/' | '~' | ':' | '@' | '%' | '+' | '=' | '?' | '&' | '#'
+        '_' | '-' | '.' | '/' | '~' | ':' | '@' | '%' | '+' | '=' | '?'
     )
+}
+
+/// Returns the exact URL/reference span containing `col`, if the surrounding
+/// whitespace-delimited run begins with a scheme people commonly encounter in
+/// terminal output. `&` and `#` are shell boundaries everywhere else, but are
+/// meaningful query/fragment separators inside these recognized references.
+fn url_span_at(row: &[GridCell], col: usize) -> Option<(usize, usize)> {
+    let mut run_start = col;
+    while run_start > 0 && !cell_char(row[run_start - 1]).is_whitespace() {
+        run_start -= 1;
+    }
+    let mut run_end = col + 1;
+    while run_end < row.len() && !cell_char(row[run_end]).is_whitespace() {
+        run_end += 1;
+    }
+
+    let mut start = run_start;
+    while start < run_end && matches!(cell_char(row[start]), '(' | '[' | '{' | '<' | '\'' | '"') {
+        start += 1;
+    }
+    let mut end = run_end;
+    while end > start
+        && matches!(
+            cell_char(row[end - 1]),
+            '.' | ',' | ';' | ':' | ')' | ']' | '}' | '\'' | '"' | '>' | '!' | '?'
+        )
+    {
+        end -= 1;
+    }
+    if col < start || col >= end {
+        return None;
+    }
+
+    let candidate: String = row[start..end].iter().copied().map(cell_char).collect();
+    let recognized = candidate.starts_with("http://")
+        || candidate.starts_with("https://")
+        || candidate.starts_with("file://")
+        || candidate
+            .strip_prefix("www.")
+            .is_some_and(|rest| rest.contains('.'));
+    recognized.then_some((start, end))
 }
 
 pub(crate) fn cell_char(cell: GridCell) -> char {
@@ -365,7 +418,7 @@ mod tests {
     #[test]
     fn double_click_keeps_paths_urls_and_flags_together() {
         let viewport = ScrollbackViewport::default();
-        let text = "open ./crates/diri-app:42 https://diri.dev/a?q=1&v=2, --all | next";
+        let text = "open ./crates/diri-app:42 https://diri.dev/a?q=1&v=2#install, --all | next";
         let mut buffer = GridBuffer::new(text.len() as u16, 1);
         buffer.cells = row(text, text.len());
         let mut selection = TerminalSelection::default();
@@ -379,7 +432,7 @@ mod tests {
         selection.select_word(&viewport, &buffer, 0, text.find("diri.dev").expect("url"));
         assert_eq!(
             selection.selected_text(&viewport, &buffer),
-            "https://diri.dev/a?q=1&v=2"
+            "https://diri.dev/a?q=1&v=2#install"
         );
 
         selection.select_word(&viewport, &buffer, 0, text.find("--all").expect("flag"));
@@ -387,6 +440,29 @@ mod tests {
 
         selection.select_word(&viewport, &buffer, 0, text.find('|').expect("pipe"));
         assert_eq!(selection.selected_text(&viewport, &buffer), "|");
+    }
+
+    #[test]
+    fn double_click_keeps_shell_operators_and_comments_as_boundaries() {
+        let viewport = ScrollbackViewport::default();
+        let text = "true&&false value#comment";
+        let mut buffer = GridBuffer::new(text.len() as u16, 1);
+        buffer.cells = row(text, text.len());
+        let mut selection = TerminalSelection::default();
+
+        selection.select_word(&viewport, &buffer, 0, text.find("true").expect("true"));
+        assert_eq!(selection.selected_text(&viewport, &buffer), "true");
+        selection.select_word(&viewport, &buffer, 0, text.find("false").expect("false"));
+        assert_eq!(selection.selected_text(&viewport, &buffer), "false");
+        selection.select_word(&viewport, &buffer, 0, text.find("value").expect("value"));
+        assert_eq!(selection.selected_text(&viewport, &buffer), "value");
+        selection.select_word(
+            &viewport,
+            &buffer,
+            0,
+            text.find("comment").expect("comment"),
+        );
+        assert_eq!(selection.selected_text(&viewport, &buffer), "comment");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- give terminal find and overlay surfaces semantic light and dark theme colors
- make find controls keyboard-accessible and prevent stale counts, navigation, and highlights after query changes
- add coherent triple-click line selection and shell-aware word boundaries without breaking URL query and fragment selection
- avoid deep scrollback clones along selection and copy interaction paths

## Verification

- full diri-term suite
- full diri-app suite
- strict all-target Clippy for terminal and app crates
- focused stale-query, shell-boundary, URL, and triple-click regressions
- formatting and diff checks clean