### PR TITLE
app: move Engine supervision off first paint

### DIFF
--- a/diri/crates/diri-app/src/daemon_launch.rs
+++ b/diri/crates/diri-app/src/daemon_launch.rs
@@ -15,31 +15,88 @@ use std::os::unix::net::UnixStream;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::Arc;
 use std::time::Duration;
 
+use diri_client::DaemonClient;
 use diri_proto::paths::{DirijorPaths, ENV_SOCKET};
 use diri_proto::{ControlMessage, HelloParams, HelloResult, Method, RUST_ENGINE_KIND};
 use sha2::{Digest, Sha256};
+use tokio::runtime::Runtime;
 
 /// Explicit development/test override pointing at an Engine executable.
 const ENV_DAEMON_PATH: &str = "DIRIJORD_PATH";
 
 const BOOT_LOG_FILE_NAME: &str = "dirijord-rs.boot.log";
 
+/// One-shot Engine supervision deferred until the desktop has scheduled its
+/// first window.
+///
+/// The token is deliberately consumed by [`Self::after_window_open`]. This
+/// keeps the process startup order explicit and prevents two app-owned
+/// supervisors from racing to refresh the same Engine. The Engine's `flock`
+/// remains the final singleton authority across independent app processes.
+pub(super) struct DeferredDaemonStartup {
+    socket_path: PathBuf,
+}
+
+impl DeferredDaemonStartup {
+    /// Plans app-owned Engine supervision from the current process layout.
+    ///
+    /// A harness that supplied `DIRIJOR_SOCKET` owns its daemon lifecycle, so
+    /// there is no deferred work and the client may connect immediately.
+    pub(super) fn for_process() -> Option<Self> {
+        if std::env::var_os(ENV_SOCKET).is_some() {
+            return None;
+        }
+        let home = std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/nonexistent"));
+        Some(Self {
+            socket_path: DirijorPaths::socket(home),
+        })
+    }
+
+    /// Starts supervision away from GPUI's main thread, then releases the
+    /// reconnecting client only after the live Engine is authoritative.
+    ///
+    /// Call this after `open_main_window`: identity probes can consume two
+    /// one-second timeouts, upgrade shutdown can wait three seconds, and
+    /// hashing a universal bundled executable performs synchronous file I/O.
+    pub(super) fn after_window_open(self, runtime: &Runtime, client: Arc<DaemonClient>) {
+        schedule_after_window_open(
+            runtime,
+            move || ensure_daemon_running(&self.socket_path),
+            move || client.connect(),
+        );
+    }
+}
+
+/// Run blocking supervision without occupying either GPUI or an async worker.
+/// Completion always runs, even when the blocking task panics, so the client's
+/// own state machine can publish a concrete connection error instead of
+/// leaving the shell in an eternal startup state.
+fn schedule_after_window_open(
+    runtime: &Runtime,
+    supervise: impl FnOnce() + Send + 'static,
+    complete: impl FnOnce() + Send + 'static,
+) {
+    let supervision = runtime.spawn_blocking(supervise);
+    let _task = runtime.spawn(async move {
+        if let Err(error) = supervision.await {
+            eprintln!("diri: Engine startup supervision failed: {error}");
+        }
+        complete();
+    });
+}
+
 /// Ensure a daemon is reachable at `socket_path`, spawning the bundled
 /// `dirijord-rs` detached if the socket is dead.
 ///
-/// Non-blocking: after a spawn we return immediately and let
-/// [`diri_client::DaemonClient`]'s own reconnect loop (500 ms → 8 s backoff)
-/// connect once the daemon's socket comes up. The UI is never blocked on
-/// daemon startup.
-pub fn ensure_daemon_running(socket_path: &Path) {
-    // A dev/test harness that manages its own daemon exports DIRIJOR_SOCKET;
-    // never spawn on top of it.
-    if std::env::var_os(ENV_SOCKET).is_some() {
-        return;
-    }
-
+/// This function performs blocking probes, hashing, and bounded upgrade waits;
+/// it must run through [`schedule_after_window_open`]. After a spawn it returns
+/// immediately and lets [`DaemonClient`]'s reconnect loop discover the socket.
+fn ensure_daemon_running(socket_path: &Path) {
     let boot_log = boot_log_path();
     ensure_daemon_running_with(socket_path, resolve_daemon_path(), boot_log.as_deref());
 }
@@ -396,7 +453,7 @@ mod tests {
     use super::*;
     use std::os::unix::fs::PermissionsExt;
     use std::os::unix::net::UnixListener;
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, Mutex, mpsc};
 
     fn touch_executable(path: &Path) {
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -439,6 +496,41 @@ mod tests {
             }
             recorded.lock().expect("methods").clone()
         })
+    }
+
+    #[test]
+    fn window_launch_is_not_gated_by_daemon_supervision() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("test runtime");
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let (completed_tx, completed_rx) = mpsc::channel();
+
+        // The call represents the line immediately after `open_main_window`.
+        // It must return while arbitrarily slow supervision remains blocked.
+        schedule_after_window_open(
+            &runtime,
+            move || {
+                started_tx.send(()).expect("publish worker start");
+                release_rx.recv().expect("release supervision");
+            },
+            move || completed_tx.send(()).expect("publish completion"),
+        );
+
+        started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("blocking work starts away from the caller");
+        assert!(
+            completed_rx.try_recv().is_err(),
+            "the client gate cannot open before supervision finishes"
+        );
+        release_tx.send(()).expect("finish supervision");
+        completed_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("completion runs after supervision");
     }
 
     #[test]

--- a/diri/crates/diri-app/src/daemon_launch.rs
+++ b/diri/crates/diri-app/src/daemon_launch.rs
@@ -15,29 +15,60 @@ use std::os::unix::net::UnixStream;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::Arc;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
 use std::time::Duration;
 
 use diri_client::DaemonClient;
 use diri_proto::paths::{DirijorPaths, ENV_SOCKET};
-use diri_proto::{ControlMessage, HelloParams, HelloResult, Method, RUST_ENGINE_KIND};
+use diri_proto::{
+    ControlMessage, DaemonShutdownIfIdleResult, HelloParams, HelloResult, Method, RUST_ENGINE_KIND,
+};
 use sha2::{Digest, Sha256};
 use tokio::runtime::Runtime;
+use tokio::task::JoinHandle;
 
 /// Explicit development/test override pointing at an Engine executable.
 const ENV_DAEMON_PATH: &str = "DIRIJORD_PATH";
 
 const BOOT_LOG_FILE_NAME: &str = "dirijord-rs.boot.log";
