### PR TITLE
app: add read-only sidebar session peeks

### DIFF
--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -283,6 +283,13 @@ impl RootView {
                     launcher.update(cx, |launcher, cx| launcher.focus(window, cx));
                 });
             }
+            if let SidebarEvent::PeekChanged(id) = event
+                && let Some(terminal) = &this.terminal
+            {
+                terminal.update(cx, |terminal, cx| {
+                    terminal.set_peeked_session(id.clone(), cx);
+                });
+            }
             if matches!(event, SidebarEvent::SessionActivated) {
                 if this.launcher.read(cx).is_open() {
                     this.launcher
@@ -954,10 +961,36 @@ impl RootView {
             cx.stop_propagation();
             return;
         }
+        let sidebar_focused = self.sidebar.read(cx).is_focused(window);
+        if !sidebar_focused && self.sidebar.read(cx).has_peek_in_flight() {
+            match event.keystroke.key.as_str() {
+                "escape" => {
+                    self.sidebar.update(cx, |sidebar, cx| {
+                        sidebar.cancel_peek(cx);
+                    });
+                    cx.stop_propagation();
+                    return;
+                }
+                "enter" if self.sidebar.read(cx).is_peeking() => {
+                    self.sidebar.update(cx, |sidebar, cx| {
+                        sidebar.commit_peek(cx);
+                    });
+                    cx.stop_propagation();
+                    return;
+                }
+                _ if self.sidebar.read(cx).is_peeking() => {
+                    // Pointer peeks preserve the original terminal focus, but
+                    // the borrowed presentation is strictly read-only.
+                    cx.stop_propagation();
+                    return;
+                }
+                _ => {}
+            }
+        }
         // The sidebar is a real keyboard surface. Let its bubble handler own
         // navigation and rename input instead of mirroring the same keystroke
         // into the live terminal during root capture.
-        if self.sidebar.read(cx).is_focused(window) {
+        if sidebar_focused {
             return;
         }
         if self.launcher.read(cx).is_open() {
@@ -1420,6 +1453,20 @@ impl RootView {
     }
 
     fn on_key_up(&mut self, event: &KeyUpEvent, window: &mut Window, cx: &mut Context<Self>) {
+        let sidebar_focused = self.sidebar.read(cx).is_focused(window);
+        if !sidebar_focused && event.keystroke.key.as_str() == "space" {
+            let released = self
+                .sidebar
+                .update(cx, |sidebar, cx| sidebar.release_keyboard_peek(cx));
+            if released {
+                cx.stop_propagation();
+                return;
+            }
+        }
+        if !sidebar_focused && self.sidebar.read(cx).is_peeking() {
+            cx.stop_propagation();
+            return;
+        }
         if let Some(surfaces) = &self.session_surfaces {
             surfaces.update(cx, |surfaces, cx| {
                 surfaces.handle_key_up(event, window, cx);
@@ -1433,6 +1480,10 @@ impl RootView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if !self.sidebar.read(cx).is_focused(window) && self.sidebar.read(cx).is_peeking() {
+            cx.stop_propagation();
+            return;
+        }
         if let Some(surfaces) = &self.session_surfaces {
             surfaces.update(cx, |surfaces, cx| {
                 surfaces.handle_modifiers_changed(event, window, cx);

--- a/diri/crates/diri-app/src/sidebar/mod.rs
+++ b/diri/crates/diri-app/src/sidebar/mod.rs
@@ -5,7 +5,9 @@ mod state;
 mod view;
 
 pub use fixture::{PreviewScenario, SidebarPreviewFixture};
-pub use state::{CursorMove, DragItem, Popover, SidebarUiState, move_before, move_to_end};
+pub use state::{
+    CursorMove, DragItem, PeekSource, Popover, SidebarUiState, move_before, move_to_end,
+};
 pub(crate) use view::DraggedSidebarItem;
 pub use view::Sidebar;
 pub(crate) use view::SidebarEvent;

--- a/diri/crates/diri-app/src/sidebar/state.rs
+++ b/diri/crates/diri-app/src/sidebar/state.rs
@@ -16,6 +16,113 @@ pub enum CursorMove {
     End,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PeekSource {
+    Pointer,
+    Keyboard,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SessionPeek {
+    pub id: SessionId,
+    pub source: PeekSource,
+}
+
+/// Owns the transient session-preview state machine.
+///
+/// Its interface deliberately knows nothing about `SessionStore`: callers can
+/// borrow and restore presentation without accidentally selecting, waking, or
+/// acknowledging a session. Gesture bookkeeping lives here as well so a
+/// pointer release cannot later masquerade as a click or drop.
+#[derive(Debug, Default)]
+pub struct PeekState {
+    active: Option<SessionPeek>,
+    space_held: bool,
+    suppress_pointer_click: bool,
+    suppress_pointer_drop: bool,
+}
+
+impl PeekState {
+    pub fn active(&self) -> Option<&SessionPeek> {
+        self.active.as_ref()
+    }
+
+    pub fn target(&self) -> Option<&SessionId> {
+        self.active.as_ref().map(|peek| &peek.id)
+    }
+
+    pub fn begin(&mut self, id: SessionId, source: PeekSource) -> bool {
+        let next = SessionPeek { id, source };
+        let changed = self.active.as_ref() != Some(&next);
+        self.active = Some(next);
+        changed
+    }
+
+    pub fn follow(&mut self, id: SessionId, source: PeekSource) -> bool {
+        if self
+            .active
+            .as_ref()
+            .is_none_or(|peek| peek.source != source)
+        {
+            return false;
+        }
+        self.begin(id, source)
+    }
+
+    pub fn end(&mut self, source: Option<PeekSource>) -> bool {
+        if source.is_some_and(|source| {
+            self.active
+                .as_ref()
+                .is_none_or(|peek| peek.source != source)
+        }) {
+            return false;
+        }
+        self.active.take().is_some()
+    }
+
+    pub fn take(&mut self) -> Option<SessionPeek> {
+        self.active.take()
+    }
+
+    pub fn hold_space(&mut self) -> bool {
+        if self.space_held {
+            return false;
+        }
+        self.space_held = true;
+        true
+    }
+
+    pub fn release_space(&mut self) -> bool {
+        std::mem::take(&mut self.space_held)
+    }
+
+    pub fn suppress_pointer_completion(&mut self, click: bool, drop: bool) {
+        self.suppress_pointer_click = click;
+        self.suppress_pointer_drop = drop;
+    }
+
+    pub fn consume_pointer_click(&mut self) -> bool {
+        std::mem::take(&mut self.suppress_pointer_click)
+    }
+
+    pub fn guards_pointer_drop(&self) -> bool {
+        self.suppress_pointer_drop
+            || self
+                .active
+                .as_ref()
+                .is_some_and(|peek| peek.source == PeekSource::Pointer)
+    }
+
+    pub fn consume_pointer_drop(&mut self) -> bool {
+        std::mem::take(&mut self.suppress_pointer_drop)
+    }
+
+    pub fn clear_completion_guards(&mut self) {
+        self.suppress_pointer_click = false;
+        self.suppress_pointer_drop = false;
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DragItem {
     Project(ProjectId),
@@ -82,6 +189,7 @@ pub struct SidebarUiState {
     /// previous row at the end) if that session disappears.
     pub focus_cursor: Option<SessionId>,
     focus_order: Vec<SessionId>,
+    pub peek: PeekState,
 }
 
 impl SidebarUiState {
@@ -106,6 +214,7 @@ impl SidebarUiState {
             preview_account: false,
             focus_cursor: None,
             focus_order: Vec::new(),
+            peek: PeekState::default(),
         }
     }
 
@@ -330,5 +439,42 @@ mod tests {
         assert!(state.pending_sibling.is_none());
         assert!(state.delegation_notice.is_none());
         assert!(state.delegation_mark.is_none());
+    }
+
+    #[test]
+    fn pointer_peek_follows_and_release_restores_presentation_only() {
+        let one = SessionId::new("one");
+        let two = SessionId::new("two");
+        let mut peek = PeekState::default();
+
+        assert!(peek.begin(one, PeekSource::Pointer));
+        assert!(peek.follow(two.clone(), PeekSource::Pointer));
+        assert_eq!(peek.target(), Some(&two));
+        assert!(peek.end(Some(PeekSource::Pointer)));
+        assert!(peek.target().is_none());
+    }
+
+    #[test]
+    fn gesture_ownership_prevents_cross_source_release() {
+        let mut peek = PeekState::default();
+        peek.begin(SessionId::new("keyboard"), PeekSource::Keyboard);
+
+        assert!(!peek.end(Some(PeekSource::Pointer)));
+        assert_eq!(
+            peek.active().map(|peek| peek.source),
+            Some(PeekSource::Keyboard)
+        );
+        assert!(!peek.release_space());
+    }
+
+    #[test]
+    fn pointer_completion_guards_are_one_shot() {
+        let mut peek = PeekState::default();
+        peek.suppress_pointer_completion(true, true);
+
+        assert!(peek.consume_pointer_click());
+        assert!(!peek.consume_pointer_click());
+        assert!(peek.consume_pointer_drop());
+        assert!(!peek.consume_pointer_drop());
     }
 }

--- a/diri/crates/diri-app/src/sidebar/state.rs
+++ b/diri/crates/diri-app/src/sidebar/state.rs
@@ -38,8 +38,11 @@ pub struct SessionPeek {
 pub struct PeekState {
     active: Option<SessionPeek>,
     space_held: bool,
-    suppress_pointer_click: bool,
-    suppress_pointer_drop: bool,
+    /// A held peek can finish as either a GPUI `Click` or `Drop`. They are
+    /// mutually exclusive terminal events for one pointer gesture, so the
+    /// first one must consume the whole guard rather than leaving its sibling
+    /// armed for an unrelated gesture.
+    suppress_pointer_completion: bool,
 }
 
 impl PeekState {
@@ -96,30 +99,24 @@ impl PeekState {
         std::mem::take(&mut self.space_held)
     }
 
-    pub fn suppress_pointer_completion(&mut self, click: bool, drop: bool) {
-        self.suppress_pointer_click = click;
-        self.suppress_pointer_drop = drop;
+    pub fn suppress_pointer_completion(&mut self) {
+        self.suppress_pointer_completion = true;
     }
 
-    pub fn consume_pointer_click(&mut self) -> bool {
-        std::mem::take(&mut self.suppress_pointer_click)
+    pub fn begin_pointer_gesture(&mut self) {
+        self.suppress_pointer_completion = false;
+    }
+
+    pub fn consume_pointer_completion(&mut self) -> bool {
+        std::mem::take(&mut self.suppress_pointer_completion)
     }
 
     pub fn guards_pointer_drop(&self) -> bool {
-        self.suppress_pointer_drop
+        self.suppress_pointer_completion
             || self
                 .active
                 .as_ref()
                 .is_some_and(|peek| peek.source == PeekSource::Pointer)
-    }
-
-    pub fn consume_pointer_drop(&mut self) -> bool {
-        std::mem::take(&mut self.suppress_pointer_drop)
-    }
-
-    pub fn clear_completion_guards(&mut self) {
-        self.suppress_pointer_click = false;
-        self.suppress_pointer_drop = false;
     }
 }
 
@@ -468,13 +465,18 @@ mod tests {
     }
 
     #[test]
-    fn pointer_completion_guards_are_one_shot() {
+    fn pointer_completion_is_mutually_exclusive_and_new_gestures_start_clean() {
         let mut peek = PeekState::default();
-        peek.suppress_pointer_completion(true, true);
+        peek.suppress_pointer_completion();
 
-        assert!(peek.consume_pointer_click());
-        assert!(!peek.consume_pointer_click());
-        assert!(peek.consume_pointer_drop());
-        assert!(!peek.consume_pointer_drop());
+        assert!(peek.guards_pointer_drop());
+        assert!(peek.consume_pointer_completion());
+        assert!(!peek.consume_pointer_completion());
+        assert!(!peek.guards_pointer_drop());
+
+        peek.suppress_pointer_completion();
+        peek.begin_pointer_gesture();
+        assert!(!peek.consume_pointer_completion());
+        assert!(!peek.guards_pointer_drop());
     }
 }

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -37,11 +37,14 @@ use crate::updates::{UpdateCommand, UpdatePhase, UpdateState};
 use crate::usage::{UsageFormat, UsageSnapshot};
 
 use super::{
-    CursorMove, DragItem, Popover, PreviewScenario, SidebarPreviewFixture, SidebarUiState,
-    move_before, move_to_end,
+    CursorMove, DragItem, PeekSource, Popover, PreviewScenario, SidebarPreviewFixture,
+    SidebarUiState, move_before, move_to_end,
 };
 
 const PREVIEW_USAGE: f64 = 4.82;
+/// Long enough that a click or intentional drag wins, short enough that
+/// scanning several sessions still feels like one continuous gesture.
+const SESSION_PEEK_DELAY: Duration = Duration::from_millis(320);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct FocusRow {
@@ -75,6 +78,9 @@ pub(crate) enum SidebarEvent {
     /// Escape left keyboard-navigation mode without changing the active
     /// session. Root owns the terminal entity, so it completes the handoff.
     FocusTerminal,
+    /// Borrow the terminal presentation for a read-only identity, or restore
+    /// the real selected session. This never travels through SessionStore.
+    PeekChanged(Option<SessionId>),
     /// The user acted on the update pill. The sidebar holds no updater of its
     /// own; RootView owns the handle and forwards these.
     Update(UpdateCommand),
@@ -107,11 +113,13 @@ impl DraggedSidebarItem {
 struct DragPreview {
     label: SharedString,
     colors: SemanticColors,
+    visible: bool,
 }
 
 impl Render for DragPreview {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
         div()
+            .opacity(if self.visible { 1.0 } else { 0.0 })
             .px(px(10.0))
             .h(px(28.0))
             .flex()
@@ -145,6 +153,9 @@ pub struct Sidebar {
     shortcut_ranks: HashMap<SessionId, usize>,
     focus_handle: FocusHandle,
     hover_generation: u64,
+    /// Invalidates a delayed hold without keeping a timer task alive.
+    peek_generation: u64,
+    pending_pointer_peek: Option<SessionId>,
     usage: Option<UsageSnapshot>,
     update: UpdateState,
     /// When visibility last flipped, so a held ⌘B cannot outrun the slide.
@@ -238,6 +249,8 @@ impl Sidebar {
             shortcut_ranks: HashMap::new(),
             focus_handle: cx.focus_handle(),
             hover_generation: 0,
+            peek_generation: 0,
+            pending_pointer_peek: None,
             usage: None,
             update: UpdateState::default(),
             last_toggle: None,
@@ -585,6 +598,173 @@ impl Sidebar {
         self.focus_handle.is_focused(window)
     }
 
+    pub fn is_peeking(&self) -> bool {
+        self.ui.peek.active().is_some()
+    }
+
+    pub fn has_peek_in_flight(&self) -> bool {
+        self.pending_pointer_peek.is_some() || self.is_peeking()
+    }
+
+    fn emit_peek(&mut self, cx: &mut Context<Self>) {
+        cx.emit(SidebarEvent::PeekChanged(self.ui.peek.target().cloned()));
+        cx.notify();
+    }
+
+    fn begin_peek(&mut self, id: SessionId, source: PeekSource, cx: &mut Context<Self>) {
+        self.pending_pointer_peek = None;
+        self.hover_generation = self.hover_generation.wrapping_add(1);
+        self.ui.hover_card = None;
+        if self.ui.peek.begin(id, source) {
+            self.emit_peek(cx);
+        }
+    }
+
+    fn follow_peek(&mut self, id: SessionId, source: PeekSource, cx: &mut Context<Self>) {
+        if self.ui.peek.follow(id, source) {
+            self.emit_peek(cx);
+        }
+    }
+
+    fn cancel_pending_pointer_peek(&mut self) {
+        self.peek_generation = self.peek_generation.wrapping_add(1);
+        self.pending_pointer_peek = None;
+    }
+
+    fn schedule_pointer_peek(
+        &mut self,
+        id: SessionId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        // A keyboard peek owns Space until key-up. Clicking during it is a
+        // commit, not the beginning of a second gesture.
+        if self.ui.peek.active().is_some() {
+            return;
+        }
+        self.ui.peek.clear_completion_guards();
+        self.cancel_pending_pointer_peek();
+        self.pending_pointer_peek = Some(id);
+        let generation = self.peek_generation;
+        cx.spawn_in(window, async move |this, cx| {
+            let executor = cx.background_executor();
+            executor.timer(SESSION_PEEK_DELAY).await;
+            let _ = this.update_in(cx, |this, _window, cx| {
+                if this.peek_generation != generation || this.ui.drag.is_some() {
+                    return;
+                }
+                if let Some(id) = this.pending_pointer_peek.clone() {
+                    this.begin_peek(id, PeekSource::Pointer, cx);
+                }
+            });
+        })
+        .detach();
+    }
+
+    fn finish_pointer_gesture(&mut self, released_row: Option<&SessionId>, cx: &mut Context<Self>) {
+        let was_pointer_peek = self
+            .ui
+            .peek
+            .active()
+            .is_some_and(|peek| peek.source == PeekSource::Pointer);
+        self.cancel_pending_pointer_peek();
+        if self.ui.peek.end(Some(PeekSource::Pointer)) {
+            // GPUI follows mouse-up with Click/Drop. Those events belong to
+            // the completed hold and must not turn restoration into a commit.
+            self.ui
+                .peek
+                .suppress_pointer_completion(released_row.is_some(), was_pointer_peek);
+            self.emit_peek(cx);
+        }
+    }
+
+    fn finish_pointer_at(&mut self, position: Point<Pixels>, cx: &mut Context<Self>) {
+        let released_row = self
+            .row_bounds
+            .borrow()
+            .iter()
+            .find(|(_, bounds)| bounds.contains(&position))
+            .map(|(id, _)| id.clone());
+        self.finish_pointer_gesture(released_row.as_ref(), cx);
+    }
+
+    pub fn cancel_peek(&mut self, cx: &mut Context<Self>) -> bool {
+        let pending = self.pending_pointer_peek.is_some();
+        let pointer_active = self
+            .ui
+            .peek
+            .active()
+            .is_some_and(|peek| peek.source == PeekSource::Pointer);
+        self.cancel_pending_pointer_peek();
+        self.ui.peek.release_space();
+        if self.ui.peek.end(None) {
+            if pointer_active {
+                self.ui.peek.suppress_pointer_completion(true, true);
+            }
+            self.emit_peek(cx);
+            true
+        } else {
+            if pending {
+                // Escape owns the rest of a pending hold too. Without these
+                // guards, releasing the still-depressed pointer would turn a
+                // cancelled preview into an ordinary activating click.
+                self.ui.peek.suppress_pointer_completion(true, true);
+                cx.notify();
+            }
+            pending
+        }
+    }
+
+    pub fn commit_peek(&mut self, cx: &mut Context<Self>) -> bool {
+        self.cancel_pending_pointer_peek();
+        self.ui.peek.release_space();
+        let Some(peek) = self.ui.peek.take() else {
+            return false;
+        };
+        let exists = {
+            let mut store = self.store.write().expect("session store lock poisoned");
+            let exists = store.sessions().contains_key(&peek.id);
+            if exists {
+                store.select(peek.id.clone());
+            }
+            exists
+        };
+        self.emit_peek(cx);
+        if exists {
+            self.ui.focus_cursor = Some(peek.id);
+            cx.emit(SidebarEvent::SessionActivated);
+        }
+        true
+    }
+
+    pub fn release_keyboard_peek(&mut self, cx: &mut Context<Self>) -> bool {
+        if !self.ui.peek.release_space() {
+            return false;
+        }
+        if self.ui.peek.end(Some(PeekSource::Keyboard)) {
+            self.emit_peek(cx);
+        }
+        true
+    }
+
+    fn consume_pointer_peek_drop(&mut self, cx: &mut Context<Self>) -> bool {
+        let pointer_active = self
+            .ui
+            .peek
+            .active()
+            .is_some_and(|peek| peek.source == PeekSource::Pointer);
+        if pointer_active {
+            self.finish_pointer_gesture(None, cx);
+        }
+        if pointer_active || self.ui.peek.consume_pointer_drop() {
+            self.finish_drag();
+            cx.notify();
+            true
+        } else {
+            false
+        }
+    }
+
     /// Enters keyboard-navigation mode from any other surface. An active row
     /// is the initial landmark, while an existing identity cursor survives
     /// subsequent trips to the terminal.
@@ -638,6 +818,9 @@ impl Sidebar {
         let visible = focus_row_ids(&rows);
         self.ui.reconcile_focus_cursor(&visible, selected.as_ref());
         self.ui.move_focus_cursor(movement, &visible);
+        if let Some(id) = self.ui.focus_cursor.clone() {
+            self.follow_peek(id, PeekSource::Keyboard, cx);
+        }
         self.scroll_focus_cursor_into_view(window);
         cx.notify();
         true
@@ -669,12 +852,18 @@ impl Sidebar {
         let (next_rows, _) = self.focus_rows_snapshot();
         self.ui
             .reconcile_focus_cursor(&focus_row_ids(&next_rows), None);
+        if let Some(id) = self.ui.focus_cursor.clone() {
+            self.follow_peek(id, PeekSource::Keyboard, cx);
+        }
         self.scroll_focus_cursor_into_view(window);
         cx.notify();
         true
     }
 
     fn activate_focus_cursor(&mut self, cx: &mut Context<Self>) -> bool {
+        if self.ui.peek.active().is_some() {
+            return self.commit_peek(cx);
+        }
         let Some(id) = self.ui.focus_cursor.clone() else {
             return true;
         };
@@ -754,12 +943,14 @@ impl Sidebar {
         }
 
         let key = event.keystroke.key.as_str();
-        if key == "escape" && self.cancel_delegation(cx) {
-            cx.stop_propagation();
-            return;
-        }
         if key == "escape" {
             cx.stop_propagation();
+            if self.cancel_peek(cx) {
+                return;
+            }
+            if self.cancel_delegation(cx) {
+                return;
+            }
             if self.ui.popover.take().is_none() {
                 cx.emit(SidebarEvent::FocusTerminal);
             }
@@ -778,12 +969,29 @@ impl Sidebar {
             "left" => self.move_focus_horizontally(false, window, cx),
             "right" => self.move_focus_horizontally(true, window, cx),
             "enter" => self.activate_focus_cursor(cx),
-            // Deliberately consumed but unbound. Hold-to-peek owns Space in
-            // the follow-up issue, and activation must remain Enter-only.
-            "space" => true,
+            "space" => {
+                if !event.is_held
+                    && self.ui.peek.hold_space()
+                    && let Some(id) = self.ui.focus_cursor.clone()
+                {
+                    self.begin_peek(id, PeekSource::Keyboard, cx);
+                }
+                true
+            }
             _ => false,
         };
         if handled {
+            cx.stop_propagation();
+        }
+    }
+
+    fn on_key_up(
+        &mut self,
+        event: &gpui::KeyUpEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if event.keystroke.key.as_str() == "space" && self.release_keyboard_peek(cx) {
             cx.stop_propagation();
         }
     }
@@ -797,6 +1005,10 @@ impl Sidebar {
     ) {
         self.hover_generation = self.hover_generation.wrapping_add(1);
         let generation = self.hover_generation;
+        if self.ui.peek.active().is_some() {
+            self.ui.hover_card = None;
+            return;
+        }
         if !hovering {
             if self
                 .ui
@@ -1211,6 +1423,7 @@ impl Sidebar {
                         cx.new(|_| DragPreview {
                             label: drag_label.clone(),
                             colors,
+                            visible: true,
                         })
                     },
                 )
@@ -1230,6 +1443,10 @@ impl Sidebar {
                     }
                 })
                 .on_drop(cx.listener(|this, _: &DraggedSidebarItem, _, cx| {
+                    if this.consume_pointer_peek_drop(cx) {
+                        cx.stop_propagation();
+                        return;
+                    }
                     this.finish_drag();
                     cx.notify();
                 }))
@@ -1421,6 +1638,7 @@ impl Sidebar {
         let focused = self.focus_handle.is_focused(window)
             && self.ui.renaming.is_none()
             && self.ui.focus_cursor.as_ref() == Some(&id);
+        let peeked = self.ui.peek.target() == Some(&id);
         let archived = session.is_archived();
         let hibernated = session.hibernation.is_some();
         let session_is_remote = session.host.is_some();
@@ -1446,6 +1664,7 @@ impl Sidebar {
             hibernated,
             row.pinned,
             !hovered && focused && shortcut.is_some(),
+            peeked,
         );
         let title_marquee_id = format!("session-title-marquee:{}", id.0);
         let fill = if selected {
@@ -1557,10 +1776,16 @@ impl Sidebar {
             .items_center()
             .gap(px(8.0))
             .rounded(px(Radius::ROW))
-            .bg(fill.color(colors))
+            .bg(if peeked && !selected {
+                Palette::CLAY.alpha(0.12)
+            } else {
+                fill.color(colors)
+            })
             .border_1()
             .border_color(if marked {
                 Palette::CLAY.alpha(0.78)
+            } else if peeked {
+                Palette::CLAY.alpha(0.94)
             } else if focused {
                 Ink::FRESH.alpha(0.82)
             } else {
@@ -1580,14 +1805,36 @@ impl Sidebar {
             .on_mouse_down(MouseButton::Left, |_, window, _| window.prevent_default())
             .on_hover(cx.listener(move |this, is_hovered: &bool, window, cx| {
                 this.ui.hovered_session = is_hovered.then(|| hover_id.clone());
+                if *is_hovered {
+                    if this.pending_pointer_peek.is_some() && this.ui.peek.active().is_none() {
+                        this.pending_pointer_peek = Some(hover_id.clone());
+                    }
+                    this.follow_peek(hover_id.clone(), PeekSource::Pointer, cx);
+                }
                 this.schedule_hover_card(hover_id.clone(), *is_hovered, window, cx);
                 cx.notify();
             }))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener({
+                    let id = id.clone();
+                    move |this, _, window, cx| {
+                        this.schedule_pointer_peek(id.clone(), window, cx);
+                    }
+                }),
+            )
             .on_click(
                 cx.listener(move |this, event: &gpui::ClickEvent, window, cx| {
+                    if this.ui.peek.consume_pointer_click() {
+                        cx.stop_propagation();
+                        cx.notify();
+                        return;
+                    }
+                    let was_peeking = this.is_peeking();
                     this.commit_rename();
                     this.ui.focus_cursor = Some(row_session.id.clone());
-                    if event.click_count() == 2 {
+                    this.cancel_peek(cx);
+                    if event.click_count() == 2 && !was_peeking {
                         this.begin_rename(&row_session, window, cx);
                         return;
                     }
@@ -1632,14 +1879,20 @@ impl Sidebar {
             )
             .on_drag(drag_payload, move |dragged, _, _, cx| {
                 let dragged = dragged.0.clone();
-                drag_entity.update(cx, |this, cx| {
-                    this.ui.drag = Some(dragged);
-                    this.ui.delegation_notice = None;
-                    cx.notify();
+                let visible = drag_entity.update(cx, |this, cx| {
+                    let pointer_peek = this.ui.peek.guards_pointer_drop();
+                    if !pointer_peek {
+                        this.cancel_pending_pointer_peek();
+                        this.ui.drag = Some(dragged);
+                        this.ui.delegation_notice = None;
+                        cx.notify();
+                    }
+                    !pointer_peek
                 });
                 cx.new(|_| DragPreview {
                     label: drag_label.clone(),
                     colors,
+                    visible,
                 })
             })
             .drag_over::<DraggedSidebarItem>({
@@ -1671,6 +1924,10 @@ impl Sidebar {
             .on_drop(cx.listener({
                 let target = id.clone();
                 move |this, dragged: &DraggedSidebarItem, _, cx| {
+                    if this.consume_pointer_peek_drop(cx) {
+                        cx.stop_propagation();
+                        return;
+                    }
                     if let Some(source) = dragged.session_id() {
                         let proposal = {
                             let store = this.store.read().expect("session store lock poisoned");
@@ -1712,6 +1969,10 @@ impl Sidebar {
             .on_drop(cx.listener({
                 let id = id.clone();
                 move |this, paths: &ExternalPaths, _, cx| {
+                    if this.consume_pointer_peek_drop(cx) {
+                        cx.stop_propagation();
+                        return;
+                    }
                     cx.stop_propagation();
                     this.external_drop(
                         paths,
@@ -1750,6 +2011,9 @@ impl Sidebar {
                 .font_weight(Typo::ROW.weight),
             )
             .when(row.pinned, |element| element.child(pin_mark(colors)))
+            .when(peeked, |element| {
+                element.child(StateChip::new("Peek", Palette::CLAY, colors))
+            })
             .when(marked, |element| {
                 element.child(StateChip::new("Delegating", Palette::CLAY, colors))
             })
@@ -1929,6 +2193,9 @@ impl Sidebar {
                 let entity = cx.entity();
                 let project_id = project_id.clone();
                 move |element, dragged, _, cx| {
+                    if entity.read(cx).ui.peek.guards_pointer_drop() {
+                        return element;
+                    }
                     let valid = match &dragged.0 {
                         DragItem::Session {
                             project, archived, ..
@@ -1950,6 +2217,10 @@ impl Sidebar {
             .on_drop(cx.listener({
                 let project_id = project_id.clone();
                 move |this, dragged: &DraggedSidebarItem, _, cx| {
+                    if this.consume_pointer_peek_drop(cx) {
+                        cx.stop_propagation();
+                        return;
+                    }
                     let ids = match &dragged.0 {
                         DragItem::Session {
                             id,
@@ -2038,6 +2309,7 @@ impl Sidebar {
         let focused = self.focus_handle.is_focused(window)
             && self.ui.renaming.is_none()
             && self.ui.focus_cursor.as_ref() == Some(&id);
+        let peeked = self.ui.peek.target() == Some(&id);
         let selected = self
             .store
             .read()
@@ -2048,6 +2320,7 @@ impl Sidebar {
         let revive_id = id.clone();
         let title = display_title(session);
         let drag_label: SharedString = title.clone().into();
+        let entity = cx.entity();
         div()
             .id(format!("archived-session:{}", id.0))
             .pl(px(Space::ROW_H + Space::INDENT))
@@ -2057,8 +2330,16 @@ impl Sidebar {
             .items_center()
             .gap(px(8.0))
             .rounded(px(Radius::ROW))
-            .opacity(if focused { 0.82 } else { 0.58 })
-            .bg(if selected {
+            .opacity(if peeked {
+                0.84
+            } else if focused {
+                0.82
+            } else {
+                0.58
+            })
+            .bg(if peeked && !selected {
+                Palette::CLAY.alpha(0.12)
+            } else if selected {
                 RowFill::Selected.color(colors)
             } else if hovered {
                 RowFill::Hover.color(colors)
@@ -2066,7 +2347,9 @@ impl Sidebar {
                 RowFill::Clear.color(colors)
             })
             .border_1()
-            .border_color(if focused {
+            .border_color(if peeked {
+                Palette::CLAY.alpha(0.94)
+            } else if focused {
                 Ink::FRESH.alpha(0.82)
             } else {
                 colors.primary.alpha(0.0)
@@ -2076,13 +2359,34 @@ impl Sidebar {
                 let id = id.clone();
                 move |this, is_hovered: &bool, _, cx| {
                     this.ui.hovered_session = is_hovered.then(|| id.clone());
+                    if *is_hovered {
+                        if this.pending_pointer_peek.is_some() && this.ui.peek.active().is_none() {
+                            this.pending_pointer_peek = Some(id.clone());
+                        }
+                        this.follow_peek(id.clone(), PeekSource::Pointer, cx);
+                    }
                     cx.notify();
                 }
             }))
-            .on_mouse_down(MouseButton::Left, |_, window, _| window.prevent_default())
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener({
+                    let id = id.clone();
+                    move |this, _, window, cx| {
+                        window.prevent_default();
+                        this.schedule_pointer_peek(id.clone(), window, cx);
+                    }
+                }),
+            )
             .on_click(cx.listener(move |this, event: &gpui::ClickEvent, _, cx| {
+                if this.ui.peek.consume_pointer_click() {
+                    cx.stop_propagation();
+                    cx.notify();
+                    return;
+                }
                 let modifiers = event.modifiers();
                 this.ui.focus_cursor = Some(row_session.id.clone());
+                this.cancel_peek(cx);
                 this.store
                     .write()
                     .expect("session store lock poisoned")
@@ -2106,9 +2410,18 @@ impl Sidebar {
                     archived: true,
                 }),
                 move |_, _, _, cx| {
+                    let visible = entity.update(cx, |this, cx| {
+                        let pointer_peek = this.ui.peek.guards_pointer_drop();
+                        if !pointer_peek {
+                            this.cancel_pending_pointer_peek();
+                            cx.notify();
+                        }
+                        !pointer_peek
+                    });
                     cx.new(|_| DragPreview {
                         label: drag_label.clone(),
                         colors,
+                        visible,
                     })
                 },
             )
@@ -2144,6 +2457,7 @@ impl Sidebar {
                     .when(hovered, |button| {
                         button.on_click(cx.listener(move |this, _, _, cx| {
                             cx.stop_propagation();
+                            this.cancel_peek(cx);
                             this.store
                                 .write()
                                 .expect("session store lock poisoned")
@@ -4611,6 +4925,10 @@ impl Render for Sidebar {
                 }
             })
             .on_drop(cx.listener(|this, dragged: &DraggedSidebarItem, _, cx| {
+                if this.consume_pointer_peek_drop(cx) {
+                    cx.stop_propagation();
+                    return;
+                }
                 if let Some(source_id) = dragged.session_id() {
                     let proposal = {
                         let store = this.store.read().expect("session store lock poisoned");
@@ -4659,9 +4977,17 @@ impl Render for Sidebar {
             .bg(Self::surface_fill(colors))
             .track_focus(&self.focus_handle)
             .on_key_down(cx.listener(Self::on_key_down))
+            .on_key_up(cx.listener(Self::on_key_up))
+            .on_mouse_up(
+                MouseButton::Left,
+                cx.listener(|this, event: &gpui::MouseUpEvent, _, cx| {
+                    this.finish_pointer_at(event.position, cx);
+                }),
+            )
             .on_mouse_up_out(
                 MouseButton::Left,
-                cx.listener(|this, _, _, cx| {
+                cx.listener(|this, event: &gpui::MouseUpEvent, _, cx| {
+                    this.finish_pointer_at(event.position, cx);
                     if this.ui.drag.is_some() {
                         this.finish_drag();
                         cx.notify();
@@ -5214,6 +5540,7 @@ fn session_title_available_width(
     hibernated: bool,
     pinned: bool,
     shortcut_visible: bool,
+    peeked: bool,
 ) -> f32 {
     // Row insets + fold column + identity glyph + the gaps between them.
     let mut available = sidebar_width - 68.0 - f32::from(depth) * (Space::INDENT + 8.0);
@@ -5234,6 +5561,9 @@ fn session_title_available_width(
     }
     if pinned {
         available -= 18.0;
+    }
+    if peeked {
+        available -= 44.0;
     }
     // The close button and the shortcut hint share the trailing slot and are
     // near enough the same width that one reservation covers both.
@@ -5259,7 +5589,10 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     use gpui::{HeadlessAppContext, size};
-    use gpui::{Modifiers, TestAppContext, VisualTestContext};
+    use gpui::{
+        KeyDownEvent, KeyUpEvent, Keystroke, Modifiers, MouseDownEvent, MouseUpEvent,
+        TestAppContext, VisualTestContext,
+    };
 
     use super::*;
 
@@ -5290,8 +5623,9 @@ mod tests {
 
     #[test]
     fn title_overflow_threshold_accounts_for_sidebar_badges() {
-        let plain =
-            session_title_available_width(248.0, 0, false, false, false, None, false, false, false);
+        let plain = session_title_available_width(
+            248.0, 0, false, false, false, None, false, false, false, false,
+        );
         let remote = session_title_available_width(
             248.0,
             0,
@@ -5302,11 +5636,13 @@ mod tests {
             false,
             false,
             true,
+            false,
         );
         assert!(plain > remote);
         // A nested row pays for every indent column it sits behind.
-        let nested =
-            session_title_available_width(248.0, 2, false, false, false, None, false, false, false);
+        let nested = session_title_available_width(
+            248.0, 2, false, false, false, None, false, false, false, false,
+        );
         assert!(plain > nested);
         assert_eq!(
             session_title_available_width(
@@ -5316,6 +5652,7 @@ mod tests {
                 true,
                 true,
                 Some("very-long-host"),
+                true,
                 true,
                 true,
                 true,
@@ -5675,6 +6012,185 @@ mod tests {
                     .expect("session store lock poisoned")
                     .selected_session_id(),
                 Some(&cursor)
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn pointer_hold_follows_then_release_restores_without_store_effects(cx: &mut TestAppContext) {
+        let (view, cx) = cx.add_window_view(|_, cx| {
+            let sidebar = cx.new(|cx| Sidebar::new(None, true, PreviewScenario::Typical, cx));
+            SidebarPopoverHarness { sidebar }
+        });
+        let sidebar = view.read_with(cx, |harness, _| harness.sidebar.clone());
+        sidebar.update(cx, |sidebar, _| {
+            let effects = sidebar
+                ._preview_effects
+                .as_mut()
+                .expect("preview effect queue");
+            while effects.try_recv().is_ok() {}
+        });
+        let (active, targets, attention, residency) = sidebar.read_with(cx, |sidebar, _| {
+            let store = sidebar.store.read().expect("session store lock poisoned");
+            let active = store
+                .selected_session_id()
+                .cloned()
+                .expect("preview selection");
+            let targets = sidebar
+                .row_bounds
+                .borrow()
+                .keys()
+                .filter(|id| *id != &active)
+                .take(2)
+                .cloned()
+                .collect::<Vec<_>>();
+            let attention = targets
+                .iter()
+                .map(|id| (id.clone(), store.sessions()[id].attention()))
+                .collect::<Vec<_>>();
+            let residency = store
+                .terminal_residency()
+                .resident()
+                .cloned()
+                .collect::<Vec<_>>();
+            (active, targets, attention, residency)
+        });
+        assert_eq!(targets.len(), 2, "fixture needs two peek targets");
+        let bounds = sidebar.read_with(cx, |sidebar, _| {
+            let rows = sidebar.row_bounds.borrow();
+            [rows[&targets[0]], rows[&targets[1]]]
+        });
+
+        cx.simulate_event(MouseDownEvent {
+            button: MouseButton::Left,
+            position: bounds[0].center(),
+            ..Default::default()
+        });
+        cx.executor().advance_clock(SESSION_PEEK_DELAY);
+        cx.run_until_parked();
+        assert_eq!(
+            sidebar.read_with(cx, |sidebar, _| sidebar.ui.peek.target().cloned()),
+            Some(targets[0].clone())
+        );
+
+        sidebar.update(cx, |sidebar, cx| {
+            sidebar.follow_peek(targets[1].clone(), PeekSource::Pointer, cx);
+        });
+        assert_eq!(
+            sidebar.read_with(cx, |sidebar, _| sidebar.ui.peek.target().cloned()),
+            Some(targets[1].clone()),
+            "the borrowed pane follows the held pointer directly"
+        );
+
+        cx.simulate_event(MouseUpEvent {
+            button: MouseButton::Left,
+            position: bounds[1].center(),
+            click_count: 1,
+            ..Default::default()
+        });
+        sidebar.read_with(cx, |sidebar, _| {
+            assert!(!sidebar.is_peeking());
+            let store = sidebar.store.read().expect("session store lock poisoned");
+            assert_eq!(store.selected_session_id(), Some(&active));
+            assert_eq!(
+                store
+                    .terminal_residency()
+                    .resident()
+                    .cloned()
+                    .collect::<Vec<_>>(),
+                residency
+            );
+            for (id, expected) in &attention {
+                assert_eq!(store.sessions()[id].attention(), *expected);
+            }
+        });
+        sidebar.update(cx, |sidebar, _| {
+            assert!(
+                matches!(
+                    sidebar
+                        ._preview_effects
+                        .as_mut()
+                        .expect("preview effect queue")
+                        .try_recv(),
+                    Err(mpsc::error::TryRecvError::Empty)
+                ),
+                "peek must emit no MarkSeen, wake, residency, or input effect"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn keyboard_peek_release_cancel_and_commit_are_deterministic(cx: &mut TestAppContext) {
+        let (view, cx) = cx.add_window_view(|_, cx| {
+            let sidebar = cx.new(|cx| Sidebar::new(None, true, PreviewScenario::Typical, cx));
+            SidebarPopoverHarness { sidebar }
+        });
+        let sidebar = view.read_with(cx, |harness, _| harness.sidebar.clone());
+        sidebar.update_in(cx, |sidebar, window, cx| sidebar.focus(window, cx));
+        let active = sidebar.read_with(cx, |sidebar, _| {
+            sidebar
+                .store
+                .read()
+                .expect("session store lock poisoned")
+                .selected_session_id()
+                .cloned()
+                .expect("preview selection")
+        });
+        let down = |key: &str| KeyDownEvent {
+            keystroke: Keystroke::parse(key).expect("keystroke"),
+            is_held: false,
+            prefer_character_input: false,
+        };
+
+        cx.simulate_event(down("space"));
+        cx.simulate_event(down("down"));
+        let followed = sidebar.read_with(cx, |sidebar, _| {
+            let target = sidebar.ui.peek.target().cloned().expect("keyboard peek");
+            assert_eq!(sidebar.ui.focus_cursor.as_ref(), Some(&target));
+            assert_eq!(
+                sidebar
+                    .store
+                    .read()
+                    .expect("session store lock poisoned")
+                    .selected_session_id(),
+                Some(&active)
+            );
+            target
+        });
+        assert_ne!(followed, active);
+        cx.simulate_event(KeyUpEvent {
+            keystroke: Keystroke::parse("space").expect("keystroke"),
+        });
+        assert!(!sidebar.read_with(cx, |sidebar, _| sidebar.is_peeking()));
+        assert_eq!(
+            sidebar.read_with(cx, |sidebar, _| sidebar
+                .store
+                .read()
+                .expect("session store lock poisoned")
+                .selected_session_id()
+                .cloned()),
+            Some(active.clone())
+        );
+
+        cx.simulate_event(down("space"));
+        cx.simulate_event(down("escape"));
+        assert!(!sidebar.read_with(cx, |sidebar, _| sidebar.is_peeking()));
+
+        cx.simulate_event(down("space"));
+        cx.simulate_event(down("down"));
+        let committed = sidebar.read_with(cx, |sidebar, _| {
+            sidebar.ui.peek.target().cloned().expect("commit target")
+        });
+        cx.simulate_event(down("enter"));
+        sidebar.read_with(cx, |sidebar, _| {
+            assert!(!sidebar.is_peeking());
+            assert_eq!(
+                sidebar
+                    .store
+                    .read()
+                    .expect("session store lock poisoned")
+                    .selected_session_id(),
+                Some(&committed)
             );
         });
     }

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -642,7 +642,7 @@ impl Sidebar {
         if self.ui.peek.active().is_some() {
             return;
         }
-        self.ui.peek.clear_completion_guards();
+        self.ui.peek.begin_pointer_gesture();
         self.cancel_pending_pointer_peek();
         self.pending_pointer_peek = Some(id);
         let generation = self.peek_generation;
@@ -661,7 +661,7 @@ impl Sidebar {
         .detach();
     }
 
-    fn finish_pointer_gesture(&mut self, released_row: Option<&SessionId>, cx: &mut Context<Self>) {
+    fn finish_pointer_gesture(&mut self, cx: &mut Context<Self>) {
         let was_pointer_peek = self
             .ui
             .peek
@@ -669,23 +669,14 @@ impl Sidebar {
             .is_some_and(|peek| peek.source == PeekSource::Pointer);
         self.cancel_pending_pointer_peek();
         if self.ui.peek.end(Some(PeekSource::Pointer)) {
-            // GPUI follows mouse-up with Click/Drop. Those events belong to
-            // the completed hold and must not turn restoration into a commit.
-            self.ui
-                .peek
-                .suppress_pointer_completion(released_row.is_some(), was_pointer_peek);
+            // GPUI follows mouse-up with either Click or Drop. Whichever one
+            // arrives belongs to this completed hold and consumes the single
+            // completion guard.
+            if was_pointer_peek {
+                self.ui.peek.suppress_pointer_completion();
+            }
             self.emit_peek(cx);
         }
-    }
-
-    fn finish_pointer_at(&mut self, position: Point<Pixels>, cx: &mut Context<Self>) {
-        let released_row = self
-            .row_bounds
-            .borrow()
-            .iter()
-            .find(|(_, bounds)| bounds.contains(&position))
-            .map(|(id, _)| id.clone());
-        self.finish_pointer_gesture(released_row.as_ref(), cx);
     }
 
     pub fn cancel_peek(&mut self, cx: &mut Context<Self>) -> bool {
@@ -699,7 +690,7 @@ impl Sidebar {
         self.ui.peek.release_space();
         if self.ui.peek.end(None) {
             if pointer_active {
-                self.ui.peek.suppress_pointer_completion(true, true);
+                self.ui.peek.suppress_pointer_completion();
             }
             self.emit_peek(cx);
             true
@@ -708,7 +699,7 @@ impl Sidebar {
                 // Escape owns the rest of a pending hold too. Without these
                 // guards, releasing the still-depressed pointer would turn a
                 // cancelled preview into an ordinary activating click.
-                self.ui.peek.suppress_pointer_completion(true, true);
+                self.ui.peek.suppress_pointer_completion();
                 cx.notify();
             }
             pending
@@ -721,6 +712,12 @@ impl Sidebar {
         let Some(peek) = self.ui.peek.take() else {
             return false;
         };
+        if peek.source == PeekSource::Pointer {
+            // Enter commits immediately, while the initiating pointer can
+            // still be depressed. Its eventual Click/Drop belongs to the old
+            // hold and must not select or move anything a second time.
+            self.ui.peek.suppress_pointer_completion();
+        }
         let exists = {
             let mut store = self.store.write().expect("session store lock poisoned");
             let exists = store.sessions().contains_key(&peek.id);
@@ -754,9 +751,9 @@ impl Sidebar {
             .active()
             .is_some_and(|peek| peek.source == PeekSource::Pointer);
         if pointer_active {
-            self.finish_pointer_gesture(None, cx);
+            self.finish_pointer_gesture(cx);
         }
-        if pointer_active || self.ui.peek.consume_pointer_drop() {
+        if pointer_active || self.ui.peek.consume_pointer_completion() {
             self.finish_drag();
             cx.notify();
             true
@@ -1825,7 +1822,7 @@ impl Sidebar {
             )
             .on_click(
                 cx.listener(move |this, event: &gpui::ClickEvent, window, cx| {
-                    if this.ui.peek.consume_pointer_click() {
+                    if this.ui.peek.consume_pointer_completion() {
                         cx.stop_propagation();
                         cx.notify();
                         return;
@@ -2379,7 +2376,7 @@ impl Sidebar {
                 }),
             )
             .on_click(cx.listener(move |this, event: &gpui::ClickEvent, _, cx| {
-                if this.ui.peek.consume_pointer_click() {
+                if this.ui.peek.consume_pointer_completion() {
                     cx.stop_propagation();
                     cx.notify();
                     return;
@@ -4978,16 +4975,22 @@ impl Render for Sidebar {
             .track_focus(&self.focus_handle)
             .on_key_down(cx.listener(Self::on_key_down))
             .on_key_up(cx.listener(Self::on_key_up))
-            .on_mouse_up(
+            .on_mouse_down(
                 MouseButton::Left,
-                cx.listener(|this, event: &gpui::MouseUpEvent, _, cx| {
-                    this.finish_pointer_at(event.position, cx);
-                }),
+                cx.listener(|this, _, _, _| this.ui.peek.begin_pointer_gesture()),
             )
+            // Finish in capture phase, before GPUI synthesizes the row Click
+            // during bubbling. Otherwise a long hold released on its origin
+            // activates that row before the completion guard exists.
+            .capture_any_mouse_up(cx.listener(|this, event: &gpui::MouseUpEvent, _, cx| {
+                if event.button == MouseButton::Left {
+                    this.finish_pointer_gesture(cx);
+                }
+            }))
             .on_mouse_up_out(
                 MouseButton::Left,
-                cx.listener(|this, event: &gpui::MouseUpEvent, _, cx| {
-                    this.finish_pointer_at(event.position, cx);
+                cx.listener(|this, _: &gpui::MouseUpEvent, _, cx| {
+                    this.finish_pointer_gesture(cx);
                     if this.ui.drag.is_some() {
                         this.finish_drag();
                         cx.notify();
@@ -5608,6 +5611,35 @@ mod tests {
         }
     }
 
+    struct PeekCommitHarness {
+        sidebar: Entity<Sidebar>,
+        activations: usize,
+    }
+
+    impl PeekCommitHarness {
+        fn new(cx: &mut Context<Self>) -> Self {
+            let sidebar = cx.new(|cx| Sidebar::new(None, true, PreviewScenario::Typical, cx));
+            cx.subscribe(&sidebar, |this, _, event, _| {
+                if matches!(event, SidebarEvent::SessionActivated) {
+                    this.activations += 1;
+                }
+            })
+            .detach();
+            Self {
+                sidebar,
+                activations: 0,
+            }
+        }
+    }
+
+    impl Render for PeekCommitHarness {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .size_full()
+                .child(div().h_full().w(px(248.0)).child(self.sidebar.clone()))
+        }
+    }
+
     #[test]
     fn long_paths_keep_final_component() {
         let result = clamp_path("/Users/preview/Projects/a/very/long/path/settings-kit");
@@ -6072,6 +6104,32 @@ mod tests {
             sidebar.read_with(cx, |sidebar, _| sidebar.ui.peek.target().cloned()),
             Some(targets[0].clone())
         );
+        cx.simulate_event(MouseUpEvent {
+            button: MouseButton::Left,
+            position: bounds[0].center(),
+            click_count: 1,
+            ..Default::default()
+        });
+        sidebar.read_with(cx, |sidebar, _| {
+            assert!(!sidebar.is_peeking());
+            assert_eq!(
+                sidebar
+                    .store
+                    .read()
+                    .expect("session store lock poisoned")
+                    .selected_session_id(),
+                Some(&active),
+                "release on the pressed row must restore, not synthesize activation"
+            );
+        });
+
+        cx.simulate_event(MouseDownEvent {
+            button: MouseButton::Left,
+            position: bounds[0].center(),
+            ..Default::default()
+        });
+        cx.executor().advance_clock(SESSION_PEEK_DELAY);
+        cx.run_until_parked();
 
         sidebar.update(cx, |sidebar, cx| {
             sidebar.follow_peek(targets[1].clone(), PeekSource::Pointer, cx);
@@ -6117,6 +6175,124 @@ mod tests {
                 "peek must emit no MarkSeen, wake, residency, or input effect"
             );
         });
+    }
+
+    #[gpui::test]
+    fn pointer_enter_commit_consumes_the_original_click_once(cx: &mut TestAppContext) {
+        let (view, cx) = cx.add_window_view(|_, cx| PeekCommitHarness::new(cx));
+        let sidebar = view.read_with(cx, |harness, _| harness.sidebar.clone());
+        sidebar.update_in(cx, |sidebar, window, cx| sidebar.focus(window, cx));
+        sidebar.update(cx, |sidebar, _| {
+            let effects = sidebar
+                ._preview_effects
+                .as_mut()
+                .expect("preview effect queue");
+            while effects.try_recv().is_ok() {}
+        });
+        let (active, targets) = sidebar.read_with(cx, |sidebar, _| {
+            let store = sidebar.store.read().expect("session store lock poisoned");
+            let active = store
+                .selected_session_id()
+                .cloned()
+                .expect("preview selection");
+            let targets = sidebar
+                .row_bounds
+                .borrow()
+                .keys()
+                .filter(|id| *id != &active)
+                .filter(|id| {
+                    store.sessions().get(*id).is_some_and(|session| {
+                        !session.is_archived() && session.hibernation.is_none()
+                    })
+                })
+                .take(2)
+                .cloned()
+                .collect::<Vec<_>>();
+            (active, targets)
+        });
+        assert_eq!(targets.len(), 2, "fixture needs two live commit targets");
+        let committed = targets[0].clone();
+        let original_press = targets[1].clone();
+        let original_bounds = sidebar.read_with(cx, |sidebar, _| {
+            sidebar.row_bounds.borrow()[&original_press]
+        });
+
+        // The pointer went down on C, then the held preview scrubbed to B.
+        // Enter commits B while C still owns GPUI's pending Click.
+        cx.simulate_event(MouseDownEvent {
+            button: MouseButton::Left,
+            position: original_bounds.center(),
+            ..Default::default()
+        });
+        cx.executor().advance_clock(SESSION_PEEK_DELAY);
+        cx.run_until_parked();
+        sidebar.update(cx, |sidebar, cx| {
+            sidebar.follow_peek(committed.clone(), PeekSource::Pointer, cx);
+            assert_eq!(sidebar.ui.peek.target(), Some(&committed));
+        });
+        cx.simulate_event(KeyDownEvent {
+            keystroke: Keystroke::parse("enter").expect("keystroke"),
+            is_held: false,
+            prefer_character_input: false,
+        });
+        cx.run_until_parked();
+
+        // Releasing over C synthesizes C's Click. It belongs to the original
+        // hold and must not overwrite B or emit a second activation.
+        cx.simulate_event(MouseUpEvent {
+            button: MouseButton::Left,
+            position: original_bounds.center(),
+            click_count: 1,
+            ..Default::default()
+        });
+        cx.run_until_parked();
+
+        let effects = sidebar.update(cx, |sidebar, _| {
+            let effects = sidebar
+                ._preview_effects
+                .as_mut()
+                .expect("preview effect queue");
+            let mut drained = Vec::new();
+            while let Ok(effect) = effects.try_recv() {
+                drained.push(effect);
+            }
+            drained
+        });
+        view.read_with(cx, |harness, _| assert_eq!(harness.activations, 1));
+        sidebar.read_with(cx, |sidebar, _| {
+            let store = sidebar.store.read().expect("session store lock poisoned");
+            assert_eq!(store.selected_session_id(), Some(&committed));
+            assert_eq!(
+                store
+                    .terminal_residency()
+                    .resident()
+                    .cloned()
+                    .collect::<Vec<_>>(),
+                vec![committed.clone()]
+            );
+        });
+        assert_eq!(
+            effects
+                .iter()
+                .filter(|effect| matches!(effect, StoreEffect::MarkSeen(id) if id == &committed))
+                .count(),
+            1
+        );
+        assert_eq!(
+            effects
+                .iter()
+                .filter(
+                    |effect| matches!(effect, StoreEffect::DetachAttachment(id) if id == &active)
+                )
+                .count(),
+            1
+        );
+        assert!(
+            !effects
+                .iter()
+                .any(|effect| matches!(effect, StoreEffect::MarkSeen(id) if id == &original_press)),
+            "the pointer's stale Click activated its original row"
+        );
     }
 
     #[gpui::test]

--- a/diri/crates/diri-app/src/terminal_pane.rs
+++ b/diri/crates/diri-app/src/terminal_pane.rs
@@ -4,6 +4,7 @@
 //! `diri-client::SessionAttachment`, `diri-term`, and the T9 session store.
 
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -30,14 +31,14 @@ use diri_term::metrics::CellMetrics;
 use diri_term::scrollback::{WheelDelta, WheelEvent, WheelRoute};
 use diri_term::theme::TermTheme;
 use diri_ui::{
-    AgentKind as UiAgentKind, Fill, FloatingSurface, Ink, Metrics, Radius, SemanticColors,
-    StatusGlyph, StatusState, Typo,
+    AgentKind as UiAgentKind, AgentLogo, Fill, FloatingSurface, Ink, Metrics, Palette, Radius,
+    SemanticColors, StatusGlyph, StatusState, Typo,
 };
 use gpui::{
     AnyElement, ClickEvent, ClipboardEntry, ClipboardItem, Context, Entity, EventEmitter,
-    FocusHandle, KeyDownEvent, KeyUpEvent, ModifiersChangedEvent, MouseButton, Render, Role,
-    ScrollDelta, ScrollWheelEvent, SharedString, StatefulInteractiveElement, Task, Window, div,
-    font, prelude::*, px, rgba,
+    FocusHandle, FontWeight, KeyDownEvent, KeyUpEvent, ModifiersChangedEvent, MouseButton, Render,
+    Role, ScrollDelta, ScrollWheelEvent, SharedString, StatefulInteractiveElement, Task, Window,
+    div, font, prelude::*, px, rgba,
 };
 use tokio::runtime::Handle;
 use tokio::sync::mpsc;
@@ -480,11 +481,12 @@ enum AttachmentCommand {
 #[derive(Clone)]
 struct AttachmentControl {
     tx: mpsc::UnboundedSender<AttachmentCommand>,
+    input_enabled: Arc<AtomicBool>,
 }
 
 impl AttachmentControl {
     fn input(&self, bytes: Vec<u8>) {
-        if bytes.is_empty() {
+        if bytes.is_empty() || !self.input_enabled.load(Ordering::Acquire) {
             return;
         }
         let _ = self.tx.send(AttachmentCommand::Input(bytes));
@@ -495,7 +497,7 @@ impl AttachmentControl {
     }
 
     fn mouse(&self, bytes: Vec<u8>) {
-        if bytes.is_empty() {
+        if bytes.is_empty() || !self.input_enabled.load(Ordering::Acquire) {
             return;
         }
         let _ = self.tx.send(AttachmentCommand::Mouse(bytes));
@@ -754,6 +756,22 @@ enum SessionSource {
     Fixed(SessionId),
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PeekAvailability {
+    Live,
+    Snapshot,
+    Status,
+}
+
+/// Read-only presentation borrowed by the sidebar. It owns no attachment and
+/// has no relationship to Store selection/residency; its optional element is
+/// a view over a buffer the primary pane already had in memory.
+struct PeekPresentation {
+    id: SessionId,
+    element: Option<TerminalElement>,
+    availability: PeekAvailability,
+}
+
 /// Grid frames parked while a column change round-trips through the daemon,
 /// so the re-wrap and the program's repaint reach the screen as one paint
 /// rather than as a jump and a correction. See [`REFLOW_HOLD`].
@@ -834,6 +852,11 @@ pub struct TerminalPane {
     reflow_holds: HashMap<SessionId, ReflowHold>,
     started_at: Instant,
     session_source: SessionSource,
+    peek: Option<PeekPresentation>,
+    /// The deepest input seam: IME, paste, key, and mouse delivery all pass
+    /// through AttachmentControl, so borrowing presentation disables them in
+    /// one place even if focus remains on the original terminal.
+    input_enabled: Arc<AtomicBool>,
     /// Last selection observed by the primary pane. Spawn responses select the
     /// daemon-created id asynchronously, so this transition is also the
     /// reliable point at which keyboard focus can leave the picker.
@@ -930,6 +953,7 @@ impl TerminalPane {
         });
 
         let tokio = tokio_owner.handle().clone();
+        let input_enabled = Arc::new(AtomicBool::new(true));
         let observed_selected_id = matches!(session_source, SessionSource::FollowSelection)
             .then(|| {
                 runtime
@@ -959,6 +983,8 @@ impl TerminalPane {
             reflow_holds: HashMap::new(),
             started_at: Instant::now(),
             session_source,
+            peek: None,
+            input_enabled,
             observed_selected_id,
             viewport: None,
             sidebar_visible: true,
@@ -1036,6 +1062,7 @@ impl TerminalPane {
                 id.clone(),
                 generation,
                 self.pane_tx.clone(),
+                Arc::clone(&self.input_enabled),
             );
             let ime_attachment = attachment.clone();
             let element = match parked {
@@ -1119,6 +1146,42 @@ impl TerminalPane {
 
     pub fn focus(&self, window: &mut Window, cx: &mut Context<Self>) {
         window.focus(&self.focus, cx);
+    }
+
+    pub fn is_peeking(&self) -> bool {
+        self.peek.is_some()
+    }
+
+    /// Changes presentation only. It does not touch terminal residency, open
+    /// an attachment, resize a PTY, select a session, acknowledge attention,
+    /// or auto-resume a hibernated process.
+    pub fn set_peeked_session(&mut self, id: Option<SessionId>, cx: &mut Context<Self>) {
+        if self.peek.as_ref().map(|peek| &peek.id) == id.as_ref() {
+            return;
+        }
+        self.input_enabled.store(id.is_none(), Ordering::Release);
+        self.peek = id.map(|id| {
+            let (buffer, availability) = if let Some(resident) = self.residents.get(&id) {
+                (Some(resident.element.buffer()), PeekAvailability::Live)
+            } else if let Some((_, buffer)) =
+                self.parked_grids.iter().find(|(parked, _)| parked == &id)
+            {
+                (Some(Arc::clone(buffer)), PeekAvailability::Snapshot)
+            } else {
+                (None, PeekAvailability::Status)
+            };
+            let element = buffer.map(|buffer| {
+                TerminalElement::new(buffer)
+                    .font(crate::fonts::terminal_font())
+                    .focused(false)
+            });
+            PeekPresentation {
+                id,
+                element,
+                availability,
+            }
+        });
+        cx.notify();
     }
 
     pub fn set_viewport(&mut self, viewport: TerminalViewport, cx: &mut Context<Self>) {
@@ -1221,7 +1284,7 @@ impl TerminalPane {
                     }
                     resident.attachment_state = state;
                 }
-                if self.selected_id().as_ref() == Some(&id) {
+                if self.visible_id().as_ref() == Some(&id) {
                     cx.notify();
                 }
             }
@@ -1275,7 +1338,7 @@ impl TerminalPane {
                     resident.bracketed_paste = bracketed_paste;
                     resident.element.set_modes(alt_screen, mouse);
                 }
-                if self.selected_id().as_ref() == Some(&id) {
+                if self.visible_id().as_ref() == Some(&id) {
                     cx.notify();
                 }
             }
@@ -1332,7 +1395,7 @@ impl TerminalPane {
                 if !self.attachment_is_current(&id, generation) {
                     return;
                 }
-                let visible = self.selected_id().as_ref() == Some(&id);
+                let visible = self.visible_id().as_ref() == Some(&id);
                 let mut next = None;
                 if let Some(resident) = self.residents.get_mut(&id)
                     && let Some(completion) = resident.find_scheduler.finish_scan(&request)
@@ -1359,7 +1422,7 @@ impl TerminalPane {
                         .complete_scrollback_fetch(result, visible_rows);
                 }
                 self.pump_scrollback_fetch(&id, visible_rows);
-                if self.selected_id().as_ref() == Some(&id) {
+                if self.visible_id().as_ref() == Some(&id) {
                     cx.notify();
                 }
             }
@@ -1367,7 +1430,7 @@ impl TerminalPane {
                 if let Some(resident) = self.residents.get_mut(&id) {
                     resident.element.fail_scrollback_fetch();
                 }
-                if self.selected_id().as_ref() == Some(&id) {
+                if self.visible_id().as_ref() == Some(&id) {
                     cx.notify();
                 }
             }
@@ -1401,7 +1464,7 @@ impl TerminalPane {
         cx: &mut Context<Self>,
     ) {
         let now = self.started_at.elapsed();
-        let selected = self.selected_id();
+        let selected = self.visible_id();
         let mut schedule_find = false;
         let mut changed = false;
         let mut applied = false;
@@ -1541,7 +1604,29 @@ impl TerminalPane {
             .map(Arc::clone)
     }
 
+    fn visible_id(&self) -> Option<SessionId> {
+        self.peek
+            .as_ref()
+            .map(|peek| peek.id.clone())
+            .or_else(|| self.selected_id())
+    }
+
+    fn visible_session(&self) -> Option<Arc<SessionRecord>> {
+        let id = self.visible_id()?;
+        self.runtime
+            .store
+            .read()
+            .expect("session store lock poisoned")
+            .sessions()
+            .get(&id)
+            .map(Arc::clone)
+    }
+
     fn open_find(&mut self, _: &OpenFind, window: &mut Window, cx: &mut Context<Self>) {
+        if self.is_peeking() {
+            cx.stop_propagation();
+            return;
+        }
         let Some(id) = self.selected_id() else {
             return;
         };
@@ -1560,6 +1645,10 @@ impl TerminalPane {
     }
 
     fn close_find(&mut self, _: &CloseFind, _window: &mut Window, cx: &mut Context<Self>) {
+        if self.is_peeking() {
+            cx.stop_propagation();
+            return;
+        }
         if self.close_find_for_selected() {
             cx.stop_propagation();
             cx.notify();
@@ -1592,6 +1681,10 @@ impl TerminalPane {
     }
 
     fn navigate_find(&mut self, backwards: bool, cx: &mut Context<Self>) {
+        if self.is_peeking() {
+            cx.stop_propagation();
+            return;
+        }
         let Some(id) = self.selected_id() else {
             return;
         };
@@ -1968,6 +2061,10 @@ impl TerminalPane {
     }
 
     fn paste(&mut self, _: &Paste, window: &mut Window, cx: &mut Context<Self>) {
+        if self.is_peeking() {
+            cx.stop_propagation();
+            return;
+        }
         let Some(item) = cx.read_from_clipboard() else {
             return;
         };
@@ -2059,6 +2156,10 @@ impl TerminalPane {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.is_peeking() {
+            cx.stop_propagation();
+            return;
+        }
         if let Some(navigation) = &self.navigation
             && navigation.read(cx).is_open()
         {
@@ -2192,6 +2293,10 @@ impl TerminalPane {
     }
 
     fn handle_key_up(&mut self, event: &KeyUpEvent, _window: &mut Window, cx: &mut Context<Self>) {
+        if self.is_peeking() {
+            cx.stop_propagation();
+            return;
+        }
         if matches!(event.keystroke.key.as_str(), "control" | "ctrl") {
             self.runtime
                 .store
@@ -2208,6 +2313,10 @@ impl TerminalPane {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.is_peeking() {
+            cx.stop_propagation();
+            return;
+        }
         let mut store = self
             .runtime
             .store
@@ -2310,6 +2419,11 @@ impl TerminalPane {
     }
 
     fn update_selected_geometry(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        // A peek borrows presentation only. Do not perturb the selected PTY's
+        // geometry bookkeeping or send a resize/reflow while it is borrowed.
+        if self.is_peeking() {
+            return;
+        }
         let Some(session) = self.selected_session() else {
             return;
         };
@@ -2654,6 +2768,163 @@ impl TerminalPane {
                     cx.open_url(url);
                 }
             }))
+            .into_any_element()
+    }
+
+    fn render_peek_header(&self, session: &SessionRecord, colors: SemanticColors) -> AnyElement {
+        let glyph = self.glyphs.get(&session.id).cloned();
+        let branch = session.git_branch.clone();
+        let availability = self
+            .peek
+            .as_ref()
+            .map_or(PeekAvailability::Status, |peek| peek.availability);
+        let availability = match availability {
+            PeekAvailability::Live => "Live · read-only",
+            PeekAvailability::Snapshot => "Last screen · read-only",
+            PeekAvailability::Status => "Status · read-only",
+        };
+        div()
+            .h(px(Metrics::TITLE_BAR))
+            .flex_none()
+            .px(px(Metrics::TOOLBAR_EDGE_INSET))
+            .flex()
+            .items_center()
+            .gap(px(Metrics::TOOLBAR_ITEM_GAP))
+            .bg(colors.sidebar_surface())
+            .child(
+                div()
+                    .flex_none()
+                    .flex()
+                    .items_center()
+                    .gap(px(4.0))
+                    .px(px(6.0))
+                    .py(px(2.0))
+                    .rounded(px(Radius::CHIP))
+                    .bg(Palette::CLAY.alpha(0.14))
+                    .border_1()
+                    .border_color(Palette::CLAY.alpha(0.55))
+                    .text_size(px(Typo::META.size - 1.0))
+                    .font_weight(FontWeight::SEMIBOLD)
+                    .text_color(Palette::CLAY)
+                    .child(sf_symbol("eye.fill", 9.0, Palette::CLAY))
+                    .child("PEEK"),
+            )
+            .child(
+                div()
+                    .min_w(px(0.0))
+                    .flex_1()
+                    .overflow_hidden()
+                    .whitespace_nowrap()
+                    .text_size(px(Typo::TITLE.size))
+                    .font_weight(Typo::TITLE.weight)
+                    .text_color(colors.primary)
+                    .child(session.title.clone()),
+            )
+            .when_some(branch, |header, branch| {
+                header.child(
+                    div()
+                        .max_w(px(150.0))
+                        .overflow_hidden()
+                        .text_ellipsis()
+                        .whitespace_nowrap()
+                        .text_size(px(Typo::META.size))
+                        .text_color(colors.tertiary)
+                        .child(branch),
+                )
+            })
+            .child(
+                div()
+                    .flex_none()
+                    .flex()
+                    .items_center()
+                    .gap(px(Metrics::TOOLBAR_ITEM_GAP))
+                    .when_some(glyph, |identity, glyph| identity.child(glyph))
+                    .child(
+                        div()
+                            .text_size(px(Typo::META.size))
+                            .font_weight(FontWeight::MEDIUM)
+                            .text_color(Palette::CLAY)
+                            .child(availability),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(Typo::META.size))
+                            .text_color(colors.tertiary)
+                            .child("Release to return · Enter to switch"),
+                    ),
+            )
+            .into_any_element()
+    }
+
+    fn render_peek_surface(
+        &self,
+        session: &SessionRecord,
+        theme: TermTheme,
+        font_size: f32,
+        colors: SemanticColors,
+    ) -> AnyElement {
+        let element = self
+            .peek
+            .as_ref()
+            .filter(|peek| peek.id == session.id)
+            .and_then(|peek| peek.element.clone());
+        let content = element.map_or_else(
+            || {
+                let message = if session.hibernation.is_some() {
+                    "Hibernated · showing the best available session state"
+                } else if session.is_archived() {
+                    "Archived · no terminal snapshot cached"
+                } else if matches!(session.status, SessionStatus::Exited(_)) {
+                    "Session ended · no terminal snapshot cached"
+                } else {
+                    "No terminal snapshot cached yet"
+                };
+                div()
+                    .size_full()
+                    .flex()
+                    .flex_col()
+                    .items_center()
+                    .justify_center()
+                    .gap(px(12.0))
+                    .bg(theme.background)
+                    .child(
+                        AgentLogo::new(ui_agent_kind(session.effective_kind()), 48.0, colors)
+                            .badged(false),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(Typo::ROW.size))
+                            .text_color(colors.secondary)
+                            .child(message),
+                    )
+                    .into_any_element()
+            },
+            |element| {
+                div()
+                    .size_full()
+                    .pt(px(2.0))
+                    .pb(px(10.0))
+                    .px(px(12.0))
+                    .bg(theme.background)
+                    .child(element.theme(theme).font_size(px(font_size)).focused(false))
+                    .into_any_element()
+            },
+        );
+        div()
+            .debug_selector(|| "TERMINAL_PEEK_SURFACE".into())
+            .relative()
+            .min_h(px(0.0))
+            .flex_1()
+            .overflow_hidden()
+            .rounded_tl(px(Radius::CARD))
+            .rounded_tr(px(Radius::CARD))
+            .border_l_2()
+            .border_color(Palette::CLAY.alpha(0.72))
+            .bg(theme.background)
+            .occlude()
+            .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+            .on_scroll_wheel(|_, _, cx| cx.stop_propagation())
+            .child(content)
             .into_any_element()
     }
 
@@ -3349,59 +3620,78 @@ impl Render for TerminalPane {
         self.sync_status_glyphs(colors, window, cx);
         self.update_selected_geometry(window, cx);
 
-        let selected = self.selected_session();
+        let selected = self.visible_session();
 
         let content = if let Some(session) = selected {
-            let chips = PaneChip::for_session(&session);
-            let visible_chip_count = toolbar_visible_chip_count(
-                &chips,
-                self.viewport.map_or(900.0, |viewport| viewport.width),
-                self.sidebar_visible,
-            );
-            if visible_chip_count >= chips.len() {
-                self.overflow_open = false;
-            }
-            let mut pane = div()
-                .relative()
-                .flex()
-                .flex_col()
-                .flex_1()
-                .h_full()
-                .overflow_hidden()
-                .border_l_1()
-                .border_color(sidebar_colors.primary.alpha(0.08))
-                .bg(sidebar_colors.sidebar_surface())
-                .child(self.render_header(
-                    &session,
+            if self.is_peeking() {
+                div()
+                    .relative()
+                    .flex()
+                    .flex_col()
+                    .flex_1()
+                    .h_full()
+                    .overflow_hidden()
+                    .border_l_1()
+                    .border_color(sidebar_colors.primary.alpha(0.08))
+                    .bg(sidebar_colors.sidebar_surface())
+                    .child(self.render_peek_header(&session, sidebar_colors))
+                    .child(self.render_peek_surface(&session, theme, font_size, colors))
+                    .into_any_element()
+            } else {
+                let chips = PaneChip::for_session(&session);
+                let visible_chip_count = toolbar_visible_chip_count(
                     &chips,
-                    visible_chip_count,
-                    sidebar_colors,
-                    cx,
-                ));
-            let terminal_surface = div()
-                .relative()
-                .min_h(px(0.0))
-                .flex_1()
-                .flex()
-                .flex_col()
-                .rounded_tl(px(Radius::CARD))
-                .rounded_tr(px(Radius::CARD))
-                .overflow_hidden()
-                .bg(theme.background)
-                .child(
-                    self.render_grid_and_overlays(&session, theme, colors, font_size, window, cx),
+                    self.viewport.map_or(900.0, |viewport| viewport.width),
+                    self.sidebar_visible,
                 );
-            pane = pane.child(terminal_surface);
-            if let Some(find) = self.render_find_bar(&session, colors, cx) {
-                pane = pane.child(find);
+                if visible_chip_count >= chips.len() {
+                    self.overflow_open = false;
+                }
+                let mut pane = div()
+                    .relative()
+                    .flex()
+                    .flex_col()
+                    .flex_1()
+                    .h_full()
+                    .overflow_hidden()
+                    .border_l_1()
+                    .border_color(sidebar_colors.primary.alpha(0.08))
+                    .bg(sidebar_colors.sidebar_surface())
+                    .child(self.render_header(
+                        &session,
+                        &chips,
+                        visible_chip_count,
+                        sidebar_colors,
+                        cx,
+                    ));
+                let terminal_surface =
+                    div()
+                        .relative()
+                        .min_h(px(0.0))
+                        .flex_1()
+                        .flex()
+                        .flex_col()
+                        .rounded_tl(px(Radius::CARD))
+                        .rounded_tr(px(Radius::CARD))
+                        .overflow_hidden()
+                        .bg(theme.background)
+                        .child(self.render_grid_and_overlays(
+                            &session, theme, colors, font_size, window, cx,
+                        ));
+                pane = pane.child(terminal_surface);
+                if let Some(find) = self.render_find_bar(&session, colors, cx) {
+                    pane = pane.child(find);
+                }
+                if let Some(popover) = self.render_checks_popover(&session, colors, cx) {
+                    pane = pane.child(popover);
+                }
+                if let Some(overflow) =
+                    self.render_overflow(&session, visible_chip_count, colors, cx)
+                {
+                    pane = pane.child(overflow);
+                }
+                pane.into_any_element()
             }
-            if let Some(popover) = self.render_checks_popover(&session, colors, cx) {
-                pane = pane.child(popover);
-            }
-            if let Some(overflow) = self.render_overflow(&session, visible_chip_count, colors, cx) {
-                pane = pane.child(overflow);
-            }
-            pane.into_any_element()
         } else {
             let show_sidebar = matches!(self.session_source, SessionSource::FollowSelection)
                 && !self.sidebar_visible;
@@ -3743,9 +4033,13 @@ fn spawn_attachment(
     id: SessionId,
     generation: AttachmentGeneration,
     pane_tx: PaneEventSender,
+    input_enabled: Arc<AtomicBool>,
 ) -> AttachmentControl {
     let (command_tx, mut commands) = mpsc::unbounded_channel();
-    let control = AttachmentControl { tx: command_tx };
+    let control = AttachmentControl {
+        tx: command_tx,
+        input_enabled,
+    };
     runtime.spawn(async move {
         // The first resize must be the measured pane geometry: deferred agent
         // launch waits for it. Do not seed an arbitrary 80×24 size.
@@ -4950,6 +5244,124 @@ mod tests {
         assert!(
             cx.debug_bounds("show-sidebar").is_some(),
             "collapsing the sidebar must leave a way to reveal it"
+        );
+    }
+
+    #[gpui::test]
+    fn peek_is_read_only_and_restores_focus_scroll_and_residency(cx: &mut TestAppContext) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        let tokio = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime"),
+        );
+        let active = fixture_session();
+        let mut sleeping = fixture_session();
+        sleeping.id = SessionId::new("sleeping-peek");
+        sleeping.title = "Sleeping preview".to_owned();
+        sleeping.hibernation = Some(diri_proto::HibernationInfo {
+            since: diri_proto::DateMillis(1.0),
+            reason: diri_proto::HibernationReason::Idle,
+            tree_pids: vec![42],
+            tree_start_times: None,
+        });
+        let attention_before = sleeping.attention();
+        {
+            let mut store = runtime.store.write().expect("session store lock poisoned");
+            store.upsert_session(active.clone());
+            store.upsert_session(sleeping.clone());
+            store.select(active.id.clone());
+        }
+
+        let runtime_for_view = Arc::clone(&runtime);
+        let (pane, cx) = cx.add_window_view(move |window, cx| {
+            TerminalPane::new(runtime_for_view, tokio, window, cx)
+        });
+        let (input_tx, mut input_rx) = mpsc::unbounded_channel();
+        let active_offset = pane.update_in(cx, |pane, window, cx| {
+            pane.focus(window, cx);
+            let input_enabled = Arc::clone(&pane.input_enabled);
+            let resident = pane.residents.get_mut(&active.id).expect("active resident");
+            assert!(resident.element.set_view_offset(4, 4));
+            let active_offset = resident.element.view_offset();
+            resident.attachment = AttachmentControl {
+                tx: input_tx,
+                input_enabled,
+            };
+
+            pane.set_peeked_session(Some(sleeping.id.clone()), cx);
+            assert!(pane.is_peeking());
+            assert!(pane.is_focused(window));
+            assert_eq!(pane.visible_id(), Some(sleeping.id.clone()));
+            assert!(!pane.residents.contains_key(&sleeping.id));
+            assert!(pane.peek.as_ref().is_some_and(|peek| {
+                peek.element.is_none() && peek.availability == PeekAvailability::Status
+            }));
+            pane.residents[&active.id].attachment.input(vec![b'x']);
+            assert!(
+                input_rx.try_recv().is_err(),
+                "the attachment seam must reject input while presentation is borrowed"
+            );
+            pane.set_viewport(
+                TerminalViewport {
+                    x: 40.0,
+                    y: 0.0,
+                    width: 520.0,
+                    height: 260.0,
+                },
+                cx,
+            );
+            pane.update_selected_geometry(window, cx);
+            assert!(
+                input_rx.try_recv().is_err(),
+                "a peek must not resize the selected PTY"
+            );
+            active_offset
+        });
+        assert!(
+            cx.debug_bounds("TERMINAL_PEEK_SURFACE").is_some(),
+            "a hibernated non-resident still paints an intentional status fallback"
+        );
+
+        pane.update_in(cx, |pane, window, cx| {
+            pane.handle_key_down(
+                &KeyDownEvent {
+                    keystroke: gpui::Keystroke::parse("x").expect("keystroke"),
+                    is_held: false,
+                    prefer_character_input: false,
+                },
+                window,
+                cx,
+            );
+            assert!(
+                input_rx.try_recv().is_err(),
+                "peek must deliver no key input"
+            );
+
+            pane.set_peeked_session(None, cx);
+            assert!(pane.is_focused(window));
+            assert_eq!(
+                pane.residents[&active.id].element.view_offset(),
+                active_offset
+            );
+            pane.residents[&active.id].attachment.input(vec![b'y']);
+            assert!(matches!(
+                input_rx.try_recv(),
+                Ok(AttachmentCommand::Input(bytes)) if bytes == b"y"
+            ));
+        });
+        let store = runtime.store.read().expect("session store lock poisoned");
+        assert_eq!(store.selected_session_id(), Some(&active.id));
+        assert_eq!(store.sessions()[&sleeping.id].attention(), attention_before);
+        assert!(store.sessions()[&sleeping.id].hibernation.is_some());
+        assert_eq!(
+            store
+                .terminal_residency()
+                .resident()
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec![active.id]
         );
     }
 


### PR DESCRIPTION
## Summary

- add delayed pointer hold, follow, and restore peeking without changing selected session identity
- add a Space plus arrow keyboard state machine with Enter commit and Escape restore
- present live output only when already resident, otherwise use cached snapshots and explicit hibernated states
- enforce read-only behavior at the deepest attachment input gate so peek never steals focus, wakes sessions, or sends input

## Verification

- full diri-app suite: 424 passed, 2 ignored
- strict all-target app and workspace Clippy
- deterministic pointer-delay, keyboard, focus, residency, selection, and input-gate regressions
- formatting and diff checks clean