### PR TITLE
app: add reusable launch recipes

### DIFF
--- a/diri/crates/diri-app/src/launch_recipe.rs
+++ b/diri/crates/diri-app/src/launch_recipe.rs
@@ -1,0 +1,814 @@
+//! Versioned, locally persisted launch recipes.
+//!
+//! The launcher is a view over this module. Recipes resolve to the same
+//! `SpawnOptions` consumed by ordinary launches, so availability, host, and
+//! worktree policy cannot drift into a second spawning implementation.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use diri_proto::{AgentKind, HostEntry, Project, ProjectId};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::agent_catalog;
+use crate::store::{SpawnOptions, WorktreeSpawn};
+
+const CURRENT_VERSION: u32 = 1;
+pub const MAX_RECIPES: usize = 64;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LaunchRecipe {
+    pub id: String,
+    pub name: String,
+    pub agent: AgentKind,
+    pub project: RecipeProject,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    #[serde(default)]
+    pub worktree: WorktreePolicy,
+    pub initial_prompt: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum RecipeProject {
+    /// A daemon-owned project identity. The latest root wins when the project
+    /// moves, while `lastKnownRoot` keeps repair UI useful if it disappears.
+    Tracked {
+        id: ProjectId,
+        last_known_root: String,
+    },
+    /// An explicit path chosen before Diri has seen a session in that project.
+    Path { path: String },
+}
+
+impl RecipeProject {
+    pub fn display_path(&self) -> &str {
+        match self {
+            Self::Tracked {
+                last_known_root, ..
+            } => last_known_root,
+            Self::Path { path } => path,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum WorktreePolicy {
+    #[default]
+    CurrentCheckout,
+    Fresh {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<String>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct LaunchRecipeBook {
+    version: u32,
+    next_id: u64,
+    items: Vec<LaunchRecipe>,
+    /// A book written by a newer Diri is kept byte-for-byte semantically
+    /// intact. This build exposes no entries and refuses mutations instead of
+    /// silently rewriting an unknown schema as version 1.
+    unsupported: Option<serde_json::Value>,
+}
+
+impl Default for LaunchRecipeBook {
+    fn default() -> Self {
+        Self {
+            version: CURRENT_VERSION,
+            next_id: 1,
+            items: Vec::new(),
+            unsupported: None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecipeBookError {
+    Full,
+    Missing,
+    UnsupportedVersion,
+}
+
+impl std::fmt::Display for RecipeBookError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Full => "Recipe library is full (64 maximum)",
+            Self::Missing => "This recipe no longer exists",
+            Self::UnsupportedVersion => {
+                "Recipes were created by a newer Diri and cannot be edited here"
+            }
+        })
+    }
+}
+
+impl std::error::Error for RecipeBookError {}
+
+#[derive(Deserialize, Serialize)]
+#[serde(default, rename_all = "camelCase")]
+struct RecipeBookV1 {
+    version: u32,
+    next_id: u64,
+    items: Vec<LaunchRecipe>,
+}
+
+impl Default for RecipeBookV1 {
+    fn default() -> Self {
+        Self {
+            version: CURRENT_VERSION,
+            next_id: 1,
+            items: Vec::new(),
+        }
+    }
+}
+
+impl Serialize for LaunchRecipeBook {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if let Some(value) = &self.unsupported {
+            return value.serialize(serializer);
+        }
+        RecipeBookV1 {
+            version: CURRENT_VERSION,
+            next_id: self.next_id,
+            items: self.items.clone(),
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for LaunchRecipeBook {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        Ok(Self::from_json(value))
+    }
+}
+
+impl LaunchRecipeBook {
+    pub fn items(&self) -> &[LaunchRecipe] {
+        &self.items
+    }
+
+    pub fn get(&self, id: &str) -> Option<&LaunchRecipe> {
+        self.items.iter().find(|recipe| recipe.id == id)
+    }
+
+    pub fn add(&mut self, mut recipe: LaunchRecipe) -> Result<&LaunchRecipe, RecipeBookError> {
+        self.ensure_mutable()?;
+        if self.items.len() >= MAX_RECIPES {
+            return Err(RecipeBookError::Full);
+        }
+        recipe.id = self.allocate_id();
+        recipe.normalize();
+        self.items.push(recipe);
+        Ok(self.items.last().expect("recipe was just inserted"))
+    }
+
+    pub fn replace(&mut self, id: &str, mut recipe: LaunchRecipe) -> Result<(), RecipeBookError> {
+        self.ensure_mutable()?;
+        let Some(index) = self.items.iter().position(|item| item.id == id) else {
+            return Err(RecipeBookError::Missing);
+        };
+        recipe.id = id.to_owned();
+        recipe.normalize();
+        self.items[index] = recipe;
+        Ok(())
+    }
+
+    pub fn rename(&mut self, id: &str, name: impl Into<String>) -> Result<(), RecipeBookError> {
+        self.ensure_mutable()?;
+        let Some(recipe) = self.items.iter_mut().find(|item| item.id == id) else {
+            return Err(RecipeBookError::Missing);
+        };
+        let name = name.into();
+        let name = name.trim();
+        if name.is_empty() {
+            return Err(RecipeBookError::Missing);
+        }
+        recipe.name = name.chars().take(80).collect();
+        Ok(())
+    }
+
+    pub fn duplicate(&mut self, id: &str) -> Result<&LaunchRecipe, RecipeBookError> {
+        self.ensure_mutable()?;
+        let mut duplicate = self.get(id).ok_or(RecipeBookError::Missing)?.clone();
+        duplicate.name = unique_copy_name(&duplicate.name, &self.items);
+        self.add(duplicate)
+    }
+
+    pub fn move_by(&mut self, id: &str, delta: isize) -> Result<bool, RecipeBookError> {
+        self.ensure_mutable()?;
+        let Some(from) = self.items.iter().position(|recipe| recipe.id == id) else {
+            return Err(RecipeBookError::Missing);
+        };
+        let to =
+            (from as isize + delta).clamp(0, self.items.len().saturating_sub(1) as isize) as usize;
+        if from == to {
+            return Ok(false);
+        }
+        let recipe = self.items.remove(from);
+        self.items.insert(to, recipe);
+        Ok(true)
+    }
+
+    pub fn remove(&mut self, id: &str) -> Result<LaunchRecipe, RecipeBookError> {
+        self.ensure_mutable()?;
+        let index = self
+            .items
+            .iter()
+            .position(|recipe| recipe.id == id)
+            .ok_or(RecipeBookError::Missing)?;
+        Ok(self.items.remove(index))
+    }
+
+    pub fn normalize(&mut self) {
+        if self.unsupported.is_some() {
+            return;
+        }
+        self.version = CURRENT_VERSION;
+        self.next_id = self.next_id.max(1);
+        self.items.truncate(MAX_RECIPES);
+
+        let mut ids = HashSet::new();
+        let mut next_id = self.next_id;
+        for recipe in &mut self.items {
+            recipe.normalize();
+            if recipe.id.is_empty() || !ids.insert(recipe.id.clone()) {
+                let (replacement, following) = first_free_id(&ids, next_id);
+                ids.insert(replacement.clone());
+                recipe.id = replacement;
+                next_id = following;
+            }
+        }
+        self.next_id = next_id.max(1);
+    }
+
+    fn allocate_id(&mut self) -> String {
+        let ids = self
+            .items
+            .iter()
+            .map(|recipe| recipe.id.clone())
+            .collect::<HashSet<_>>();
+        let (id, following) = first_free_id(&ids, self.next_id);
+        self.next_id = following;
+        id
+    }
+
+    fn ensure_mutable(&self) -> Result<(), RecipeBookError> {
+        if self.unsupported.is_some() {
+            Err(RecipeBookError::UnsupportedVersion)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn from_json(value: serde_json::Value) -> Self {
+        let version = value
+            .get("version")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|value| u32::try_from(value).ok())
+            .unwrap_or(CURRENT_VERSION);
+        if version != CURRENT_VERSION {
+            return Self {
+                version,
+                next_id: 1,
+                items: Vec::new(),
+                unsupported: Some(value),
+            };
+        }
+        let next_id = value
+            .get("nextId")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(1);
+        let items = value
+            .get("items")
+            .and_then(serde_json::Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|item| serde_json::from_value(item.clone()).ok())
+            .collect();
+        let mut book = Self {
+            version: CURRENT_VERSION,
+            next_id,
+            items,
+            unsupported: None,
+        };
+        book.normalize();
+        book
+    }
+}
+
+fn first_free_id(ids: &HashSet<String>, preferred: u64) -> (String, u64) {
+    // A valid book contains at most 64 entries, so this finite candidate set
+    // always contains a free id even for adversarial `u64::MAX` input.
+    std::iter::once(preferred.max(1))
+        .chain(1..=u64::try_from(MAX_RECIPES + 1).unwrap_or(65))
+        .find_map(|candidate| {
+            let id = format!("recipe-{candidate}");
+            (!ids.contains(&id)).then(|| (id, candidate.wrapping_add(1).max(1)))
+        })
+        .expect("65 candidates cannot all be occupied by a 64-entry book")
+}
+
+impl LaunchRecipe {
+    pub fn draft(
+        name: impl Into<String>,
+        agent: AgentKind,
+        project: RecipeProject,
+        host: Option<String>,
+        initial_prompt: impl Into<String>,
+    ) -> Self {
+        let mut recipe = Self {
+            id: String::new(),
+            name: name.into(),
+            agent,
+            project,
+            host,
+            worktree: WorktreePolicy::CurrentCheckout,
+            initial_prompt: initial_prompt.into(),
+            title: None,
+        };
+        recipe.normalize();
+        recipe
+    }
+
+    pub fn resolve(
+        &self,
+        projects: &HashMap<ProjectId, Project>,
+        hosts: &[HostEntry],
+        catalog: Option<&diri_proto::AgentReadinessResult>,
+        effective_host: impl Fn(&Project) -> Option<String>,
+    ) -> Result<ResolvedRecipe, RecipeIssue> {
+        if self.initial_prompt.trim().is_empty() {
+            return Err(RecipeIssue::EmptyPrompt);
+        }
+        if let Some(host) = self.host.as_deref()
+            && !hosts.iter().any(|candidate| candidate.id == host)
+        {
+            return Err(RecipeIssue::MissingHost(host.to_owned()));
+        }
+        if catalog.is_none() {
+            return Err(RecipeIssue::AgentsLoading);
+        }
+        if !agent_catalog::kind_spawnable(&self.agent, catalog) {
+            return Err(RecipeIssue::AgentUnavailable(self.agent.clone()));
+        }
+        if self.host.is_some() && matches!(self.worktree, WorktreePolicy::Fresh { .. }) {
+            return Err(RecipeIssue::RemoteWorktreeUnsupported);
+        }
+
+        let cwd = match &self.project {
+            RecipeProject::Tracked { id, .. } => {
+                let project = projects
+                    .get(id)
+                    .ok_or_else(|| RecipeIssue::MissingProject(id.clone()))?;
+                let actual_host = effective_host(project);
+                if actual_host != self.host {
+                    return Err(RecipeIssue::ProjectMoved {
+                        expected_host: self.host.clone(),
+                        actual_host,
+                    });
+                }
+                project.root.clone()
+            }
+            RecipeProject::Path { path } if self.host.is_none() && !Path::new(path).is_dir() => {
+                return Err(RecipeIssue::MissingPath(path.clone()));
+            }
+            RecipeProject::Path { path } => path.clone(),
+        };
+
+        let worktree = match &self.worktree {
+            WorktreePolicy::CurrentCheckout => None,
+            WorktreePolicy::Fresh { branch } => Some(WorktreeSpawn {
+                create: true,
+                branch: branch.clone(),
+            }),
+        };
+        Ok(ResolvedRecipe {
+            kind: self.agent.clone(),
+            options: SpawnOptions {
+                cwd: Some(cwd),
+                host: self.host.clone(),
+                worktree,
+                title: self.title.clone(),
+                initial_prompt: Some(self.initial_prompt.trim().to_owned()),
+                ..SpawnOptions::default()
+            },
+        })
+    }
+
+    fn normalize(&mut self) {
+        self.name = self.name.trim().chars().take(80).collect();
+        self.initial_prompt = self.initial_prompt.trim().chars().take(32_768).collect();
+        self.title = self
+            .title
+            .take()
+            .map(|title| title.trim().chars().take(160).collect::<String>())
+            .filter(|title| !title.is_empty());
+        if let WorktreePolicy::Fresh { branch } = &mut self.worktree {
+            *branch = branch
+                .take()
+                .map(|branch| branch.trim().chars().take(180).collect::<String>())
+                .filter(|branch| !branch.is_empty());
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedRecipe {
+    pub kind: AgentKind,
+    pub options: SpawnOptions,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RecipeIssue {
+    EmptyPrompt,
+    MissingHost(String),
+    MissingProject(ProjectId),
+    MissingPath(String),
+    ProjectMoved {
+        expected_host: Option<String>,
+        actual_host: Option<String>,
+    },
+    AgentsLoading,
+    AgentUnavailable(AgentKind),
+    RemoteWorktreeUnsupported,
+}
+
+impl RecipeIssue {
+    pub fn message(&self) -> String {
+        match self {
+            Self::EmptyPrompt => "Add an initial prompt to repair this recipe".to_owned(),
+            Self::MissingHost(host) => format!("Host ‘{host}’ is missing — choose a new host"),
+            Self::MissingProject(_) => "Project is missing — choose a new project".to_owned(),
+            Self::MissingPath(path) => {
+                format!("Folder ‘{path}’ is missing — choose a new folder")
+            }
+            Self::ProjectMoved { .. } => {
+                "Project moved to a different host — review the destination".to_owned()
+            }
+            Self::AgentsLoading => "Checking which Agents are available…".to_owned(),
+            Self::AgentUnavailable(kind) => {
+                format!("{} is unavailable — choose another Agent", kind.id())
+            }
+            Self::RemoteWorktreeUnsupported => {
+                "Remote recipes cannot create local worktrees".to_owned()
+            }
+        }
+    }
+}
+
+/// Kept as a named preference boundary so older preference annotations and
+/// focused tests remain readable. `LaunchRecipeBook` owns item-level recovery
+/// and unknown-version preservation.
+pub fn deserialize_recipe_book<'de, D>(deserializer: D) -> Result<LaunchRecipeBook, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    LaunchRecipeBook::deserialize(deserializer)
+}
+
+pub fn suggested_recipe_name(prompt: &str) -> String {
+    let first_line = prompt
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or("");
+    let compact = first_line.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.is_empty() {
+        return "New recipe".to_owned();
+    }
+    let mut name = compact.chars().take(42).collect::<String>();
+    if compact.chars().count() > 42 {
+        name.push('…');
+    }
+    name
+}
+
+fn unique_copy_name(name: &str, existing: &[LaunchRecipe]) -> String {
+    let base = format!("{} copy", name.trim());
+    if !existing.iter().any(|recipe| recipe.name == base) {
+        return base;
+    }
+    for suffix in 2.. {
+        let candidate = format!("{base} {suffix}");
+        if !existing.iter().any(|recipe| recipe.name == candidate) {
+            return candidate;
+        }
+    }
+    unreachable!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::{Prefs, SessionStore, StoreEffect};
+    use diri_proto::{AgentDescriptor, AgentReadinessItem, SessionSpawnParams};
+
+    fn catalog(kind: &AgentKind, ready: bool) -> diri_proto::AgentReadinessResult {
+        diri_proto::AgentReadinessResult {
+            agents: vec![AgentReadinessItem {
+                kind: kind.clone(),
+                binary: kind.id().to_owned(),
+                path: ready.then(|| format!("/usr/bin/{}", kind.id())),
+                descriptor: Some(AgentDescriptor {
+                    id: kind.id().to_owned(),
+                    display_name: "Agent".into(),
+                    ..AgentDescriptor::default()
+                }),
+                ..AgentReadinessItem::default()
+            }],
+            ..diri_proto::AgentReadinessResult::default()
+        }
+    }
+
+    fn project(id: &str, root: &str, host: Option<&str>) -> Project {
+        Project {
+            id: ProjectId(id.into()),
+            root: root.into(),
+            name: "Diri".into(),
+            pinned_order: None,
+            host: host.map(str::to_owned),
+        }
+    }
+
+    #[test]
+    fn book_supports_stable_crud_and_ordering() {
+        let project = RecipeProject::Path {
+            path: "/tmp".into(),
+        };
+        let mut book = LaunchRecipeBook::default();
+        let first = book
+            .add(LaunchRecipe::draft(
+                "Review",
+                AgentKind::CODEX,
+                project.clone(),
+                None,
+                "Review this PR",
+            ))
+            .expect("add first")
+            .id
+            .clone();
+        let second = book
+            .add(LaunchRecipe::draft(
+                "Tests",
+                AgentKind::CLAUDE_CODE,
+                project,
+                None,
+                "Fix the tests",
+            ))
+            .expect("add second")
+            .id
+            .clone();
+
+        book.rename(&first, "Review carefully").expect("rename");
+        let copy = book.duplicate(&first).expect("duplicate").id.clone();
+        assert!(book.move_by(&copy, -2).expect("move"));
+        assert_eq!(book.items()[0].id, copy);
+        assert_eq!(book.items()[1].name, "Review carefully");
+        assert_eq!(book.remove(&second).expect("remove").name, "Tests");
+        assert_eq!(book.items().len(), 2);
+    }
+
+    #[test]
+    fn tracked_recipe_resolves_through_the_canonical_spawn_options() {
+        let kind = AgentKind::CODEX;
+        let mut recipe = LaunchRecipe::draft(
+            "Fresh review",
+            kind.clone(),
+            RecipeProject::Tracked {
+                id: ProjectId("diri".into()),
+                last_known_root: "/old/diri".into(),
+            },
+            None,
+            "Review this branch",
+        );
+        recipe.title = Some("Review lane".into());
+        recipe.worktree = WorktreePolicy::Fresh {
+            branch: Some("review/diri".into()),
+        };
+        let projects =
+            HashMap::from([(ProjectId("diri".into()), project("diri", "/new/diri", None))]);
+
+        let resolved = recipe
+            .resolve(&projects, &[], Some(&catalog(&kind, true)), |project| {
+                project.host.clone()
+            })
+            .expect("recipe resolves");
+        assert_eq!(resolved.kind, kind);
+        assert_eq!(resolved.options.cwd.as_deref(), Some("/new/diri"));
+        assert_eq!(resolved.options.title.as_deref(), Some("Review lane"));
+        assert_eq!(
+            resolved.options.worktree,
+            Some(WorktreeSpawn {
+                create: true,
+                branch: Some("review/diri".into())
+            })
+        );
+
+        let (mut store, mut effects) = SessionStore::headless(Prefs::default());
+        store.spawn_kind(resolved.kind, resolved.options);
+        assert_eq!(
+            effects.try_recv().expect("canonical spawn effect"),
+            StoreEffect::Spawn(SessionSpawnParams {
+                kind: AgentKind::CODEX,
+                cwd: "/new/diri".into(),
+                new_worktree: Some(true),
+                worktree_branch: Some("review/diri".into()),
+                title: Some("Review lane".into()),
+                initial_prompt: Some("Review this branch".into()),
+                parent: None,
+                initial_cols: None,
+                initial_rows: None,
+                host: None,
+                same_repo_as: None,
+            })
+        );
+    }
+
+    #[test]
+    fn legacy_remote_project_resolves_through_the_effective_host_projection() {
+        let kind = AgentKind::CODEX;
+        let recipe = LaunchRecipe::draft(
+            "Remote tests",
+            kind.clone(),
+            RecipeProject::Tracked {
+                id: ProjectId("diri".into()),
+                last_known_root: "~/old/diri".into(),
+            },
+            Some("forge".into()),
+            "Run tests",
+        );
+        let projects = HashMap::from([(ProjectId("diri".into()), project("diri", "~/diri", None))]);
+        let hosts = vec![HostEntry {
+            id: "forge".into(),
+            name: Some("Forge".into()),
+            ssh: "forge".into(),
+            default_cwd: None,
+            node: None,
+        }];
+        let resolved = recipe
+            .resolve(&projects, &hosts, Some(&catalog(&kind, true)), |_| {
+                Some("forge".into())
+            })
+            .expect("legacy project uses its session-derived host");
+        assert_eq!(resolved.options.host.as_deref(), Some("forge"));
+        assert_eq!(resolved.options.cwd.as_deref(), Some("~/diri"));
+    }
+
+    #[test]
+    fn stale_dependencies_fail_with_specific_repair_states() {
+        let kind = AgentKind::CODEX;
+        let mut recipe = LaunchRecipe::draft(
+            "Remote",
+            kind.clone(),
+            RecipeProject::Path {
+                path: "~/diri".into(),
+            },
+            Some("forge".into()),
+            "Run the tests",
+        );
+        assert_eq!(
+            recipe.resolve(
+                &HashMap::new(),
+                &[],
+                Some(&catalog(&kind, true)),
+                |project| project.host.clone()
+            ),
+            Err(RecipeIssue::MissingHost("forge".into()))
+        );
+
+        let hosts = vec![HostEntry {
+            id: "forge".into(),
+            name: Some("Forge".into()),
+            ssh: "forge".into(),
+            default_cwd: None,
+            node: None,
+        }];
+        recipe.worktree = WorktreePolicy::Fresh { branch: None };
+        assert_eq!(
+            recipe.resolve(
+                &HashMap::new(),
+                &hosts,
+                Some(&catalog(&kind, true)),
+                |project| project.host.clone()
+            ),
+            Err(RecipeIssue::RemoteWorktreeUnsupported)
+        );
+        recipe.worktree = WorktreePolicy::CurrentCheckout;
+        assert!(matches!(
+            recipe.resolve(
+                &HashMap::new(),
+                &hosts,
+                Some(&catalog(&kind, false)),
+                |project| project.host.clone()
+            ),
+            Err(RecipeIssue::AgentUnavailable(_))
+        ));
+    }
+
+    #[test]
+    fn malformed_entries_are_isolated_and_unknown_versions_are_preserved() {
+        let good = serde_json::to_value(LaunchRecipe::draft(
+            "Review",
+            AgentKind::CODEX,
+            RecipeProject::Path {
+                path: "/tmp".into(),
+            },
+            None,
+            "Review this",
+        ))
+        .expect("serialize recipe");
+        let json = serde_json::json!({
+            "version": 1,
+            "nextId": 2,
+            "items": [good.clone(), {"broken": true}, good]
+        });
+        let book: LaunchRecipeBook = serde_json::from_value(json).expect("decode tolerant book");
+        assert_eq!(book.items().len(), 2);
+
+        let future = serde_json::json!({
+            "version": 99,
+            "nextId": 900,
+            "items": [{"futureShape": true}],
+            "futurePolicy": "keep-me"
+        });
+        let mut book: LaunchRecipeBook =
+            serde_json::from_value(future.clone()).expect("preserve future book");
+        assert!(book.items().is_empty());
+        assert_eq!(
+            book.add(LaunchRecipe::draft(
+                "No downgrade",
+                AgentKind::CODEX,
+                RecipeProject::Path {
+                    path: "/tmp".into()
+                },
+                None,
+                "Stay intact"
+            )),
+            Err(RecipeBookError::UnsupportedVersion)
+        );
+        assert_eq!(serde_json::to_value(book).expect("reserialize"), future);
+    }
+
+    #[test]
+    fn capacity_and_maximum_id_are_bounded() {
+        let mut value = serde_json::json!({
+            "version": 1,
+            "nextId": u64::MAX,
+            "items": []
+        });
+        let items = value["items"].as_array_mut().expect("items");
+        for id in 1..=MAX_RECIPES {
+            let mut recipe = serde_json::to_value(LaunchRecipe::draft(
+                format!("Recipe {id}"),
+                AgentKind::CODEX,
+                RecipeProject::Path {
+                    path: "/tmp".into(),
+                },
+                None,
+                "Run",
+            ))
+            .expect("recipe");
+            recipe["id"] = serde_json::Value::String(if id == 1 {
+                format!("recipe-{}", u64::MAX)
+            } else {
+                format!("recipe-{id}")
+            });
+            items.push(recipe);
+        }
+        let mut book: LaunchRecipeBook = serde_json::from_value(value).expect("decode max id");
+        assert_eq!(book.items().len(), MAX_RECIPES);
+        assert_eq!(
+            book.add(LaunchRecipe::draft(
+                "One too many",
+                AgentKind::CODEX,
+                RecipeProject::Path {
+                    path: "/tmp".into()
+                },
+                None,
+                "Run"
+            )),
+            Err(RecipeBookError::Full)
+        );
+    }
+
+    #[test]
+    fn generated_names_are_short_and_human() {
+        assert_eq!(
+            suggested_recipe_name("\n  Fix   the flaky test\nthen run it"),
+            "Fix the flaky test"
+        );
+        assert!(suggested_recipe_name(&"x".repeat(80)).ends_with('…'));
+    }
+}

--- a/diri/crates/diri-app/src/launch_recipe.rs
+++ b/diri/crates/diri-app/src/launch_recipe.rs
@@ -6,6 +6,8 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use diri_proto::{AgentKind, HostEntry, Project, ProjectId};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -15,6 +17,11 @@ use crate::store::{SpawnOptions, WorktreeSpawn};
 
 const CURRENT_VERSION: u32 = 1;
 pub const MAX_RECIPES: usize = 64;
+const MAX_RECIPE_NAME_CHARS: usize = 80;
+const MAX_BRANCH_PREFIX_CHARS: usize = 120;
+const WORKTREE_BRANCH_ATTEMPTS: usize = 16;
+
+static LAUNCH_NONCE: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -62,6 +69,9 @@ pub enum WorktreePolicy {
     #[default]
     CurrentCheckout,
     Fresh {
+        /// A reusable naming convention, not a literal branch. Every launch
+        /// appends a collision-resistant token so one recipe can be run more
+        /// than once without reusing a branch or sibling worktree path.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         branch: Option<String>,
     },
@@ -196,7 +206,7 @@ impl LaunchRecipeBook {
         if name.is_empty() {
             return Err(RecipeBookError::Missing);
         }
-        recipe.name = name.chars().take(80).collect();
+        recipe.name = name.chars().take(MAX_RECIPE_NAME_CHARS).collect();
         Ok(())
     }
 
@@ -350,6 +360,52 @@ impl LaunchRecipe {
         catalog: Option<&diri_proto::AgentReadinessResult>,
         effective_host: impl Fn(&Project) -> Option<String>,
     ) -> Result<ResolvedRecipe, RecipeIssue> {
+        let cwd = self.validated_cwd(projects, hosts, catalog, &effective_host)?;
+        let worktree = match &self.worktree {
+            WorktreePolicy::CurrentCheckout => None,
+            WorktreePolicy::Fresh { branch } => Some(WorktreeSpawn {
+                create: true,
+                branch: Some(unique_worktree_branch(
+                    branch.as_deref(),
+                    Path::new(&cwd),
+                    launch_token,
+                )?),
+            }),
+        };
+        Ok(ResolvedRecipe {
+            kind: self.agent.clone(),
+            options: SpawnOptions {
+                cwd: Some(cwd),
+                host: self.host.clone(),
+                worktree,
+                title: self.title.clone(),
+                initial_prompt: Some(self.initial_prompt.trim().to_owned()),
+                ..SpawnOptions::default()
+            },
+        })
+    }
+
+    /// Checks every dependency that can go stale without allocating a branch
+    /// token or reading Git refs. Picker paints call this cheap path; only the
+    /// explicit launch materializes and collision-checks a worktree name.
+    pub fn validate(
+        &self,
+        projects: &HashMap<ProjectId, Project>,
+        hosts: &[HostEntry],
+        catalog: Option<&diri_proto::AgentReadinessResult>,
+        effective_host: impl Fn(&Project) -> Option<String>,
+    ) -> Result<(), RecipeIssue> {
+        self.validated_cwd(projects, hosts, catalog, &effective_host)
+            .map(|_| ())
+    }
+
+    fn validated_cwd(
+        &self,
+        projects: &HashMap<ProjectId, Project>,
+        hosts: &[HostEntry],
+        catalog: Option<&diri_proto::AgentReadinessResult>,
+        effective_host: &impl Fn(&Project) -> Option<String>,
+    ) -> Result<String, RecipeIssue> {
         if self.initial_prompt.trim().is_empty() {
             return Err(RecipeIssue::EmptyPrompt);
         }
@@ -388,28 +444,25 @@ impl LaunchRecipe {
             RecipeProject::Path { path } => path.clone(),
         };
 
-        let worktree = match &self.worktree {
-            WorktreePolicy::CurrentCheckout => None,
-            WorktreePolicy::Fresh { branch } => Some(WorktreeSpawn {
-                create: true,
-                branch: branch.clone(),
-            }),
-        };
-        Ok(ResolvedRecipe {
-            kind: self.agent.clone(),
-            options: SpawnOptions {
-                cwd: Some(cwd),
-                host: self.host.clone(),
-                worktree,
-                title: self.title.clone(),
-                initial_prompt: Some(self.initial_prompt.trim().to_owned()),
-                ..SpawnOptions::default()
-            },
-        })
+        if self.host.is_none() && !Path::new(&cwd).is_dir() {
+            return Err(RecipeIssue::MissingPath(cwd));
+        }
+
+        if matches!(self.worktree, WorktreePolicy::Fresh { .. })
+            && !Path::new(&cwd).join(".git").exists()
+        {
+            return Err(RecipeIssue::NotRepository(cwd));
+        }
+        Ok(cwd)
     }
 
     fn normalize(&mut self) {
-        self.name = self.name.trim().chars().take(80).collect();
+        self.name = self
+            .name
+            .trim()
+            .chars()
+            .take(MAX_RECIPE_NAME_CHARS)
+            .collect();
         self.initial_prompt = self.initial_prompt.trim().chars().take(32_768).collect();
         self.title = self
             .title
@@ -419,7 +472,7 @@ impl LaunchRecipe {
         if let WorktreePolicy::Fresh { branch } = &mut self.worktree {
             *branch = branch
                 .take()
-                .map(|branch| branch.trim().chars().take(180).collect::<String>())
+                .map(|branch| normalized_branch_prefix(&branch))
                 .filter(|branch| !branch.is_empty());
         }
     }
@@ -437,6 +490,8 @@ pub enum RecipeIssue {
     MissingHost(String),
     MissingProject(ProjectId),
     MissingPath(String),
+    NotRepository(String),
+    WorktreeCollision(String),
     ProjectMoved {
         expected_host: Option<String>,
         actual_host: Option<String>,
@@ -454,6 +509,12 @@ impl RecipeIssue {
             Self::MissingProject(_) => "Project is missing — choose a new project".to_owned(),
             Self::MissingPath(path) => {
                 format!("Folder ‘{path}’ is missing — choose a new folder")
+            }
+            Self::NotRepository(path) => {
+                format!("Folder ‘{path}’ is not a repository root — choose a repository")
+            }
+            Self::WorktreeCollision(path) => {
+                format!("Worktree destination ‘{path}’ already exists — change the branch prefix")
             }
             Self::ProjectMoved { .. } => {
                 "Project moved to a different host — review the destination".to_owned()
@@ -496,17 +557,118 @@ pub fn suggested_recipe_name(prompt: &str) -> String {
 }
 
 fn unique_copy_name(name: &str, existing: &[LaunchRecipe]) -> String {
-    let base = format!("{} copy", name.trim());
-    if !existing.iter().any(|recipe| recipe.name == base) {
-        return base;
-    }
-    for suffix in 2.. {
-        let candidate = format!("{base} {suffix}");
+    for copy in 1..=existing.len().saturating_add(1) {
+        let suffix = if copy == 1 {
+            " copy".to_owned()
+        } else {
+            format!(" copy {copy}")
+        };
+        let base_budget = MAX_RECIPE_NAME_CHARS.saturating_sub(suffix.chars().count());
+        let base = name.trim().chars().take(base_budget).collect::<String>();
+        let candidate = format!("{}{suffix}", base.trim_end());
         if !existing.iter().any(|recipe| recipe.name == candidate) {
             return candidate;
         }
     }
-    unreachable!()
+    unreachable!("one more copy name than existing recipes must be available")
+}
+
+fn normalized_branch_prefix(value: &str) -> String {
+    let mut result = String::new();
+    let mut separator = false;
+    for character in value
+        .trim()
+        .chars()
+        .take(MAX_BRANCH_PREFIX_CHARS)
+        .flat_map(char::to_lowercase)
+    {
+        if character.is_ascii_alphanumeric() {
+            result.push(character);
+            separator = false;
+        } else if character == '/' {
+            while result.ends_with('-') {
+                result.pop();
+            }
+            if !result.is_empty() && !result.ends_with('/') {
+                result.push('/');
+            }
+            separator = false;
+        } else if !separator && !result.is_empty() && !result.ends_with('/') {
+            result.push('-');
+            separator = true;
+        }
+    }
+    result.trim_matches(['-', '/']).to_owned()
+}
+
+fn launch_token() -> String {
+    let elapsed = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as u64;
+    let serial = LAUNCH_NONCE.fetch_add(1, Ordering::Relaxed);
+    let mixed = elapsed
+        ^ serial.wrapping_mul(0x9e37_79b9_7f4a_7c15)
+        ^ u64::from(std::process::id()).rotate_left(17);
+    format!("{mixed:016x}")
+}
+
+fn unique_worktree_branch(
+    prefix: Option<&str>,
+    repository: &Path,
+    mut token: impl FnMut() -> String,
+) -> Result<String, RecipeIssue> {
+    let prefix = prefix
+        .map(normalized_branch_prefix)
+        .filter(|prefix| !prefix.is_empty())
+        .unwrap_or_else(|| "dirijor/recipe".to_owned());
+    let mut last_destination = repository.to_path_buf();
+    for _ in 0..WORKTREE_BRANCH_ATTEMPTS {
+        let branch = format!("{prefix}/{}", token());
+        let destination = worktree_destination(repository, &branch);
+        let branch_ref = repository.join(".git/refs/heads").join(&branch);
+        if !destination.exists()
+            && !branch_ref.exists()
+            && !packed_branch_exists(repository, &branch)
+        {
+            return Ok(branch);
+        }
+        last_destination = destination;
+    }
+    Err(RecipeIssue::WorktreeCollision(
+        last_destination.to_string_lossy().into_owned(),
+    ))
+}
+
+fn worktree_destination(repository: &Path, branch: &str) -> std::path::PathBuf {
+    let mut slug = String::with_capacity(branch.len());
+    let mut separator = false;
+    for character in branch.to_lowercase().chars() {
+        if character.is_ascii_lowercase() || character.is_ascii_digit() {
+            slug.push(character);
+            separator = false;
+        } else if !separator {
+            slug.push('-');
+            separator = true;
+        }
+    }
+    let slug = slug.trim_matches('-');
+    let parent = repository.parent().unwrap_or_else(|| Path::new("."));
+    let name = repository
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_else(|| "repo".into());
+    parent.join(format!("{name}-{slug}"))
+}
+
+fn packed_branch_exists(repository: &Path, branch: &str) -> bool {
+    std::fs::read_to_string(repository.join(".git/packed-refs")).is_ok_and(|packed| {
+        let reference = format!("refs/heads/{branch}");
+        packed.lines().any(|line| {
+            line.split_once(' ')
+                .is_some_and(|(_, candidate)| candidate == reference)
+        })
+    })
 }
 
 #[cfg(test)]
@@ -582,6 +744,9 @@ mod tests {
 
     #[test]
     fn tracked_recipe_resolves_through_the_canonical_spawn_options() {
+        let repository = tempfile::tempdir().expect("repository");
+        std::fs::create_dir(repository.path().join(".git")).expect("git directory");
+        let root = repository.path().to_string_lossy().into_owned();
         let kind = AgentKind::CODEX;
         let mut recipe = LaunchRecipe::draft(
             "Fresh review",
@@ -597,8 +762,7 @@ mod tests {
         recipe.worktree = WorktreePolicy::Fresh {
             branch: Some("review/diri".into()),
         };
-        let projects =
-            HashMap::from([(ProjectId("diri".into()), project("diri", "/new/diri", None))]);
+        let projects = HashMap::from([(ProjectId("diri".into()), project("diri", &root, None))]);
 
         let resolved = recipe
             .resolve(&projects, &[], Some(&catalog(&kind, true)), |project| {
@@ -606,15 +770,15 @@ mod tests {
             })
             .expect("recipe resolves");
         assert_eq!(resolved.kind, kind);
-        assert_eq!(resolved.options.cwd.as_deref(), Some("/new/diri"));
+        assert_eq!(resolved.options.cwd.as_deref(), Some(root.as_str()));
         assert_eq!(resolved.options.title.as_deref(), Some("Review lane"));
-        assert_eq!(
-            resolved.options.worktree,
-            Some(WorktreeSpawn {
-                create: true,
-                branch: Some("review/diri".into())
-            })
-        );
+        let branch = resolved
+            .options
+            .worktree
+            .as_ref()
+            .and_then(|worktree| worktree.branch.clone())
+            .expect("materialized branch");
+        assert!(branch.starts_with("review/diri/"));
 
         let (mut store, mut effects) = SessionStore::headless(Prefs::default());
         store.spawn_kind(resolved.kind, resolved.options);
@@ -622,9 +786,9 @@ mod tests {
             effects.try_recv().expect("canonical spawn effect"),
             StoreEffect::Spawn(SessionSpawnParams {
                 kind: AgentKind::CODEX,
-                cwd: "/new/diri".into(),
+                cwd: root,
                 new_worktree: Some(true),
-                worktree_branch: Some("review/diri".into()),
+                worktree_branch: Some(branch),
                 title: Some("Review lane".into()),
                 initial_prompt: Some("Review this branch".into()),
                 parent: None,
@@ -801,6 +965,107 @@ mod tests {
             )),
             Err(RecipeBookError::Full)
         );
+    }
+
+    #[test]
+    fn fresh_recipe_materializes_a_new_branch_for_every_run() {
+        let repository = tempfile::tempdir().expect("repository");
+        std::fs::create_dir(repository.path().join(".git")).expect("git directory");
+        let root = repository.path().to_string_lossy().into_owned();
+        let kind = AgentKind::CODEX;
+        let mut recipe = LaunchRecipe::draft(
+            "Review",
+            kind.clone(),
+            RecipeProject::Path { path: root },
+            None,
+            "Review this",
+        );
+        recipe.worktree = WorktreePolicy::Fresh {
+            branch: Some("Review / Diri".into()),
+        };
+
+        let first = recipe
+            .resolve(&HashMap::new(), &[], Some(&catalog(&kind, true)), |_| None)
+            .expect("first run")
+            .options
+            .worktree
+            .and_then(|worktree| worktree.branch)
+            .expect("first branch");
+        let second = recipe
+            .resolve(&HashMap::new(), &[], Some(&catalog(&kind, true)), |_| None)
+            .expect("second run")
+            .options
+            .worktree
+            .and_then(|worktree| worktree.branch)
+            .expect("second branch");
+
+        assert!(first.starts_with("review/diri/"));
+        assert!(second.starts_with("review/diri/"));
+        assert_ne!(first, second, "a reusable recipe cannot reuse its branch");
+    }
+
+    #[test]
+    fn local_path_repository_and_worktree_collisions_are_repair_states() {
+        let kind = AgentKind::CODEX;
+        let missing = LaunchRecipe::draft(
+            "Missing",
+            kind.clone(),
+            RecipeProject::Path {
+                path: "/path/that/does/not/exist".into(),
+            },
+            None,
+            "Run",
+        );
+        assert!(matches!(
+            missing.resolve(&HashMap::new(), &[], Some(&catalog(&kind, true)), |_| None),
+            Err(RecipeIssue::MissingPath(_))
+        ));
+
+        let directory = tempfile::tempdir().expect("directory");
+        let root = directory.path().to_string_lossy().into_owned();
+        let mut fresh = LaunchRecipe::draft(
+            "Fresh",
+            kind.clone(),
+            RecipeProject::Path { path: root },
+            None,
+            "Run",
+        );
+        fresh.worktree = WorktreePolicy::Fresh { branch: None };
+        assert!(matches!(
+            fresh.resolve(&HashMap::new(), &[], Some(&catalog(&kind, true)), |_| None),
+            Err(RecipeIssue::NotRepository(_))
+        ));
+
+        std::fs::create_dir(directory.path().join(".git")).expect("git directory");
+        let branch = "review/same";
+        let collision = worktree_destination(directory.path(), branch);
+        std::fs::create_dir(&collision).expect("colliding worktree path");
+        assert!(matches!(
+            unique_worktree_branch(Some("review"), directory.path(), || "same".into()),
+            Err(RecipeIssue::WorktreeCollision(path)) if path == collision.to_string_lossy()
+        ));
+    }
+
+    #[test]
+    fn duplicate_names_remain_distinct_at_the_length_limit() {
+        let mut book = LaunchRecipeBook::default();
+        let original = book
+            .add(LaunchRecipe::draft(
+                "x".repeat(MAX_RECIPE_NAME_CHARS),
+                AgentKind::CODEX,
+                RecipeProject::Path {
+                    path: "/tmp".into(),
+                },
+                None,
+                "Run",
+            ))
+            .expect("original")
+            .clone();
+        let duplicate = book.duplicate(&original.id).expect("duplicate").clone();
+
+        assert_ne!(duplicate.name, original.name);
+        assert!(duplicate.name.ends_with(" copy"));
+        assert!(duplicate.name.chars().count() <= MAX_RECIPE_NAME_CHARS);
     }
 
     #[test]

--- a/diri/crates/diri-app/src/launcher.rs
+++ b/diri/crates/diri-app/src/launcher.rs
@@ -12,7 +12,8 @@ use diri_ui::{
 };
 use gpui::{
     AnyElement, App, Context, EventEmitter, FocusHandle, Focusable, FontWeight, HighlightStyle,
-    KeyDownEvent, MouseButton, PathPromptOptions, Render, Task, Window, div, prelude::*, px, rgba,
+    KeyDownEvent, MouseButton, PathPromptOptions, Render, Role, Task, Window, div, prelude::*, px,
+    rgba,
 };
 
 use crate::AppServices;
@@ -20,10 +21,13 @@ use crate::agent_catalog::{AgentOption, quick_agent_options, title_case_id};
 use crate::composer::PromptComposer;
 use crate::delegation::HandoffProposal;
 use crate::icons::{SymbolWeight, sf_symbol, sf_symbol_weighted};
+use crate::launch_recipe::{
+    LaunchRecipe, RecipeBookError, RecipeIssue, RecipeProject, WorktreePolicy,
+    suggested_recipe_name,
+};
 use crate::navigation::CARET;
 use crate::notifications::SendTextCommand;
-use crate::query_editor::{self, ClipboardEdit, Edit};
-use crate::store::SpawnOptions;
+use crate::query_editor::{self, ClipboardEdit, Edit, QueryEditor};
 
 const PANEL_WIDTH: f32 = 540.0;
 const TITLE_HEIGHT: f32 = 36.0;
@@ -108,6 +112,17 @@ pub(crate) struct LauncherOverlay {
     selected_harness: AgentKind,
     selected_root: String,
     selected_host: Option<String>,
+    selected_worktree: WorktreePolicy,
+    selected_title: Option<String>,
+    draft_recipe_name: Option<String>,
+    /// Set while a saved workflow is being previewed. Editing launcher fields
+    /// remains a one-off override until the explicit “Update recipe” action.
+    active_recipe: Option<LaunchRecipe>,
+    /// The saved project identity remains authoritative during repair until
+    /// the user explicitly chooses another project or folder.
+    recipe_project_edited: bool,
+    recipe_editor: Option<RecipeMetadataEditor>,
+    pending_recipe_delete: Option<String>,
     fallback_notice: Option<String>,
     /// Finder drops may partially succeed. Keep their ignored-path detail
     /// inline with the staged draft until the user sends or replaces it; a
@@ -122,10 +137,87 @@ pub(crate) struct LauncherOverlay {
     _store_changes: Task<()>,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Picker {
     Harness,
     Project,
+    Recipe,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RecipeMetadataField {
+    Name,
+    Title,
+    Branch,
+}
+
+impl RecipeMetadataField {
+    const fn adjacent(self, backwards: bool) -> Self {
+        match (self, backwards) {
+            (Self::Name, false) | (Self::Branch, true) => Self::Title,
+            (Self::Title, false) => Self::Branch,
+            (Self::Title, true) => Self::Name,
+            (Self::Branch, false) | (Self::Name, true) => Self::Name,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct RecipeMetadataEditor {
+    /// `Some` edits the persisted recipe; `None` edits only the current launch
+    /// draft, including one-off overrides from a saved recipe.
+    id: Option<String>,
+    name: QueryEditor,
+    title: QueryEditor,
+    branch: QueryEditor,
+    active_field: RecipeMetadataField,
+    error: Option<String>,
+}
+
+impl RecipeMetadataEditor {
+    fn saved(recipe: &LaunchRecipe) -> Self {
+        Self {
+            id: Some(recipe.id.clone()),
+            name: text_editor(&recipe.name),
+            title: text_editor(recipe.title.as_deref().unwrap_or_default()),
+            branch: text_editor(match &recipe.worktree {
+                WorktreePolicy::Fresh { branch } => branch.as_deref().unwrap_or_default(),
+                WorktreePolicy::CurrentCheckout => "",
+            }),
+            active_field: RecipeMetadataField::Name,
+            error: None,
+        }
+    }
+
+    fn draft(name: &str, title: Option<&str>, worktree: &WorktreePolicy) -> Self {
+        Self {
+            id: None,
+            name: text_editor(name),
+            title: text_editor(title.unwrap_or_default()),
+            branch: text_editor(match worktree {
+                WorktreePolicy::Fresh { branch } => branch.as_deref().unwrap_or_default(),
+                WorktreePolicy::CurrentCheckout => "",
+            }),
+            active_field: RecipeMetadataField::Name,
+            error: None,
+        }
+    }
+
+    fn field_mut(&mut self) -> &mut QueryEditor {
+        match self.active_field {
+            RecipeMetadataField::Name => &mut self.name,
+            RecipeMetadataField::Title => &mut self.title,
+            RecipeMetadataField::Branch => &mut self.branch,
+        }
+    }
+
+    fn field(&self, field: RecipeMetadataField) -> &QueryEditor {
+        match field {
+            RecipeMetadataField::Name => &self.name,
+            RecipeMetadataField::Title => &self.title,
+            RecipeMetadataField::Branch => &self.branch,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -198,6 +290,7 @@ impl LauncherOverlay {
                                 if this.open
                                     && matches!(this.target, LauncherTarget::NewSession)
                                     && matches!(this.mode, LauncherMode::NewSession)
+                                    && this.active_recipe.is_none()
                                 {
                                     this.reconcile_harness();
                                 }
@@ -227,6 +320,13 @@ impl LauncherOverlay {
             selected_harness,
             selected_root,
             selected_host,
+            selected_worktree: WorktreePolicy::CurrentCheckout,
+            selected_title: None,
+            draft_recipe_name: None,
+            active_recipe: None,
+            recipe_project_edited: false,
+            recipe_editor: None,
+            pending_recipe_delete: None,
             fallback_notice: None,
             drop_notice: None,
             picker: None,
@@ -254,6 +354,11 @@ impl LauncherOverlay {
             self.selected_harness = harness;
             self.selected_root = root;
             self.selected_host = host;
+            self.selected_worktree = WorktreePolicy::CurrentCheckout;
+            self.selected_title = None;
+            self.draft_recipe_name = None;
+            self.active_recipe = None;
+            self.recipe_project_edited = false;
             self.fallback_notice = None;
         }
         self.activate_new_session(window, cx);
@@ -287,6 +392,11 @@ impl LauncherOverlay {
         self.switch_target(LauncherTarget::NewSession);
         self.selected_root = root;
         self.selected_host = None;
+        self.selected_worktree = WorktreePolicy::CurrentCheckout;
+        self.selected_title = None;
+        self.draft_recipe_name = None;
+        self.active_recipe = None;
+        self.recipe_project_edited = false;
         self.fallback_notice = None;
         self.drop_notice = notice;
         self.activate_new_session(window, cx);
@@ -453,7 +563,7 @@ impl LauncherOverlay {
                 catalog.is_some(),
             )
         };
-        if spawnable || !catalog_known {
+        if spawnable || !catalog_known || self.active_recipe.is_some() {
             return;
         }
         let choices = self.harness_choices();
@@ -508,6 +618,401 @@ impl LauncherOverlay {
                 })
         });
         projects
+    }
+
+    fn recipes(&self) -> Vec<LaunchRecipe> {
+        self.services
+            .store
+            .store
+            .read()
+            .expect("session store lock poisoned")
+            .preferences()
+            .launch_recipes
+            .items()
+            .to_vec()
+    }
+
+    fn current_recipe(&self, name: String) -> LaunchRecipe {
+        let projects = self.projects();
+        let project = recipe_project_for_draft(
+            self.active_recipe.as_ref(),
+            self.recipe_project_edited,
+            &self.selected_root,
+            self.selected_host.as_deref(),
+            &projects,
+        );
+        let mut recipe = LaunchRecipe::draft(
+            name,
+            self.selected_harness.clone(),
+            project,
+            self.selected_host.clone(),
+            self.prompt.text(),
+        );
+        recipe.worktree = self.selected_worktree.clone();
+        recipe.title.clone_from(&self.selected_title);
+        recipe
+    }
+
+    fn resolve_recipe(
+        &self,
+        recipe: &LaunchRecipe,
+    ) -> Result<crate::launch_recipe::ResolvedRecipe, RecipeIssue> {
+        let store = self
+            .services
+            .store
+            .store
+            .read()
+            .expect("session store lock poisoned");
+        recipe.resolve(
+            store.projects(),
+            store.hosts(),
+            store.agent_catalog(recipe.host.as_deref()),
+            |project| {
+                project.host.clone().or_else(|| {
+                    store
+                        .sessions()
+                        .values()
+                        .find(|session| session.project_id == project.id)
+                        .and_then(|session| session.host.clone())
+                })
+            },
+        )
+    }
+
+    /// Available recipes are one-click launches. A stale recipe unfolds into
+    /// the ordinary launcher with its fields preserved and one specific repair
+    /// message, so no missing dependency can silently retarget a run.
+    fn activate_recipe(&mut self, id: &str, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(recipe) = self.recipes().into_iter().find(|recipe| recipe.id == id) else {
+            self.fallback_notice = Some("This recipe no longer exists".to_owned());
+            return;
+        };
+        match self.resolve_recipe(&recipe) {
+            Ok(resolved) if !self.preview => {
+                self.services
+                    .store
+                    .store
+                    .write()
+                    .expect("session store lock poisoned")
+                    .spawn_kind(resolved.kind, resolved.options);
+                self.new_session_draft.clear();
+                self.prompt.clear();
+                self.close(cx);
+            }
+            result => {
+                self.preview_recipe(&recipe);
+                self.fallback_notice = result.err().map(|issue| issue.message()).or_else(|| {
+                    self.preview
+                        .then(|| "Preview mode — no Agent will be launched".to_owned())
+                });
+                self.services
+                    .store
+                    .store
+                    .write()
+                    .expect("session store lock poisoned")
+                    .request_agent_catalog(recipe.host.clone(), false);
+                self.picker = None;
+                window.focus(&self.focus, cx);
+                cx.notify();
+            }
+        }
+    }
+
+    fn preview_recipe(&mut self, recipe: &LaunchRecipe) {
+        self.selected_harness.clone_from(&recipe.agent);
+        self.selected_host.clone_from(&recipe.host);
+        self.selected_worktree.clone_from(&recipe.worktree);
+        self.selected_title.clone_from(&recipe.title);
+        self.draft_recipe_name = Some(recipe.name.clone());
+        self.selected_root = match &recipe.project {
+            RecipeProject::Tracked {
+                id,
+                last_known_root,
+            } => self
+                .services
+                .store
+                .store
+                .read()
+                .expect("session store lock poisoned")
+                .projects()
+                .get(id)
+                .map_or_else(|| last_known_root.clone(), |project| project.root.clone()),
+            RecipeProject::Path { path } => path.clone(),
+        };
+        self.prompt.clear();
+        self.prompt.insert_multiline(&recipe.initial_prompt);
+        self.active_recipe = Some(recipe.clone());
+        self.recipe_project_edited = false;
+    }
+
+    fn update_recipe_book(
+        &self,
+        update: impl FnOnce(&mut crate::launch_recipe::LaunchRecipeBook) -> Result<(), RecipeBookError>,
+    ) -> Result<(), String> {
+        let mut book_result = None;
+        let io_result = self
+            .services
+            .store
+            .store
+            .write()
+            .expect("session store lock poisoned")
+            .update_preferences(|prefs| {
+                book_result = Some(update(&mut prefs.launch_recipes));
+            });
+        io_result.map_err(|error| error.to_string()).and_then(|()| {
+            book_result
+                .expect("recipe update closure ran")
+                .map_err(|e| e.to_string())
+        })
+    }
+
+    fn save_current_recipe(&mut self, cx: &mut Context<Self>) {
+        if self.prompt.text().trim().is_empty() || self.selected_root.is_empty() {
+            self.fallback_notice = Some("Add a task and project before saving a recipe".to_owned());
+            cx.notify();
+            return;
+        }
+        let name = self
+            .draft_recipe_name
+            .clone()
+            .unwrap_or_else(|| suggested_recipe_name(self.prompt.text()));
+        let recipe = self.current_recipe(name.clone());
+        if let Err(issue) = self.resolve_recipe(&recipe) {
+            self.fallback_notice = Some(issue.message());
+            cx.notify();
+            return;
+        }
+        let result = self.update_recipe_book(|book| book.add(recipe).map(|_| ()));
+        self.fallback_notice = Some(match result {
+            Ok(()) => format!("Saved “{name}” — it is now a one-click recipe"),
+            Err(error) => format!("Could not save recipe: {error}"),
+        });
+        self.picker = None;
+        cx.notify();
+    }
+
+    fn update_active_recipe(&mut self, cx: &mut Context<Self>) {
+        let Some(active) = self.active_recipe.clone() else {
+            self.save_current_recipe(cx);
+            return;
+        };
+        let id = active.id;
+        let name = self.draft_recipe_name.clone().unwrap_or(active.name);
+        let mut recipe = self.current_recipe(name.clone());
+        if let Err(issue) = self.resolve_recipe(&recipe) {
+            self.fallback_notice = Some(issue.message());
+            cx.notify();
+            return;
+        }
+        let stored = recipe.clone();
+        let result = self.update_recipe_book(|book| book.replace(&id, recipe));
+        if result.is_ok() {
+            recipe = stored;
+            recipe.id = id;
+            self.active_recipe = Some(recipe);
+            self.recipe_project_edited = false;
+        }
+        self.fallback_notice = Some(match result {
+            Ok(()) => format!("Updated “{name}”"),
+            Err(error) => format!("Could not update recipe: {error}"),
+        });
+        cx.notify();
+    }
+
+    fn remove_recipe(&mut self, id: &str, cx: &mut Context<Self>) {
+        let result = self.update_recipe_book(|book| book.remove(id).map(|_| ()));
+        if self.active_recipe.as_ref().map(|recipe| recipe.id.as_str()) == Some(id) {
+            self.active_recipe = None;
+            self.recipe_project_edited = false;
+        }
+        if let Err(error) = result {
+            self.fallback_notice = Some(format!("Could not delete recipe: {error}"));
+        }
+        let count = self.recipes().len().saturating_add(1);
+        self.highlight = self.highlight.min(count.saturating_sub(1));
+        cx.notify();
+    }
+
+    fn duplicate_recipe(&mut self, id: &str, cx: &mut Context<Self>) {
+        let result = self.update_recipe_book(|book| book.duplicate(id).map(|_| ()));
+        if let Err(error) = result {
+            self.fallback_notice = Some(format!("Could not duplicate recipe: {error}"));
+        }
+        cx.notify();
+    }
+
+    fn move_recipe(&mut self, id: &str, delta: isize, cx: &mut Context<Self>) {
+        let result = self.update_recipe_book(|book| book.move_by(id, delta).map(|_| ()));
+        if let Err(error) = result {
+            self.fallback_notice = Some(format!("Could not reorder recipe: {error}"));
+        }
+        cx.notify();
+    }
+
+    fn edit_recipe(&mut self, id: &str, cx: &mut Context<Self>) {
+        let Some(recipe) = self.recipes().into_iter().find(|recipe| recipe.id == id) else {
+            self.fallback_notice = Some("This recipe no longer exists".to_owned());
+            cx.notify();
+            return;
+        };
+        self.recipe_editor = Some(RecipeMetadataEditor::saved(&recipe));
+        self.pending_recipe_delete = None;
+        cx.notify();
+    }
+
+    fn edit_launch_details(&mut self, cx: &mut Context<Self>) {
+        let name = self
+            .draft_recipe_name
+            .clone()
+            .unwrap_or_else(|| suggested_recipe_name(self.prompt.text()));
+        self.recipe_editor = Some(RecipeMetadataEditor::draft(
+            &name,
+            self.selected_title.as_deref(),
+            &self.selected_worktree,
+        ));
+        self.pending_recipe_delete = None;
+        self.picker = Some(Picker::Recipe);
+        cx.notify();
+    }
+
+    fn save_recipe_editor(&mut self, cx: &mut Context<Self>) {
+        let Some(editor) = self.recipe_editor.clone() else {
+            return;
+        };
+        let name = editor.name.text().trim();
+        if name.is_empty() {
+            if let Some(editor) = &mut self.recipe_editor {
+                editor.error = Some("Give the recipe a name".to_owned());
+            }
+            cx.notify();
+            return;
+        }
+        if editor.id.is_none() {
+            if self.selected_host.is_some() && !editor.branch.is_empty() {
+                if let Some(editor) = &mut self.recipe_editor {
+                    editor.error = Some("Remote launches cannot create local worktrees".to_owned());
+                }
+                cx.notify();
+                return;
+            }
+            self.draft_recipe_name = Some(name.to_owned());
+            self.selected_title = nonempty(editor.title.text());
+            let branch = nonempty(editor.branch.text());
+            self.selected_worktree = match (&self.selected_worktree, branch) {
+                (_, Some(branch)) => WorktreePolicy::Fresh {
+                    branch: Some(branch),
+                },
+                (WorktreePolicy::Fresh { .. }, None) => WorktreePolicy::Fresh { branch: None },
+                (WorktreePolicy::CurrentCheckout, None) => WorktreePolicy::CurrentCheckout,
+            };
+            self.recipe_editor = None;
+            self.picker = None;
+            self.fallback_notice = Some(if self.active_recipe.is_some() {
+                "Launch details changed for this run — the saved recipe is untouched".to_owned()
+            } else {
+                "Launch details updated".to_owned()
+            });
+            cx.notify();
+            return;
+        }
+        let id = editor.id.expect("saved recipe editor has an id");
+        let Some(mut recipe) = self.recipes().into_iter().find(|recipe| recipe.id == id) else {
+            self.recipe_editor = None;
+            self.fallback_notice = Some("This recipe no longer exists".to_owned());
+            cx.notify();
+            return;
+        };
+        recipe.name = name.to_owned();
+        recipe.title = nonempty(editor.title.text());
+        if let WorktreePolicy::Fresh { branch } = &mut recipe.worktree {
+            *branch = nonempty(editor.branch.text());
+        } else if let Some(branch) = nonempty(editor.branch.text()) {
+            recipe.worktree = WorktreePolicy::Fresh {
+                branch: Some(branch),
+            };
+        }
+        if recipe.host.is_some() && matches!(recipe.worktree, WorktreePolicy::Fresh { .. }) {
+            if let Some(editor) = &mut self.recipe_editor {
+                editor.error = Some("Remote recipes cannot create local worktrees".to_owned());
+            }
+            cx.notify();
+            return;
+        }
+        let updated = recipe.clone();
+        match self.update_recipe_book(|book| book.replace(&id, recipe)) {
+            Ok(()) => {
+                if self
+                    .active_recipe
+                    .as_ref()
+                    .is_some_and(|active| active.id == id)
+                {
+                    self.preview_recipe(&updated);
+                }
+                self.recipe_editor = None;
+                self.fallback_notice = Some(format!("Updated “{}”", updated.name));
+            }
+            Err(error) => {
+                if let Some(editor) = &mut self.recipe_editor {
+                    editor.error = Some(error);
+                }
+            }
+        }
+        cx.notify();
+    }
+
+    fn request_recipe_delete(&mut self, id: &str, cx: &mut Context<Self>) {
+        if self.pending_recipe_delete.as_deref() == Some(id) {
+            self.pending_recipe_delete = None;
+            self.remove_recipe(id, cx);
+            return;
+        }
+        self.pending_recipe_delete = Some(id.to_owned());
+        self.fallback_notice = Some("Press Delete again to remove this recipe".to_owned());
+        cx.notify();
+    }
+
+    fn handle_recipe_editor_key(&mut self, event: &KeyDownEvent, cx: &mut Context<Self>) -> bool {
+        let Some(editor) = &mut self.recipe_editor else {
+            return false;
+        };
+        match event.keystroke.key.as_str() {
+            "escape" => {
+                self.recipe_editor = None;
+                cx.notify();
+            }
+            "tab" => {
+                editor.active_field = editor
+                    .active_field
+                    .adjacent(event.keystroke.modifiers.shift);
+                editor.error = None;
+                cx.notify();
+            }
+            "enter" => self.save_recipe_editor(cx),
+            _ => {
+                let Some(edit) = query_editor::edit_for(&event.keystroke) else {
+                    return true;
+                };
+                match edit {
+                    Edit::Local(local) => {
+                        editor.field_mut().apply(local);
+                    }
+                    Edit::Clipboard(ClipboardEdit::Copy) => {
+                        query_editor::copy_selection(editor.field_mut(), cx);
+                    }
+                    Edit::Clipboard(ClipboardEdit::Cut) => {
+                        query_editor::cut_selection(editor.field_mut(), cx);
+                    }
+                    Edit::Clipboard(ClipboardEdit::Paste) => {
+                        if let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) {
+                            editor.field_mut().insert(&text);
+                        }
+                    }
+                }
+                editor.error = None;
+                cx.notify();
+            }
+        }
+        true
     }
 
     fn selected_harness_label(&self) -> String {
@@ -571,46 +1076,30 @@ impl LauncherOverlay {
             return (session.host.is_some() && self.session_drafts_with_local_paths.contains(id))
                 .then(|| "Local paths cannot be used on a remote session".to_owned());
         }
-        if self.selected_root.is_empty() {
-            return Some("Choose a project to start in".to_owned());
+        let recipe = self.current_recipe("New Agent".to_owned());
+        match self.resolve_recipe(&recipe) {
+            Ok(_) => None,
+            Err(RecipeIssue::AgentsLoading) => {
+                let scan_error = self
+                    .services
+                    .store
+                    .store
+                    .read()
+                    .expect("session store lock poisoned")
+                    .agent_catalog_error(self.selected_host.as_deref())
+                    .map(str::to_owned);
+                Some(scan_error.map_or_else(
+                    || {
+                        format!(
+                            "Checking whether {} is available here…",
+                            self.selected_harness_label()
+                        )
+                    },
+                    |error| format!("Could not check Agents on this host: {error}"),
+                ))
+            }
+            Err(issue) => Some(issue.message()),
         }
-        let (spawnable, catalog_known, scan_error) = {
-            let store = self
-                .services
-                .store
-                .store
-                .read()
-                .expect("session store lock poisoned");
-            let host = self.selected_host.as_deref();
-            let catalog = store.agent_catalog(host);
-            (
-                crate::agent_catalog::kind_spawnable(&self.selected_harness, catalog),
-                catalog.is_some(),
-                store.agent_catalog_error(host).map(str::to_owned),
-            )
-        };
-        if spawnable {
-            return None;
-        }
-        if catalog_known {
-            return Some(format!(
-                "{} is not available on this host",
-                self.selected_harness_label()
-            ));
-        }
-        // Readiness for this target has not answered yet, so submitting would
-        // spawn blind. Name the state rather than claiming absence — and leave
-        // the Agent menu usable, since picking Terminal explicitly stays a
-        // valid escape hatch when a scan cannot answer at all.
-        Some(scan_error.map_or_else(
-            || {
-                format!(
-                    "Checking whether {} is available here…",
-                    self.selected_harness_label()
-                )
-            },
-            |error| format!("Could not check Agents on this host: {error}"),
-        ))
     }
 
     fn can_submit(&self) -> bool {
@@ -664,21 +1153,19 @@ impl LauncherOverlay {
         let prompt = self.prompt.text().trim().to_owned();
         match &self.target {
             LauncherTarget::NewSession => {
+                let recipe = self.current_recipe("One-off launch".to_owned());
+                let Ok(resolved) = self.resolve_recipe(&recipe) else {
+                    return false;
+                };
                 self.services
                     .store
                     .store
                     .write()
                     .expect("session store lock poisoned")
-                    .spawn_kind(
-                        self.selected_harness.clone(),
-                        SpawnOptions {
-                            cwd: Some(self.selected_root.clone()),
-                            initial_prompt: Some(prompt),
-                            host: self.selected_host.clone(),
-                            ..SpawnOptions::default()
-                        },
-                    );
+                    .spawn_kind(resolved.kind, resolved.options);
                 self.new_session_draft.clear();
+                self.active_recipe = None;
+                self.recipe_project_edited = false;
             }
             LauncherTarget::Session(id) => {
                 // Selection can attach or resume terminal state, so it belongs
@@ -722,6 +1209,9 @@ impl LauncherOverlay {
         if self.handoff_delivery.is_sending() {
             return true;
         }
+        if self.handle_recipe_editor_key(event, cx) {
+            return true;
+        }
         if self.picker.is_some() && self.handle_picker_key(event, window, cx) {
             return true;
         }
@@ -737,6 +1227,20 @@ impl LauncherOverlay {
                 true
             }
             "enter" => self.submit(cx),
+            "r" if event.keystroke.modifiers.platform
+                && event.keystroke.modifiers.shift
+                && matches!(self.target, LauncherTarget::NewSession) =>
+            {
+                self.edit_launch_details(cx);
+                true
+            }
+            "r" if event.keystroke.modifiers.platform
+                && matches!(self.target, LauncherTarget::NewSession) =>
+            {
+                self.toggle_picker(Picker::Recipe);
+                cx.notify();
+                true
+            }
             // Cycling the agent from the keyboard: the picker was mouse-only,
             // which is a strange thing to require of a surface you reached
             // with ⌘N and are about to leave with ↵.
@@ -769,9 +1273,60 @@ impl LauncherOverlay {
         let count = match self.picker {
             Some(Picker::Harness) => self.harness_choices().len(),
             Some(Picker::Project) => self.projects().len() + 1,
+            Some(Picker::Recipe) => self.recipes().len() + 1,
             None => return false,
         };
-        match event.keystroke.key.as_str() {
+        let key = event.keystroke.key.as_str();
+        let modifiers = event.keystroke.modifiers;
+        if self.picker == Some(Picker::Recipe) {
+            let recipes = self.recipes();
+            let selected = recipes.get(self.highlight).map(|recipe| recipe.id.clone());
+            match key {
+                "space" => {
+                    if let Some(recipe) = recipes.get(self.highlight) {
+                        self.preview_recipe(recipe);
+                        self.fallback_notice = Some(
+                            "Previewing — changes apply once unless you update the recipe"
+                                .to_owned(),
+                        );
+                        self.picker = None;
+                        window.focus(&self.focus, cx);
+                    }
+                    cx.notify();
+                    return true;
+                }
+                "e" => {
+                    if let Some(id) = selected {
+                        self.edit_recipe(&id, cx);
+                    }
+                    return true;
+                }
+                "d" if modifiers.platform => {
+                    if let Some(id) = selected {
+                        self.duplicate_recipe(&id, cx);
+                    }
+                    return true;
+                }
+                "up" | "down" if modifiers.platform => {
+                    if let Some(id) = selected {
+                        let delta = if key == "up" { -1 } else { 1 };
+                        self.move_recipe(&id, delta, cx);
+                        self.highlight = (self.highlight as isize + delta)
+                            .clamp(0, recipes.len().saturating_sub(1) as isize)
+                            as usize;
+                    }
+                    return true;
+                }
+                "backspace" | "delete" => {
+                    if let Some(id) = selected {
+                        self.request_recipe_delete(&id, cx);
+                    }
+                    return true;
+                }
+                _ => {}
+            }
+        }
+        match key {
             "escape" => {
                 self.picker = None;
                 cx.notify();
@@ -809,19 +1364,32 @@ impl LauncherOverlay {
                     ProjectCommit::Recent(index) => {
                         self.selected_root.clone_from(&projects[index].project.root);
                         self.selected_host.clone_from(&projects[index].host);
+                        self.recipe_project_edited = true;
                         self.services
                             .store
                             .store
                             .write()
                             .expect("session store lock poisoned")
                             .request_agent_catalog(projects[index].host.clone(), false);
-                        self.reconcile_harness();
+                        if self.active_recipe.is_none() {
+                            self.reconcile_harness();
+                        }
                         self.picker = None;
                         window.focus(&self.focus, cx);
                     }
                     ProjectCommit::ChooseFolder => {
                         self.choose_folder(window, cx);
                     }
+                }
+                return;
+            }
+            Some(Picker::Recipe) => {
+                let recipes = self.recipes();
+                if let Some(recipe) = recipes.get(self.highlight) {
+                    let id = recipe.id.clone();
+                    self.activate_recipe(&id, window, cx);
+                } else {
+                    self.save_current_recipe(cx);
                 }
                 return;
             }
@@ -843,6 +1411,11 @@ impl LauncherOverlay {
             Picker::Project => self.projects().iter().position(|project| {
                 project.project.root == self.selected_root && project.host == self.selected_host
             }),
+            Picker::Recipe => self.active_recipe.as_ref().and_then(|active| {
+                self.recipes()
+                    .iter()
+                    .position(|recipe| recipe.id == active.id)
+            }),
         }
         .unwrap_or(0);
         self.picker = Some(picker);
@@ -861,6 +1434,17 @@ impl LauncherOverlay {
         let count = choices.len() as isize;
         let next = (current as isize + delta).rem_euclid(count) as usize;
         self.selected_harness = choices[next].kind.clone();
+        self.fallback_notice = None;
+    }
+
+    fn toggle_worktree(&mut self) {
+        self.selected_worktree = match &self.selected_worktree {
+            WorktreePolicy::Fresh { .. } => WorktreePolicy::CurrentCheckout,
+            WorktreePolicy::CurrentCheckout if self.selected_host.is_none() => {
+                WorktreePolicy::Fresh { branch: None }
+            }
+            WorktreePolicy::CurrentCheckout => return,
+        };
         self.fallback_notice = None;
     }
 
@@ -916,13 +1500,16 @@ impl LauncherOverlay {
             let _ = this.update_in(cx, |this, window, cx| {
                 if apply_folder_choice(&mut this.selected_root, selected.as_deref()) {
                     this.selected_host = None;
+                    this.recipe_project_edited = true;
                     this.services
                         .store
                         .store
                         .write()
                         .expect("session store lock poisoned")
                         .request_agent_catalog(None, false);
-                    this.reconcile_harness();
+                    if this.active_recipe.is_none() {
+                        this.reconcile_harness();
+                    }
                 }
                 window.focus(&this.focus, cx);
                 cx.notify();
@@ -1034,6 +1621,7 @@ impl LauncherOverlay {
                     .flex()
                     .items_center()
                     .gap(px(9.0))
+                    .group("recipe-row")
                     .rounded(px(8.0))
                     .cursor_pointer()
                     .when(highlighted, |row| row.bg(colors.primary.alpha(0.08)))
@@ -1041,13 +1629,16 @@ impl LauncherOverlay {
                     .on_click(cx.listener(move |this, _, _, cx| {
                         this.selected_root.clone_from(&root);
                         this.selected_host.clone_from(&host);
+                        this.recipe_project_edited = true;
                         this.services
                             .store
                             .store
                             .write()
                             .expect("session store lock poisoned")
                             .request_agent_catalog(host.clone(), false);
-                        this.reconcile_harness();
+                        if this.active_recipe.is_none() {
+                            this.reconcile_harness();
+                        }
                         this.picker = None;
                         cx.notify();
                     }))
@@ -1113,6 +1704,440 @@ impl LauncherOverlay {
         FloatingSurface::new(colors, list).into_any_element()
     }
 
+    fn render_recipe_picker(&self, colors: SemanticColors, cx: &mut Context<Self>) -> AnyElement {
+        if let Some(editor) = &self.recipe_editor {
+            return self.render_recipe_editor(editor, colors, cx);
+        }
+        let recipes = self.recipes();
+        let mut list = div()
+            .id("launcher-recipe-list")
+            .py(px(6.0))
+            .w(px(430.0))
+            .max_h(px(320.0))
+            .overflow_y_scroll();
+
+        if recipes.is_empty() {
+            list = list.child(
+                div()
+                    .px(px(16.0))
+                    .py(px(18.0))
+                    .flex()
+                    .flex_col()
+                    .gap(px(4.0))
+                    .child(
+                        div()
+                            .text_size(px(12.0))
+                            .font_weight(FontWeight::MEDIUM)
+                            .text_color(colors.primary)
+                            .child("Make this task repeatable"),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(10.0))
+                            .line_height(px(14.0))
+                            .text_color(colors.secondary)
+                            .child("Recipes remember the Agent, project, destination, and prompt."),
+                    ),
+            );
+        }
+
+        for (index, recipe) in recipes.into_iter().enumerate() {
+            let id = recipe.id.clone();
+            let preview_id = id.clone();
+            let edit_id = id.clone();
+            let duplicate_id = id.clone();
+            let up_id = id.clone();
+            let down_id = id.clone();
+            let delete_id = id.clone();
+            let issue = self.resolve_recipe(&recipe).err();
+            let highlighted = self.highlight == index;
+            let active = self
+                .active_recipe
+                .as_ref()
+                .is_some_and(|active| active.id == recipe.id);
+            let metadata = format!(
+                "{}  ·  {}",
+                title_case_id(recipe.agent.id()),
+                recipe.project.display_path()
+            );
+            let status = issue.as_ref().map(RecipeIssue::message);
+            list = list.child(
+                div()
+                    .id(format!("launcher-recipe-{id}"))
+                    .mx(px(6.0))
+                    .min_h(px(54.0))
+                    .px(px(9.0))
+                    .py(px(6.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(9.0))
+                    .rounded(px(Radius::ROW))
+                    .role(Role::Button)
+                    .aria_label(format!("Launch recipe {}", recipe.name))
+                    .aria_description(
+                        "Enter launches, Space previews, E edits, Command-D duplicates, Command-Up or Command-Down reorders, Delete removes",
+                    )
+                    .cursor_pointer()
+                    .when(highlighted || active, |row| {
+                        row.bg(colors.primary.alpha(if active { 0.10 } else { 0.07 }))
+                    })
+                    .hover(move |row| row.bg(colors.primary.alpha(0.07)))
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        this.activate_recipe(&id, window, cx);
+                    }))
+                    .child(sf_symbol(
+                        if issue.is_some() {
+                            "exclamationmark.triangle"
+                        } else {
+                            "chevron.right"
+                        },
+                        11.0,
+                        if issue.is_some() {
+                            Ink::ATTENTION
+                        } else {
+                            Palette::CLAY
+                        },
+                    ))
+                    .child(
+                        div()
+                            .min_w(px(0.0))
+                            .flex_1()
+                            .flex()
+                            .flex_col()
+                            .gap(px(2.0))
+                            .child(
+                                div()
+                                    .whitespace_nowrap()
+                                    .overflow_hidden()
+                                    .text_ellipsis()
+                                    .text_size(px(12.0))
+                                    .font_weight(FontWeight::MEDIUM)
+                                    .text_color(colors.primary)
+                                    .child(recipe.name),
+                            )
+                            .child(
+                                div()
+                                    .whitespace_nowrap()
+                                    .overflow_hidden()
+                                    .text_ellipsis()
+                                    .text_size(px(9.0))
+                                    .text_color(if status.is_some() {
+                                        Ink::ATTENTION
+                                    } else {
+                                        colors.tertiary
+                                    })
+                                    .child(status.unwrap_or(metadata)),
+                            ),
+                    )
+                    .child(
+                        div()
+                            .flex_none()
+                            .flex()
+                            .items_center()
+                            .gap(px(2.0))
+                            .when(!(highlighted || active), |actions| {
+                                actions
+                                    .invisible()
+                                    .group_hover("recipe-row", |style| style.visible())
+                            })
+                            .child(recipe_action(
+                                format!("recipe-preview-{preview_id}"),
+                                "cursorarrow.rays",
+                                "Preview and override recipe",
+                                colors,
+                                cx.listener(move |this, _, _, cx| {
+                                    cx.stop_propagation();
+                                    if let Some(recipe) = this
+                                        .recipes()
+                                        .into_iter()
+                                        .find(|recipe| recipe.id == preview_id)
+                                    {
+                                        this.preview_recipe(&recipe);
+                                        this.fallback_notice = Some(
+                                            "Previewing — changes apply once unless you update the recipe"
+                                                .to_owned(),
+                                        );
+                                        this.picker = None;
+                                        cx.notify();
+                                    }
+                                }),
+                            ))
+                            .child(recipe_action(
+                                format!("recipe-edit-{edit_id}"),
+                                "gearshape",
+                                "Edit recipe details",
+                                colors,
+                                cx.listener(move |this, _, _, cx| {
+                                    cx.stop_propagation();
+                                    this.edit_recipe(&edit_id, cx);
+                                }),
+                            ))
+                            .child(recipe_action(
+                                format!("recipe-duplicate-{duplicate_id}"),
+                                "square.stack.3d.up",
+                                "Duplicate recipe",
+                                colors,
+                                cx.listener(move |this, _, _, cx| {
+                                    cx.stop_propagation();
+                                    this.duplicate_recipe(&duplicate_id, cx);
+                                }),
+                            ))
+                            .child(recipe_action(
+                                format!("recipe-up-{up_id}"),
+                                "chevron.up",
+                                "Move recipe up",
+                                colors,
+                                cx.listener(move |this, _, _, cx| {
+                                    cx.stop_propagation();
+                                    this.move_recipe(&up_id, -1, cx);
+                                }),
+                            ))
+                            .child(recipe_action(
+                                format!("recipe-down-{down_id}"),
+                                "chevron.down",
+                                "Move recipe down",
+                                colors,
+                                cx.listener(move |this, _, _, cx| {
+                                    cx.stop_propagation();
+                                    this.move_recipe(&down_id, 1, cx);
+                                }),
+                            ))
+                            .child(recipe_action(
+                                format!("recipe-delete-{delete_id}"),
+                                "trash",
+                                "Delete recipe",
+                                colors,
+                                cx.listener(move |this, _, _, cx| {
+                                    cx.stop_propagation();
+                                    this.request_recipe_delete(&delete_id, cx);
+                                }),
+                            )),
+                    ),
+            );
+        }
+
+        let update = self.active_recipe.is_some();
+        list = list.child(
+            div()
+                .id("launcher-save-recipe")
+                .mt(px(4.0))
+                .mx(px(6.0))
+                .pt(px(5.0))
+                .h(px(38.0))
+                .px(px(9.0))
+                .border_t_1()
+                .border_color(colors.primary.alpha(0.07))
+                .flex()
+                .items_center()
+                .gap(px(8.0))
+                .rounded(px(Radius::ROW))
+                .role(Role::Button)
+                .aria_label(if update {
+                    "Update active recipe"
+                } else {
+                    "Save current fields as a recipe"
+                })
+                .cursor_pointer()
+                .hover(move |row| row.bg(colors.primary.alpha(0.06)))
+                .on_click(cx.listener(|this, _, _, cx| {
+                    this.update_active_recipe(cx);
+                }))
+                .child(sf_symbol(
+                    if update {
+                        "arrow.triangle.2.circlepath"
+                    } else {
+                        "plus"
+                    },
+                    11.0,
+                    colors.secondary,
+                ))
+                .child(
+                    div()
+                        .text_size(px(11.0))
+                        .text_color(colors.secondary)
+                        .child(if update {
+                            "Update recipe with these fields"
+                        } else {
+                            "Save current fields as a recipe"
+                        }),
+                ),
+        );
+        FloatingSurface::new(colors, list).into_any_element()
+    }
+
+    fn render_recipe_editor(
+        &self,
+        editor: &RecipeMetadataEditor,
+        colors: SemanticColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let mut form = div()
+            .id("launcher-recipe-editor")
+            .w(px(430.0))
+            .p(px(12.0))
+            .flex()
+            .flex_col()
+            .gap(px(10.0))
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .justify_between()
+                    .child(
+                        div()
+                            .text_size(px(12.0))
+                            .font_weight(FontWeight::MEDIUM)
+                            .text_color(colors.primary)
+                            .child("Recipe details"),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(9.0))
+                            .text_color(colors.tertiary)
+                            .child("Tab fields · Return saves · Esc cancels"),
+                    ),
+            )
+            .child(self.recipe_text_field(
+                "Name",
+                "Review this PR",
+                editor,
+                RecipeMetadataField::Name,
+                colors,
+                cx,
+            ))
+            .child(
+                div()
+                    .flex()
+                    .gap(px(8.0))
+                    .child(div().min_w(px(0.0)).flex_1().child(self.recipe_text_field(
+                        "Session title",
+                        "Optional",
+                        editor,
+                        RecipeMetadataField::Title,
+                        colors,
+                        cx,
+                    )))
+                    .child(div().min_w(px(0.0)).flex_1().child(self.recipe_text_field(
+                        "Fresh branch",
+                        "Optional",
+                        editor,
+                        RecipeMetadataField::Branch,
+                        colors,
+                        cx,
+                    ))),
+            );
+        if let Some(error) = &editor.error {
+            form = form.child(
+                div()
+                    .text_size(px(10.0))
+                    .text_color(Ink::DANGER)
+                    .child(error.clone()),
+            );
+        }
+        form = form.child(
+            div()
+                .flex()
+                .items_center()
+                .justify_end()
+                .gap(px(7.0))
+                .child(
+                    div()
+                        .id("cancel-recipe-editor")
+                        .h(px(28.0))
+                        .px(px(9.0))
+                        .rounded(px(Radius::CHIP))
+                        .cursor_pointer()
+                        .text_size(px(10.0))
+                        .text_color(colors.secondary)
+                        .flex()
+                        .items_center()
+                        .hover(move |button| button.bg(colors.primary.alpha(0.07)))
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            this.recipe_editor = None;
+                            cx.notify();
+                        }))
+                        .child("Cancel"),
+                )
+                .child(
+                    div()
+                        .id("save-recipe-editor")
+                        .h(px(28.0))
+                        .px(px(10.0))
+                        .rounded(px(Radius::CHIP))
+                        .cursor_pointer()
+                        .bg(colors.primary)
+                        .text_size(px(10.0))
+                        .font_weight(FontWeight::MEDIUM)
+                        .text_color(colors.background)
+                        .flex()
+                        .items_center()
+                        .hover(move |button| button.opacity(0.86))
+                        .on_click(cx.listener(|this, _, _, cx| this.save_recipe_editor(cx)))
+                        .child("Save details"),
+                ),
+        );
+        FloatingSurface::new(colors, form).into_any_element()
+    }
+
+    fn recipe_text_field(
+        &self,
+        label: &'static str,
+        placeholder: &'static str,
+        editor: &RecipeMetadataEditor,
+        field: RecipeMetadataField,
+        colors: SemanticColors,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let active = editor.active_field == field;
+        let value = editor.field(field);
+        let content = if active {
+            crate::navigation::query_label(value)
+        } else if value.is_empty() {
+            div()
+                .text_color(colors.tertiary)
+                .child(placeholder)
+                .into_any_element()
+        } else {
+            div().child(value.text().to_owned()).into_any_element()
+        };
+        div()
+            .min_w(px(0.0))
+            .flex()
+            .flex_col()
+            .gap(px(4.0))
+            .child(
+                div()
+                    .text_size(px(9.0))
+                    .font_weight(FontWeight::MEDIUM)
+                    .text_color(colors.secondary)
+                    .child(label),
+            )
+            .child(
+                div()
+                    .id(format!("recipe-field-{field:?}"))
+                    .h(px(32.0))
+                    .px(px(9.0))
+                    .rounded(px(Radius::CHIP))
+                    .border_1()
+                    .border_color(colors.primary.alpha(if active { 0.28 } else { 0.10 }))
+                    .bg(colors.primary.alpha(if active { 0.07 } else { 0.035 }))
+                    .cursor_pointer()
+                    .flex()
+                    .items_center()
+                    .overflow_hidden()
+                    .text_size(px(10.0))
+                    .text_color(colors.primary)
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        if let Some(editor) = &mut this.recipe_editor {
+                            editor.active_field = field;
+                            editor.field_mut().set_cursor(usize::MAX, false);
+                        }
+                        cx.notify();
+                    }))
+                    .child(content),
+            )
+    }
+
     fn render_panel(
         &self,
         colors: SemanticColors,
@@ -1128,6 +2153,8 @@ impl LauncherOverlay {
         let can_submit = self.can_submit();
         let harness_open = self.picker == Some(Picker::Harness);
         let project_open = self.picker == Some(Picker::Project);
+        let recipe_open = self.picker == Some(Picker::Recipe);
+        let recipe_count = self.recipes().len();
         let text_height = composer_text_height(self.prompt.line_count());
         let composer_height = text_height + COMPOSER_CONTROLS_HEIGHT;
         // The pickers hang off the bottom of the panel, which now moves with
@@ -1136,6 +2163,8 @@ impl LauncherOverlay {
         let blocker = self.blocker();
         let harness_label = self.selected_harness_label();
         let project_label = self.selected_project_label();
+        let fresh_worktree = matches!(self.selected_worktree, WorktreePolicy::Fresh { .. });
+        let worktree_enabled = fresh_worktree || self.selected_host.is_none();
         let logo = ui_agent_kind(&self.selected_harness);
         let fills = launcher_surface_fills(colors);
 
@@ -1179,12 +2208,54 @@ impl LauncherOverlay {
         let panel = div()
             .relative()
             .w(px(PANEL_WIDTH))
+            .flex()
+            .flex_col()
             .child(
                 div()
+                    .relative()
                     .h(px(TITLE_HEIGHT))
                     .flex()
                     .items_center()
                     .justify_center()
+                    .child(
+                        div()
+                            .id("launcher-recipes-button")
+                            .absolute()
+                            .left(px(COMPOSER_INSET))
+                            .h(px(28.0))
+                            .px(px(9.0))
+                            .flex()
+                            .items_center()
+                            .gap(px(6.0))
+                            .rounded(px(CONTROL_RADIUS))
+                            .role(Role::Button)
+                            .aria_label("Open launch recipes")
+                            .aria_keyshortcuts("Meta+R")
+                            .cursor_pointer()
+                            .bg(if recipe_open {
+                                colors.primary.alpha(0.10)
+                            } else {
+                                colors.primary.alpha(0.0)
+                            })
+                            .hover(move |button| button.bg(colors.primary.alpha(0.07)))
+                            .active(move |button| button.bg(colors.primary.alpha(0.11)))
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.toggle_picker(Picker::Recipe);
+                                cx.notify();
+                            }))
+                            .child(sf_symbol("square.stack.3d.up", 10.0, Palette::CLAY))
+                            .child(
+                                div()
+                                    .text_size(px(10.0))
+                                    .font_weight(FontWeight::MEDIUM)
+                                    .text_color(colors.secondary)
+                                    .child(if recipe_count == 0 {
+                                        "Recipes".to_owned()
+                                    } else {
+                                        format!("Recipes  {recipe_count}")
+                                    }),
+                            ),
+                    )
                     .child(
                         div()
                             .text_size(px(22.0))
@@ -1396,23 +2467,90 @@ impl LauncherOverlay {
                     )
                     .child(
                         div()
-                            .id("launcher-new-project")
-                            .h(px(CONTROL_SIZE - 2.0))
-                            .px(px(8.0))
                             .flex()
                             .items_center()
-                            .gap(px(6.0))
-                            .rounded(px(CONTROL_RADIUS - 1.0))
-                            .cursor_pointer()
-                            .text_size(px(11.0))
-                            .text_color(colors.secondary)
-                            .hover(move |button| button.bg(colors.primary.alpha(0.08)))
-                            .active(move |button| button.bg(colors.primary.alpha(0.11)))
-                            .child(sf_symbol("plus", 9.0, colors.tertiary))
-                            .child("Choose folder…")
-                            .on_click(cx.listener(|this, _, window, cx| {
-                                this.choose_folder(window, cx);
-                            })),
+                            .gap(px(4.0))
+                            .child(
+                                div()
+                                    .id("launcher-details-button")
+                                    .size(px(CONTROL_SIZE - 2.0))
+                                    .flex()
+                                    .items_center()
+                                    .justify_center()
+                                    .rounded(px(CONTROL_RADIUS - 1.0))
+                                    .role(Role::Button)
+                                    .aria_label("Edit recipe name, session title, and branch")
+                                    .aria_keyshortcuts("Meta+Shift+R")
+                                    .cursor_pointer()
+                                    .hover(move |button| button.bg(colors.primary.alpha(0.08)))
+                                    .active(move |button| button.bg(colors.primary.alpha(0.11)))
+                                    .on_click(cx.listener(|this, _, _, cx| {
+                                        this.edit_launch_details(cx);
+                                    }))
+                                    .child(sf_symbol(
+                                        "gearshape",
+                                        10.0,
+                                        if self.selected_title.is_some()
+                                            || matches!(
+                                                self.selected_worktree,
+                                                WorktreePolicy::Fresh { branch: Some(_) }
+                                            )
+                                        {
+                                            Palette::CLAY
+                                        } else {
+                                            colors.tertiary
+                                        },
+                                    )),
+                            )
+                            .child(
+                                div()
+                                    .id("launcher-worktree-button")
+                                    .h(px(CONTROL_SIZE - 2.0))
+                                    .px(px(8.0))
+                                    .flex()
+                                    .items_center()
+                                    .gap(px(6.0))
+                                    .rounded(px(CONTROL_RADIUS - 1.0))
+                                    .text_size(px(10.0))
+                                    .text_color(if worktree_enabled {
+                                        colors.secondary
+                                    } else {
+                                        colors.tertiary
+                                    })
+                                    .bg(if fresh_worktree {
+                                        Palette::CLAY.alpha(0.12)
+                                    } else {
+                                        colors.primary.alpha(0.0)
+                                    })
+                                    .when(worktree_enabled, |button| {
+                                        button
+                                            .cursor_pointer()
+                                            .hover(move |button| {
+                                                button.bg(colors.primary.alpha(0.08))
+                                            })
+                                            .active(move |button| {
+                                                button.bg(colors.primary.alpha(0.11))
+                                            })
+                                            .on_click(cx.listener(|this, _, _, cx| {
+                                                this.toggle_worktree();
+                                                cx.notify();
+                                            }))
+                                    })
+                                    .child(sf_symbol(
+                                        "point.3.filled.connected.trianglepath.dotted",
+                                        10.0,
+                                        if fresh_worktree {
+                                            Palette::CLAY
+                                        } else {
+                                            colors.tertiary
+                                        },
+                                    ))
+                                    .child(if fresh_worktree {
+                                        "Fresh lane"
+                                    } else {
+                                        "Current"
+                                    }),
+                            ),
                     ),
             )
             .when(harness_open, |panel| {
@@ -1427,6 +2565,13 @@ impl LauncherOverlay {
                     self.floating(picker_top, cx)
                         .left(px(COMPOSER_INSET))
                         .child(self.render_project_picker(colors, cx)),
+                )
+            })
+            .when(recipe_open, |panel| {
+                panel.child(
+                    self.floating(picker_top, cx)
+                        .left(px(COMPOSER_INSET))
+                        .child(self.render_recipe_picker(colors, cx)),
                 )
             })
             .when_some(self.drop_notice.clone(), |panel, notice| {
@@ -1444,11 +2589,7 @@ impl LauncherOverlay {
                         .bg(Ink::ATTENTION.alpha(0.08))
                         .border_1()
                         .border_color(Ink::ATTENTION.alpha(0.20))
-                        .child(sf_symbol(
-                            "exclamationmark.circle.fill",
-                            11.0,
-                            Ink::ATTENTION,
-                        ))
+                        .child(sf_symbol("exclamationmark.triangle", 11.0, Ink::ATTENTION))
                         .child(
                             div()
                                 .flex_1()
@@ -2067,6 +3208,43 @@ fn initial_target(services: &AppServices) -> (AgentKind, String, Option<String>)
     )
 }
 
+fn text_editor(value: &str) -> QueryEditor {
+    let mut editor = QueryEditor::default();
+    editor.insert(value);
+    editor
+}
+
+fn nonempty(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_owned())
+}
+
+fn recipe_project_for_draft(
+    active: Option<&LaunchRecipe>,
+    project_edited: bool,
+    selected_root: &str,
+    selected_host: Option<&str>,
+    projects: &[LauncherProject],
+) -> RecipeProject {
+    if !project_edited && let Some(active) = active {
+        return active.project.clone();
+    }
+    projects
+        .iter()
+        .find(|project| {
+            project.project.root == selected_root && project.host.as_deref() == selected_host
+        })
+        .map_or_else(
+            || RecipeProject::Path {
+                path: selected_root.to_owned(),
+            },
+            |project| RecipeProject::Tracked {
+                id: project.project.id.clone(),
+                last_known_root: project.project.root.clone(),
+            },
+        )
+}
+
 fn transition_draft(
     current: &LauncherTarget,
     next: &LauncherTarget,
@@ -2132,13 +3310,53 @@ fn apply_folder_choice(selected_root: &mut String, chosen: Option<&Path>) -> boo
     true
 }
 
+fn recipe_action(
+    id: String,
+    system_image: &'static str,
+    label: &'static str,
+    colors: SemanticColors,
+    on_click: impl Fn(&gpui::ClickEvent, &mut Window, &mut App) + 'static,
+) -> AnyElement {
+    div()
+        .id(id)
+        .size(px(26.0))
+        .flex()
+        .items_center()
+        .justify_center()
+        .rounded(px(Radius::CHIP))
+        .role(Role::Button)
+        .aria_label(label)
+        .cursor_pointer()
+        .hover(move |button| button.bg(colors.primary.alpha(0.08)))
+        .active(move |button| button.bg(colors.primary.alpha(0.12)))
+        .on_click(on_click)
+        .child(sf_symbol(system_image, 9.0, colors.secondary))
+        .into_any_element()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::sidebar::{PreviewScenario, SidebarPreviewFixture};
     use crate::store::StoreRuntime;
     use crate::usage::UsageSnapshot;
-    use gpui::TestAppContext;
+    use gpui::{Keystroke, TestAppContext};
+
+    fn key(value: &str) -> KeyDownEvent {
+        let mut keystroke = Keystroke::parse(value).expect("valid test key");
+        if !keystroke.modifiers.platform
+            && !keystroke.modifiers.control
+            && !keystroke.modifiers.function
+            && keystroke.key.chars().count() == 1
+        {
+            keystroke.key_char = Some(keystroke.key.clone());
+        }
+        KeyDownEvent {
+            keystroke,
+            is_held: false,
+            prefer_character_input: false,
+        }
+    }
 
     #[test]
     fn manifest_ids_have_readable_fallback_labels() {
@@ -2175,6 +3393,201 @@ mod tests {
             assert!(!launcher.toggle(window, cx));
         });
         assert!(!launcher.read_with(cx, |launcher, _| launcher.is_open()));
+    }
+
+    #[gpui::test]
+    fn recipes_are_fully_manageable_from_the_keyboard(cx: &mut TestAppContext) {
+        let store = Arc::new(StoreRuntime::inert());
+        store
+            .store
+            .write()
+            .expect("store lock")
+            .update_preferences(|prefs| {
+                prefs
+                    .launch_recipes
+                    .add(LaunchRecipe::draft(
+                        "Review",
+                        AgentKind::CODEX,
+                        RecipeProject::Path {
+                            path: "/tmp".into(),
+                        },
+                        None,
+                        "Review this change",
+                    ))
+                    .expect("add recipe");
+            })
+            .expect("save fixture recipe");
+        let tokio = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime"),
+        );
+        let (usage_tx, _) = tokio::sync::watch::channel(UsageSnapshot::default());
+        let services = Arc::new(AppServices {
+            store: Arc::clone(&store),
+            usage_tx,
+            updates: crate::updates::inert(),
+            tokio,
+            dev_build: None,
+        });
+        let (launcher, cx) =
+            cx.add_window_view(move |_window, cx| LauncherOverlay::new(services, true, cx));
+
+        launcher.update_in(cx, |launcher, window, cx| {
+            launcher.open(window, cx);
+            assert!(launcher.handle_key_down(&key("cmd-shift-r"), window, cx));
+            assert!(
+                launcher
+                    .recipe_editor
+                    .as_ref()
+                    .is_some_and(|editor| editor.id.is_none())
+            );
+            assert!(launcher.handle_key_down(&key("tab"), window, cx));
+            assert!(launcher.handle_key_down(&key("l"), window, cx));
+            assert!(launcher.handle_key_down(&key("enter"), window, cx));
+            assert_eq!(launcher.selected_title.as_deref(), Some("l"));
+
+            assert!(launcher.handle_key_down(&key("cmd-r"), window, cx));
+            assert_eq!(launcher.picker, Some(Picker::Recipe));
+
+            assert!(launcher.handle_key_down(&key("space"), window, cx));
+            assert_eq!(
+                launcher
+                    .active_recipe
+                    .as_ref()
+                    .map(|recipe| recipe.name.as_str()),
+                Some("Review")
+            );
+
+            assert!(launcher.handle_key_down(&key("cmd-r"), window, cx));
+            assert!(launcher.handle_key_down(&key("e"), window, cx));
+            assert!(launcher.recipe_editor.is_some());
+            assert!(launcher.handle_key_down(&key("x"), window, cx));
+            assert!(launcher.handle_key_down(&key("tab"), window, cx));
+            assert!(launcher.handle_key_down(&key("tab"), window, cx));
+            assert!(launcher.handle_key_down(&key("enter"), window, cx));
+            assert!(launcher.recipe_editor.is_none());
+
+            assert!(launcher.handle_key_down(&key("cmd-d"), window, cx));
+            assert_eq!(launcher.recipes().len(), 2);
+            assert!(launcher.handle_key_down(&key("cmd-down"), window, cx));
+            assert_eq!(launcher.highlight, 1);
+            assert!(launcher.handle_key_down(&key("backspace"), window, cx));
+            assert!(launcher.pending_recipe_delete.is_some());
+            assert!(launcher.handle_key_down(&key("backspace"), window, cx));
+            assert_eq!(launcher.recipes().len(), 1);
+
+            // Enter is the one-action launch key. Preview mode intentionally
+            // unfolds the fields instead of spawning, which is observable as
+            // a selected active recipe and a closed picker.
+            launcher.highlight = 0;
+            assert!(launcher.handle_key_down(&key("enter"), window, cx));
+            assert!(launcher.active_recipe.is_some());
+            assert!(launcher.picker.is_none());
+        });
+    }
+
+    /// Writes a deterministic visual artifact for design review without live
+    /// user state or Screen Recording permission.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "writes the deterministic launch-recipes screenshot artifact"]
+    fn render_launch_recipes_preview_screenshot() {
+        use std::path::PathBuf;
+
+        let output = std::env::var_os("DIRI_VISUAL_OUTPUT")
+            .map(PathBuf::from)
+            .expect("set DIRI_VISUAL_OUTPUT to the target PNG path");
+        let platform = gpui_platform::current_platform(true);
+        let mut cx = gpui::HeadlessAppContext::with_platform(
+            platform.text_system(),
+            Arc::new(diri_ui::IconAssets),
+            gpui_platform::current_headless_renderer,
+        );
+        cx.update(|cx| crate::fonts::init(cx));
+
+        let runtime = Arc::new(StoreRuntime::inert());
+        {
+            let mut store = runtime.store.write().expect("store lock");
+            store.set_agent_catalog(diri_proto::AgentReadinessResult {
+                agents: vec![diri_proto::AgentReadinessItem {
+                    kind: AgentKind::CODEX,
+                    binary: "codex".into(),
+                    path: Some("/usr/local/bin/codex".into()),
+                    ..diri_proto::AgentReadinessItem::default()
+                }],
+                ..diri_proto::AgentReadinessResult::default()
+            });
+            store
+                .update_preferences(|prefs| {
+                    let mut fresh = LaunchRecipe::draft(
+                        "Review this PR",
+                        AgentKind::CODEX,
+                        RecipeProject::Path {
+                            path: "/tmp".into(),
+                        },
+                        None,
+                        "Review this branch for correctness and product quality",
+                    );
+                    fresh.title = Some("PR review".into());
+                    fresh.worktree = WorktreePolicy::Fresh {
+                        branch: Some("review/current".into()),
+                    };
+                    prefs.launch_recipes.add(fresh).expect("add fresh recipe");
+                    prefs
+                        .launch_recipes
+                        .add(LaunchRecipe::draft(
+                            "Fix failing tests remotely",
+                            AgentKind::CODEX,
+                            RecipeProject::Path {
+                                path: "~/diri".into(),
+                            },
+                            Some("missing-forge".into()),
+                            "Find the failure and ship the smallest robust fix",
+                        ))
+                        .expect("add stale recipe");
+                })
+                .expect("save fixture recipes");
+        }
+        let tokio = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime"),
+        );
+        let (usage_tx, _) = tokio::sync::watch::channel(UsageSnapshot::default());
+        let services = Arc::new(AppServices {
+            store: runtime,
+            usage_tx,
+            updates: crate::updates::inert(),
+            tokio,
+            dev_build: None,
+        });
+        let window = cx
+            .open_window(gpui::size(px(760.0), px(620.0)), move |window, cx| {
+                cx.new(|cx| {
+                    let mut launcher = LauncherOverlay::new(services, true, cx);
+                    launcher.open(window, cx);
+                    launcher
+                        .prompt
+                        .insert_multiline("Audit this change before merge");
+                    launcher.picker = Some(Picker::Recipe);
+                    launcher
+                })
+            })
+            .expect("open headless launcher window");
+        cx.run_until_parked();
+        cx.update_window(window.into(), |_, window, _| window.refresh())
+            .expect("refresh launcher window");
+        cx.run_until_parked();
+        let screenshot = cx
+            .capture_screenshot(window.into())
+            .expect("capture launcher screenshot");
+        if let Some(parent) = output.parent() {
+            std::fs::create_dir_all(parent).expect("create screenshot directory");
+        }
+        screenshot.save(output).expect("save launcher screenshot");
     }
 
     #[test]
@@ -2215,6 +3628,75 @@ mod tests {
         ));
         assert_eq!(selected, "/work/chosen");
         assert_eq!(prompt.text(), "keep this\nunfinished prompt");
+    }
+
+    #[test]
+    fn active_recipe_keeps_stable_project_identity_until_an_explicit_repair() {
+        let active = LaunchRecipe::draft(
+            "Missing project",
+            AgentKind::CODEX,
+            RecipeProject::Tracked {
+                id: diri_proto::ProjectId("gone".into()),
+                last_known_root: "/tmp".into(),
+            },
+            None,
+            "Repair me",
+        );
+        let replacement = LauncherProject {
+            project: Project {
+                id: diri_proto::ProjectId("replacement".into()),
+                root: "/tmp".into(),
+                name: "Replacement".into(),
+                pinned_order: None,
+                host: None,
+            },
+            host: None,
+        };
+
+        assert!(matches!(
+            recipe_project_for_draft(
+                Some(&active),
+                false,
+                "/tmp",
+                None,
+                std::slice::from_ref(&replacement),
+            ),
+            RecipeProject::Tracked { id, .. } if id.0 == "gone"
+        ));
+        assert!(matches!(
+            recipe_project_for_draft(Some(&active), true, "/tmp", None, &[replacement]),
+            RecipeProject::Tracked { id, .. } if id.0 == "replacement"
+        ));
+    }
+
+    #[test]
+    fn metadata_editor_preserves_recipe_until_explicit_save() {
+        let mut recipe = LaunchRecipe::draft(
+            "Review",
+            AgentKind::CODEX,
+            RecipeProject::Path {
+                path: "/tmp".into(),
+            },
+            None,
+            "Review this",
+        );
+        recipe.id = "recipe-1".into();
+        recipe.title = Some("Old title".into());
+        let serialized = serde_json::to_vec(&recipe).expect("serialize original");
+
+        let mut editor = RecipeMetadataEditor::saved(&recipe);
+        editor.name.select_all();
+        editor.name.insert("Updated review");
+        editor.title.select_all();
+        editor.title.insert("New title");
+
+        assert_eq!(
+            serde_json::to_vec(&recipe).expect("serialize after one-off editing"),
+            serialized,
+            "draft metadata cannot mutate the saved value"
+        );
+        assert_eq!(editor.name.text(), "Updated review");
+        assert_eq!(editor.title.text(), "New title");
     }
 
     #[test]

--- a/diri/crates/diri-app/src/launcher.rs
+++ b/diri/crates/diri-app/src/launcher.rs
@@ -151,6 +151,10 @@ pub(crate) struct LauncherOverlay {
     recipe_project_edited: bool,
     recipe_editor: Option<RecipeMetadataEditor>,
     pending_recipe_delete: Option<String>,
+    /// A recipe click made before its host catalog arrives is still one
+    /// launch action. Readiness changes retry this identity automatically;
+    /// closing the launcher or choosing another recipe cancels it.
+    pending_recipe_activation: Option<String>,
     fallback_notice: Option<String>,
     /// Finder drops may partially succeed. Keep their ignored-path detail
     /// inline with the staged draft until the user sends or replaces it; a
@@ -316,6 +320,7 @@ impl LauncherOverlay {
                     Ok(()) | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
                         if this
                             .update(cx, |this, cx| {
+                                this.resume_pending_recipe_activation(cx);
                                 if this.open
                                     && matches!(this.target, LauncherTarget::NewSession)
                                     && matches!(this.mode, LauncherMode::NewSession)
@@ -356,6 +361,7 @@ impl LauncherOverlay {
             recipe_project_edited: false,
             recipe_editor: None,
             pending_recipe_delete: None,
+            pending_recipe_activation: None,
             fallback_notice: None,
             drop_notice: None,
             picker: None,
@@ -535,6 +541,7 @@ impl LauncherOverlay {
         }
         self.open = false;
         self.picker = None;
+        self.pending_recipe_activation = None;
         self.restore_new_prompt();
         cx.emit(LauncherEvent::Closed);
         cx.notify();
@@ -814,21 +821,38 @@ impl LauncherOverlay {
     /// the ordinary launcher with its fields preserved and one specific repair
     /// message, so no missing dependency can silently retarget a run.
     fn activate_recipe(&mut self, id: &str, window: &mut Window, cx: &mut Context<Self>) {
+        // A second recipe choice supersedes a cold launch that was still
+        // waiting for readiness. There must never be two delayed launches.
+        self.pending_recipe_activation = None;
         let Some(recipe) = self.recipes().into_iter().find(|recipe| recipe.id == id) else {
             self.fallback_notice = Some("This recipe no longer exists".to_owned());
             return;
         };
         match self.resolve_recipe(&recipe) {
             Ok(resolved) if !self.preview => {
+                self.complete_recipe_activation(resolved, cx);
+            }
+            Err(RecipeIssue::AgentsLoading) if !self.preview => {
+                self.preview_recipe(&recipe);
+                self.pending_recipe_activation = Some(recipe.id.clone());
+                let force = self
+                    .services
+                    .store
+                    .store
+                    .read()
+                    .expect("session store lock poisoned")
+                    .agent_catalog_error(recipe.host.as_deref())
+                    .is_some();
+                self.fallback_notice = Some(RecipeIssue::AgentsLoading.message());
                 self.services
                     .store
                     .store
                     .write()
                     .expect("session store lock poisoned")
-                    .spawn_kind(resolved.kind, resolved.options);
-                self.new_session_draft.clear();
-                self.prompt.clear();
-                self.close(cx);
+                    .request_agent_catalog(recipe.host.clone(), force);
+                self.picker = None;
+                window.focus(&self.focus, cx);
+                cx.notify();
             }
             result => {
                 self.preview_recipe(&recipe);
@@ -849,7 +873,76 @@ impl LauncherOverlay {
         }
     }
 
+    fn complete_recipe_activation(
+        &mut self,
+        resolved: crate::launch_recipe::ResolvedRecipe,
+        cx: &mut Context<Self>,
+    ) {
+        self.pending_recipe_activation = None;
+        self.services
+            .store
+            .store
+            .write()
+            .expect("session store lock poisoned")
+            .spawn_kind(resolved.kind, resolved.options);
+        self.new_session_draft.clear();
+        self.prompt.clear();
+        self.close(cx);
+    }
+
+    /// Store readiness is asynchronous, but a recipe activation is not a
+    /// two-click interaction. Keep retrying the exact saved identity until its
+    /// catalog arrives, then launch it through the canonical resolver. Any
+    /// terminal repair state leaves the populated launcher open.
+    fn resume_pending_recipe_activation(&mut self, cx: &mut Context<Self>) {
+        let Some(id) = self.pending_recipe_activation.clone() else {
+            return;
+        };
+        let Some(recipe) = self.recipes().into_iter().find(|recipe| recipe.id == id) else {
+            self.pending_recipe_activation = None;
+            self.fallback_notice = Some("This recipe no longer exists".to_owned());
+            return;
+        };
+        match self.resolve_recipe(&recipe) {
+            Ok(resolved) if !self.preview => self.complete_recipe_activation(resolved, cx),
+            Err(RecipeIssue::AgentsLoading) => {
+                let (error, still_loading) = {
+                    let store = self
+                        .services
+                        .store
+                        .store
+                        .read()
+                        .expect("session store lock poisoned");
+                    (
+                        store
+                            .agent_catalog_error(recipe.host.as_deref())
+                            .map(str::to_owned),
+                        store.agent_catalog_is_loading(recipe.host.as_deref()),
+                    )
+                };
+                if let Some(error) = error
+                    && !still_loading
+                {
+                    self.pending_recipe_activation = None;
+                    self.fallback_notice = Some(format!(
+                        "Could not check Agents on this host: {error}. Choose the recipe again to retry."
+                    ));
+                }
+            }
+            Err(issue) => {
+                self.pending_recipe_activation = None;
+                self.fallback_notice = Some(issue.message());
+            }
+            Ok(_) => {
+                // Preview launchers never enqueue activations, but avoid
+                // retaining stale state if a test or future caller does.
+                self.pending_recipe_activation = None;
+            }
+        }
+    }
+
     fn preview_recipe(&mut self, recipe: &LaunchRecipe) {
+        self.pending_recipe_activation = None;
         self.selected_harness.clone_from(&recipe.agent);
         self.selected_host.clone_from(&recipe.host);
         self.selected_worktree.clone_from(&recipe.worktree);
@@ -897,6 +990,19 @@ impl LauncherOverlay {
         })
     }
 
+    /// Rebind callers to the book's normalized value, never to the input
+    /// draft. The book owns trimming and length limits, so keeping the draft
+    /// object would make the active baseline disagree with durable prefs.
+    fn replace_recipe(&self, id: &str, recipe: LaunchRecipe) -> Result<LaunchRecipe, String> {
+        let mut persisted = None;
+        self.update_recipe_book(|book| {
+            book.replace(id, recipe)?;
+            persisted = book.get(id).cloned();
+            Ok(())
+        })?;
+        persisted.ok_or_else(|| "updated recipe disappeared".to_owned())
+    }
+
     fn save_current_recipe(&mut self, cx: &mut Context<Self>) {
         if self.prompt.text().trim().is_empty() || self.selected_root.is_empty() {
             self.fallback_notice = Some("Add a task and project before saving a recipe".to_owned());
@@ -920,7 +1026,10 @@ impl LauncherOverlay {
         });
         if result.is_ok() {
             self.active_recipe = saved;
-            self.draft_recipe_name = Some(name.clone());
+            self.draft_recipe_name = self
+                .active_recipe
+                .as_ref()
+                .map(|recipe| recipe.name.clone());
             self.recipe_project_edited = false;
         }
         self.fallback_notice = Some(match result {
@@ -938,22 +1047,20 @@ impl LauncherOverlay {
         };
         let id = active.id;
         let name = self.draft_recipe_name.clone().unwrap_or(active.name);
-        let mut recipe = self.current_recipe(name.clone());
+        let recipe = self.current_recipe(name.clone());
         if let Err(issue) = self.validate_recipe(&recipe) {
             self.fallback_notice = Some(issue.message());
             cx.notify();
             return;
         }
-        let stored = recipe.clone();
-        let result = self.update_recipe_book(|book| book.replace(&id, recipe));
-        if result.is_ok() {
-            recipe = stored;
-            recipe.id = id;
-            self.active_recipe = Some(recipe);
+        let result = self.replace_recipe(&id, recipe);
+        if let Ok(persisted) = &result {
+            self.draft_recipe_name = Some(persisted.name.clone());
+            self.active_recipe = Some(persisted.clone());
             self.recipe_project_edited = false;
         }
         self.fallback_notice = Some(match result {
-            Ok(()) => format!("Updated “{name}”"),
+            Ok(persisted) => format!("Updated “{}”", persisted.name),
             Err(error) => format!("Could not update recipe: {error}"),
         });
         cx.notify();
@@ -991,6 +1098,7 @@ impl LauncherOverlay {
     }
 
     fn edit_recipe(&mut self, id: &str, cx: &mut Context<Self>) {
+        self.pending_recipe_activation = None;
         let Some(recipe) = self.recipes().into_iter().find(|recipe| recipe.id == id) else {
             self.fallback_notice = Some("This recipe no longer exists".to_owned());
             cx.notify();
@@ -1002,6 +1110,7 @@ impl LauncherOverlay {
     }
 
     fn edit_launch_details(&mut self, cx: &mut Context<Self>) {
+        self.pending_recipe_activation = None;
         let name = self
             .draft_recipe_name
             .clone()
@@ -1063,6 +1172,12 @@ impl LauncherOverlay {
             cx.notify();
             return;
         };
+        let preserve_live_name_override = self
+            .active_recipe
+            .as_ref()
+            .filter(|active| active.id == id)
+            .zip(self.draft_recipe_name.as_ref())
+            .is_some_and(|(active, draft)| draft != &active.name);
         recipe.name = name.to_owned();
         recipe.title = nonempty(editor.title.text());
         if let WorktreePolicy::Fresh { branch } = &mut recipe.worktree {
@@ -1079,9 +1194,8 @@ impl LauncherOverlay {
             cx.notify();
             return;
         }
-        let updated = recipe.clone();
-        match self.update_recipe_book(|book| book.replace(&id, recipe)) {
-            Ok(()) => {
+        match self.replace_recipe(&id, recipe) {
+            Ok(persisted) => {
                 if self
                     .active_recipe
                     .as_ref()
@@ -1090,11 +1204,13 @@ impl LauncherOverlay {
                     // This editor mutates the saved baseline only. The live
                     // launcher may contain one-off prompt, Agent, project,
                     // title, or worktree overrides and must not be reloaded.
-                    self.active_recipe = Some(updated.clone());
-                    self.draft_recipe_name = Some(updated.name.clone());
+                    if !preserve_live_name_override {
+                        self.draft_recipe_name = Some(persisted.name.clone());
+                    }
+                    self.active_recipe = Some(persisted.clone());
                 }
                 self.recipe_editor = None;
-                self.fallback_notice = Some(format!("Updated “{}”", updated.name));
+                self.fallback_notice = Some(format!("Updated “{}”", persisted.name));
             }
             Err(error) => {
                 if let Some(editor) = &mut self.recipe_editor {
@@ -1508,6 +1624,7 @@ impl LauncherOverlay {
         match self.picker {
             Some(Picker::Harness) => {
                 if let Some(choice) = self.harness_choices().get(self.highlight) {
+                    self.pending_recipe_activation = None;
                     self.selected_harness = choice.kind.clone();
                     self.fallback_notice = None;
                 }
@@ -1516,6 +1633,7 @@ impl LauncherOverlay {
                 let projects = self.projects();
                 match project_commit(projects.len(), self.highlight) {
                     ProjectCommit::Recent(index) => {
+                        self.pending_recipe_activation = None;
                         self.selected_root.clone_from(&projects[index].project.root);
                         self.selected_host.clone_from(&projects[index].host);
                         self.recipe_project_edited = true;
@@ -1591,11 +1709,13 @@ impl LauncherOverlay {
             .unwrap_or(0);
         let count = choices.len() as isize;
         let next = (current as isize + delta).rem_euclid(count) as usize;
+        self.pending_recipe_activation = None;
         self.selected_harness = choices[next].kind.clone();
         self.fallback_notice = None;
     }
 
     fn toggle_worktree(&mut self) {
+        self.pending_recipe_activation = None;
         self.selected_worktree = match &self.selected_worktree {
             WorktreePolicy::Fresh { .. } => WorktreePolicy::CurrentCheckout,
             WorktreePolicy::CurrentCheckout if self.selected_host.is_none() => {
@@ -1612,16 +1732,19 @@ impl LauncherOverlay {
         };
         match edit {
             Edit::Local(local) => {
+                self.pending_recipe_activation = None;
                 self.prompt.apply(local);
             }
             Edit::Clipboard(ClipboardEdit::Copy) => {
                 query_editor::copy_selection(self.prompt.editor(), cx);
             }
             Edit::Clipboard(ClipboardEdit::Cut) => {
+                self.pending_recipe_activation = None;
                 query_editor::cut_selection(self.prompt.editor_mut(), cx);
             }
             Edit::Clipboard(ClipboardEdit::Paste) => {
                 if let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) {
+                    self.pending_recipe_activation = None;
                     self.prompt.insert_multiline(&text);
                 }
             }
@@ -1657,6 +1780,7 @@ impl LauncherOverlay {
             };
             let _ = this.update_in(cx, |this, window, cx| {
                 if apply_folder_choice(&mut this.selected_root, selected.as_deref()) {
+                    this.pending_recipe_activation = None;
                     this.selected_host = None;
                     this.recipe_project_edited = true;
                     this.services
@@ -1704,6 +1828,7 @@ impl LauncherOverlay {
                     .cursor_pointer()
                     .hover(move |row| row.bg(colors.primary.alpha(0.06)))
                     .on_click(cx.listener(move |this, _, _, cx| {
+                        this.pending_recipe_activation = None;
                         this.selected_harness = kind.clone();
                         this.fallback_notice = None;
                         this.picker = None;
@@ -1786,6 +1911,7 @@ impl LauncherOverlay {
                     .when(highlighted, |row| row.bg(colors.primary.alpha(0.08)))
                     .hover(move |row| row.bg(colors.primary.alpha(0.06)))
                     .on_click(cx.listener(move |this, _, _, cx| {
+                        this.pending_recipe_activation = None;
                         this.selected_root.clone_from(&root);
                         this.selected_host.clone_from(&host);
                         this.recipe_project_edited = true;
@@ -3790,6 +3916,128 @@ mod tests {
             let active = launcher.active_recipe.as_ref().expect("active baseline");
             assert_eq!(active.name, "Renamed baseline");
             assert_eq!(active.title.as_deref(), Some("Stored title"));
+        });
+    }
+
+    #[gpui::test]
+    fn metadata_rename_preserves_a_live_name_override_and_rebinds_the_normalized_baseline(
+        cx: &mut TestAppContext,
+    ) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        let stored = {
+            let mut store = runtime.store.write().expect("store lock");
+            store
+                .update_preferences(|prefs| {
+                    prefs
+                        .launch_recipes
+                        .add(LaunchRecipe::draft(
+                            "Review",
+                            AgentKind::CODEX,
+                            RecipeProject::Path {
+                                path: "/tmp".into(),
+                            },
+                            None,
+                            "Stored prompt",
+                        ))
+                        .expect("add recipe");
+                })
+                .expect("save fixture");
+            store.preferences().launch_recipes.items()[0].clone()
+        };
+        let services = test_services(Arc::clone(&runtime));
+        let (launcher, _cx) =
+            cx.add_window_view(move |_window, cx| LauncherOverlay::new(services, true, cx));
+
+        launcher.update(cx, |launcher, cx| {
+            launcher.preview_recipe(&stored);
+            launcher.draft_recipe_name = Some("One-off display name".into());
+            launcher.edit_recipe(&stored.id, cx);
+            let editor = launcher.recipe_editor.as_mut().expect("editor");
+            editor.name.select_all();
+            editor.name.insert(&"N".repeat(100));
+            launcher.save_recipe_editor(cx);
+
+            let persisted = launcher.recipes().into_iter().next().expect("recipe");
+            let active = launcher.active_recipe.as_ref().expect("active baseline");
+            assert_eq!(active, &persisted);
+            assert_eq!(active.name.chars().count(), 80);
+            assert_eq!(
+                launcher.draft_recipe_name.as_deref(),
+                Some("One-off display name")
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn cold_remote_recipe_launches_when_readiness_arrives_without_a_second_action(
+        cx: &mut TestAppContext,
+    ) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        let stored = {
+            let mut store = runtime.store.write().expect("store lock");
+            store.set_hosts(vec![diri_proto::HostEntry {
+                id: "forge".into(),
+                name: Some("Build Forge".into()),
+                ssh: "forge".into(),
+                default_cwd: None,
+                node: None,
+            }]);
+            store
+                .update_preferences(|prefs| {
+                    prefs
+                        .launch_recipes
+                        .add(LaunchRecipe::draft(
+                            "Remote review",
+                            AgentKind::CODEX,
+                            RecipeProject::Path {
+                                path: "~/diri".into(),
+                            },
+                            Some("forge".into()),
+                            "Review the change",
+                        ))
+                        .expect("add recipe");
+                })
+                .expect("save fixture");
+            store.preferences().launch_recipes.items()[0].clone()
+        };
+        let services = test_services(Arc::clone(&runtime));
+        let (launcher, cx) =
+            cx.add_window_view(move |_window, cx| LauncherOverlay::new(services, false, cx));
+
+        launcher.update_in(cx, |launcher, window, cx| {
+            launcher.open(window, cx);
+            launcher.activate_recipe(&stored.id, window, cx);
+            assert!(launcher.open, "the launcher stays visible while checking");
+            assert_eq!(
+                launcher.pending_recipe_activation.as_deref(),
+                Some(stored.id.as_str())
+            );
+        });
+
+        runtime
+            .store
+            .write()
+            .expect("store lock")
+            .set_agent_catalog(diri_proto::AgentReadinessResult {
+                host: Some("forge".into()),
+                agents: vec![diri_proto::AgentReadinessItem {
+                    kind: AgentKind::CODEX,
+                    binary: "codex".into(),
+                    path: Some("/usr/bin/codex".into()),
+                    ..diri_proto::AgentReadinessItem::default()
+                }],
+                ..diri_proto::AgentReadinessResult::default()
+            });
+        runtime.publish_local_change();
+        cx.run_until_parked();
+
+        launcher.read_with(cx, |launcher, _| {
+            assert!(
+                !launcher.open,
+                "readiness must complete the original activation"
+            );
+            assert!(launcher.pending_recipe_activation.is_none());
+            assert!(launcher.prompt.is_empty());
         });
     }
 

--- a/diri/crates/diri-app/src/launcher.rs
+++ b/diri/crates/diri-app/src/launcher.rs
@@ -12,8 +12,8 @@ use diri_ui::{
 };
 use gpui::{
     AnyElement, App, Context, EventEmitter, FocusHandle, Focusable, FontWeight, HighlightStyle,
-    KeyDownEvent, MouseButton, PathPromptOptions, Render, Role, Task, Window, div, prelude::*, px,
-    rgba,
+    KeyDownEvent, MouseButton, PathPromptOptions, Render, Role, ScrollHandle, Task, Window, div,
+    prelude::*, px, rgba,
 };
 
 use crate::AppServices;
@@ -36,6 +36,11 @@ const CONTROL_SIZE: f32 = 32.0;
 const CONTROL_RADIUS: f32 = 9.0;
 const SHELF_HEIGHT: f32 = 40.0;
 const PICKER_HEIGHT: f32 = 200.0;
+const RECIPE_PICKER_MIN_HEIGHT: f32 = 156.0;
+const RECIPE_PICKER_MAX_HEIGHT: f32 = 320.0;
+const RECIPE_PICKER_GAP: f32 = 8.0;
+const PANEL_EDGE_INSET: f32 = 12.0;
+const RECIPE_ROW_GROUP: &str = "recipe-row";
 
 /// Composer metrics. The text area is sized from the wrapped line count
 /// rather than pinned at one height: a one-line prompt should not sit in a
@@ -55,6 +60,29 @@ const COMPOSER_CONTROLS_HEIGHT: f32 = 44.0;
 /// The width text actually wraps at, derived from the panel so the two cannot
 /// drift apart: the panel, less the composer's margin, padding and border.
 const COMPOSER_TEXT_WIDTH: f32 = PANEL_WIDTH - 2.0 * COMPOSER_INSET - 2.0 * COMPOSER_PADDING - 2.0;
+
+fn recipe_picker_height(viewport_height: f32, composer_height: f32) -> f32 {
+    let base_height = TITLE_HEIGHT + TITLE_GAP + composer_height + SHELF_HEIGHT;
+    (viewport_height - base_height - RECIPE_PICKER_GAP - 2.0 * PANEL_EDGE_INSET)
+        .clamp(RECIPE_PICKER_MIN_HEIGHT, RECIPE_PICKER_MAX_HEIGHT)
+}
+
+fn recipe_surface_height(recipe_count: usize, editor_open: bool, budget: f32) -> f32 {
+    if editor_open {
+        budget.min(206.0)
+    } else {
+        let desired = ((recipe_count as f32 * 54.0) + 54.0).max(128.0);
+        if desired <= budget {
+            desired
+        } else {
+            // Rows are 54pt. Quantizing the crowded viewport keeps both edges
+            // intentional instead of exposing a chopped half-row after
+            // keyboard navigation scrolls to the end.
+            let visible_rows = ((budget - 12.0) / 54.0).floor().max(2.0);
+            12.0 + visible_rows * 54.0
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct LauncherSurfaceFills {
@@ -132,6 +160,7 @@ pub(crate) struct LauncherOverlay {
     /// so both are reachable without the mouse.
     picker: Option<Picker>,
     highlight: usize,
+    recipe_scroll: ScrollHandle,
     open: bool,
     preview: bool,
     _store_changes: Task<()>,
@@ -331,6 +360,7 @@ impl LauncherOverlay {
             drop_notice: None,
             picker: None,
             highlight: 0,
+            recipe_scroll: ScrollHandle::new(),
             open: false,
             preview,
             _store_changes: store_changes,
@@ -632,6 +662,84 @@ impl LauncherOverlay {
             .to_vec()
     }
 
+    /// Opening the library warms every distinct valid destination in one pass.
+    /// A remote recipe should not need a sacrificial first click merely to
+    /// discover whether its Agent is installed.
+    fn warm_recipe_catalogs(&self) {
+        let targets = self
+            .recipes()
+            .into_iter()
+            .map(|recipe| recipe.host)
+            .collect::<HashSet<_>>();
+        let mut store = self
+            .services
+            .store
+            .store
+            .write()
+            .expect("session store lock poisoned");
+        let targets = targets
+            .into_iter()
+            .filter(|target| {
+                target.is_none()
+                    || target
+                        .as_deref()
+                        .is_some_and(|host| store.host(host).is_some())
+            })
+            .filter(|target| store.agent_catalog(target.as_deref()).is_none())
+            .collect::<Vec<_>>();
+        for target in targets {
+            store.request_agent_catalog(target, false);
+        }
+    }
+
+    fn host_label(&self, host: Option<&str>) -> String {
+        match host {
+            None => "This Mac".to_owned(),
+            Some(host) => self
+                .services
+                .store
+                .store
+                .read()
+                .expect("session store lock poisoned")
+                .host_display_name(host),
+        }
+    }
+
+    fn recipe_render_facts(&self, recipes: &[LaunchRecipe]) -> Vec<(Option<RecipeIssue>, String)> {
+        let store = self
+            .services
+            .store
+            .store
+            .read()
+            .expect("session store lock poisoned");
+        recipes
+            .iter()
+            .map(|recipe| {
+                let issue = recipe
+                    .validate(
+                        store.projects(),
+                        store.hosts(),
+                        store.agent_catalog(recipe.host.as_deref()),
+                        |project| {
+                            project.host.clone().or_else(|| {
+                                store
+                                    .sessions()
+                                    .values()
+                                    .find(|session| session.project_id == project.id)
+                                    .and_then(|session| session.host.clone())
+                            })
+                        },
+                    )
+                    .err();
+                let destination = recipe.host.as_deref().map_or_else(
+                    || "This Mac".to_owned(),
+                    |host| store.host_display_name(host),
+                );
+                (issue, destination)
+            })
+            .collect()
+    }
+
     fn current_recipe(&self, name: String) -> LaunchRecipe {
         let projects = self.projects();
         let project = recipe_project_for_draft(
@@ -664,6 +772,29 @@ impl LauncherOverlay {
             .read()
             .expect("session store lock poisoned");
         recipe.resolve(
+            store.projects(),
+            store.hosts(),
+            store.agent_catalog(recipe.host.as_deref()),
+            |project| {
+                project.host.clone().or_else(|| {
+                    store
+                        .sessions()
+                        .values()
+                        .find(|session| session.project_id == project.id)
+                        .and_then(|session| session.host.clone())
+                })
+            },
+        )
+    }
+
+    fn validate_recipe(&self, recipe: &LaunchRecipe) -> Result<(), RecipeIssue> {
+        let store = self
+            .services
+            .store
+            .store
+            .read()
+            .expect("session store lock poisoned");
+        recipe.validate(
             store.projects(),
             store.hosts(),
             store.agent_catalog(recipe.host.as_deref()),
@@ -777,12 +908,21 @@ impl LauncherOverlay {
             .clone()
             .unwrap_or_else(|| suggested_recipe_name(self.prompt.text()));
         let recipe = self.current_recipe(name.clone());
-        if let Err(issue) = self.resolve_recipe(&recipe) {
+        if let Err(issue) = self.validate_recipe(&recipe) {
             self.fallback_notice = Some(issue.message());
             cx.notify();
             return;
         }
-        let result = self.update_recipe_book(|book| book.add(recipe).map(|_| ()));
+        let mut saved = None;
+        let result = self.update_recipe_book(|book| {
+            saved = Some(book.add(recipe)?.clone());
+            Ok(())
+        });
+        if result.is_ok() {
+            self.active_recipe = saved;
+            self.draft_recipe_name = Some(name.clone());
+            self.recipe_project_edited = false;
+        }
         self.fallback_notice = Some(match result {
             Ok(()) => format!("Saved “{name}” — it is now a one-click recipe"),
             Err(error) => format!("Could not save recipe: {error}"),
@@ -799,7 +939,7 @@ impl LauncherOverlay {
         let id = active.id;
         let name = self.draft_recipe_name.clone().unwrap_or(active.name);
         let mut recipe = self.current_recipe(name.clone());
-        if let Err(issue) = self.resolve_recipe(&recipe) {
+        if let Err(issue) = self.validate_recipe(&recipe) {
             self.fallback_notice = Some(issue.message());
             cx.notify();
             return;
@@ -821,13 +961,14 @@ impl LauncherOverlay {
 
     fn remove_recipe(&mut self, id: &str, cx: &mut Context<Self>) {
         let result = self.update_recipe_book(|book| book.remove(id).map(|_| ()));
-        if self.active_recipe.as_ref().map(|recipe| recipe.id.as_str()) == Some(id) {
+        if delete_clears_active_recipe(result.is_ok(), self.active_recipe.as_ref(), id) {
             self.active_recipe = None;
             self.recipe_project_edited = false;
         }
-        if let Err(error) = result {
-            self.fallback_notice = Some(format!("Could not delete recipe: {error}"));
-        }
+        self.fallback_notice = Some(match result {
+            Ok(()) => "Recipe deleted".to_owned(),
+            Err(error) => format!("Could not delete recipe: {error}"),
+        });
         let count = self.recipes().len().saturating_add(1);
         self.highlight = self.highlight.min(count.saturating_sub(1));
         cx.notify();
@@ -946,7 +1087,11 @@ impl LauncherOverlay {
                     .as_ref()
                     .is_some_and(|active| active.id == id)
                 {
-                    self.preview_recipe(&updated);
+                    // This editor mutates the saved baseline only. The live
+                    // launcher may contain one-off prompt, Agent, project,
+                    // title, or worktree overrides and must not be reloaded.
+                    self.active_recipe = Some(updated.clone());
+                    self.draft_recipe_name = Some(updated.name.clone());
                 }
                 self.recipe_editor = None;
                 self.fallback_notice = Some(format!("Updated “{}”", updated.name));
@@ -1024,7 +1169,8 @@ impl LauncherOverlay {
     }
 
     fn selected_project_label(&self) -> String {
-        self.projects()
+        let project = self
+            .projects()
             .into_iter()
             .find(|project| {
                 project.project.root == self.selected_root && project.host == self.selected_host
@@ -1037,7 +1183,11 @@ impl LauncherOverlay {
                     .map(str::to_owned)
             })
             .filter(|name| !name.is_empty())
-            .unwrap_or_else(|| "Choose project".to_owned())
+            .unwrap_or_else(|| "Choose project".to_owned());
+        format!(
+            "{project} · {}",
+            self.host_label(self.selected_host.as_deref())
+        )
     }
 
     /// Why the prompt cannot be sent yet, as something to show the user.
@@ -1077,7 +1227,7 @@ impl LauncherOverlay {
                 .then(|| "Local paths cannot be used on a remote session".to_owned());
         }
         let recipe = self.current_recipe("New Agent".to_owned());
-        match self.resolve_recipe(&recipe) {
+        match self.validate_recipe(&recipe) {
             Ok(_) => None,
             Err(RecipeIssue::AgentsLoading) => {
                 let scan_error = self
@@ -1314,6 +1464,7 @@ impl LauncherOverlay {
                         self.highlight = (self.highlight as isize + delta)
                             .clamp(0, recipes.len().saturating_sub(1) as isize)
                             as usize;
+                        self.recipe_scroll.scroll_to_item(self.highlight);
                     }
                     return true;
                 }
@@ -1338,6 +1489,9 @@ impl LauncherOverlay {
                 } else {
                     (self.highlight + 1).min(count - 1)
                 };
+                if self.picker == Some(Picker::Recipe) {
+                    self.recipe_scroll.scroll_to_item(self.highlight);
+                }
                 cx.notify();
                 true
             }
@@ -1402,6 +1556,10 @@ impl LauncherOverlay {
         if self.picker == Some(picker) {
             self.picker = None;
             return;
+        }
+        if picker == Picker::Recipe {
+            self.warm_recipe_catalogs();
+            self.recipe_scroll = ScrollHandle::new();
         }
         self.highlight = match picker {
             Picker::Harness => self
@@ -1611,6 +1769,8 @@ impl LauncherOverlay {
             let highlighted = self.highlight == index;
             let root = project.project.root.clone();
             let host = project.host.clone();
+            let destination = self.host_label(host.as_deref());
+            let project_detail = format!("{}  ·  {destination}", project.project.root);
             list = list.child(
                 div()
                     .id(format!("launcher-project-{index}"))
@@ -1621,7 +1781,6 @@ impl LauncherOverlay {
                     .flex()
                     .items_center()
                     .gap(px(9.0))
-                    .group("recipe-row")
                     .rounded(px(8.0))
                     .cursor_pointer()
                     .when(highlighted, |row| row.bg(colors.primary.alpha(0.08)))
@@ -1662,7 +1821,7 @@ impl LauncherOverlay {
                                     .text_color(colors.tertiary)
                                     .whitespace_nowrap()
                                     .overflow_hidden()
-                                    .child(project.project.root),
+                                    .child(project_detail),
                             ),
                     )
                     .when(selected, |row| {
@@ -1704,17 +1863,30 @@ impl LauncherOverlay {
         FloatingSurface::new(colors, list).into_any_element()
     }
 
-    fn render_recipe_picker(&self, colors: SemanticColors, cx: &mut Context<Self>) -> AnyElement {
+    fn render_recipe_picker(
+        &self,
+        max_height: f32,
+        colors: SemanticColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
         if let Some(editor) = &self.recipe_editor {
-            return self.render_recipe_editor(editor, colors, cx);
+            return div()
+                .id("launcher-recipe-editor-scroll")
+                .h(px(max_height))
+                .overflow_y_scroll()
+                .child(self.render_recipe_editor(editor, colors, cx))
+                .into_any_element();
         }
         let recipes = self.recipes();
+        let facts = self.recipe_render_facts(&recipes);
         let mut list = div()
             .id("launcher-recipe-list")
+            .debug_selector(|| "launcher-recipe-list".into())
             .py(px(6.0))
-            .w(px(430.0))
-            .max_h(px(320.0))
-            .overflow_y_scroll();
+            .w(px(PANEL_WIDTH - 2.0 * COMPOSER_INSET))
+            .h(px(max_height))
+            .overflow_y_scroll()
+            .track_scroll(&self.recipe_scroll);
 
         if recipes.is_empty() {
             list = list.child(
@@ -1741,7 +1913,7 @@ impl LauncherOverlay {
             );
         }
 
-        for (index, recipe) in recipes.into_iter().enumerate() {
+        for (index, (recipe, (issue, destination))) in recipes.into_iter().zip(facts).enumerate() {
             let id = recipe.id.clone();
             let preview_id = id.clone();
             let edit_id = id.clone();
@@ -1749,21 +1921,25 @@ impl LauncherOverlay {
             let up_id = id.clone();
             let down_id = id.clone();
             let delete_id = id.clone();
-            let issue = self.resolve_recipe(&recipe).err();
             let highlighted = self.highlight == index;
             let active = self
                 .active_recipe
                 .as_ref()
                 .is_some_and(|active| active.id == recipe.id);
             let metadata = format!(
-                "{}  ·  {}",
+                "{}  ·  {}  ·  {}",
                 title_case_id(recipe.agent.id()),
+                destination,
                 recipe.project.display_path()
             );
             let status = issue.as_ref().map(RecipeIssue::message);
             list = list.child(
                 div()
                     .id(format!("launcher-recipe-{id}"))
+                    .debug_selector({
+                        let id = id.clone();
+                        move || format!("launcher-recipe-{id}")
+                    })
                     .mx(px(6.0))
                     .min_h(px(54.0))
                     .px(px(9.0))
@@ -1771,6 +1947,7 @@ impl LauncherOverlay {
                     .flex()
                     .items_center()
                     .gap(px(9.0))
+                    .group(RECIPE_ROW_GROUP)
                     .rounded(px(Radius::ROW))
                     .role(Role::Button)
                     .aria_label(format!("Launch recipe {}", recipe.name))
@@ -1838,7 +2015,7 @@ impl LauncherOverlay {
                             .when(!(highlighted || active), |actions| {
                                 actions
                                     .invisible()
-                                    .group_hover("recipe-row", |style| style.visible())
+                                    .group_hover(RECIPE_ROW_GROUP, |style| style.visible())
                             })
                             .child(recipe_action(
                                 format!("recipe-preview-{preview_id}"),
@@ -1973,7 +2150,7 @@ impl LauncherOverlay {
     ) -> AnyElement {
         let mut form = div()
             .id("launcher-recipe-editor")
-            .w(px(430.0))
+            .w(px(PANEL_WIDTH - 2.0 * COMPOSER_INSET))
             .p(px(12.0))
             .flex()
             .flex_col()
@@ -2018,8 +2195,8 @@ impl LauncherOverlay {
                         cx,
                     )))
                     .child(div().min_w(px(0.0)).flex_1().child(self.recipe_text_field(
-                        "Fresh branch",
-                        "Optional",
+                        "Branch prefix",
+                        "Optional · unique suffix added",
                         editor,
                         RecipeMetadataField::Branch,
                         colors,
@@ -2140,6 +2317,7 @@ impl LauncherOverlay {
 
     fn render_panel(
         &self,
+        viewport_height: f32,
         colors: SemanticColors,
         focused: bool,
         cx: &mut Context<Self>,
@@ -2157,6 +2335,12 @@ impl LauncherOverlay {
         let recipe_count = self.recipes().len();
         let text_height = composer_text_height(self.prompt.line_count());
         let composer_height = text_height + COMPOSER_CONTROLS_HEIGHT;
+        let recipe_picker_budget = recipe_picker_height(viewport_height, composer_height);
+        let recipe_picker_height = recipe_surface_height(
+            recipe_count,
+            self.recipe_editor.is_some(),
+            recipe_picker_budget,
+        );
         // The pickers hang off the bottom of the panel, which now moves with
         // the composer.
         let picker_top = TITLE_HEIGHT + TITLE_GAP + composer_height + SHELF_HEIGHT + 8.0;
@@ -2220,6 +2404,7 @@ impl LauncherOverlay {
                     .child(
                         div()
                             .id("launcher-recipes-button")
+                            .debug_selector(|| "launcher-recipes-button".into())
                             .absolute()
                             .left(px(COMPOSER_INSET))
                             .h(px(28.0))
@@ -2569,9 +2754,17 @@ impl LauncherOverlay {
             })
             .when(recipe_open, |panel| {
                 panel.child(
-                    self.floating(picker_top, cx)
-                        .left(px(COMPOSER_INSET))
-                        .child(self.render_recipe_picker(colors, cx)),
+                    div()
+                        .mt(px(RECIPE_PICKER_GAP))
+                        .ml(px(COMPOSER_INSET))
+                        .w(px(PANEL_WIDTH - 2.0 * COMPOSER_INSET))
+                        .h(px(recipe_picker_height))
+                        .overflow_hidden()
+                        .on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(|_, _, _, cx| cx.stop_propagation()),
+                        )
+                        .child(self.render_recipe_picker(recipe_picker_height, colors, cx)),
                 )
             })
             .when_some(self.drop_notice.clone(), |panel, notice| {
@@ -3168,7 +3361,7 @@ impl Render for LauncherOverlay {
             )
             // Command-N is a high-frequency keyboard action; the destination
             // appears immediately rather than making the user wait on motion.
-            .child(self.render_panel(colors, focused, cx))
+            .child(self.render_panel(window.viewport_size().height.as_f32(), colors, focused, cx))
     }
 }
 
@@ -3217,6 +3410,14 @@ fn text_editor(value: &str) -> QueryEditor {
 fn nonempty(value: &str) -> Option<String> {
     let value = value.trim();
     (!value.is_empty()).then(|| value.to_owned())
+}
+
+fn delete_clears_active_recipe(
+    persisted: bool,
+    active: Option<&LaunchRecipe>,
+    deleted_id: &str,
+) -> bool {
+    persisted && active.is_some_and(|recipe| recipe.id == deleted_id)
 }
 
 fn recipe_project_for_draft(
@@ -3317,8 +3518,10 @@ fn recipe_action(
     colors: SemanticColors,
     on_click: impl Fn(&gpui::ClickEvent, &mut Window, &mut App) + 'static,
 ) -> AnyElement {
+    let debug_id = id.clone();
     div()
         .id(id)
+        .debug_selector(move || debug_id)
         .size(px(26.0))
         .flex()
         .items_center()
@@ -3340,7 +3543,24 @@ mod tests {
     use crate::sidebar::{PreviewScenario, SidebarPreviewFixture};
     use crate::store::StoreRuntime;
     use crate::usage::UsageSnapshot;
-    use gpui::{Keystroke, TestAppContext};
+    use gpui::{Keystroke, Modifiers, TestAppContext};
+
+    fn test_services(store: Arc<StoreRuntime>) -> Arc<AppServices> {
+        let tokio = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime"),
+        );
+        let (usage_tx, _) = tokio::sync::watch::channel(UsageSnapshot::default());
+        Arc::new(AppServices {
+            store,
+            usage_tx,
+            updates: crate::updates::inert(),
+            tokio,
+            dev_build: None,
+        })
+    }
 
     fn key(value: &str) -> KeyDownEvent {
         let mut keystroke = Keystroke::parse(value).expect("valid test key");
@@ -3488,6 +3708,255 @@ mod tests {
         });
     }
 
+    #[gpui::test]
+    fn saving_a_recipe_binds_the_current_draft_to_its_allocated_identity(cx: &mut TestAppContext) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        runtime
+            .store
+            .write()
+            .expect("store lock")
+            .set_agent_catalog(diri_proto::AgentReadinessResult {
+                agents: vec![diri_proto::AgentReadinessItem {
+                    kind: AgentKind::CODEX,
+                    binary: "codex".into(),
+                    path: Some("/usr/bin/codex".into()),
+                    ..diri_proto::AgentReadinessItem::default()
+                }],
+                ..diri_proto::AgentReadinessResult::default()
+            });
+        let services = test_services(Arc::clone(&runtime));
+        let (launcher, _cx) =
+            cx.add_window_view(move |_window, cx| LauncherOverlay::new(services, true, cx));
+
+        launcher.update(cx, |launcher, cx| {
+            launcher.selected_harness = AgentKind::CODEX;
+            launcher.selected_root = "/tmp".into();
+            launcher.prompt.insert_multiline("Review this change");
+            launcher.save_current_recipe(cx);
+            let active = launcher.active_recipe.as_ref().expect("bound saved recipe");
+            assert!(!active.id.is_empty());
+            assert_eq!(launcher.recipes().len(), 1);
+            assert_eq!(launcher.recipes()[0].id, active.id);
+        });
+    }
+
+    #[gpui::test]
+    fn saved_metadata_edits_preserve_live_one_off_overrides(cx: &mut TestAppContext) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        let stored = {
+            let mut store = runtime.store.write().expect("store lock");
+            store
+                .update_preferences(|prefs| {
+                    prefs
+                        .launch_recipes
+                        .add(LaunchRecipe::draft(
+                            "Review",
+                            AgentKind::CODEX,
+                            RecipeProject::Path {
+                                path: "/tmp".into(),
+                            },
+                            None,
+                            "Stored prompt",
+                        ))
+                        .expect("add recipe");
+                })
+                .expect("save fixture");
+            store.preferences().launch_recipes.items()[0].clone()
+        };
+        let services = test_services(Arc::clone(&runtime));
+        let (launcher, _cx) =
+            cx.add_window_view(move |_window, cx| LauncherOverlay::new(services, true, cx));
+
+        launcher.update(cx, |launcher, cx| {
+            launcher.preview_recipe(&stored);
+            launcher.prompt.clear();
+            launcher.prompt.insert_multiline("One-off prompt");
+            launcher.selected_root = "/private/tmp".into();
+            launcher.recipe_project_edited = true;
+            launcher.selected_harness = AgentKind::SHELL;
+            launcher.selected_title = Some("One-off title".into());
+            launcher.edit_recipe(&stored.id, cx);
+            let editor = launcher.recipe_editor.as_mut().expect("editor");
+            editor.name.select_all();
+            editor.name.insert("Renamed baseline");
+            editor.title.select_all();
+            editor.title.insert("Stored title");
+            launcher.save_recipe_editor(cx);
+
+            assert_eq!(launcher.prompt.text(), "One-off prompt");
+            assert_eq!(launcher.selected_root, "/private/tmp");
+            assert_eq!(launcher.selected_harness, AgentKind::SHELL);
+            assert_eq!(launcher.selected_title.as_deref(), Some("One-off title"));
+            let active = launcher.active_recipe.as_ref().expect("active baseline");
+            assert_eq!(active.name, "Renamed baseline");
+            assert_eq!(active.title.as_deref(), Some("Stored title"));
+        });
+    }
+
+    #[gpui::test]
+    fn opening_recipes_warms_each_valid_destination_and_names_the_host(cx: &mut TestAppContext) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        {
+            let mut store = runtime.store.write().expect("store lock");
+            store.set_hosts(vec![diri_proto::HostEntry {
+                id: "forge".into(),
+                name: Some("Build Forge".into()),
+                ssh: "forge".into(),
+                default_cwd: None,
+                node: None,
+            }]);
+            store
+                .update_preferences(|prefs| {
+                    for name in ["Remote review", "Remote tests"] {
+                        prefs
+                            .launch_recipes
+                            .add(LaunchRecipe::draft(
+                                name,
+                                AgentKind::CODEX,
+                                RecipeProject::Path {
+                                    path: "~/diri".into(),
+                                },
+                                Some("forge".into()),
+                                "Run",
+                            ))
+                            .expect("add recipe");
+                    }
+                })
+                .expect("save recipes");
+        }
+        let services = test_services(Arc::clone(&runtime));
+        let (launcher, _cx) =
+            cx.add_window_view(move |_window, cx| LauncherOverlay::new(services, true, cx));
+        launcher.update(cx, |launcher, _| {
+            launcher.selected_root = "~/diri".into();
+            launcher.selected_host = Some("forge".into());
+            launcher.toggle_picker(Picker::Recipe);
+            assert_eq!(launcher.host_label(Some("forge")), "Build Forge");
+            assert_eq!(launcher.selected_project_label(), "diri · Build Forge");
+        });
+        assert!(
+            runtime
+                .store
+                .read()
+                .expect("store lock")
+                .agent_catalog_is_loading(Some("forge")),
+            "opening the picker must start readiness before a row is clicked"
+        );
+    }
+
+    #[test]
+    fn failed_delete_keeps_the_active_recipe_identity() {
+        let mut recipe = LaunchRecipe::draft(
+            "Review",
+            AgentKind::CODEX,
+            RecipeProject::Path {
+                path: "/tmp".into(),
+            },
+            None,
+            "Run",
+        );
+        recipe.id = "recipe-1".into();
+        assert!(!delete_clears_active_recipe(
+            false,
+            Some(&recipe),
+            "recipe-1"
+        ));
+        assert!(delete_clears_active_recipe(true, Some(&recipe), "recipe-1"));
+    }
+
+    #[test]
+    fn recipe_picker_budget_fits_the_minimum_window_even_with_a_tall_composer() {
+        for lines in [COMPOSER_MIN_LINES, COMPOSER_MAX_LINES] {
+            let composer = composer_text_height(lines) + COMPOSER_CONTROLS_HEIGHT;
+            let picker = recipe_picker_height(560.0, composer);
+            let total =
+                TITLE_HEIGHT + TITLE_GAP + composer + SHELF_HEIGHT + RECIPE_PICKER_GAP + picker;
+            assert!(total <= 560.0 - 2.0 * PANEL_EDGE_INSET + 0.01);
+            assert!(picker >= RECIPE_PICKER_MIN_HEIGHT);
+        }
+    }
+
+    #[gpui::test]
+    fn crowded_recipe_picker_stays_in_view_scrolls_with_keys_and_reveals_hover_actions(
+        cx: &mut TestAppContext,
+    ) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        {
+            let mut store = runtime.store.write().expect("store lock");
+            store.set_agent_catalog(diri_proto::AgentReadinessResult {
+                agents: vec![diri_proto::AgentReadinessItem {
+                    kind: AgentKind::CODEX,
+                    binary: "codex".into(),
+                    path: Some("/usr/bin/codex".into()),
+                    ..diri_proto::AgentReadinessItem::default()
+                }],
+                ..diri_proto::AgentReadinessResult::default()
+            });
+            store
+                .update_preferences(|prefs| {
+                    for index in 1..=8 {
+                        prefs
+                            .launch_recipes
+                            .add(LaunchRecipe::draft(
+                                format!("Recipe {index}"),
+                                AgentKind::CODEX,
+                                RecipeProject::Path {
+                                    path: "/tmp".into(),
+                                },
+                                None,
+                                "Run",
+                            ))
+                            .expect("add recipe");
+                    }
+                })
+                .expect("save recipes");
+        }
+        let services = test_services(runtime);
+        let (launcher, cx) =
+            cx.add_window_view(move |_window, cx| LauncherOverlay::new(services, true, cx));
+        launcher.update_in(cx, |launcher, window, cx| {
+            launcher.open(window, cx);
+            launcher.selected_harness = AgentKind::CODEX;
+            launcher.selected_root = "/tmp".into();
+            launcher.toggle_picker(Picker::Recipe);
+            cx.notify();
+        });
+        cx.simulate_resize(gpui::size(px(760.0), px(560.0)));
+
+        assert!(
+            cx.debug_bounds("launcher-recipes-button").is_some(),
+            "open launcher renders"
+        );
+        let list = cx
+            .debug_bounds("launcher-recipe-list")
+            .expect("recipe viewport");
+        assert!(list.top() >= px(0.0));
+        assert!(list.bottom() <= px(560.0));
+
+        let second = cx
+            .debug_bounds("launcher-recipe-recipe-2")
+            .expect("second recipe");
+        cx.simulate_mouse_move(second.center(), None, Modifiers::default());
+        assert!(
+            cx.debug_bounds("recipe-edit-recipe-2").is_some(),
+            "hovering an ordinary row must reveal its management controls"
+        );
+
+        launcher.update_in(cx, |launcher, window, cx| {
+            for _ in 0..7 {
+                assert!(launcher.handle_key_down(&key("down"), window, cx));
+            }
+        });
+        let list = cx
+            .debug_bounds("launcher-recipe-list")
+            .expect("recipe viewport after navigation");
+        let last = cx
+            .debug_bounds("launcher-recipe-recipe-8")
+            .expect("keyboard-selected last recipe");
+        assert!(last.top() >= list.top());
+        assert!(last.bottom() <= list.bottom());
+    }
+
     /// Writes a deterministic visual artifact for design review without live
     /// user state or Screen Recording permission.
     #[cfg(target_os = "macos")]
@@ -3508,6 +3977,14 @@ mod tests {
         cx.update(|cx| crate::fonts::init(cx));
 
         let runtime = Arc::new(StoreRuntime::inert());
+        let repository_root = std::env::current_dir()
+            .expect("fixture repository")
+            .ancestors()
+            .find(|path| path.join(".git").exists())
+            .expect("fixture runs inside a repository")
+            .to_string_lossy()
+            .into_owned();
+        assert!(Path::new(&repository_root).is_dir(), "fixture root exists");
         {
             let mut store = runtime.store.write().expect("store lock");
             store.set_agent_catalog(diri_proto::AgentReadinessResult {
@@ -3525,7 +4002,7 @@ mod tests {
                         "Review this PR",
                         AgentKind::CODEX,
                         RecipeProject::Path {
-                            path: "/tmp".into(),
+                            path: repository_root.clone(),
                         },
                         None,
                         "Review this branch for correctness and product quality",
@@ -3547,6 +4024,36 @@ mod tests {
                             "Find the failure and ship the smallest robust fix",
                         ))
                         .expect("add stale recipe");
+                    for (name, prompt) in [
+                        ("Audit terminal latency", "Profile input-to-paint latency"),
+                        (
+                            "Review accessibility",
+                            "Audit keyboard and screen reader flows",
+                        ),
+                        ("Triage release blockers", "Find and rank release blockers"),
+                        (
+                            "Polish onboarding",
+                            "Make the first-run path feel inevitable",
+                        ),
+                        (
+                            "Harden persistence",
+                            "Stress-test durable state transitions",
+                        ),
+                        ("Prepare changelog", "Draft a concise human changelog"),
+                    ] {
+                        prefs
+                            .launch_recipes
+                            .add(LaunchRecipe::draft(
+                                name,
+                                AgentKind::CODEX,
+                                RecipeProject::Path {
+                                    path: repository_root.clone(),
+                                },
+                                None,
+                                prompt,
+                            ))
+                            .expect("add crowded fixture recipe");
+                    }
                 })
                 .expect("save fixture recipes");
         }
@@ -3565,20 +4072,28 @@ mod tests {
             dev_build: None,
         });
         let window = cx
-            .open_window(gpui::size(px(760.0), px(620.0)), move |window, cx| {
+            .open_window(gpui::size(px(760.0), px(560.0)), move |window, cx| {
                 cx.new(|cx| {
                     let mut launcher = LauncherOverlay::new(services, true, cx);
                     launcher.open(window, cx);
                     launcher
                         .prompt
                         .insert_multiline("Audit this change before merge");
+                    launcher.selected_root.clone_from(&repository_root);
+                    launcher.selected_harness = AgentKind::CODEX;
                     launcher.picker = Some(Picker::Recipe);
+                    launcher.highlight = 7;
+                    launcher.recipe_scroll.scroll_to_item(7);
                     launcher
                 })
             })
             .expect("open headless launcher window");
         cx.run_until_parked();
-        cx.update_window(window.into(), |_, window, _| window.refresh())
+        window
+            .update(&mut cx, |launcher, window, _| {
+                launcher.recipe_scroll.scroll_to_item(7);
+                window.refresh();
+            })
             .expect("refresh launcher window");
         cx.run_until_parked();
         let screenshot = cx

--- a/diri/crates/diri-app/src/main.rs
+++ b/diri/crates/diri-app/src/main.rs
@@ -18,6 +18,7 @@ mod git_review;
 pub mod history;
 mod icons;
 mod inspector;
+mod launch_recipe;
 mod launcher;
 pub mod markdown;
 mod markdown_view;

--- a/diri/crates/diri-app/src/store/mod.rs
+++ b/diri/crates/diri-app/src/store/mod.rs
@@ -835,10 +835,18 @@ impl SessionStore {
     }
 
     pub fn update_preferences(&mut self, update: impl FnOnce(&mut Prefs)) -> io::Result<()> {
-        update(&mut self.prefs);
-        self.prefs.normalize();
+        // Preference edits are a tiny transaction: the UI must never observe
+        // a mutation which failed to reach disk and will disappear on restart.
+        // This matters especially for recipe management, where an optimistic
+        // “Saved” row would otherwise be a lie.
+        let mut next = self.prefs.clone();
+        update(&mut next);
+        next.normalize();
+        if let Some(path) = self.prefs_path.as_deref() {
+            next.save(path)?;
+        }
+        self.prefs = next;
         self.invalidate_projection();
-        self.persist_preferences()?;
         if matches!(self.daemon_state, DaemonState::Connected) {
             self.emit(StoreEffect::ConfigureGovernor(self.governor_settings()));
         }

--- a/diri/crates/diri-app/src/store/prefs.rs
+++ b/diri/crates/diri-app/src/store/prefs.rs
@@ -6,6 +6,8 @@ use diri_proto::paths::DirijorPaths;
 use diri_proto::{AgentKind, ProjectId, SessionId};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::launch_recipe::{LaunchRecipeBook, deserialize_recipe_book};
+
 const DEFAULT_THEME: &str = "dirijor-dark";
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
@@ -117,6 +119,9 @@ pub struct Prefs {
     /// Sessions whose spawned children are folded away.
     pub sidebar_collapsed_sessions: Vec<SessionId>,
     pub sidebar_expanded_archives: Vec<ProjectId>,
+    /// Versioned, locally owned one-action Agent workflows.
+    #[serde(default, deserialize_with = "deserialize_recipe_book")]
+    pub launch_recipes: LaunchRecipeBook,
     /// Session that should regain focus after the daemon's initial hydrate.
     pub last_selected_session: Option<SessionId>,
 }
@@ -150,6 +155,7 @@ impl Default for Prefs {
             sidebar_collapsed_projects: Vec::new(),
             sidebar_collapsed_sessions: Vec::new(),
             sidebar_expanded_archives: Vec::new(),
+            launch_recipes: LaunchRecipeBook::default(),
             last_selected_session: None,
         }
     }
@@ -242,5 +248,60 @@ impl Prefs {
         if self.terminal_theme.is_empty() {
             self.terminal_theme = DEFAULT_THEME.to_owned();
         }
+        self.launch_recipes.normalize();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::launch_recipe::{LaunchRecipe, RecipeProject};
+
+    #[test]
+    fn older_preferences_migrate_to_an_empty_recipe_book() {
+        let mut value = serde_json::to_value(Prefs::default()).expect("serialize prefs");
+        value
+            .as_object_mut()
+            .expect("prefs object")
+            .remove("launchRecipes");
+        let prefs: Prefs = serde_json::from_value(value).expect("old preferences remain readable");
+        assert!(prefs.launch_recipes.items().is_empty());
+    }
+
+    #[test]
+    fn malformed_recipe_data_does_not_discard_other_preferences() {
+        let mut value = serde_json::to_value(Prefs {
+            status_sounds: false,
+            ..Prefs::default()
+        })
+        .expect("serialize prefs");
+        value["launchRecipes"] = serde_json::json!({"version": 1, "items": "broken"});
+        let prefs: Prefs =
+            serde_json::from_value(value).expect("malformed recipe field is isolated");
+        assert!(!prefs.status_sounds);
+        assert!(prefs.launch_recipes.items().is_empty());
+    }
+
+    #[test]
+    fn recipe_book_round_trips_through_preferences() {
+        let mut prefs = Prefs::default();
+        prefs
+            .launch_recipes
+            .add(LaunchRecipe::draft(
+                "Review",
+                AgentKind::CODEX,
+                RecipeProject::Path {
+                    path: "/tmp".into(),
+                },
+                None,
+                "Review this branch",
+            ))
+            .expect("add recipe");
+        let json = serde_json::to_vec(&prefs).expect("serialize prefs");
+        let restored: Prefs = serde_json::from_slice(&json).expect("deserialize prefs");
+        assert_eq!(
+            restored.launch_recipes.items(),
+            prefs.launch_recipes.items()
+        );
     }
 }

--- a/diri/crates/diri-app/src/store/tests.rs
+++ b/diri/crates/diri-app/src/store/tests.rs
@@ -1324,6 +1324,30 @@ fn unknown_saved_default_repairs_to_available_first_class_then_shell() {
 }
 
 #[test]
+fn failed_preference_write_does_not_publish_an_ephemeral_mutation() {
+    let tmp = tempfile::tempdir().expect("temporary directory");
+    let blocked_parent = tmp.path().join("not-a-directory");
+    let path = blocked_parent.join("preferences.json");
+    let (mut store, _) = SessionStore::load(path).expect("missing preference file loads defaults");
+    std::fs::write(&blocked_parent, b"file").expect("create blocking file");
+    let before = store.preferences().clone();
+
+    let error = store
+        .update_preferences(|prefs| prefs.status_sounds = !prefs.status_sounds)
+        .expect_err("write through a file parent must fail");
+
+    assert!(matches!(
+        error.kind(),
+        std::io::ErrorKind::AlreadyExists | std::io::ErrorKind::NotADirectory
+    ));
+    assert_eq!(
+        store.preferences(),
+        &before,
+        "failed persistence must leave the visible settings unchanged"
+    );
+}
+
+#[test]
 fn a_configure_issued_during_an_inflight_scan_still_reaches_the_engine() {
     let (mut store, mut effects) = SessionStore::headless(Prefs::default());
     store.request_agent_catalog(Some("forge".into()), false);


### PR DESCRIPTION
## Summary

- add saved one-click launch recipes with stable project, host, agent, prompt, title, and worktree intent
- surface explicit repair states for moved projects, missing paths, unavailable agents, and remote incompatibilities
- generate collision-free reusable worktree branches and resume cold remote recipes after agent readiness
- provide keyboard management, adaptive scrolling, host transparency, transactional save and delete, rename, duplicate, and reorder flows

## Verification

- full diri-app suite: 442 passed, 3 ignored
- strict all-target Clippy
- deterministic remote-readiness, repair, branch collision, persistence, keyboard, and 560px crowded-layout tests
- formatting and diff checks clean