+const STARTUP_RELEASE_PUBLICATION_TIMEOUT: Duration = Duration::from_secs(10);
+const STARTUP_RELEASE_CLIENT_GRACE: Duration = Duration::from_millis(400);
+const STARTUP_RELEASE_RETRY: Duration = Duration::from_millis(50);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StartupOutcome {
+    EngineExpected,
+    NoEngineExpected,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StartupPhase {
+    Planned,
+    Running,
+    Cancelling,
+    Complete(StartupOutcome),
+    Cleaning,
+    Cleaned,
+}
 
 /// One-shot Engine supervision deferred until the desktop has scheduled its
 /// first window.
 ///
-/// The token is deliberately consumed by [`Self::after_window_open`]. This
-/// keeps the process startup order explicit and prevents two app-owned
-/// supervisors from racing to refresh the same Engine. The Engine's `flock`
-/// remains the final singleton authority across independent app processes.
+/// This coordinator owns the complete task, rather than merely spawning it.
+/// App shutdown cancels future mutation checkpoints and transfers idle release
+/// to runtime-owned blocking work that survives GPUI's quit-future budget. The
+/// Engine's `flock` remains the final singleton authority across independent
+/// app processes.
 pub(super) struct DeferredDaemonStartup {
     socket_path: PathBuf,
+    cancelled: Arc<AtomicBool>,
+    phase: Arc<Mutex<StartupPhase>>,
+    task: Mutex<Option<JoinHandle<StartupOutcome>>>,
+    cleanup_tasks: Mutex<Vec<JoinHandle<()>>>,
+    release: Arc<dyn Fn() + Send + Sync>,
 }
 
 impl DeferredDaemonStartup {
@@ -52,8 +83,15 @@ impl DeferredDaemonStartup {
         let home = std::env::var_os("HOME")
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from("/nonexistent"));
+        let socket_path = DirijorPaths::socket(home);
+        let release_socket = socket_path.clone();
         Some(Self {
-            socket_path: DirijorPaths::socket(home),
+            socket_path,
+            cancelled: Arc::new(AtomicBool::new(false)),
+            phase: Arc::new(Mutex::new(StartupPhase::Planned)),
+            task: Mutex::new(None),
+            cleanup_tasks: Mutex::new(Vec::new()),
+            release: Arc::new(move || release_daemon_if_idle(&release_socket)),
         })
     }
 
@@ -63,55 +101,212 @@ impl DeferredDaemonStartup {
     /// Call this after `open_main_window`: identity probes can consume two
     /// one-second timeouts, upgrade shutdown can wait three seconds, and
     /// hashing a universal bundled executable performs synchronous file I/O.
-    pub(super) fn after_window_open(self, runtime: &Runtime, client: Arc<DaemonClient>) {
-        schedule_after_window_open(
-            runtime,
-            move || ensure_daemon_running(&self.socket_path),
-            move || client.connect(),
-        );
+    pub(super) fn after_window_open(&self, runtime: &Runtime, client: Arc<DaemonClient>) {
+        let socket_path = self.socket_path.clone();
+        self.start_after_window_open_with(runtime, client, move |cancelled| {
+            ensure_daemon_running(&socket_path, &cancelled)
+        });
+    }
+
+    fn start_after_window_open_with(
+        &self,
+        runtime: &Runtime,
+        client: Arc<DaemonClient>,
+        supervise: impl FnOnce(Arc<AtomicBool>) -> StartupOutcome + Send + 'static,
+    ) {
+        let mut task = self.task.lock().expect("daemon startup task lock poisoned");
+        let mut phase = self
+            .phase
+            .lock()
+            .expect("daemon startup phase lock poisoned");
+        if task.is_some() || *phase != StartupPhase::Planned {
+            return;
+        }
+        *phase = StartupPhase::Running;
+        drop(phase);
+
+        let cancelled = Arc::clone(&self.cancelled);
+        let phase = Arc::clone(&self.phase);
+        let release = Arc::clone(&self.release);
+        let handle = runtime.handle().clone();
+        *task = Some(runtime.spawn_blocking(move || {
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                supervise(Arc::clone(&cancelled))
+            }))
+            .unwrap_or_else(|_| {
+                // The supervisor may have panicked after a successful spawn.
+                // Conservatively assume cleanup is required.
+                eprintln!("diri: Engine startup supervision panicked");
+                StartupOutcome::EngineExpected
+            });
+
+            // Connect only on the ordinary completion path. `connect` uses
+            // Tokio's ambient handle, so explicitly enter the app runtime from
+            // this blocking worker.
+            if !cancelled.load(Ordering::Acquire) {
+                let _runtime = handle.enter();
+                client.connect();
+            }
+
+            let should_clean = {
+                let mut phase = phase.lock().expect("daemon startup phase lock poisoned");
+                match *phase {
+                    StartupPhase::Running => {
+                        *phase = StartupPhase::Complete(outcome);
+                        false
+                    }
+                    StartupPhase::Cancelling => {
+                        *phase = StartupPhase::Cleaning;
+                        true
+                    }
+                    _ => false,
+                }
+            };
+            if should_clean {
+                if outcome == StartupOutcome::EngineExpected {
+                    release();
+                }
+                *phase.lock().expect("daemon startup phase lock poisoned") = StartupPhase::Cleaned;
+            }
+            outcome
+        }));
+    }
+
+    /// Cancels startup within GPUI's synchronous quit callback and transfers
+    /// cleanup to a runtime-owned blocking worker.
+    ///
+    /// GPUI gives quit futures only a short grace period, so this method never
+    /// waits and never takes the sole startup handle. Tokio runtime teardown
+    /// waits for blocking tasks even after ordinary async tasks are aborted.
+    pub(super) fn request_shutdown(&self, runtime: &Runtime, client: &DaemonClient) {
+        self.cancelled.store(true, Ordering::Release);
+        // GPUI may drop its quit future after 200 ms. Publish this signal in
+        // the synchronous callback so the app's persistent control connection
+        // can close while raw idle-release requests are being retried.
+        client.begin_shutdown();
+        let schedule_release = {
+            let mut phase = self
+                .phase
+                .lock()
+                .expect("daemon startup phase lock poisoned");
+            match *phase {
+                StartupPhase::Planned => {
+                    *phase = StartupPhase::Cleaned;
+                    false
+                }
+                StartupPhase::Running => {
+                    // The startup worker owns cleanup after its last possible
+                    // mutation. This preserves ordering even if it has already
+                    // crossed the final spawn checkpoint.
+                    *phase = StartupPhase::Cancelling;
+                    false
+                }
+                StartupPhase::Complete(StartupOutcome::EngineExpected) => {
+                    *phase = StartupPhase::Cleaning;
+                    true
+                }
+                StartupPhase::Complete(StartupOutcome::NoEngineExpected) => {
+                    *phase = StartupPhase::Cleaned;
+                    false
+                }
+                StartupPhase::Cancelling | StartupPhase::Cleaning | StartupPhase::Cleaned => false,
+            }
+        };
+        if schedule_release {
+            let release = Arc::clone(&self.release);
+            let phase = Arc::clone(&self.phase);
+            let cleanup = runtime.spawn_blocking(move || {
+                release();
+                *phase.lock().expect("daemon startup phase lock poisoned") = StartupPhase::Cleaned;
+            });
+            self.cleanup_tasks
+                .lock()
+                .expect("daemon cleanup task lock poisoned")
+                .push(cleanup);
+        }
     }
 }
 
-/// Run blocking supervision without occupying either GPUI or an async worker.
-/// Completion always runs, even when the blocking task panics, so the client's
-/// own state machine can publish a concrete connection error instead of
-/// leaving the shell in an eternal startup state.
-fn schedule_after_window_open(
-    runtime: &Runtime,
-    supervise: impl FnOnce() + Send + 'static,
-    complete: impl FnOnce() + Send + 'static,
-) {
-    let supervision = runtime.spawn_blocking(supervise);
-    let _task = runtime.spawn(async move {
-        if let Err(error) = supervision.await {
-            eprintln!("diri: Engine startup supervision failed: {error}");
+impl Drop for DeferredDaemonStartup {
+    fn drop(&mut self) {
+        self.cancelled.store(true, Ordering::Release);
+        let release_now = {
+            let mut phase = self
+                .phase
+                .lock()
+                .expect("daemon startup phase lock poisoned");
+            match *phase {
+                StartupPhase::Planned => {
+                    *phase = StartupPhase::Cleaned;
+                    false
+                }
+                StartupPhase::Running => {
+                    // Tokio waits for this blocking task while tearing down;
+                    // it will perform the release after supervision settles.
+                    *phase = StartupPhase::Cancelling;
+                    false
+                }
+                StartupPhase::Complete(StartupOutcome::EngineExpected) => {
+                    *phase = StartupPhase::Cleaning;
+                    true
+                }
+                StartupPhase::Complete(StartupOutcome::NoEngineExpected) => {
+                    *phase = StartupPhase::Cleaned;
+                    false
+                }
+                StartupPhase::Cancelling | StartupPhase::Cleaning | StartupPhase::Cleaned => false,
+            }
+        };
+        // Early unwinding has no live GPUI callback in which to schedule work.
+        // Blocking here is preferable to leaking an Engine the app just made.
+        if release_now {
+            (self.release)();
+            *self
+                .phase
+                .lock()
+                .expect("daemon startup phase lock poisoned") = StartupPhase::Cleaned;
         }
-        complete();
-    });
+    }
 }
 
 /// Ensure a daemon is reachable at `socket_path`, spawning the bundled
 /// `dirijord-rs` detached if the socket is dead.
 ///
 /// This function performs blocking probes, hashing, and bounded upgrade waits;
-/// it must run through [`schedule_after_window_open`]. After a spawn it returns
+/// it must run through [`DeferredDaemonStartup`]. After a spawn it returns
 /// immediately and lets [`DaemonClient`]'s reconnect loop discover the socket.
-fn ensure_daemon_running(socket_path: &Path) {
+fn ensure_daemon_running(socket_path: &Path, cancelled: &AtomicBool) -> StartupOutcome {
     let boot_log = boot_log_path();
-    ensure_daemon_running_with(socket_path, resolve_daemon_path(), boot_log.as_deref());
+    ensure_daemon_running_with_cancellation(
+        socket_path,
+        resolve_daemon_path(),
+        boot_log.as_deref(),
+        cancelled,
+    )
 }
 
+#[cfg(test)]
 fn ensure_daemon_running_with(
     socket_path: &Path,
     daemon: Option<PathBuf>,
     boot_log: Option<&Path>,
 ) {
+    let cancelled = AtomicBool::new(false);
+    let _ = ensure_daemon_running_with_cancellation(socket_path, daemon, boot_log, &cancelled);
+}
+
+fn ensure_daemon_running_with_cancellation(
+    socket_path: &Path,
+    daemon: Option<PathBuf>,
+    boot_log: Option<&Path>,
+    cancelled: &AtomicBool,
+) -> StartupOutcome {
     match probe_daemon(socket_path) {
         Ok(hello) if hello.engine_kind.as_deref() == Some(RUST_ENGINE_KIND) => {
             let Some(daemon) = daemon.as_ref() else {
                 // An externally managed Rust Engine has no local artifact to
                 // compare. Keep it running rather than guessing ownership.
-                return;
+                return StartupOutcome::EngineExpected;
             };
             let expected_hash = match executable_sha256(daemon) {
                 Ok(hash) => hash,
@@ -120,23 +315,26 @@ fn ensure_daemon_running_with(
                         "diri: cannot verify bundled daemon {}: {error}; keeping the live Engine",
                         daemon.display()
                     );
-                    return;
+                    return StartupOutcome::EngineExpected;
                 }
             };
             if !daemon_needs_refresh(&hello, &expected_hash) {
-                return;
+                return StartupOutcome::EngineExpected;
             }
             eprintln!(
                 "diri: refreshing Rust Engine {:?} from bundled executable {}",
                 hello.build,
                 daemon.display()
             );
+            if cancelled.load(Ordering::Acquire) {
+                return StartupOutcome::EngineExpected;
+            }
             if let Err(error) = stop_daemon_for_upgrade(socket_path, Some(hello.pid)) {
                 eprintln!(
                     "diri: could not stop the outdated Rust Engine at {}: {error}",
                     socket_path.display()
                 );
-                return;
+                return StartupOutcome::EngineExpected;
             }
         }
         Ok(hello) => {
@@ -158,14 +356,17 @@ fn ensure_daemon_running_with(
                     "diri: no bundled Engine to replace it with; leaving {} alone",
                     socket_path.display()
                 );
-                return;
+                return StartupOutcome::NoEngineExpected;
+            }
+            if cancelled.load(Ordering::Acquire) {
+                return StartupOutcome::NoEngineExpected;
             }
             if let Err(error) = stop_daemon_for_upgrade(socket_path, Some(hello.pid)) {
                 eprintln!(
                     "diri: could not stop the previous daemon at {}: {error}",
                     socket_path.display()
                 );
-                return;
+                return StartupOutcome::NoEngineExpected;
             }
         }
         Err(error)
@@ -194,14 +395,17 @@ fn ensure_daemon_running_with(
             );
             if daemon.is_none() {
                 eprintln!("diri: no bundled Engine to replace it with; leaving it alone");
-                return;
+                return StartupOutcome::NoEngineExpected;
+            }
+            if cancelled.load(Ordering::Acquire) {
+                return StartupOutcome::NoEngineExpected;
             }
             if let Err(error) = stop_daemon_for_upgrade(socket_path, None) {
                 eprintln!(
                     "diri: could not stop the unidentified Engine at {}: {error}",
                     socket_path.display()
                 );
-                return;
+                return StartupOutcome::NoEngineExpected;
             }
         }
         Err(error) => {
@@ -209,24 +413,84 @@ fn ensure_daemon_running_with(
                 "diri: the Engine at {} answered a retried identity probe; leaving it alone ({error})",
                 socket_path.display()
             );
-            return;
+            return StartupOutcome::EngineExpected;
         }
     }
 
+    if cancelled.load(Ordering::Acquire) {
+        return StartupOutcome::NoEngineExpected;
+    }
     match daemon {
         Some(daemon) => match spawn_detached(&daemon, boot_log) {
-            Ok(()) => eprintln!("diri: launched bundled daemon at {}", daemon.display()),
+            Ok(()) => {
+                eprintln!("diri: launched bundled daemon at {}", daemon.display());
+                StartupOutcome::EngineExpected
+            }
             Err(err) => {
                 eprintln!(
                     "diri: failed to launch bundled daemon {}: {err}",
                     daemon.display()
                 );
+                StartupOutcome::NoEngineExpected
             }
         },
-        None => eprintln!(
-            "diri: no bundled dirijord-rs found next to the executable; \
-             relying on an externally managed daemon"
-        ),
+        None => {
+            eprintln!(
+                "diri: no bundled dirijord-rs found next to the executable; \
+                 relying on an externally managed daemon"
+            );
+            StartupOutcome::NoEngineExpected
+        }
+    }
+}
+
+/// Best-effort synchronous release used by the startup coordinator during app
+/// shutdown. It is intentionally independent of `DaemonClient`: a GPUI quit
+/// future may be dropped before that client's async shutdown runs. The Engine
+/// itself remains the authority and refuses while live sessions need it.
+fn release_daemon_if_idle(socket_path: &Path) {
+    let publication_deadline = std::time::Instant::now() + STARTUP_RELEASE_PUBLICATION_TIMEOUT;
+    let mut client_grace_deadline = None;
+    loop {
+        match control_request(socket_path, 3, Method::DAEMON_SHUTDOWN_IF_IDLE, None) {
+            Ok(value) => match serde_json::from_value::<DaemonShutdownIfIdleResult>(value) {
+                Ok(result) if result.will_exit => return,
+                Ok(result)
+                    if result.reason.as_deref()
+                        == Some("another control client still requires the Engine")
+                        && std::time::Instant::now()
+                            < *client_grace_deadline.get_or_insert_with(|| {
+                                std::time::Instant::now() + STARTUP_RELEASE_CLIENT_GRACE
+                            }) =>
+                {
+                    // `request_shutdown` has already signalled the app client.
+                    // Give its async socket task one short grace period to
+                    // observe that signal, but never pin runtime teardown on a
+                    // genuinely independent client.
+                }
+                Ok(_) => return,
+                Err(error) => {
+                    eprintln!("diri: invalid idle-release response during shutdown: {error}");
+                    return;
+                }
+            },
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::NotFound | io::ErrorKind::ConnectionRefused
+                ) && std::time::Instant::now() < publication_deadline =>
+            {
+                // A detached Engine may not have published its socket yet.
+            }
+            Err(error) => {
+                eprintln!(
+                    "diri: could not release the Engine after cancelled startup at {}: {error}",
+                    socket_path.display()
+                );
+                return;
+            }
+        }
+        std::thread::sleep(STARTUP_RELEASE_RETRY);
     }
 }
 
@@ -452,7 +716,8 @@ fn is_executable(path: &Path) -> bool {
 mod tests {
     use super::*;
     use std::os::unix::fs::PermissionsExt;
-    use std::os::unix::net::UnixListener;
+    use std::os::unix::net::{UnixListener, UnixStream};
+    use std::sync::atomic::AtomicUsize;
     use std::sync::{Arc, Mutex, mpsc};
 
     fn touch_executable(path: &Path) {
@@ -498,39 +763,548 @@ mod tests {
         })
     }
 
+    fn test_startup(release: impl Fn() + Send + Sync + 'static) -> Arc<DeferredDaemonStartup> {
+        Arc::new(DeferredDaemonStartup {
+            socket_path: PathBuf::from("/nonexistent/diri-test.sock"),
+            cancelled: Arc::new(AtomicBool::new(false)),
+            phase: Arc::new(Mutex::new(StartupPhase::Planned)),
+            task: Mutex::new(None),
+            cleanup_tasks: Mutex::new(Vec::new()),
+            release: Arc::new(release),
+        })
+    }
+
+    fn wait_for_phase(startup: &DeferredDaemonStartup, expected: StartupPhase) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            let actual = *startup
+                .phase
+                .lock()
+                .expect("daemon startup phase lock poisoned");
+            if actual == expected {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "startup phase stayed at {actual:?}; expected {expected:?}"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    struct FixtureConnectionGuard(Arc<AtomicUsize>);
+
+    impl Drop for FixtureConnectionGuard {
+        fn drop(&mut self) {
+            self.0.fetch_sub(1, Ordering::AcqRel);
+        }
+    }
+
+    /// A small Engine control fixture that applies the real active-connection
+    /// rule: the idle-release connection may exit only when it is the sole
+    /// connection. Long-lived Hello clients remain open until their peer
+    /// closes, so these tests catch ordering mistakes hidden by a scripted
+    /// one-request server.
+    struct CountAwareDaemon {
+        stop: Arc<AtomicBool>,
+        active: Arc<AtomicUsize>,
+        refusals: mpsc::Receiver<()>,
+        accepted: mpsc::Receiver<()>,
+        server: std::thread::JoinHandle<Vec<String>>,
+    }
+
+    impl CountAwareDaemon {
+        fn bind(socket: &Path) -> Self {
+            let listener = UnixListener::bind(socket).expect("bind count-aware daemon");
+            listener
+                .set_nonblocking(true)
+                .expect("configure count-aware listener");
+            let stop = Arc::new(AtomicBool::new(false));
+            let active = Arc::new(AtomicUsize::new(0));
+            let methods = Arc::new(Mutex::new(Vec::new()));
+            let (refusal_tx, refusals) = mpsc::channel();
+            let (accepted_tx, accepted) = mpsc::channel();
+            let server_stop = Arc::clone(&stop);
+            let server_active = Arc::clone(&active);
+            let server_methods = Arc::clone(&methods);
+            let server = std::thread::spawn(move || {
+                let mut workers = Vec::new();
+                while !server_stop.load(Ordering::Acquire) {
+                    match listener.accept() {
+                        Ok((stream, _)) => {
+                            stream
+                                .set_nonblocking(false)
+                                .expect("configure counted connection");
+                            server_active.fetch_add(1, Ordering::AcqRel);
+                            let active = Arc::clone(&server_active);
+                            let methods = Arc::clone(&server_methods);
+                            let refusal_tx = refusal_tx.clone();
+                            let accepted_tx = accepted_tx.clone();
+                            workers.push(std::thread::spawn(move || {
+                                let _connection = FixtureConnectionGuard(Arc::clone(&active));
+                                serve_counted_connection(
+                                    stream,
+                                    &active,
+                                    &methods,
+                                    &refusal_tx,
+                                    &accepted_tx,
+                                );
+                            }));
+                        }
+                        Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                            std::thread::sleep(Duration::from_millis(5));
+                        }
+                        Err(error) => panic!("accept count-aware connection: {error}"),
+                    }
+                }
+                for worker in workers {
+                    worker.join().expect("count-aware connection worker");
+                }
+                server_methods.lock().expect("recorded methods").clone()
+            });
+            Self {
+                stop,
+                active,
+                refusals,
+                accepted,
+                server,
+            }
+        }
+
+        fn finish(self) -> Vec<String> {
+            self.stop.store(true, Ordering::Release);
+            self.server.join().expect("count-aware daemon")
+        }
+    }
+
+    fn serve_counted_connection(
+        mut stream: UnixStream,
+        active: &AtomicUsize,
+        methods: &Mutex<Vec<String>>,
+        refusal_tx: &mpsc::Sender<()>,
+        accepted_tx: &mpsc::Sender<()>,
+    ) {
+        let mut reader = BufReader::new(stream.try_clone().expect("clone counted connection"));
+        loop {
+            let mut request = String::new();
+            match reader.read_line(&mut request) {
+                Ok(0) => return,
+                Err(error) => panic!("read counted request: {error}"),
+                Ok(_) => {}
+            }
+            let request: ControlMessage =
+                serde_json::from_str(&request).expect("decode counted request");
+            let (id, method) = match request {
+                ControlMessage::Request { id, method, .. } => (id, method),
+                other => panic!("unexpected counted message: {other:?}"),
+            };
+            methods.lock().expect("record methods").push(method.clone());
+            let result = match method.as_str() {
+                Method::HELLO => serde_json::json!({
+                    "proto": diri_proto::WIRE_VERSION,
+                    "build": "fixture",
+                    "pid": 42,
+                    "engineKind": RUST_ENGINE_KIND,
+                }),
+                Method::DAEMON_SHUTDOWN_IF_IDLE if active.load(Ordering::Acquire) > 1 => {
+                    let _ = refusal_tx.send(());
+                    serde_json::json!({
+                        "willExit": false,
+                        "reason": "another control client still requires the Engine",
+                    })
+                }
+                Method::DAEMON_SHUTDOWN_IF_IDLE => {
+                    let _ = accepted_tx.send(());
+                    serde_json::json!({ "willExit": true })
+                }
+                other => panic!("unexpected counted method: {other}"),
+            };
+            serde_json::to_writer(
+                &mut stream,
+                &ControlMessage::Response {
+                    id,
+                    result: Ok(result),
+                },
+            )
+            .expect("write counted response");
+            stream.write_all(b"\n").expect("terminate counted response");
+        }
+    }
+
+    fn open_fixture_client(socket: &Path) -> UnixStream {
+        let mut stream = UnixStream::connect(socket).expect("connect fixture client");
+        fixture_hello(&mut stream, 99);
+        stream
+    }
+
+    fn fixture_hello(stream: &mut UnixStream, id: u64) {
+        serde_json::to_writer(
+            &mut *stream,
+            &ControlMessage::Request {
+                id,
+                method: Method::HELLO.to_owned(),
+                params: Some(serde_json::json!({
+                    "proto": diri_proto::WIRE_VERSION,
+                    "build": "fixture-client",
+                })),
+            },
+        )
+        .expect("write fixture Hello");
+        stream.write_all(b"\n").expect("terminate fixture Hello");
+        let mut response = String::new();
+        BufReader::new(stream.try_clone().expect("clone fixture client"))
+            .read_line(&mut response)
+            .expect("read fixture Hello");
+        let response: ControlMessage = serde_json::from_str(&response).expect("decode Hello reply");
+        assert!(
+            matches!(response, ControlMessage::Response { id: response_id, result: Ok(_)} if response_id == id)
+        );
+    }
+
     #[test]
-    fn window_launch_is_not_gated_by_daemon_supervision() {
+    fn normal_completion_releases_the_client_only_after_supervision() {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(1)
             .enable_all()
             .build()
             .expect("test runtime");
+        let startup = test_startup(|| {});
+        let client = Arc::new(DaemonClient::with_socket_path(
+            "/nonexistent/diri-test.sock",
+        ));
         let (started_tx, started_rx) = mpsc::channel();
         let (release_tx, release_rx) = mpsc::channel();
-        let (completed_tx, completed_rx) = mpsc::channel();
 
         // The call represents the line immediately after `open_main_window`.
         // It must return while arbitrarily slow supervision remains blocked.
-        schedule_after_window_open(
-            &runtime,
-            move || {
-                started_tx.send(()).expect("publish worker start");
-                release_rx.recv().expect("release supervision");
-            },
-            move || completed_tx.send(()).expect("publish completion"),
-        );
+        startup.start_after_window_open_with(&runtime, Arc::clone(&client), move |_| {
+            started_tx.send(()).expect("publish worker start");
+            release_rx.recv().expect("release supervision");
+            StartupOutcome::EngineExpected
+        });
 
         started_rx
             .recv_timeout(Duration::from_secs(1))
             .expect("blocking work starts away from the caller");
-        assert!(
-            completed_rx.try_recv().is_err(),
-            "the client gate cannot open before supervision finishes"
-        );
+        assert!(matches!(
+            &*client.connection_state().borrow(),
+            diri_client::ConnectionState::Disconnected(message)
+                if message == "not connected to daemon"
+        ));
         release_tx.send(()).expect("finish supervision");
-        completed_rx
+        wait_for_phase(
+            &startup,
+            StartupPhase::Complete(StartupOutcome::EngineExpected),
+        );
+        assert!(
+            !matches!(
+                &*client.connection_state().borrow(),
+                diri_client::ConnectionState::Disconnected(message)
+                    if message == "not connected to daemon"
+            ),
+            "normal completion must release the reconnect loop"
+        );
+    }
+
+    #[test]
+    fn completed_startup_signals_its_client_then_owns_real_idle_release() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime");
+        let tmp = tempfile::tempdir().expect("temporary lifecycle fixture");
+        let socket = tmp.path().join("daemon.sock");
+        let fixture = CountAwareDaemon::bind(&socket);
+        let release_socket = socket.clone();
+        let startup = test_startup(move || release_daemon_if_idle(&release_socket));
+        let client = Arc::new(DaemonClient::with_socket_path(socket));
+
+        startup.start_after_window_open_with(&runtime, Arc::clone(&client), |_| {
+            StartupOutcome::EngineExpected
+        });
+        wait_for_phase(
+            &startup,
+            StartupPhase::Complete(StartupOutcome::EngineExpected),
+        );
+        runtime
+            .block_on(client.wait_until_connected(Duration::from_secs(2)))
+            .expect("client performs authoritative Hello");
+
+        let quit_started = std::time::Instant::now();
+        startup.request_shutdown(&runtime, &client);
+        assert!(
+            quit_started.elapsed() < Duration::from_millis(200),
+            "real idle release must be transferred within GPUI's quit budget"
+        );
+        fixture
+            .refusals
             .recv_timeout(Duration::from_secs(1))
-            .expect("completion runs after supervision");
+            .expect("idle release refuses while the paused app client is open");
+
+        // `request_shutdown` already sent the synchronous signal. Merely
+        // polling the runtime must close the app connection; no quit future or
+        // awaited DaemonClient::shutdown is required.
+        runtime.block_on(async {
+            let mut states = client.connection_state();
+            tokio::time::timeout(Duration::from_secs(1), async {
+                while !matches!(
+                    &*states.borrow_and_update(),
+                    diri_client::ConnectionState::Disconnected(_)
+                ) {
+                    states.changed().await.expect("client state channel");
+                }
+            })
+            .await
+            .expect("begin_shutdown closes the app client");
+        });
+        fixture
+            .accepted
+            .recv_timeout(Duration::from_secs(1))
+            .expect("retry becomes the sole connection and is accepted");
+        wait_for_phase(&startup, StartupPhase::Cleaned);
+        let methods = fixture.finish();
+        assert_eq!(methods.first().map(String::as_str), Some(Method::HELLO));
+        assert!(
+            methods
+                .iter()
+                .filter(|method| method.as_str() == Method::DAEMON_SHUTDOWN_IF_IDLE)
+                .count()
+                >= 2
+        );
+    }
+
+    #[test]
+    fn persistent_second_client_does_not_pin_runtime_teardown() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("test runtime");
+        let tmp = tempfile::tempdir().expect("temporary lifecycle fixture");
+        let socket = tmp.path().join("daemon.sock");
+        let fixture = CountAwareDaemon::bind(&socket);
+        let release_socket = socket.clone();
+        let startup = test_startup(move || release_daemon_if_idle(&release_socket));
+        let client = Arc::new(DaemonClient::with_socket_path(&socket));
+
+        startup.start_after_window_open_with(&runtime, Arc::clone(&client), |_| {
+            StartupOutcome::EngineExpected
+        });
+        runtime
+            .block_on(client.wait_until_connected(Duration::from_secs(2)))
+            .expect("app client connects");
+        wait_for_phase(
+            &startup,
+            StartupPhase::Complete(StartupOutcome::EngineExpected),
+        );
+        let mut external_client = open_fixture_client(&socket);
+
+        let shutdown_started = std::time::Instant::now();
+        startup.request_shutdown(&runtime, &client);
+        fixture
+            .refusals
+            .recv_timeout(Duration::from_secs(1))
+            .expect("external client makes idle release authoritative refusal");
+        drop(runtime);
+        assert!(
+            shutdown_started.elapsed() < Duration::from_secs(1),
+            "an independent client must not make Tokio teardown wait for the 10s publication timeout"
+        );
+        assert_eq!(
+            *startup.phase.lock().unwrap(),
+            StartupPhase::Cleaned,
+            "runtime teardown waits for the bounded cleanup worker"
+        );
+        let connection_deadline = std::time::Instant::now() + Duration::from_millis(200);
+        while fixture.active.load(Ordering::Acquire) != 1
+            && std::time::Instant::now() < connection_deadline
+        {
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert_eq!(
+            fixture.active.load(Ordering::Acquire),
+            1,
+            "only the independent client remains after app shutdown"
+        );
+        assert!(
+            fixture.accepted.try_recv().is_err(),
+            "the Engine must honor the independent client's refusal"
+        );
+        fixture_hello(&mut external_client, 100);
+
+        drop(external_client);
+        drop(client);
+        let methods = fixture.finish();
+        assert!(
+            methods
+                .iter()
+                .filter(|method| method.as_str() == Method::DAEMON_SHUTDOWN_IF_IDLE)
+                .count()
+                >= 2,
+            "cleanup retries only for its short client-close grace"
+        );
+    }
+
+    #[test]
+    fn delayed_socket_publication_keeps_the_long_retry_window() {
+        let tmp = tempfile::tempdir().expect("temporary delayed daemon fixture");
+        let socket = tmp.path().join("daemon.sock");
+        let server_socket = socket.clone();
+        let server = std::thread::spawn(move || {
+            std::thread::sleep(STARTUP_RELEASE_CLIENT_GRACE + Duration::from_millis(200));
+            let listener = UnixListener::bind(server_socket).expect("publish delayed socket");
+            let (mut stream, _) = listener.accept().expect("accept delayed idle release");
+            let mut request = String::new();
+            BufReader::new(stream.try_clone().expect("clone delayed release"))
+                .read_line(&mut request)
+                .expect("read delayed release");
+            let request: ControlMessage =
+                serde_json::from_str(&request).expect("decode delayed release");
+            let id = match request {
+                ControlMessage::Request { id, method, .. }
+                    if method == Method::DAEMON_SHUTDOWN_IF_IDLE =>
+                {
+                    id
+                }
+                other => panic!("unexpected delayed release request: {other:?}"),
+            };
+            serde_json::to_writer(
+                &mut stream,
+                &ControlMessage::Response {
+                    id,
+                    result: Ok(serde_json::json!({ "willExit": true })),
+                },
+            )
+            .expect("write delayed release response");
+            stream
+                .write_all(b"\n")
+                .expect("terminate delayed release response");
+        });
+
+        let release_started = std::time::Instant::now();
+        release_daemon_if_idle(&socket);
+        let elapsed = release_started.elapsed();
+        server.join().expect("delayed publication fixture");
+        assert!(
+            elapsed >= STARTUP_RELEASE_CLIENT_GRACE + Duration::from_millis(150),
+            "socket publication retries must outlive the unrelated client-close grace"
+        );
+        assert!(elapsed < Duration::from_secs(2));
+    }
+
+    #[test]
+    fn quit_returns_inside_gpui_budget_and_worker_cancels_pending_mutation() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("test runtime");
+        let startup = test_startup(|| {});
+        let client = Arc::new(DaemonClient::with_socket_path(
+            "/nonexistent/diri-test.sock",
+        ));
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let (mutated_tx, mutated_rx) = mpsc::channel();
+
+        startup.start_after_window_open_with(&runtime, Arc::clone(&client), move |cancelled| {
+            started_tx.send(()).expect("publish worker start");
+            release_rx.recv().expect("release supervision");
+            if cancelled.load(Ordering::Acquire) {
+                StartupOutcome::NoEngineExpected
+            } else {
+                mutated_tx.send(()).expect("publish mutation");
+                StartupOutcome::EngineExpected
+            }
+        });
+        started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("supervision starts");
+
+        let quit_started = std::time::Instant::now();
+        startup.request_shutdown(&runtime, &client);
+        assert!(
+            quit_started.elapsed() < Duration::from_millis(200),
+            "startup cancellation must fit inside GPUI's quit-future budget"
+        );
+        assert_eq!(
+            *startup.phase.lock().unwrap(),
+            StartupPhase::Cancelling,
+            "the worker retains cleanup ownership while supervision is blocked"
+        );
+        assert!(
+            startup.task.lock().unwrap().is_some(),
+            "quit must never take and detach the sole startup handle"
+        );
+
+        release_tx.send(()).expect("release supervision");
+        wait_for_phase(&startup, StartupPhase::Cleaned);
+        assert!(
+            mutated_rx.try_recv().is_err(),
+            "a mutation behind a cancellation checkpoint must not run during quit"
+        );
+    }
+
+    #[test]
+    fn dropped_quit_future_cannot_leak_an_engine_from_inflight_startup() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("test runtime");
+        let (cleaned_tx, cleaned_rx) = mpsc::channel();
+        let startup = test_startup(move || cleaned_tx.send(()).expect("publish idle release"));
+        let client = Arc::new(DaemonClient::with_socket_path(
+            "/nonexistent/diri-test.sock",
+        ));
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+
+        startup.start_after_window_open_with(&runtime, Arc::clone(&client), move |_| {
+            started_tx.send(()).expect("publish worker start");
+            release_rx.recv().expect("release supervision");
+            // Model supervision that crossed its final spawn checkpoint just
+            // before quit published cancellation.
+            StartupOutcome::EngineExpected
+        });
+        started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("supervision starts");
+        startup.request_shutdown(&runtime, &client);
+
+        // No future is awaited here. Releasing the in-flight worker models
+        // GPUI dropping its quit future; the supervisor must clean itself.
+        release_tx.send(()).expect("release supervision");
+        cleaned_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("runtime-owned worker performs idle release");
+        wait_for_phase(&startup, StartupPhase::Cleaned);
+    }
+
+    #[test]
+    fn cancellation_checkpoint_prevents_a_pending_daemon_spawn() {
+        let tmp = tempfile::tempdir().expect("temporary daemon fixture");
+        let socket = tmp.path().join("absent.sock");
+        let marker = tmp.path().join("spawned");
+        let daemon = tmp.path().join("dirijord-rs");
+        std::fs::write(
+            &daemon,
+            format!("#!/bin/sh\nprintf launched > '{}'\n", marker.display()),
+        )
+        .expect("write fixture daemon");
+        let mut permissions = std::fs::metadata(&daemon).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&daemon, permissions).unwrap();
+        let cancelled = AtomicBool::new(true);
+
+        assert_eq!(
+            ensure_daemon_running_with_cancellation(&socket, Some(daemon), None, &cancelled),
+            StartupOutcome::NoEngineExpected
+        );
+        assert!(
+            !marker.exists(),
+            "quit cancellation must be observed before detached spawn"
+        );
     }
 
     #[test]

--- a/diri/crates/diri-app/src/launcher.rs
+++ b/diri/crates/diri-app/src/launcher.rs
@@ -2162,6 +2162,8 @@ mod tests {
             updates: crate::updates::inert(),
             tokio,
             dev_build: None,
+            #[cfg(unix)]
+            daemon_startup: None,
         });
         let (launcher, cx) =
             cx.add_window_view(move |_window, cx| LauncherOverlay::new(services, true, cx));
@@ -2344,6 +2346,8 @@ mod tests {
             updates: crate::updates::inert(),
             tokio,
             dev_build: None,
+            #[cfg(unix)]
+            daemon_startup: None,
         });
         let (launcher, cx) =
             cx.add_window_view(move |_window, cx| LauncherOverlay::new(services, true, cx));

--- a/diri/crates/diri-app/src/main.rs
+++ b/diri/crates/diri-app/src/main.rs
@@ -187,25 +187,26 @@ fn main() {
             .expect("failed to start diri async runtime"),
     );
 
-    // diri is self-contained: if no daemon socket is live, launch the daemon
-    // bundled in Contents/Resources/bin, then let DaemonClient's reconnect loop
-    // pick it up. A Rust Engine whose executable hash differs from the
-    // bundled one is gracefully replaced so app and remote Helper catalogs
-    // advance together; Holder-owned sessions survive and are adopted.
+    // Plan app-owned Engine supervision now, but do not probe the socket or
+    // hash the bundled executable on GPUI's first-paint path. The one-shot plan
+    // is consumed only after the first window has been opened below.
     #[cfg(unix)]
-    if !preview {
-        let home = std::env::var_os("HOME")
-            .map(std::path::PathBuf::from)
-            .unwrap_or_else(|| std::path::PathBuf::from("/nonexistent"));
-        let socket_path = diri_proto::paths::DirijorPaths::socket(home);
-        daemon_launch::ensure_daemon_running(&socket_path);
-    }
+    let daemon_startup = (!preview)
+        .then(daemon_launch::DeferredDaemonStartup::for_process)
+        .flatten();
+    #[cfg(unix)]
+    let defer_client_start = daemon_startup.is_some();
+    #[cfg(not(unix))]
+    let defer_client_start = false;
 
     let client = Arc::new(DaemonClient::new());
     let store_runtime = {
         let _guard = tokio.enter();
         Arc::new(if preview {
             StoreRuntime::inert()
+        } else if defer_client_start {
+            StoreRuntime::start_default_deferred(Arc::clone(&client))
+                .expect("failed to load diri state")
         } else {
             StoreRuntime::start_default(Arc::clone(&client)).expect("failed to load diri state")
         })
@@ -377,8 +378,17 @@ fn main() {
             }
         })
         .detach();
-        open_main_window(cx, services, preview, scenario);
+        open_main_window(cx, Arc::clone(&services), preview, scenario);
         cx.activate(true);
+        // `open_main_window` must stay before this call. The supervisor can
+        // spend up to five seconds probing and retiring an outdated Engine;
+        // it runs on Tokio's blocking pool and releases the reconnect loop
+        // only after replacement is complete, so the UI cannot race a daemon
+        // that is about to shut down.
+        #[cfg(unix)]
+        if let Some(startup) = daemon_startup {
+            startup.after_window_open(&services.tokio, Arc::clone(services.store.client()));
+        }
         if smoke_test {
             cx.spawn(async move |cx| {
                 cx.background_executor()

--- a/diri/crates/diri-app/src/main.rs
+++ b/diri/crates/diri-app/src/main.rs
@@ -150,8 +150,12 @@ pub(crate) struct AppServices {
     pub(crate) store: Arc<StoreRuntime>,
     pub(crate) usage_tx: tokio::sync::watch::Sender<UsageSnapshot>,
     pub(crate) updates: UpdateHandle,
-    pub(crate) tokio: Arc<Runtime>,
     pub(crate) dev_build: Option<DevBuildIdentity>,
+    #[cfg(unix)]
+    daemon_startup: Option<daemon_launch::DeferredDaemonStartup>,
+    // Declared last so every service and its owned startup handle drops before
+    // the executor during early unwinding as well as ordinary app shutdown.
+    pub(crate) tokio: Arc<Runtime>,
 }
 
 fn main() {
@@ -328,8 +332,10 @@ fn main() {
         store: store_runtime,
         usage_tx,
         updates,
-        tokio,
         dev_build,
+        #[cfg(unix)]
+        daemon_startup,
+        tokio,
     });
 
     let app = application().with_assets(diri_ui::IconAssets);
@@ -349,15 +355,32 @@ fn main() {
         diri_ui::set_mark_rasterizer(macos::brand_raster::raster_mark);
         commands::bind_default_keys(cx);
         install_app_menus(cx);
-        let quit_store = Arc::clone(&services.store);
+        let quit_services = Arc::clone(&services);
         let quit_updates = services.updates.clone();
         let release_owned_daemon =
             !preview && std::env::var_os(diri_proto::paths::ENV_SOCKET).is_none();
         cx.on_app_quit(move |_| {
-            let quit_store = Arc::clone(&quit_store);
+            let quit_services = Arc::clone(&quit_services);
             let quit_updates = quit_updates.clone();
+            // This runs while GPUI is constructing the quit future, before its
+            // 200 ms grace period begins. The coordinator never transfers its
+            // sole task handle into that cancellable future: pending startup
+            // and idle release remain owned by runtime blocking workers.
+            #[cfg(unix)]
+            let startup_owns_release =
+                quit_services
+                    .daemon_startup
+                    .as_ref()
+                    .is_some_and(|startup| {
+                        startup
+                            .request_shutdown(&quit_services.tokio, quit_services.store.client());
+                        true
+                    });
+            #[cfg(not(unix))]
+            let startup_owns_release = false;
             async move {
-                if let Err(error) = quit_store
+                if let Err(error) = quit_services
+                    .store
                     .store
                     .write()
                     .expect("session store lock poisoned")
@@ -370,11 +393,12 @@ fn main() {
                 // exit and deliberately does not reopen an app the user quit.
                 quit_updates.install_on_quit();
                 if release_owned_daemon
-                    && let Err(error) = quit_store.client().shutdown_daemon_if_idle().await
+                    && !startup_owns_release
+                    && let Err(error) = quit_services.store.client().shutdown_daemon_if_idle().await
                 {
                     eprintln!("diri: could not release the idle Engine while quitting: {error}");
                 }
-                quit_store.shutdown().await;
+                quit_services.store.shutdown().await;
             }
         })
         .detach();
@@ -386,7 +410,7 @@ fn main() {
         // only after replacement is complete, so the UI cannot race a daemon
         // that is about to shut down.
         #[cfg(unix)]
-        if let Some(startup) = daemon_startup {
+        if let Some(startup) = services.daemon_startup.as_ref() {
             startup.after_window_open(&services.tokio, Arc::clone(services.store.client()));
         }
         if smoke_test {

--- a/diri/crates/diri-app/src/store/mod.rs
+++ b/diri/crates/diri-app/src/store/mod.rs
@@ -2384,14 +2384,39 @@ pub struct StoreRuntime {
     tasks: Mutex<Vec<JoinHandle<()>>>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ClientStartup {
+    Immediate,
+    Deferred,
+}
+
 impl StoreRuntime {
     pub fn start(client: Arc<DaemonClient>, prefs_path: impl Into<PathBuf>) -> io::Result<Self> {
         let (store, effects) = SessionStore::load(prefs_path)?;
-        Ok(Self::start_with_store(client, store, effects))
+        Ok(Self::start_with_store(
+            client,
+            store,
+            effects,
+            ClientStartup::Immediate,
+        ))
     }
 
     pub fn start_default(client: Arc<DaemonClient>) -> io::Result<Self> {
         Self::start(client, Prefs::path())
+    }
+
+    /// Builds the UI-facing store bridge without opening the daemon socket.
+    /// Process startup uses this while it verifies or refreshes the bundled
+    /// Engine off the GPUI thread; the supervisor starts the client exactly
+    /// once after that authoritative decision finishes.
+    pub(crate) fn start_default_deferred(client: Arc<DaemonClient>) -> io::Result<Self> {
+        let (store, effects) = SessionStore::load(Prefs::path())?;
+        Ok(Self::start_with_store(
+            client,
+            store,
+            effects,
+            ClientStartup::Deferred,
+        ))
     }
 
     /// A task-free runtime for deterministic previews. The preview sidebar
@@ -2425,6 +2450,7 @@ impl StoreRuntime {
         client: Arc<DaemonClient>,
         store: SessionStore,
         effects: mpsc::UnboundedReceiver<StoreEffect>,
+        client_startup: ClientStartup,
     ) -> Self {
         let store = Arc::new(RwLock::new(store));
         let (detach_tx, _) = broadcast::channel(16);
@@ -2494,8 +2520,21 @@ impl StoreRuntime {
         let state_snapshots = snapshot_tx.clone();
         let mut states = client.connection_state();
         tasks.push(tokio::spawn(async move {
+            let mut waiting_for_deferred_start = client_startup == ClientStartup::Deferred;
             loop {
                 let state = states.borrow_and_update().clone();
+                // A deferred client intentionally retains its constructor's
+                // initial Disconnected state while Engine supervision runs.
+                // Keep the visible shell in Connecting until `client.connect`
+                // publishes the real first attempt; otherwise first paint
+                // flashes a false "unreachable" recovery notice.
+                if waiting_for_deferred_start && matches!(state, ConnectionState::Disconnected(_)) {
+                    if states.changed().await.is_err() {
+                        break;
+                    }
+                    continue;
+                }
+                waiting_for_deferred_start = false;
                 match state {
                     ConnectionState::Connecting => {
                         state_store
@@ -2615,7 +2654,9 @@ impl StoreRuntime {
             }
         }));
 
-        client.connect();
+        if client_startup == ClientStartup::Immediate {
+            client.connect();
+        }
         Self {
             store,
             client,

--- a/diri/crates/diri-app/src/store/tests.rs
+++ b/diri/crates/diri-app/src/store/tests.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use diri_client::{ConnectionState, DaemonClient};
 use diri_proto::{
     AgentDescriptor, AgentKind, AgentReadinessItem, AgentReadinessResult, AttentionLevel,
     DateMillis, ExitInfo, ExitReason, Project, ProjectId, Resumability, SessionId,
@@ -13,9 +14,9 @@ use tokio::sync::mpsc;
 use crate::notifications::NotificationSound;
 
 use super::{
-    ClickModifiers, EventEnvelope, InspectorTab, Prefs, SessionStore, SidebarProjection,
-    StoreEffect, StoreEventChange, TerminalResidency, WindowMode, WindowPlacement,
-    event_publication_policy,
+    ClickModifiers, ClientStartup, EventEnvelope, InspectorTab, Prefs, SessionStore,
+    SidebarProjection, StoreEffect, StoreEventChange, StoreRuntime, TerminalResidency, WindowMode,
+    WindowPlacement, event_publication_policy,
 };
 use crate::switcher::{OverviewFilter, OverviewLane, SwitcherKey};
 
@@ -2066,6 +2067,38 @@ fn inert_runtime_has_no_background_tasks_or_live_sessions() {
             .is_empty()
     );
     assert!(runtime.snapshots().borrow().sessions.is_empty());
+}
+
+#[tokio::test]
+async fn deferred_client_start_keeps_first_paint_in_connecting_state() {
+    let tmp = tempdir().expect("temporary socket home");
+    let client = Arc::new(DaemonClient::with_socket_path(
+        tmp.path().join("engine.sock"),
+    ));
+    let (store, effects) = SessionStore::headless(Prefs::default());
+    let runtime = StoreRuntime::start_with_store(
+        Arc::clone(&client),
+        store,
+        effects,
+        ClientStartup::Deferred,
+    );
+
+    // Give the connection-state bridge enough turns to observe the client's
+    // constructor state. Deferred startup must not render that intentional
+    // state as a false daemon failure while the background supervisor runs.
+    for _ in 0..3 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(
+        runtime.store.read().unwrap().daemon_state(),
+        &super::DaemonState::Connecting
+    );
+    assert!(matches!(
+        &*client.connection_state().borrow(),
+        ConnectionState::Disconnected(message) if message == "not connected to daemon"
+    ));
+
+    runtime.shutdown().await;
 }
 
 #[test]

--- a/diri/crates/diri-client/src/client.rs
+++ b/diri/crates/diri-client/src/client.rs
@@ -335,9 +335,18 @@ impl DaemonClient {
         *lifecycle = Some(tokio::spawn(async move { run_lifecycle(core).await }));
     }
 
+    /// Synchronously asks the connect/reconnect loop to close its control
+    /// connection. This is the non-waiting half of [`Self::shutdown`] for
+    /// lifecycle callbacks whose futures may be cancelled immediately.
+    ///
+    /// The signal is idempotent and never sends a daemon shutdown request.
+    pub fn begin_shutdown(&self) {
+        self.core.shutdown_tx.send_replace(true);
+    }
+
     /// Stops this client only. This never sends a shutdown request to the daemon.
     pub async fn shutdown(&self) {
-        self.core.shutdown_tx.send_replace(true);
+        self.begin_shutdown();
         let task = self
             .lifecycle
             .lock()
@@ -834,7 +843,7 @@ impl DaemonClient {
 
 impl Drop for DaemonClient {
     fn drop(&mut self) {
-        self.core.shutdown_tx.send_replace(true);
+        self.begin_shutdown();
         if let Ok(slot) = self.lifecycle.get_mut()
             && let Some(task) = slot.take()
         {
@@ -988,6 +997,16 @@ mod tests {
     use std::error::Error;
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn begin_shutdown_publishes_without_an_async_runtime_turn() {
+        let client = DaemonClient::with_socket_path("/nonexistent/diri-test.sock");
+        let shutdown = client.core.shutdown_tx.subscribe();
+
+        client.begin_shutdown();
+
+        assert!(*shutdown.borrow());
+    }
 
     #[tokio::test]
     async fn retry_now_wakes_the_lifecycle_signal_without_spawning_a_daemon() {


### PR DESCRIPTION
## Summary

- create and activate the GPUI window before Engine probing, hashing, replacement waits, or startup supervision
- defer client connection until authoritative supervision completes without flashing a false disconnected state
- make startup ownership cancellation-safe within GPUI shutdown limits
- synchronously signal client shutdown and bound multi-client idle-release cleanup

## Verification

- full diri-app suite: 425 passed, 2 ignored
- strict all-target Clippy
- deterministic blocked-supervision, early-quit, delayed-socket, and multi-client lifecycle tests
- formatting, lockfile, and diff checks clean