### PR TITLE
mcp: make agent mutations idempotent and retry-safe

### DIFF
--- a/diri/PLAN.md
+++ b/diri/PLAN.md
@@ -231,3 +231,26 @@ Dependencies are noted; tasks with the same phase and no dep arrow are parallel.
 
 ## 11. Later (post-v1 backlog)
 Remote/TCP endpoint + token auth (iOS parity), port-forward channel UI, a Rust daemon (only if ever needed — would ship behind the same wire protocol), Linux/Windows builds, per-session split panes, GPU screenshot-based switcher previews, multi-desktop geometry roles.
+
+---
+
+## MCP mutation contract
+
+`spawn_agent` accepts an optional `requestKey` (1–128 bytes). The Engine
+namespaces it by `(caller session, tool, requestKey)`, coalesces concurrent
+calls, and replays the original successful result—including the same session
+and worktree IDs—across MCP stdio reconnects. Reusing a key with different
+normalized arguments returns `idempotency_conflict`. Omitting the key retains
+the historical non-idempotent behavior.
+
+Successful results are retained for 24 hours, at most 128 entries per caller,
+and are removed when the caller session is removed. Pre-mutation validation or
+infrastructure failures release the key and may be retried with it. The one
+post-mutation failure, `initial_prompt_delivery_failed`, is retained: its
+message names the already-created session, and replay must never create a
+second child.
+
+Failed MCP tool results retain `isError: true`, while their text is serialized
+JSON with stable `code`, `retryable`, `modelGuidance`, optional
+`suggestedTool`, and `details` fields. Older clients can display the JSON;
+newer agents can parse it and choose a corrective action.

--- a/diri/PLAN.md
+++ b/diri/PLAN.md
@@ -245,10 +245,11 @@ the historical non-idempotent behavior.
 
 Successful results are retained for 24 hours, at most 128 entries per caller,
 and are removed when the caller session is removed. Pre-mutation validation or
-infrastructure failures release the key and may be retried with it. The one
-post-mutation failure, `initial_prompt_delivery_failed`, is retained: its
-message names the already-created session, and replay must never create a
-second child.
+infrastructure failures release the key and may be retried with it. Outcomes
+that imply a possible commit — `initial_prompt_delivery_failed` and
+`idempotency_outcome_uncertain` after a panic — remain sticky for the caller's
+whole lifetime: recovery must inspect the existing sessions/worktrees and
+never create a second child automatically.
 
 Failed MCP tool results retain `isError: true`, while their text is serialized
 JSON with stable `code`, `retryable`, `modelGuidance`, optional

--- a/diri/crates/diri-app/src/store/mod.rs
+++ b/diri/crates/diri-app/src/store/mod.rs
@@ -2003,6 +2003,7 @@ impl SessionStore {
             initial_rows: None,
             host: session.host.clone(),
             same_repo_as: None,
+            request_key: None,
         }));
         true
     }
@@ -2041,6 +2042,7 @@ impl SessionStore {
             initial_rows: options.initial_rows,
             host,
             same_repo_as: options.same_repo_as,
+            request_key: None,
         }));
     }
 

--- a/diri/crates/diri-client/src/attachment.rs
+++ b/diri/crates/diri-client/src/attachment.rs
@@ -485,6 +485,7 @@ mod tests {
             initial_rows: None,
             host: None,
             same_repo_as: None,
+            request_key: None,
         };
         let session: SessionRecord = control.request(Method::SESSION_SPAWN, &spawn).await?;
         let session_id = session.id;

--- a/diri/crates/diri-client/src/client.rs
+++ b/diri/crates/diri-client/src/client.rs
@@ -1059,6 +1059,7 @@ mod tests {
                     initial_rows: Some(24),
                     host: None,
                     same_repo_as: None,
+                    request_key: None,
                 })
                 .await?;
 

--- a/diri/crates/diri-engine/src/control.rs
+++ b/diri/crates/diri-engine/src/control.rs
@@ -745,7 +745,47 @@ impl ControlServer {
                     .collect()
             })
             .unwrap_or_default();
-        let p: diri_proto::SessionSpawnParams = decode(Some(raw))?;
+        let mut p: diri_proto::SessionSpawnParams = decode(Some(raw))?;
+        let request_key = p.request_key.take();
+        if let Some(request_key) = request_key {
+            if request_key.trim().is_empty() || request_key.len() > 128 {
+                return Err(ControlError::bad_request(
+                    "requestKey must contain 1 to 128 bytes",
+                ));
+            }
+            let caller = p
+                .parent
+                .as_ref()
+                .map(|caller| caller.0.clone())
+                .ok_or_else(|| {
+                    ControlError::new(
+                        "idempotency_requires_caller",
+                        "requestKey requires a caller session identity",
+                    )
+                })?;
+            let ledger = {
+                let registry = self.registry.lock().map_err(poisoned)?;
+                if registry.record(&caller).is_none() {
+                    return Err(ControlError::new(
+                        "idempotency_caller_not_found",
+                        format!("caller session {caller:?} does not exist"),
+                    ));
+                }
+                registry.spawn_requests()
+            };
+            let fingerprint = spawn_fingerprint(&p, &argv)?;
+            return ledger.run(&caller, "spawn_agent", &request_key, fingerprint, || {
+                self.session_spawn_decoded(p, argv)
+            });
+        }
+        self.session_spawn_decoded(p, argv)
+    }
+
+    fn session_spawn_decoded(
+        &self,
+        p: diri_proto::SessionSpawnParams,
+        argv: Vec<String>,
+    ) -> Result<JsonValue, ControlError> {
         if p.host.is_some() {
             return self.session_spawn_remote(p, argv);
         }
@@ -767,6 +807,24 @@ impl ControlServer {
             argv
         };
 
+        // Resolve every fallible, side-effect-free launch dependency before a
+        // requested worktree is created. A typo in the agent kind must not
+        // leave an orphan checkout behind.
+        let engine = self.registry.lock().map_err(poisoned)?.engine();
+        let manifest = engine
+            .manifest(&kind)
+            .ok_or_else(|| ControlError::not_found(format!("no manifest for agent {kind:?}")))?;
+        let mut descriptor = manifest.agent.clone().unwrap_or_default();
+        if let Some(binary) = descriptor.binary.as_deref() {
+            descriptor.binary = Some(self.resolve_local_agent_executable(&kind, binary)?);
+        }
+        let authority = descriptor.authority();
+        if descriptor.binary.is_none() && argv.is_empty() {
+            return Err(ControlError::bad_request(format!(
+                "agent {kind:?} declares no binary, so argv is required"
+            )));
+        }
+
         // A worktree spawn creates the checkout first, then lands in it.
         let mut cwd = p.cwd.clone();
         let mut worktree_path = None;
@@ -785,17 +843,6 @@ impl ControlServer {
                 "cwd {cwd:?} is not a directory"
             )));
         }
-
-        let mut registry = self.registry.lock().map_err(poisoned)?;
-        let engine = registry.engine();
-        let manifest = engine
-            .manifest(&kind)
-            .ok_or_else(|| ControlError::not_found(format!("no manifest for agent {kind:?}")))?;
-        let mut descriptor = manifest.agent.clone().unwrap_or_default();
-        if let Some(binary) = descriptor.binary.as_deref() {
-            descriptor.binary = Some(self.resolve_local_agent_executable(&kind, binary)?);
-        }
-        let authority = descriptor.authority();
 
         let id = next_session_id();
         // Build the complete agent argv before `spawn_spec`: agents declaring
@@ -847,12 +894,11 @@ impl ControlServer {
         // A linked worktree is an execution cwd inside the project selected
         // by the user; it does not become a new first-level sidebar project.
         record.project_id = crate::registry::session_project_id(&p.cwd, None);
-        registry.ensure_session_project(&p.cwd, None);
         if let Some(title) = &p.title {
             record.title = title.clone();
             record.title_source = diri_proto::TitleSource::DirijorAssigned;
         }
-        record.worktree_path = worktree_path;
+        record.worktree_path = worktree_path.clone();
         record.git_branch = git_branch.or_else(|| crate::git::branch(&cwd_path));
         record.parent = p.parent.clone();
         if let (Some(cols), Some(rows)) = (p.initial_cols, p.initial_rows) {
@@ -899,9 +945,15 @@ impl ControlServer {
             remote: None,
             defer_launch: true,
         };
-        registry
-            .spawn(spec, record)
-            .map_err(|error| ControlError::internal(error.to_string()))?;
+        let mut registry = self.registry.lock().map_err(poisoned)?;
+        registry.ensure_session_project(&p.cwd, None);
+        if let Err(error) = registry.spawn(spec, record) {
+            drop(registry);
+            if let Some(worktree) = worktree_path.as_deref() {
+                let _ = crate::git::remove_worktree(Path::new(&p.cwd), worktree, true);
+            }
+            return Err(ControlError::internal(error.to_string()));
+        }
         let _ = registry.persist();
         self.publish_updated(&registry, &id);
 
@@ -2905,6 +2957,30 @@ fn io_control_error(error: std::io::Error) -> ControlError {
     }
 }
 
+fn spawn_fingerprint(
+    params: &diri_proto::SessionSpawnParams,
+    argv: &[String],
+) -> Result<String, ControlError> {
+    let mut normalized =
+        serde_json::to_value(params).map_err(|error| ControlError::internal(error.to_string()))?;
+    let object = normalized
+        .as_object_mut()
+        .ok_or_else(|| ControlError::internal("spawn parameters did not encode as an object"))?;
+    // `false` and omission are the same operation at the spawn boundary.
+    object.insert(
+        "newWorktree".into(),
+        Value::Bool(params.new_worktree.unwrap_or(false)),
+    );
+    object.insert(
+        "argv".into(),
+        serde_json::to_value(argv).map_err(|error| ControlError::internal(error.to_string()))?,
+    );
+    let bytes = serde_json::to_vec(&normalized)
+        .map_err(|error| ControlError::internal(error.to_string()))?;
+    let digest = Sha256::digest(bytes);
+    Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
 fn agent_unavailable(kind: &str, host: Option<&str>, detail: Option<&str>) -> ControlError {
     let target = host.map_or_else(|| "this Mac".to_owned(), ToOwned::to_owned);
     let suffix = detail.map_or_else(String::new, |detail| format!(": {detail}"));
@@ -4411,6 +4487,89 @@ mod tests {
             err_of(call(&server, "session.resize", Some(json!({ "id": "s" })))).code,
             "bad_request"
         );
+    }
+
+    #[test]
+    fn concurrent_keyed_control_spawns_create_exactly_one_session() {
+        let temp = tempfile::tempdir().expect("temp");
+        let server = server(temp.path());
+        server
+            .registry
+            .lock()
+            .expect("registry")
+            .insert_record(test_record("s_parent"));
+        let params = json!({
+            "kind": {"shell": {}},
+            "cwd": temp.path(),
+            "parent": "s_parent",
+            "title": "idempotent child",
+            "requestKey": "turn-9/reviewer",
+        });
+        let gate = Arc::new(std::sync::Barrier::new(3));
+        let mut workers = Vec::new();
+        for _ in 0..2 {
+            let server = Arc::clone(&server);
+            let params = params.clone();
+            let gate = Arc::clone(&gate);
+            workers.push(std::thread::spawn(move || {
+                gate.wait();
+                ok_of(call(&server, Method::SESSION_SPAWN, Some(params)))
+            }));
+        }
+        gate.wait();
+        let results = workers
+            .into_iter()
+            .map(|worker| worker.join().expect("spawn worker"))
+            .collect::<Vec<_>>();
+        assert_eq!(results[0]["id"], results[1]["id"]);
+
+        let child_id = results[0]["id"].as_str().expect("child id").to_owned();
+        let records = server.registry.lock().expect("registry").records();
+        assert_eq!(
+            records
+                .iter()
+                .filter(|record| record
+                    .parent
+                    .as_ref()
+                    .is_some_and(|parent| parent.0 == "s_parent"))
+                .count(),
+            1
+        );
+        let mut registry = server.registry.lock().expect("registry");
+        let _ = registry.terminate(&child_id, Duration::from_millis(500));
+        registry.forget(&child_id);
+    }
+
+    #[test]
+    fn keyed_spawn_arguments_are_normalized_before_conflict_checks() {
+        let temp = tempfile::tempdir().expect("temp");
+        let server = server(temp.path());
+        server
+            .registry
+            .lock()
+            .expect("registry")
+            .insert_record(test_record("s_parent"));
+        let base = json!({
+            "kind": {"shell": {}},
+            "cwd": temp.path(),
+            "parent": "s_parent",
+            "requestKey": "turn-9/normalized",
+        });
+        let first = ok_of(call(&server, Method::SESSION_SPAWN, Some(base.clone())));
+        let mut explicit_false = base.clone();
+        explicit_false["newWorktree"] = json!(false);
+        let replay = ok_of(call(&server, Method::SESSION_SPAWN, Some(explicit_false)));
+        assert_eq!(first["id"], replay["id"]);
+
+        let mut changed = base;
+        changed["title"] = json!("different title");
+        let conflict = err_of(call(&server, Method::SESSION_SPAWN, Some(changed)));
+        assert_eq!(conflict.code, "idempotency_conflict");
+
+        let child_id = first["id"].as_str().expect("child id");
+        let mut registry = server.registry.lock().expect("registry");
+        let _ = registry.terminate(child_id, Duration::from_millis(500));
+        registry.forget(child_id);
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/control.rs
+++ b/diri/crates/diri-engine/src/control.rs
@@ -837,6 +837,11 @@ impl ControlServer {
             cwd.clone_from(&info.path);
             worktree_path = Some(info.path);
         }
+        let mut worktree_rollback = crate::git::WorktreeRollback::new(
+            PathBuf::from(&p.cwd),
+            worktree_path.clone(),
+            git_branch.clone(),
+        );
         let cwd_path = PathBuf::from(&cwd);
         if !cwd_path.is_dir() {
             return Err(ControlError::bad_request(format!(
@@ -947,13 +952,10 @@ impl ControlServer {
         };
         let mut registry = self.registry.lock().map_err(poisoned)?;
         registry.ensure_session_project(&p.cwd, None);
-        if let Err(error) = registry.spawn(spec, record) {
-            drop(registry);
-            if let Some(worktree) = worktree_path.as_deref() {
-                let _ = crate::git::remove_worktree(Path::new(&p.cwd), worktree, true);
-            }
-            return Err(ControlError::internal(error.to_string()));
-        }
+        registry
+            .spawn(spec, record)
+            .map_err(|error| ControlError::internal(error.to_string()))?;
+        worktree_rollback.disarm();
         let _ = registry.persist();
         self.publish_updated(&registry, &id);
 

--- a/diri/crates/diri-engine/src/git.rs
+++ b/diri/crates/diri-engine/src/git.rs
@@ -283,6 +283,46 @@ pub fn remove_worktree(repo: &Path, worktree: &str, force: bool) -> std::io::Res
     Ok(())
 }
 
+/// Owns a newly-created linked worktree until a session record commits it.
+/// Any early return or unwind removes the checkout and branch-side metadata,
+/// so retryable launch failures cannot accumulate orphan worktrees.
+pub struct WorktreeRollback {
+    repo: PathBuf,
+    worktree: Option<String>,
+    created_branch: Option<String>,
+}
+
+impl WorktreeRollback {
+    #[must_use]
+    pub fn new(
+        repo: impl Into<PathBuf>,
+        worktree: Option<String>,
+        created_branch: Option<String>,
+    ) -> Self {
+        Self {
+            repo: repo.into(),
+            worktree,
+            created_branch,
+        }
+    }
+
+    pub fn disarm(&mut self) {
+        self.worktree = None;
+        self.created_branch = None;
+    }
+}
+
+impl Drop for WorktreeRollback {
+    fn drop(&mut self) {
+        if let Some(worktree) = self.worktree.as_deref()
+            && remove_worktree(&self.repo, worktree, true).is_ok()
+            && let Some(branch) = self.created_branch.as_deref()
+        {
+            let _ = run(&["branch", "-D", branch], &self.repo);
+        }
+    }
+}
+
 /// The response stays below the NDJSON ceiling after base64 encoding.
 const MAX_PATCH_BYTES: usize = 2 * 1024 * 1024;
 const MAX_DIFF_RESPONSE_BYTES: usize = MAX_PATCH_BYTES + 16 * 1024;
@@ -578,6 +618,66 @@ mod tests {
 
         remove_worktree(&repo, &created.path, true).expect("remove");
         assert_eq!(list_worktrees(&repo).expect("list").len(), 1);
+    }
+
+    #[test]
+    fn rollback_removes_the_created_worktree_and_branch_before_retry() {
+        let temp = tempfile::tempdir().expect("temp");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("mkdir");
+        let git = |args: &[&str]| {
+            let output = std::process::Command::new("/usr/bin/git")
+                .args(args)
+                .current_dir(&repo)
+                .env_clear()
+                .env("PATH", "/usr/bin:/bin")
+                .env("HOME", temp.path())
+                .env("GIT_CONFIG_NOSYSTEM", "1")
+                .output()
+                .expect("run git");
+            assert!(output.status.success(), "git {args:?}");
+        };
+        git(&["init", "--quiet", "--initial-branch=main"]);
+        std::fs::write(repo.join("f.txt"), b"x").expect("write");
+        git(&["add", "."]);
+        git(&[
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.invalid",
+            "commit",
+            "--quiet",
+            "-m",
+            "init",
+        ]);
+
+        let created = create_worktree(&repo, Some("test/rollback"), None).expect("create");
+        let path = created.path.clone();
+        let branch = created.branch.clone().expect("created branch");
+        drop(WorktreeRollback::new(
+            &repo,
+            Some(path.clone()),
+            Some(branch.clone()),
+        ));
+
+        assert!(!Path::new(&path).exists());
+        assert_eq!(list_worktrees(&repo).expect("list").len(), 1);
+        let branch_ref = format!("refs/heads/{branch}");
+        let branch_exists = std::process::Command::new("/usr/bin/git")
+            .args(["show-ref", "--verify", "--quiet", &branch_ref])
+            .current_dir(&repo)
+            .env_clear()
+            .env("PATH", "/usr/bin:/bin")
+            .env("HOME", temp.path())
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .status()
+            .expect("probe branch")
+            .success();
+        assert!(!branch_exists, "rollback must remove its created branch");
+
+        let retried = create_worktree(&repo, Some("test/rollback"), None).expect("retry");
+        remove_worktree(&repo, &retried.path, true).expect("cleanup retry");
+        run(&["branch", "-D", "test/rollback"], &repo).expect("cleanup branch");
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/idempotency.rs
+++ b/diri/crates/diri-engine/src/idempotency.rs
@@ -1,0 +1,351 @@
+//! Caller-scoped idempotency for daemon-owned mutations.
+//!
+//! The stdio MCP adapter is intentionally disposable. Retry state therefore
+//! lives here, in the long-running Engine, and is shared by every control
+//! connection. Only successful mutations are retained: failures release the
+//! key so a later request can try again.
+
+use std::collections::HashMap;
+use std::sync::{Condvar, Mutex};
+use std::time::{Duration, Instant};
+
+use diri_proto::ControlError;
+use serde_json::Value;
+
+const DEFAULT_ENTRY_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+const DEFAULT_MAX_ENTRIES_PER_CALLER: usize = 128;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct RequestIdentity {
+    caller: String,
+    tool: &'static str,
+    request_key: String,
+}
+
+#[derive(Clone, Debug)]
+enum EntryState {
+    Running,
+    Complete {
+        result: Result<Value, ControlError>,
+        completed_at: Instant,
+    },
+}
+
+#[derive(Clone, Debug)]
+struct Entry {
+    fingerprint: String,
+    state: EntryState,
+}
+
+#[derive(Debug, Default)]
+struct State {
+    entries: HashMap<RequestIdentity, Entry>,
+}
+
+/// A bounded, process-lifetime registry for successful mutation results.
+///
+/// Concurrent callers wait behind the first owner of a key. Reusing a key
+/// with different normalized arguments is rejected before the mutation runs.
+pub struct MutationLedger {
+    state: Mutex<State>,
+    changed: Condvar,
+    entry_ttl: Duration,
+    max_entries_per_caller: usize,
+}
+
+impl Default for MutationLedger {
+    fn default() -> Self {
+        Self::new(DEFAULT_ENTRY_TTL, DEFAULT_MAX_ENTRIES_PER_CALLER)
+    }
+}
+
+impl MutationLedger {
+    pub fn new(entry_ttl: Duration, max_entries_per_caller: usize) -> Self {
+        Self {
+            state: Mutex::new(State::default()),
+            changed: Condvar::new(),
+            entry_ttl,
+            max_entries_per_caller: max_entries_per_caller.max(1),
+        }
+    }
+
+    /// Runs `mutation` at most once for a successful identity/fingerprint.
+    ///
+    /// Errors are deliberately not cached. A reservation guard removes a
+    /// running entry even during unwinding, so a crashed worker cannot wedge
+    /// every future retry behind a key that will never finish.
+    pub fn run(
+        &self,
+        caller: &str,
+        tool: &'static str,
+        request_key: &str,
+        fingerprint: String,
+        mutation: impl FnOnce() -> Result<Value, ControlError>,
+    ) -> Result<Value, ControlError> {
+        let identity = RequestIdentity {
+            caller: caller.to_owned(),
+            tool,
+            request_key: request_key.to_owned(),
+        };
+
+        let mut state = self.state.lock().map_err(poisoned)?;
+        loop {
+            self.prune_expired(&mut state);
+            match state.entries.get(&identity) {
+                Some(entry) if entry.fingerprint != fingerprint => {
+                    return Err(ControlError::new(
+                        "idempotency_conflict",
+                        "requestKey was already used with different arguments",
+                    ));
+                }
+                Some(Entry {
+                    state: EntryState::Complete { result, .. },
+                    ..
+                }) => return result.clone(),
+                Some(Entry {
+                    state: EntryState::Running,
+                    ..
+                }) => {
+                    state = self.changed.wait(state).map_err(poisoned)?;
+                }
+                None => {
+                    self.make_room(&mut state, caller)?;
+                    state.entries.insert(
+                        identity.clone(),
+                        Entry {
+                            fingerprint: fingerprint.clone(),
+                            state: EntryState::Running,
+                        },
+                    );
+                    break;
+                }
+            }
+        }
+        drop(state);
+
+        let mut reservation = Reservation {
+            ledger: self,
+            identity,
+            fingerprint,
+            finished: false,
+        };
+        let result = mutation();
+        if match &result {
+            Ok(_) => true,
+            Err(error) => cacheable_error(error),
+        } {
+            reservation.complete(result.clone());
+        }
+        result
+    }
+
+    /// Drops retry history when its caller session is removed from Diri.
+    pub fn forget_caller(&self, caller: &str) {
+        if let Ok(mut state) = self.state.lock() {
+            state
+                .entries
+                .retain(|identity, _| identity.caller != caller);
+            self.changed.notify_all();
+        }
+    }
+
+    fn prune_expired(&self, state: &mut State) {
+        let ttl = self.entry_ttl;
+        state.entries.retain(|_, entry| match entry.state {
+            EntryState::Running => true,
+            EntryState::Complete { completed_at, .. } => completed_at.elapsed() < ttl,
+        });
+    }
+
+    fn make_room(&self, state: &mut State, caller: &str) -> Result<(), ControlError> {
+        let caller_count = state
+            .entries
+            .keys()
+            .filter(|identity| identity.caller == caller)
+            .count();
+        if caller_count < self.max_entries_per_caller {
+            return Ok(());
+        }
+
+        let oldest = state
+            .entries
+            .iter()
+            .filter_map(|(identity, entry)| match entry.state {
+                EntryState::Complete { completed_at, .. } if identity.caller == caller => {
+                    Some((identity.clone(), completed_at))
+                }
+                _ => None,
+            })
+            .min_by_key(|(_, completed_at)| *completed_at)
+            .map(|(identity, _)| identity);
+        if let Some(oldest) = oldest {
+            state.entries.remove(&oldest);
+            Ok(())
+        } else {
+            Err(ControlError::new(
+                "idempotency_capacity",
+                "too many idempotent mutations are already running for this caller",
+            ))
+        }
+    }
+}
+
+struct Reservation<'a> {
+    ledger: &'a MutationLedger,
+    identity: RequestIdentity,
+    fingerprint: String,
+    finished: bool,
+}
+
+impl Reservation<'_> {
+    fn complete(&mut self, result: Result<Value, ControlError>) {
+        if let Ok(mut state) = self.ledger.state.lock()
+            && let Some(entry) = state.entries.get_mut(&self.identity)
+            && entry.fingerprint == self.fingerprint
+            && matches!(entry.state, EntryState::Running)
+        {
+            entry.state = EntryState::Complete {
+                result,
+                completed_at: Instant::now(),
+            };
+            self.finished = true;
+            self.ledger.changed.notify_all();
+        }
+    }
+}
+
+impl Drop for Reservation<'_> {
+    fn drop(&mut self) {
+        if self.finished {
+            return;
+        }
+        if let Ok(mut state) = self.ledger.state.lock() {
+            let should_remove = state.entries.get(&self.identity).is_some_and(|entry| {
+                entry.fingerprint == self.fingerprint && matches!(entry.state, EntryState::Running)
+            });
+            if should_remove {
+                state.entries.remove(&self.identity);
+            }
+            self.ledger.changed.notify_all();
+        }
+    }
+}
+
+fn poisoned<T>(_: std::sync::PoisonError<T>) -> ControlError {
+    ControlError::internal("idempotency registry lock was poisoned")
+}
+
+/// A prompt-delivery failure is reported only after the session exists. It is
+/// retained to prevent a retry from creating a second child. Validation and
+/// infrastructure failures happen before acknowledgement and remain retryable.
+fn cacheable_error(error: &ControlError) -> bool {
+    error.code == "initial_prompt_delivery_failed"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn concurrent_retries_share_one_success() {
+        let ledger = Arc::new(MutationLedger::default());
+        let mutations = Arc::new(AtomicUsize::new(0));
+        let gate = Arc::new(std::sync::Barrier::new(3));
+        let mut threads = Vec::new();
+        for _ in 0..2 {
+            let ledger = Arc::clone(&ledger);
+            let mutations = Arc::clone(&mutations);
+            let gate = Arc::clone(&gate);
+            threads.push(std::thread::spawn(move || {
+                gate.wait();
+                ledger
+                    .run("parent", "spawn_agent", "turn-7", "same".into(), || {
+                        mutations.fetch_add(1, Ordering::SeqCst);
+                        std::thread::sleep(Duration::from_millis(30));
+                        Ok(serde_json::json!({"id": "s_once"}))
+                    })
+                    .expect("spawn")
+            }));
+        }
+        gate.wait();
+        let values = threads
+            .into_iter()
+            .map(|thread| thread.join().expect("join"))
+            .collect::<Vec<_>>();
+        assert_eq!(mutations.load(Ordering::SeqCst), 1);
+        assert_eq!(values[0], values[1]);
+    }
+
+    #[test]
+    fn conflicts_are_scoped_and_failures_are_retryable() {
+        let ledger = MutationLedger::default();
+        let first = ledger
+            .run("one", "spawn_agent", "k", "a".into(), || {
+                Ok(serde_json::json!({"id": "s_one"}))
+            })
+            .expect("first");
+        let conflict = ledger
+            .run("one", "spawn_agent", "k", "b".into(), || unreachable!())
+            .expect_err("conflict");
+        assert_eq!(conflict.code, "idempotency_conflict");
+
+        let other = ledger
+            .run("two", "spawn_agent", "k", "b".into(), || {
+                Ok(serde_json::json!({"id": "s_two"}))
+            })
+            .expect("other caller");
+        assert_ne!(first, other);
+
+        let transient = ledger.run("one", "spawn_agent", "retry", "x".into(), || {
+            Err(ControlError::internal("temporary"))
+        });
+        assert!(transient.is_err());
+        let retried = ledger
+            .run("one", "spawn_agent", "retry", "x".into(), || {
+                Ok(serde_json::json!({"id": "s_retry"}))
+            })
+            .expect("retry");
+        assert_eq!(retried["id"], "s_retry");
+
+        let runs = AtomicUsize::new(0);
+        for _ in 0..2 {
+            let failure = ledger
+                .run("one", "spawn_agent", "partial", "x".into(), || {
+                    runs.fetch_add(1, Ordering::SeqCst);
+                    Err(ControlError::new(
+                        "initial_prompt_delivery_failed",
+                        "session s_created already exists",
+                    ))
+                })
+                .expect_err("sticky post-mutation failure");
+            assert_eq!(failure.code, "initial_prompt_delivery_failed");
+        }
+        assert_eq!(runs.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn caller_removal_and_capacity_bound_retention() {
+        let ledger = MutationLedger::new(Duration::from_secs(60), 1);
+        let first = ledger
+            .run("one", "spawn_agent", "a", "a".into(), || {
+                Ok(serde_json::json!({"id": 1}))
+            })
+            .expect("first");
+        let second = ledger
+            .run("one", "spawn_agent", "b", "b".into(), || {
+                Ok(serde_json::json!({"id": 2}))
+            })
+            .expect("evicts oldest");
+        assert_ne!(first, second);
+
+        ledger.forget_caller("one");
+        let replayed_as_new = ledger
+            .run("one", "spawn_agent", "b", "b".into(), || {
+                Ok(serde_json::json!({"id": 3}))
+            })
+            .expect("new lifetime");
+        assert_eq!(replayed_as_new["id"], 3);
+    }
+}

--- a/diri/crates/diri-engine/src/idempotency.rs
+++ b/diri/crates/diri-engine/src/idempotency.rs
@@ -6,7 +6,7 @@
 //! unless their outcome proves or may imply that the mutation already
 //! committed.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::{Condvar, Mutex};
 use std::time::{Duration, Instant};
@@ -45,6 +45,7 @@ struct State {
     entries: HashMap<RequestIdentity, Entry>,
     caller_generations: HashMap<String, u64>,
     retired_callers: HashMap<String, Instant>,
+    pending_activations: HashSet<String>,
     next_generation: u64,
 }
 
@@ -54,6 +55,7 @@ impl Default for State {
             entries: HashMap::new(),
             caller_generations: HashMap::new(),
             retired_callers: HashMap::new(),
+            pending_activations: HashSet::new(),
             next_generation: 1,
         }
     }
@@ -66,6 +68,18 @@ impl State {
         self.caller_generations
             .insert(caller.to_owned(), generation);
         generation
+    }
+
+    fn activate_after_owner_settles(&mut self, identity: &RequestIdentity) {
+        let old_owner_running = self.entries.iter().any(|(candidate, entry)| {
+            candidate.caller == identity.caller
+                && candidate.generation == identity.generation
+                && matches!(entry.state, EntryState::Running)
+        });
+        if !old_owner_running && self.pending_activations.remove(&identity.caller) {
+            self.retired_callers.remove(&identity.caller);
+            self.allocate_generation(&identity.caller);
+        }
     }
 }
 
@@ -110,6 +124,7 @@ impl MutationLedger {
         mutation: impl FnOnce() -> Result<Value, ControlError>,
     ) -> Result<Value, ControlError> {
         let mut state = self.state.lock().map_err(poisoned)?;
+        self.prune_expired(&mut state);
         let generation = state
             .caller_generations
             .get(caller)
@@ -197,6 +212,9 @@ impl MutationLedger {
     pub fn forget_caller(&self, caller: &str) {
         if let Ok(mut state) = self.state.lock() {
             self.prune_expired(&mut state);
+            // A second removal supersedes any pending reopen from the prior
+            // lifetime. Only a later explicit activation may reopen it.
+            state.pending_activations.remove(caller);
             state
                 .retired_callers
                 .insert(caller.to_owned(), Instant::now());
@@ -211,9 +229,24 @@ impl MutationLedger {
     /// later reopened. The generation makes old owners and waiters incapable
     /// of completing or reserving entries in the new lifetime.
     pub fn activate_caller(&self, caller: &str) {
-        if let Ok(mut state) = self.state.lock()
-            && state.retired_callers.remove(caller).is_some()
-        {
+        if let Ok(mut state) = self.state.lock() {
+            if !state.retired_callers.contains_key(caller) {
+                return;
+            }
+            let old_owner_running = state.entries.iter().any(|(identity, entry)| {
+                identity.caller == caller && matches!(entry.state, EntryState::Running)
+            });
+            if old_owner_running {
+                // A reopened record may be visible while its previous
+                // lifetime's mutation is still settling. Keep that lifetime
+                // retired: allowing a new generation now would let the same
+                // requestKey execute twice concurrently. The old reservation
+                // completes the deferred activation after the last old owner
+                // settles.
+                state.pending_activations.insert(caller.to_owned());
+                return;
+            }
+            state.retired_callers.remove(caller);
             state.allocate_generation(caller);
             self.changed.notify_all();
         }
@@ -247,6 +280,7 @@ impl MutationLedger {
         for caller in expired_callers {
             state.retired_callers.remove(&caller);
             state.caller_generations.remove(&caller);
+            state.pending_activations.remove(&caller);
         }
     }
 
@@ -322,6 +356,7 @@ impl Reservation<'_> {
                     };
                 } else {
                     state.entries.remove(&self.identity);
+                    state.activate_after_owner_settles(&self.identity);
                 }
                 self.finished = true;
                 self.ledger.changed.notify_all();
@@ -341,6 +376,7 @@ impl Drop for Reservation<'_> {
             });
             if should_remove {
                 state.entries.remove(&self.identity);
+                state.activate_after_owner_settles(&self.identity);
             }
             self.ledger.changed.notify_all();
         }
@@ -503,6 +539,7 @@ mod tests {
         };
         started_rx.recv().expect("owner started");
         ledger.forget_caller("parent");
+        ledger.activate_caller("parent");
 
         let retry = ledger
             .run("parent", "spawn_agent", "same", "same".into(), || {
@@ -519,6 +556,15 @@ mod tests {
             "s_only"
         );
         assert_eq!(mutations.load(Ordering::SeqCst), 1);
+
+        let new_lifetime = ledger
+            .run("parent", "spawn_agent", "same", "same".into(), || {
+                mutations.fetch_add(1, Ordering::SeqCst);
+                Ok(serde_json::json!({"id": "s_reopened"}))
+            })
+            .expect("the reopened caller activates after the old owner settles");
+        assert_eq!(new_lifetime["id"], "s_reopened");
+        assert_eq!(mutations.load(Ordering::SeqCst), 2);
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/idempotency.rs
+++ b/diri/crates/diri-engine/src/idempotency.rs
@@ -2,10 +2,12 @@
 //!
 //! The stdio MCP adapter is intentionally disposable. Retry state therefore
 //! lives here, in the long-running Engine, and is shared by every control
-//! connection. Only successful mutations are retained: failures release the
-//! key so a later request can try again.
+//! connection. Successful mutations are retained; failures release the key
+//! unless their outcome proves or may imply that the mutation already
+//! committed.
 
 use std::collections::HashMap;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::{Condvar, Mutex};
 use std::time::{Duration, Instant};
 
@@ -18,6 +20,7 @@ const DEFAULT_MAX_ENTRIES_PER_CALLER: usize = 128;
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct RequestIdentity {
     caller: String,
+    generation: u64,
     tool: &'static str,
     request_key: String,
 }
@@ -37,9 +40,33 @@ struct Entry {
     state: EntryState,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct State {
     entries: HashMap<RequestIdentity, Entry>,
+    caller_generations: HashMap<String, u64>,
+    retired_callers: HashMap<String, Instant>,
+    next_generation: u64,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            entries: HashMap::new(),
+            caller_generations: HashMap::new(),
+            retired_callers: HashMap::new(),
+            next_generation: 1,
+        }
+    }
+}
+
+impl State {
+    fn allocate_generation(&mut self, caller: &str) -> u64 {
+        let generation = self.next_generation;
+        self.next_generation = self.next_generation.saturating_add(1);
+        self.caller_generations
+            .insert(caller.to_owned(), generation);
+        generation
+    }
 }
 
 /// A bounded, process-lifetime registry for successful mutation results.
@@ -71,9 +98,9 @@ impl MutationLedger {
 
     /// Runs `mutation` at most once for a successful identity/fingerprint.
     ///
-    /// Errors are deliberately not cached. A reservation guard removes a
-    /// running entry even during unwinding, so a crashed worker cannot wedge
-    /// every future retry behind a key that will never finish.
+    /// Pre-commit errors are deliberately not cached. Panics fail closed as a
+    /// sticky uncertain outcome because they cannot prove whether the
+    /// mutation had already crossed its irreversible commit point.
     pub fn run(
         &self,
         caller: &str,
@@ -82,15 +109,25 @@ impl MutationLedger {
         fingerprint: String,
         mutation: impl FnOnce() -> Result<Value, ControlError>,
     ) -> Result<Value, ControlError> {
+        let mut state = self.state.lock().map_err(poisoned)?;
+        let generation = state
+            .caller_generations
+            .get(caller)
+            .copied()
+            .unwrap_or_else(|| state.allocate_generation(caller));
         let identity = RequestIdentity {
             caller: caller.to_owned(),
+            generation,
             tool,
             request_key: request_key.to_owned(),
         };
-
-        let mut state = self.state.lock().map_err(poisoned)?;
         loop {
             self.prune_expired(&mut state);
+            if state.retired_callers.contains_key(caller)
+                || state.caller_generations.get(caller).copied() != Some(generation)
+            {
+                return Err(caller_retired(caller));
+            }
             match state.entries.get(&identity) {
                 Some(entry) if entry.fingerprint != fingerprint => {
                     return Err(ControlError::new(
@@ -109,7 +146,7 @@ impl MutationLedger {
                     state = self.changed.wait(state).map_err(poisoned)?;
                 }
                 None => {
-                    self.make_room(&mut state, caller)?;
+                    self.make_room(&mut state, caller, generation)?;
                     state.entries.insert(
                         identity.clone(),
                         Entry {
@@ -129,22 +166,55 @@ impl MutationLedger {
             fingerprint,
             finished: false,
         };
-        let result = mutation();
-        if match &result {
-            Ok(_) => true,
-            Err(error) => cacheable_error(error),
-        } {
-            reservation.complete(result.clone());
+        match catch_unwind(AssertUnwindSafe(mutation)) {
+            Ok(result) => {
+                if match &result {
+                    Ok(_) => true,
+                    Err(error) => cacheable_error(error),
+                } {
+                    reservation.complete(result.clone());
+                }
+                result
+            }
+            Err(_) => {
+                // Once arbitrary mutation code has started, a panic cannot
+                // prove whether a process/worktree was already created. Keep
+                // the key sticky so recovery can inspect state but can never
+                // accidentally repeat the mutation.
+                let error = ControlError::new(
+                    "idempotency_outcome_uncertain",
+                    "the mutation panicked after its outcome became uncertain",
+                );
+                reservation.complete(Err(error.clone()));
+                Err(error)
+            }
         }
-        result
     }
 
-    /// Drops retry history when its caller session is removed from Diri.
+    /// Retires a caller lifetime without reopening any mutation already in
+    /// flight. Completed history is discarded immediately; running owners are
+    /// allowed to settle, while all old waiters fail closed.
     pub fn forget_caller(&self, caller: &str) {
         if let Ok(mut state) = self.state.lock() {
+            self.prune_expired(&mut state);
             state
-                .entries
-                .retain(|identity, _| identity.caller != caller);
+                .retired_callers
+                .insert(caller.to_owned(), Instant::now());
+            state.entries.retain(|identity, entry| {
+                identity.caller != caller || matches!(entry.state, EntryState::Running)
+            });
+            self.changed.notify_all();
+        }
+    }
+
+    /// Begins a new lifetime for a session ID that was explicitly removed and
+    /// later reopened. The generation makes old owners and waiters incapable
+    /// of completing or reserving entries in the new lifetime.
+    pub fn activate_caller(&self, caller: &str) {
+        if let Ok(mut state) = self.state.lock()
+            && state.retired_callers.remove(caller).is_some()
+        {
+            state.allocate_generation(caller);
             self.changed.notify_all();
         }
     }
@@ -153,15 +223,43 @@ impl MutationLedger {
         let ttl = self.entry_ttl;
         state.entries.retain(|_, entry| match entry.state {
             EntryState::Running => true,
-            EntryState::Complete { completed_at, .. } => completed_at.elapsed() < ttl,
+            EntryState::Complete {
+                ref result,
+                completed_at,
+            } => sticky_result(result) || completed_at.elapsed() < ttl,
         });
+
+        // Tombstones only coordinate requests that crossed a caller-removal
+        // race. Once their TTL elapsed and no old owner remains, the daemon
+        // does not need to retain removed session IDs forever.
+        let expired_callers = state
+            .retired_callers
+            .iter()
+            .filter(|(caller, retired_at)| {
+                retired_at.elapsed() >= ttl
+                    && !state
+                        .entries
+                        .keys()
+                        .any(|identity| &identity.caller == *caller)
+            })
+            .map(|(caller, _)| caller.clone())
+            .collect::<Vec<_>>();
+        for caller in expired_callers {
+            state.retired_callers.remove(&caller);
+            state.caller_generations.remove(&caller);
+        }
     }
 
-    fn make_room(&self, state: &mut State, caller: &str) -> Result<(), ControlError> {
+    fn make_room(
+        &self,
+        state: &mut State,
+        caller: &str,
+        generation: u64,
+    ) -> Result<(), ControlError> {
         let caller_count = state
             .entries
             .keys()
-            .filter(|identity| identity.caller == caller)
+            .filter(|identity| identity.caller == caller && identity.generation == generation)
             .count();
         if caller_count < self.max_entries_per_caller {
             return Ok(());
@@ -171,7 +269,13 @@ impl MutationLedger {
             .entries
             .iter()
             .filter_map(|(identity, entry)| match entry.state {
-                EntryState::Complete { completed_at, .. } if identity.caller == caller => {
+                EntryState::Complete {
+                    ref result,
+                    completed_at,
+                } if identity.caller == caller
+                    && identity.generation == generation
+                    && !sticky_result(result) =>
+                {
                     Some((identity.clone(), completed_at))
                 }
                 _ => None,
@@ -199,17 +303,29 @@ struct Reservation<'a> {
 
 impl Reservation<'_> {
     fn complete(&mut self, result: Result<Value, ControlError>) {
-        if let Ok(mut state) = self.ledger.state.lock()
-            && let Some(entry) = state.entries.get_mut(&self.identity)
-            && entry.fingerprint == self.fingerprint
-            && matches!(entry.state, EntryState::Running)
-        {
-            entry.state = EntryState::Complete {
-                result,
-                completed_at: Instant::now(),
-            };
-            self.finished = true;
-            self.ledger.changed.notify_all();
+        if let Ok(mut state) = self.ledger.state.lock() {
+            let is_current = !state.retired_callers.contains_key(&self.identity.caller)
+                && state.caller_generations.get(&self.identity.caller).copied()
+                    == Some(self.identity.generation);
+            let owns_entry = state.entries.get(&self.identity).is_some_and(|entry| {
+                entry.fingerprint == self.fingerprint && matches!(entry.state, EntryState::Running)
+            });
+            if owns_entry {
+                if is_current {
+                    state
+                        .entries
+                        .get_mut(&self.identity)
+                        .expect("checked")
+                        .state = EntryState::Complete {
+                        result,
+                        completed_at: Instant::now(),
+                    };
+                } else {
+                    state.entries.remove(&self.identity);
+                }
+                self.finished = true;
+                self.ledger.changed.notify_all();
+            }
         }
     }
 }
@@ -235,11 +351,28 @@ fn poisoned<T>(_: std::sync::PoisonError<T>) -> ControlError {
     ControlError::internal("idempotency registry lock was poisoned")
 }
 
+fn caller_retired(caller: &str) -> ControlError {
+    ControlError::new(
+        "idempotency_caller_retired",
+        format!("caller session {caller:?} was removed while the mutation was running"),
+    )
+}
+
 /// A prompt-delivery failure is reported only after the session exists. It is
 /// retained to prevent a retry from creating a second child. Validation and
 /// infrastructure failures happen before acknowledgement and remain retryable.
 fn cacheable_error(error: &ControlError) -> bool {
     error.code == "initial_prompt_delivery_failed"
+}
+
+/// Outcomes that may follow an irreversible side effect are never evicted or
+/// expired within a caller lifetime. The per-caller capacity remains the hard
+/// memory bound; retirement clears them when that lifetime ends.
+fn sticky_result(result: &Result<Value, ControlError>) -> bool {
+    result.as_ref().is_err_and(|error| {
+        error.code == "initial_prompt_delivery_failed"
+            || error.code == "idempotency_outcome_uncertain"
+    })
 }
 
 #[cfg(test)]
@@ -341,11 +474,87 @@ mod tests {
         assert_ne!(first, second);
 
         ledger.forget_caller("one");
+        ledger.activate_caller("one");
         let replayed_as_new = ledger
             .run("one", "spawn_agent", "b", "b".into(), || {
                 Ok(serde_json::json!({"id": 3}))
             })
             .expect("new lifetime");
         assert_eq!(replayed_as_new["id"], 3);
+    }
+
+    #[test]
+    fn retiring_a_caller_never_reopens_its_running_key() {
+        let ledger = Arc::new(MutationLedger::default());
+        let mutations = Arc::new(AtomicUsize::new(0));
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (finish_tx, finish_rx) = std::sync::mpsc::channel();
+        let owner = {
+            let ledger = Arc::clone(&ledger);
+            let mutations = Arc::clone(&mutations);
+            std::thread::spawn(move || {
+                ledger.run("parent", "spawn_agent", "same", "same".into(), || {
+                    mutations.fetch_add(1, Ordering::SeqCst);
+                    started_tx.send(()).expect("announce mutation");
+                    finish_rx.recv().expect("finish mutation");
+                    Ok(serde_json::json!({"id": "s_only"}))
+                })
+            })
+        };
+        started_rx.recv().expect("owner started");
+        ledger.forget_caller("parent");
+
+        let retry = ledger
+            .run("parent", "spawn_agent", "same", "same".into(), || {
+                mutations.fetch_add(1, Ordering::SeqCst);
+                Ok(serde_json::json!({"id": "s_duplicate"}))
+            })
+            .expect_err("retired caller must fail closed");
+        assert_eq!(retry.code, "idempotency_caller_retired");
+        assert_eq!(mutations.load(Ordering::SeqCst), 1);
+
+        finish_tx.send(()).expect("release owner");
+        assert_eq!(
+            owner.join().expect("owner thread").expect("owner result")["id"],
+            "s_only"
+        );
+        assert_eq!(mutations.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn panics_become_sticky_uncertain_outcomes() {
+        let ledger = MutationLedger::new(Duration::ZERO, 128);
+        let mutations = AtomicUsize::new(0);
+        for _ in 0..2 {
+            let error = ledger
+                .run("parent", "spawn_agent", "panic", "same".into(), || {
+                    mutations.fetch_add(1, Ordering::SeqCst);
+                    panic!("after a hypothetical process launch")
+                })
+                .expect_err("panic must fail closed");
+            assert_eq!(error.code, "idempotency_outcome_uncertain");
+        }
+        assert_eq!(mutations.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn settled_retirement_tombstones_expire_without_generation_aliasing() {
+        let ledger = MutationLedger::new(Duration::ZERO, 8);
+        ledger
+            .run("old", "spawn_agent", "k", "same".into(), || {
+                Ok(serde_json::json!({"id": "s_old"}))
+            })
+            .expect("old lifetime");
+        ledger.forget_caller("old");
+
+        ledger
+            .run("other", "spawn_agent", "k", "same".into(), || {
+                Ok(serde_json::json!({"id": "s_other"}))
+            })
+            .expect("trigger pruning");
+
+        let state = ledger.state.lock().expect("ledger");
+        assert!(!state.retired_callers.contains_key("old"));
+        assert!(!state.caller_generations.contains_key("old"));
     }
 }

--- a/diri/crates/diri-engine/src/lib.rs
+++ b/diri/crates/diri-engine/src/lib.rs
@@ -35,6 +35,7 @@ pub mod history;
 pub mod holder;
 pub mod hooks;
 pub mod hosts;
+mod idempotency;
 pub mod inject;
 pub mod legacy_remote;
 pub mod log;

--- a/diri/crates/diri-engine/src/mcp/host.rs
+++ b/diri/crates/diri-engine/src/mcp/host.rs
@@ -299,6 +299,54 @@ impl RegistryHost {
     /// control-backed MCP server and returns an error if the child never
     /// accepts it.
     fn spawn_agent(&self, arguments: &Value) -> Result<Value, String> {
+        let Some(request_key) = arguments.get("requestKey").and_then(Value::as_str) else {
+            return self.spawn_agent_once(arguments);
+        };
+        if request_key.is_empty() || request_key.len() > 128 {
+            return Err("requestKey must contain 1 to 128 bytes".into());
+        }
+        let caller = self
+            .caller
+            .as_deref()
+            .ok_or_else(|| "requestKey requires a caller session identity".to_owned())?;
+        let ledger = {
+            let registry = self.registry()?;
+            if registry.record(caller).is_none() {
+                return Err(format!("caller session {caller:?} does not exist"));
+            }
+            registry.spawn_requests()
+        };
+        let mut normalized = arguments.clone();
+        let object = normalized
+            .as_object_mut()
+            .ok_or_else(|| "spawn_agent arguments must be an object".to_owned())?;
+        object.remove("requestKey");
+        object.insert(
+            "worktree".into(),
+            Value::Bool(
+                arguments
+                    .get("worktree")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+            ),
+        );
+        let fingerprint = serde_json::to_string(&normalized)
+            .map_err(|error| format!("could not normalize spawn arguments: {error}"))?;
+        ledger
+            .run(caller, "spawn_agent", request_key, fingerprint, || {
+                self.spawn_agent_once(arguments).map_err(|message| {
+                    let code = if message.starts_with("initial_prompt_delivery_failed:") {
+                        "initial_prompt_delivery_failed"
+                    } else {
+                        "mcp_tool_failed"
+                    };
+                    diri_proto::ControlError::new(code, message)
+                })
+            })
+            .map_err(|error| error.to_string())
+    }
+
+    fn spawn_agent_once(&self, arguments: &Value) -> Result<Value, String> {
         let kind = required_str(arguments, "kind")?;
         let cwd = required_str(arguments, "cwd")?;
         if let Some(host) = arguments.get("host").and_then(Value::as_str) {

--- a/diri/crates/diri-engine/src/mcp/host.rs
+++ b/diri/crates/diri-engine/src/mcp/host.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use diri_proto::{SessionId, SessionStatus};
+use diri_proto::{ControlError, McpToolErrorEnvelope, SessionId, SessionStatus};
 use serde_json::{Value, json};
 
 use super::ToolHost;
@@ -24,6 +24,32 @@ const DEFAULT_CHILDREN_WAIT_SECONDS: f64 = 600.0;
 /// How often a wait re-checks. Long enough not to spin, short enough that a
 /// state change is noticed promptly.
 const WAIT_POLL: Duration = Duration::from_millis(100);
+
+/// Owns a newly-created worktree until the session record owns it. Any
+/// validation, registry-lock, or PTY failure in between rolls the checkout
+/// back, so a retry starts from the same repository state.
+struct WorktreeRollback {
+    repo: PathBuf,
+    worktree: Option<String>,
+}
+
+impl WorktreeRollback {
+    fn new(repo: PathBuf, worktree: Option<String>) -> Self {
+        Self { repo, worktree }
+    }
+
+    fn disarm(&mut self) {
+        self.worktree = None;
+    }
+}
+
+impl Drop for WorktreeRollback {
+    fn drop(&mut self) {
+        if let Some(worktree) = self.worktree.as_deref() {
+            let _ = git::remove_worktree(&self.repo, worktree, true);
+        }
+    }
+}
 
 pub struct RegistryHost {
     registry: Arc<Mutex<Registry>>,
@@ -61,6 +87,12 @@ impl RegistryHost {
             .lock()
             .map_err(|_| "engine state is poisoned".to_string())
     }
+
+    fn registry_control(&self) -> Result<std::sync::MutexGuard<'_, Registry>, ControlError> {
+        self.registry
+            .lock()
+            .map_err(|_| ControlError::internal("engine state is poisoned"))
+    }
 }
 
 fn required_str(arguments: &Value, key: &str) -> Result<String, String> {
@@ -69,6 +101,23 @@ fn required_str(arguments: &Value, key: &str) -> Result<String, String> {
         .and_then(Value::as_str)
         .map(str::to_string)
         .ok_or_else(|| format!("{key} is required"))
+}
+
+fn strict_request_key(arguments: &Value) -> Result<Option<String>, ControlError> {
+    let Some(value) = arguments.get("requestKey") else {
+        return Ok(None);
+    };
+    let Some(value) = value.as_str() else {
+        return Err(ControlError::bad_request(
+            "requestKey must be a string containing 1 to 128 bytes",
+        ));
+    };
+    if value.trim().is_empty() || value.len() > 128 {
+        return Err(ControlError::bad_request(
+            "requestKey must be a string containing 1 to 128 bytes",
+        ));
+    }
+    Ok(Some(value.to_owned()))
 }
 
 fn status_word(status: &SessionStatus) -> &'static str {
@@ -299,27 +348,34 @@ impl RegistryHost {
     /// control-backed MCP server and returns an error if the child never
     /// accepts it.
     fn spawn_agent(&self, arguments: &Value) -> Result<Value, String> {
-        let Some(request_key) = arguments.get("requestKey").and_then(Value::as_str) else {
+        self.spawn_agent_control(arguments)
+            .map_err(|error| McpToolErrorEnvelope::from_control(error).to_text())
+    }
+
+    fn spawn_agent_control(&self, arguments: &Value) -> Result<Value, ControlError> {
+        let Some(request_key) = strict_request_key(arguments)? else {
             return self.spawn_agent_once(arguments);
         };
-        if request_key.is_empty() || request_key.len() > 128 {
-            return Err("requestKey must contain 1 to 128 bytes".into());
-        }
-        let caller = self
-            .caller
-            .as_deref()
-            .ok_or_else(|| "requestKey requires a caller session identity".to_owned())?;
+        let caller = self.caller.as_deref().ok_or_else(|| {
+            ControlError::new(
+                "idempotency_requires_caller",
+                "requestKey requires a caller session identity",
+            )
+        })?;
         let ledger = {
-            let registry = self.registry()?;
+            let registry = self.registry_control()?;
             if registry.record(caller).is_none() {
-                return Err(format!("caller session {caller:?} does not exist"));
+                return Err(ControlError::new(
+                    "idempotency_caller_not_found",
+                    format!("caller session {caller:?} does not exist"),
+                ));
             }
             registry.spawn_requests()
         };
         let mut normalized = arguments.clone();
         let object = normalized
             .as_object_mut()
-            .ok_or_else(|| "spawn_agent arguments must be an object".to_owned())?;
+            .ok_or_else(|| ControlError::bad_request("spawn_agent arguments must be an object"))?;
         object.remove("requestKey");
         object.insert(
             "worktree".into(),
@@ -330,31 +386,25 @@ impl RegistryHost {
                     .unwrap_or(false),
             ),
         );
-        let fingerprint = serde_json::to_string(&normalized)
-            .map_err(|error| format!("could not normalize spawn arguments: {error}"))?;
-        ledger
-            .run(caller, "spawn_agent", request_key, fingerprint, || {
-                self.spawn_agent_once(arguments).map_err(|message| {
-                    let code = if message.starts_with("initial_prompt_delivery_failed:") {
-                        "initial_prompt_delivery_failed"
-                    } else {
-                        "mcp_tool_failed"
-                    };
-                    diri_proto::ControlError::new(code, message)
-                })
-            })
-            .map_err(|error| error.to_string())
+        let fingerprint = serde_json::to_string(&normalized).map_err(|error| {
+            ControlError::internal(format!("could not normalize spawn arguments: {error}"))
+        })?;
+        ledger.run(caller, "spawn_agent", &request_key, fingerprint, || {
+            self.spawn_agent_once(arguments)
+        })
     }
 
-    fn spawn_agent_once(&self, arguments: &Value) -> Result<Value, String> {
-        let kind = required_str(arguments, "kind")?;
-        let cwd = required_str(arguments, "cwd")?;
+    fn spawn_agent_once(&self, arguments: &Value) -> Result<Value, ControlError> {
+        let kind = required_str(arguments, "kind").map_err(ControlError::bad_request)?;
+        let cwd = required_str(arguments, "cwd").map_err(ControlError::bad_request)?;
         if let Some(host) = arguments.get("host").and_then(Value::as_str) {
             return self.spawn_agent_remote(arguments, &kind, &cwd, host);
         }
         let cwd_path = PathBuf::from(&cwd);
         if !cwd_path.is_dir() {
-            return Err(format!("cwd {cwd:?} is not a directory"));
+            return Err(ControlError::bad_request(format!(
+                "cwd {cwd:?} is not a directory"
+            )));
         }
         let wants_worktree = arguments
             .get("worktree")
@@ -369,24 +419,35 @@ impl RegistryHost {
             .and_then(Value::as_str)
             .map(str::to_string);
 
-        // A worktree is created before the session so the agent starts inside
-        // it, rather than in the repo and moving later.
+        // Resolve every fallible, side-effect-free launch dependency before
+        // creating a checkout. A typo must not leave an orphan worktree.
+        let (descriptor, authority) = {
+            let registry = self.registry_control()?;
+            let engine = registry.engine();
+            let manifest = engine.manifest(&kind).ok_or_else(|| {
+                ControlError::not_found(format!("no manifest for agent {kind:?}"))
+            })?;
+            let descriptor = manifest.agent.clone().unwrap_or_default();
+            let authority = descriptor.authority();
+            (descriptor, authority)
+        };
+        if descriptor.binary.is_none() && kind != diri_proto::AgentKind::SHELL_ID {
+            return Err(ControlError::bad_request(format!(
+                "agent {kind:?} declares no binary, so it cannot be spawned by name"
+            )));
+        }
+
+        // The rollback guard owns the checkout until Registry::spawn commits.
         let (working_dir, worktree_path, branch) = if wants_worktree {
-            let info = git::create_worktree(&cwd_path, None, None)
-                .map_err(|error| format!("could not create a worktree: {error}"))?;
+            let info = git::create_worktree(&cwd_path, None, None).map_err(|error| {
+                ControlError::internal(format!("could not create a worktree: {error}"))
+            })?;
             let path = PathBuf::from(&info.path);
             (path, Some(info.path), info.branch)
         } else {
             (cwd_path, None, git::branch(Path::new(&cwd)))
         };
-
-        let mut registry = self.registry()?;
-        let engine = registry.engine();
-        let manifest = engine
-            .manifest(&kind)
-            .ok_or_else(|| format!("no manifest for agent {kind:?}"))?;
-        let descriptor = manifest.agent.clone().unwrap_or_default();
-        let authority = descriptor.authority();
+        let mut rollback = WorktreeRollback::new(PathBuf::from(&cwd), worktree_path.clone());
 
         let inherited: Vec<(String, String)> = std::env::vars().collect();
         let pty = if let Some(pty) = descriptor.spawn_spec(&working_dir, inherited.clone(), &[]) {
@@ -397,9 +458,9 @@ impl RegistryHost {
             pty.env = inherited;
             pty
         } else {
-            return Err(format!(
+            return Err(ControlError::bad_request(format!(
                 "agent {kind:?} declares no binary, so it cannot be spawned by name"
-            ));
+            )));
         };
 
         let id = crate::control::next_session_id();
@@ -422,9 +483,11 @@ impl RegistryHost {
             remote: None,
             defer_launch: true,
         };
+        let mut registry = self.registry_control()?;
         registry
             .spawn(spec, record)
-            .map_err(|error| format!("could not start {kind}: {error}"))?;
+            .map_err(|error| ControlError::internal(format!("could not start {kind}: {error}")))?;
+        rollback.disarm();
         let _ = registry.persist();
         drop(registry);
 
@@ -437,8 +500,11 @@ impl RegistryHost {
                 Some(prompt),
             )
             .map_err(|error| {
-                format!(
-                    "initial_prompt_delivery_failed: session {id} was created, but its initial prompt was not delivered: {error}"
+                ControlError::new(
+                    "initial_prompt_delivery_failed",
+                    format!(
+                        "session {id} was created, but its initial prompt was not delivered: {error}"
+                    ),
                 )
             })?;
         } else if accept_claude_workspace {
@@ -480,12 +546,8 @@ impl RegistryHost {
         _kind: &str,
         _cwd: &str,
         _host_id: &str,
-    ) -> Result<Value, String> {
-        Err(format!(
-            "{}: {}",
-            crate::remote::TRANSPORT_UNAVAILABLE_CODE,
-            crate::remote::transport_unavailable().message
-        ))
+    ) -> Result<Value, ControlError> {
+        Err(crate::remote::transport_unavailable())
     }
 
     fn wait_for(&self, id: &str, until: &str, timeout_seconds: f64) -> Result<Value, String> {

--- a/diri/crates/diri-engine/src/mcp/host.rs
+++ b/diri/crates/diri-engine/src/mcp/host.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 
 use diri_proto::{ControlError, McpToolErrorEnvelope, SessionId, SessionStatus};
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 
 use super::ToolHost;
 use crate::git;
@@ -24,32 +25,6 @@ const DEFAULT_CHILDREN_WAIT_SECONDS: f64 = 600.0;
 /// How often a wait re-checks. Long enough not to spin, short enough that a
 /// state change is noticed promptly.
 const WAIT_POLL: Duration = Duration::from_millis(100);
-
-/// Owns a newly-created worktree until the session record owns it. Any
-/// validation, registry-lock, or PTY failure in between rolls the checkout
-/// back, so a retry starts from the same repository state.
-struct WorktreeRollback {
-    repo: PathBuf,
-    worktree: Option<String>,
-}
-
-impl WorktreeRollback {
-    fn new(repo: PathBuf, worktree: Option<String>) -> Self {
-        Self { repo, worktree }
-    }
-
-    fn disarm(&mut self) {
-        self.worktree = None;
-    }
-}
-
-impl Drop for WorktreeRollback {
-    fn drop(&mut self) {
-        if let Some(worktree) = self.worktree.as_deref() {
-            let _ = git::remove_worktree(&self.repo, worktree, true);
-        }
-    }
-}
 
 pub struct RegistryHost {
     registry: Arc<Mutex<Registry>>,
@@ -372,23 +347,7 @@ impl RegistryHost {
             }
             registry.spawn_requests()
         };
-        let mut normalized = arguments.clone();
-        let object = normalized
-            .as_object_mut()
-            .ok_or_else(|| ControlError::bad_request("spawn_agent arguments must be an object"))?;
-        object.remove("requestKey");
-        object.insert(
-            "worktree".into(),
-            Value::Bool(
-                arguments
-                    .get("worktree")
-                    .and_then(Value::as_bool)
-                    .unwrap_or(false),
-            ),
-        );
-        let fingerprint = serde_json::to_string(&normalized).map_err(|error| {
-            ControlError::internal(format!("could not normalize spawn arguments: {error}"))
-        })?;
+        let fingerprint = spawn_agent_fingerprint_digest(arguments)?;
         ledger.run(caller, "spawn_agent", &request_key, fingerprint, || {
             self.spawn_agent_once(arguments)
         })
@@ -447,7 +406,8 @@ impl RegistryHost {
         } else {
             (cwd_path, None, git::branch(Path::new(&cwd)))
         };
-        let mut rollback = WorktreeRollback::new(PathBuf::from(&cwd), worktree_path.clone());
+        let mut rollback =
+            git::WorktreeRollback::new(PathBuf::from(&cwd), worktree_path.clone(), branch.clone());
 
         let inherited: Vec<(String, String)> = std::env::vars().collect();
         let pty = if let Some(pty) = descriptor.spawn_spec(&working_dir, inherited.clone(), &[]) {
@@ -635,5 +595,65 @@ impl RegistryHost {
     /// Where session logs live, for hosts that spawn.
     pub fn logs_dir(&self) -> &Path {
         &self.logs_dir
+    }
+}
+
+fn spawn_agent_fingerprint(arguments: &Value) -> Result<Value, ControlError> {
+    let kind = required_str(arguments, "kind").map_err(ControlError::bad_request)?;
+    let cwd = required_str(arguments, "cwd").map_err(ControlError::bad_request)?;
+    Ok(json!({
+        "kind": kind,
+        "cwd": cwd,
+        "host": arguments.get("host").and_then(Value::as_str),
+        "worktree": arguments.get("worktree").and_then(Value::as_bool).unwrap_or(false),
+        "prompt": arguments.get("prompt").and_then(Value::as_str),
+        "name": arguments.get("name").and_then(Value::as_str),
+    }))
+}
+
+fn spawn_agent_fingerprint_digest(arguments: &Value) -> Result<String, ControlError> {
+    let normalized = spawn_agent_fingerprint(arguments)?;
+    let bytes = serde_json::to_vec(&normalized).map_err(|error| {
+        ControlError::internal(format!("could not normalize spawn arguments: {error}"))
+    })?;
+    let digest = Sha256::digest(bytes);
+    Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+#[cfg(test)]
+mod fingerprint_tests {
+    use super::*;
+
+    #[test]
+    fn omitted_null_and_unknown_fields_share_one_semantic_fingerprint() {
+        let base = json!({"kind": "shell", "cwd": "/tmp"});
+        let noisy = json!({
+            "kind": "shell",
+            "cwd": "/tmp",
+            "host": null,
+            "worktree": false,
+            "prompt": null,
+            "name": null,
+            "requestKey": "ignored",
+            "futureField": {"ignored": true},
+        });
+        assert_eq!(
+            spawn_agent_fingerprint(&base).expect("base"),
+            spawn_agent_fingerprint(&noisy).expect("normalized")
+        );
+
+        let changed = json!({"kind": "shell", "cwd": "/tmp", "name": "worker"});
+        assert_ne!(
+            spawn_agent_fingerprint(&base).expect("base"),
+            spawn_agent_fingerprint(&changed).expect("changed")
+        );
+        assert_eq!(
+            spawn_agent_fingerprint_digest(&base).expect("base digest"),
+            spawn_agent_fingerprint_digest(&noisy).expect("normalized digest")
+        );
+        assert_ne!(
+            spawn_agent_fingerprint_digest(&base).expect("base digest"),
+            spawn_agent_fingerprint_digest(&changed).expect("changed digest")
+        );
     }
 }

--- a/diri/crates/diri-engine/src/mcp/mod.rs
+++ b/diri/crates/diri-engine/src/mcp/mod.rs
@@ -17,6 +17,7 @@ mod tools;
 pub use host::RegistryHost;
 pub use tools::{ToolDefinition, tool_definitions, tool_definitions_for};
 
+use diri_proto::McpToolErrorEnvelope;
 use serde_json::{Value, json};
 
 pub const SERVER_NAME: &str = "dirijor";
@@ -137,7 +138,7 @@ fn render(value: &Value) -> String {
 
 fn tool_error(message: &str) -> Value {
     json!({
-        "content": [{ "type": "text", "text": message }],
+        "content": [{ "type": "text", "text": McpToolErrorEnvelope::normalize_text(message) }],
         "isError": true,
     })
 }
@@ -296,10 +297,15 @@ mod tests {
 
         assert_eq!(response["result"]["isError"], true);
         assert!(response["error"].is_null(), "not a transport error");
-        assert_eq!(
-            response["result"]["content"][0]["text"],
-            "no session s_missing"
-        );
+        let failure: Value = serde_json::from_str(
+            response["result"]["content"][0]["text"]
+                .as_str()
+                .expect("typed failure text"),
+        )
+        .expect("valid JSON");
+        assert_eq!(failure["error"]["code"], "session_not_found");
+        assert_eq!(failure["error"]["retryable"], false);
+        assert_eq!(failure["error"]["suggestedTool"], "list_agents");
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/mcp/tools.rs
+++ b/diri/crates/diri-engine/src/mcp/tools.rs
@@ -58,7 +58,13 @@ pub fn tool_definitions_for(kinds: &[String]) -> Vec<ToolDefinition> {
                     "cwd": { "type": "string", "description": "Working directory (a repo path when worktree is true)." },
                     "worktree": { "type": "boolean", "description": "Create a fresh git worktree off cwd and run there (local spawns only)." },
                     "prompt": { "type": "string", "description": "Initial prompt to send once the agent is ready." },
-                    "name": { "type": "string", "description": "Session title." }
+                    "name": { "type": "string", "description": "Session title." },
+                    "requestKey": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 128,
+                        "description": "Stable caller-scoped key. Retry the same operation with the same key to receive its original result."
+                    }
                 },
                 "required": ["kind", "cwd"]
             }),

--- a/diri/crates/diri-engine/src/registry.rs
+++ b/diri/crates/diri-engine/src/registry.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::detect::ManifestEngine;
 use crate::holder::{HolderClient, HolderManagerPaths, HolderPaths};
+use crate::idempotency::MutationLedger;
 use crate::session::{HolderConfig, RemoteAdoptSpec, Session, SessionSpec, SessionView};
 
 /// The versioned on-disk snapshot.
@@ -51,6 +52,9 @@ pub struct Registry {
     /// tab switch), and the flusher or the next persist call writes it out.
     dirty: bool,
     last_persist: Option<std::time::Instant>,
+    /// Successful caller-scoped mutation results outlive disposable MCP stdio
+    /// processes, but remain bounded to this Registry's daemon lifetime.
+    spawn_requests: Arc<MutationLedger>,
 }
 
 /// How long consecutive persists coalesce. Matches the Swift daemon's
@@ -96,6 +100,7 @@ impl Registry {
             state_file: state_file.into(),
             dirty: false,
             last_persist: None,
+            spawn_requests: Arc::new(MutationLedger::default()),
         }
     }
 
@@ -378,6 +383,10 @@ impl Registry {
         Arc::clone(&self.engine)
     }
 
+    pub(crate) fn spawn_requests(&self) -> Arc<MutationLedger> {
+        Arc::clone(&self.spawn_requests)
+    }
+
     pub fn get(&self, id: &str) -> Option<&Session> {
         self.sessions.get(id)
     }
@@ -517,6 +526,7 @@ impl Registry {
     pub fn forget(&mut self, id: &str) {
         self.sessions.remove(id);
         self.records.remove(id);
+        self.spawn_requests.forget_caller(id);
     }
 
     /// Ends the session (if live), deletes its record AND its output log.
@@ -533,6 +543,7 @@ impl Registry {
             self.recently_closed.remove(0);
         }
         self.sessions.remove(id);
+        self.spawn_requests.forget_caller(id);
         let _ = std::fs::remove_file(logs_dir.join(format!("{id}.bin")));
         Ok(())
     }

--- a/diri/crates/diri-engine/src/registry.rs
+++ b/diri/crates/diri-engine/src/registry.rs
@@ -216,6 +216,7 @@ impl Registry {
     ///
     /// [`spawn`]: Registry::spawn
     pub fn insert_record(&mut self, record: SessionRecord) {
+        self.spawn_requests.activate_caller(&record.id.0);
         self.records.insert(record.id.0.clone(), record);
     }
 
@@ -223,6 +224,7 @@ impl Registry {
     pub fn spawn(&mut self, spec: SessionSpec, record: SessionRecord) -> std::io::Result<String> {
         let id = spec.id.clone();
         let session = Session::spawn(spec, Arc::clone(&self.engine))?;
+        self.spawn_requests.activate_caller(&id);
         self.records.insert(id.clone(), record);
         self.sessions.insert(id.clone(), session);
         Ok(id)
@@ -556,6 +558,7 @@ impl Registry {
             if record.host.is_none() && !Path::new(&record.cwd).exists() {
                 continue; // the folder is gone; try the next candidate
             }
+            self.spawn_requests.activate_caller(&record.id.0);
             self.records.insert(record.id.0.clone(), record.clone());
             return Some(record);
         }

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -581,6 +581,36 @@ struct RemoteLaunchCleanup {
     armed: bool,
 }
 
+/// Owns a direct PTY until the pump thread has successfully taken over. A
+/// failure after `fork` but before `Session` construction must kill and reap
+/// the child; dropping `std::process::Child` alone does neither.
+struct DirectLaunchCleanup {
+    pty: Arc<Mutex<Pty>>,
+    armed: bool,
+}
+
+impl DirectLaunchCleanup {
+    fn new(pty: Arc<Mutex<Pty>>) -> Self {
+        Self { pty, armed: true }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for DirectLaunchCleanup {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        if let Ok(mut pty) = self.pty.lock() {
+            let _ = pty.kill_group(libc::SIGKILL);
+            let _ = pty.wait();
+        }
+    }
+}
+
 impl RemoteLaunchCleanup {
     fn disarm(&mut self) {
         self.armed = false;
@@ -778,13 +808,17 @@ impl Session {
     }
 
     fn spawn_direct(spec: SessionSpec, engine: Arc<ManifestEngine>) -> std::io::Result<Self> {
-        let pty = Pty::spawn(&spec.pty)?;
+        let pty = Arc::new(Mutex::new(Pty::spawn(&spec.pty)?));
+        let mut cleanup = DirectLaunchCleanup::new(Arc::clone(&pty));
         let log = OutputLog::writer(&spec.logs_dir, &spec.id)?;
         let shared = new_shared(&spec, log, &engine);
-        shared.child_pid.store(pty.pid() as i32, Ordering::SeqCst);
-
-        let reader = pty.reader()?;
-        let pty = Arc::new(Mutex::new(pty));
+        let (pid, reader) = {
+            let pty = pty
+                .lock()
+                .map_err(|_| std::io::Error::other("new PTY lock was poisoned"))?;
+            (pty.pid(), pty.reader()?)
+        };
+        shared.child_pid.store(pid as i32, Ordering::SeqCst);
 
         let pump = {
             let shared = Arc::clone(&shared);
@@ -795,6 +829,7 @@ impl Session {
                 .name(format!("diri-session-{}", spec.id))
                 .spawn(move || pump(shared, engine, pty, reader, manifest_id))?
         };
+        cleanup.disarm();
 
         Ok(Self {
             shared,
@@ -1635,6 +1670,33 @@ impl Session {
             let _ = pump.join();
         }
         Ok(exit)
+    }
+}
+
+#[cfg(test)]
+mod direct_launch_cleanup_tests {
+    use super::*;
+
+    #[test]
+    fn a_failed_direct_launch_guard_kills_and_reaps_its_child() {
+        let spec = PtySpec::new(
+            vec!["/bin/sh".into(), "-c".into(), "sleep 30".into()],
+            "/tmp",
+        )
+        .env("PATH", "/usr/bin:/bin")
+        .env("TERM", "xterm-256color");
+        let pty = Arc::new(Mutex::new(Pty::spawn(&spec).expect("spawn test child")));
+        let pid = pty.lock().expect("pty").pid() as i32;
+        let cleanup = DirectLaunchCleanup::new(Arc::clone(&pty));
+        drop(cleanup);
+
+        // SAFETY: signal 0 only probes whether this exact PID still exists.
+        let result = unsafe { libc::kill(pid, 0) };
+        assert_eq!(result, -1, "cleanup must not leave the child running");
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::ESRCH)
+        );
     }
 }
 

--- a/diri/crates/diri-engine/tests/mcp_tools.rs
+++ b/diri/crates/diri-engine/tests/mcp_tools.rs
@@ -603,3 +603,61 @@ fn a_spawned_session_records_its_parent_and_appears_as_a_child() {
 
     call(&server, "release_agent", json!({ "session_id": id })).expect("release");
 }
+
+#[test]
+fn embedded_keyed_spawn_normalizes_null_and_unknown_fields() {
+    let temp = tempfile::tempdir().expect("temp");
+    let logs = temp.path().join("logs");
+    let mut inner = Registry::new(engine(), temp.path().join("state.json"));
+    inner.insert_record(record("s_parent", None));
+    let registry = Arc::new(Mutex::new(inner));
+    let server = McpServer::new(
+        tool_definitions(),
+        RegistryHost::new(Arc::clone(&registry), &logs).with_caller(Some("s_parent".into())),
+    );
+
+    let first = call(
+        &server,
+        "spawn_agent",
+        json!({
+            "kind": "shell",
+            "cwd": "/tmp",
+            "requestKey": "turn-2/normalized",
+        }),
+    )
+    .expect("first spawn");
+    let replay = call(
+        &server,
+        "spawn_agent",
+        json!({
+            "kind": "shell",
+            "cwd": "/tmp",
+            "worktree": false,
+            "prompt": null,
+            "name": null,
+            "host": null,
+            "futureField": "ignored",
+            "requestKey": "turn-2/normalized",
+        }),
+    )
+    .expect("semantic replay");
+    assert_eq!(first["id"], replay["id"]);
+
+    let conflict = call(
+        &server,
+        "spawn_agent",
+        json!({
+            "kind": "shell",
+            "cwd": "/tmp",
+            "name": "a real change",
+            "requestKey": "turn-2/normalized",
+        }),
+    )
+    .expect_err("semantic change conflicts");
+    assert_eq!(
+        typed_error(&conflict)["error"]["code"],
+        "idempotency_conflict"
+    );
+
+    call(&server, "release_agent", json!({"session_id": first["id"]})).expect("release child");
+}

--- a/diri/crates/diri-engine/tests/mcp_tools.rs
+++ b/diri/crates/diri-engine/tests/mcp_tools.rs
@@ -105,6 +105,10 @@ fn call(server: &McpServer<RegistryHost>, tool: &str, arguments: Value) -> Resul
     Ok(serde_json::from_str(&text).unwrap_or(Value::String(text)))
 }
 
+fn typed_error(text: &str) -> Value {
+    serde_json::from_str(text).expect("MCP failures must be typed JSON")
+}
+
 #[test]
 fn the_binary_free_shell_manifest_spawns_the_users_login_shell() {
     let temp = tempfile::tempdir().expect("temp");
@@ -365,6 +369,52 @@ fn worktree_tools_work_against_a_real_repository() {
     );
 
     let repo_arg = repo.to_string_lossy().to_string();
+
+    let baseline =
+        call(&server, "list_worktrees", json!({ "repo": repo_arg })).expect("baseline worktrees");
+    let baseline_count = baseline["worktrees"].as_array().expect("array").len();
+
+    let invalid = call(
+        &server,
+        "spawn_agent",
+        json!({"kind": "not-an-agent", "cwd": repo_arg, "worktree": true}),
+    )
+    .expect_err("invalid agent");
+    assert_eq!(typed_error(&invalid)["error"]["code"], "resource_not_found");
+    let after_validation = call(&server, "list_worktrees", json!({ "repo": repo_arg }))
+        .expect("worktrees after validation failure");
+    assert_eq!(
+        after_validation["worktrees"]
+            .as_array()
+            .expect("array")
+            .len(),
+        baseline_count,
+        "side-effect-free validation must precede worktree creation"
+    );
+
+    // Force Registry::spawn to fail after checkout creation. The rollback
+    // guard must remove that checkout before returning the typed failure.
+    let blocked_logs = temp.path().join("blocked-logs");
+    std::fs::write(&blocked_logs, "not a directory").expect("block logs path");
+    let failing_server = McpServer::new(
+        tool_definitions(),
+        RegistryHost::new(Arc::clone(&registry), &blocked_logs),
+    );
+    let failed_spawn = call(
+        &failing_server,
+        "spawn_agent",
+        json!({"kind": "shell", "cwd": repo_arg, "worktree": true}),
+    )
+    .expect_err("spawn must fail at the blocked log path");
+    assert_eq!(typed_error(&failed_spawn)["error"]["code"], "internal");
+    let after_rollback = call(&server, "list_worktrees", json!({ "repo": repo_arg }))
+        .expect("worktrees after rollback");
+    assert_eq!(
+        after_rollback["worktrees"].as_array().expect("array").len(),
+        baseline_count,
+        "post-checkout spawn failures must roll the worktree back"
+    );
+
     let created = call(&server, "create_worktree", json!({ "repo": repo_arg })).expect("create");
     let path = created["path"].as_str().expect("a path").to_string();
     assert!(Path::new(&path).is_dir());
@@ -414,6 +464,7 @@ fn spawn_agent_starts_a_session_owned_by_its_caller() {
     )
     .expect_err("unknown agent");
     assert!(unknown.contains("no manifest"), "got {unknown}");
+    assert_eq!(typed_error(&unknown)["error"]["code"], "resource_not_found");
 
     // A missing directory is caught before anything is started.
     let bad_cwd = call(
@@ -423,6 +474,7 @@ fn spawn_agent_starts_a_session_owned_by_its_caller() {
     )
     .expect_err("bad cwd");
     assert!(bad_cwd.contains("not a directory"), "got {bad_cwd}");
+    assert_eq!(typed_error(&bad_cwd)["error"]["code"], "cwd_not_found");
 
     // Old clients may still send `host`; fail before cwd inspection, host
     // lookup, code sync, or session creation while the new transport is dark.
@@ -435,6 +487,53 @@ fn spawn_agent_starts_a_session_owned_by_its_caller() {
     assert!(
         unavailable.contains("remote_transport_unavailable"),
         "got {unavailable}"
+    );
+    assert_eq!(
+        typed_error(&unavailable)["error"]["code"],
+        "remote_transport_unavailable"
+    );
+
+    for request_key in [json!(""), json!(42), Value::Null] {
+        let malformed = call(
+            &server,
+            "spawn_agent",
+            json!({
+                "kind": "shell",
+                "cwd": "/tmp",
+                "requestKey": request_key,
+            }),
+        )
+        .expect_err("malformed key must not spawn");
+        assert_eq!(
+            typed_error(&malformed)["error"]["code"],
+            "invalid_arguments"
+        );
+    }
+
+    let unknown_caller = call(
+        &server,
+        "spawn_agent",
+        json!({"kind": "shell", "cwd": "/tmp", "requestKey": "turn-1/child"}),
+    )
+    .expect_err("keyed spawn requires a live caller record");
+    assert_eq!(
+        typed_error(&unknown_caller)["error"]["code"],
+        "idempotency_caller_not_found"
+    );
+
+    let unscoped_server = McpServer::new(
+        tool_definitions(),
+        RegistryHost::new(Arc::clone(&registry), &logs).with_caller(None),
+    );
+    let missing_caller = call(
+        &unscoped_server,
+        "spawn_agent",
+        json!({"kind": "shell", "cwd": "/tmp", "requestKey": "turn-1/child"}),
+    )
+    .expect_err("keyed spawn requires a caller identity");
+    assert_eq!(
+        typed_error(&missing_caller)["error"]["code"],
+        "idempotency_requires_caller"
     );
 
     assert_eq!(

--- a/diri/crates/diri-proto/src/lib.rs
+++ b/diri/crates/diri-proto/src/lib.rs
@@ -4,6 +4,7 @@ pub mod control;
 pub mod frames;
 pub mod grid;
 pub mod hosts;
+pub mod mcp;
 pub mod methods;
 pub mod model;
 pub mod node;
@@ -13,6 +14,7 @@ pub mod terminal;
 
 pub use control::{ControlError, ControlMessage, JsonValue, WIRE_VERSION};
 pub use hosts::{HostEntry, HostNodeConfig, HostsConfig};
+pub use mcp::{McpToolError, McpToolErrorEnvelope};
 pub use methods::*;
 pub use model::*;
 pub use node::*;

--- a/diri/crates/diri-proto/src/mcp.rs
+++ b/diri/crates/diri-proto/src/mcp.rs
@@ -80,7 +80,10 @@ impl McpToolErrorEnvelope {
                 None,
             );
         }
-        if lower.contains("no session") || lower.contains("session not found") {
+        if lower.contains("no session")
+            || lower.contains("no such session")
+            || lower.contains("session not found")
+        {
             return Self::new(
                 "session_not_found",
                 message,
@@ -90,8 +93,11 @@ impl McpToolErrorEnvelope {
             );
         }
         if lower.contains("cannot target")
+            || lower.contains("cannot terminate")
             || lower.contains("refuses to kill")
             || lower.contains("must run inside a diri session")
+            || lower.contains("did not identify itself")
+            || lower.contains("dirijor_session_id is unset")
         {
             return Self::new(
                 "authorization_denied",
@@ -117,6 +123,24 @@ impl McpToolErrorEnvelope {
                 "Use the original arguments for this requestKey, or choose a new requestKey for a different spawn.",
                 false,
                 None,
+            );
+        }
+        if lower.contains("timed out") || lower.contains("timeout") {
+            return Self::new(
+                "timeout",
+                message,
+                "Inspect current Diri state before retrying a mutation with the same requestKey.",
+                true,
+                Some("list_agents"),
+            );
+        }
+        if lower.contains("poisoned") || lower.contains("internal error") {
+            return Self::new(
+                "internal",
+                message,
+                "Inspect current Diri state, then retry once if no mutation occurred.",
+                true,
+                Some("list_agents"),
             );
         }
         Self::new(
@@ -270,6 +294,28 @@ mod tests {
         ))
         .expect("valid JSON");
         assert_eq!(upgraded["error"]["code"], "invalid_arguments");
+
+        for (message, code, retryable) in [
+            ("no such session: s_gone", "session_not_found", false),
+            (
+                "release_agent cannot terminate its caller",
+                "authorization_denied",
+                false,
+            ),
+            (
+                "this session did not identify itself; DIRIJOR_SESSION_ID is unset",
+                "authorization_denied",
+                false,
+            ),
+            ("engine state is poisoned", "internal", true),
+            ("operation timed out", "timeout", true),
+        ] {
+            let upgraded: McpToolErrorEnvelope =
+                serde_json::from_str(&McpToolErrorEnvelope::normalize_text(message))
+                    .expect("typed JSON");
+            assert_eq!(upgraded.error.code, code, "{message}");
+            assert_eq!(upgraded.error.retryable, retryable, "{message}");
+        }
     }
 
     #[test]

--- a/diri/crates/diri-proto/src/mcp.rs
+++ b/diri/crates/diri-proto/src/mcp.rs
@@ -3,6 +3,8 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
+use crate::control::ControlError;
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct McpToolErrorEnvelope {
     pub error: McpToolError,
@@ -125,6 +127,109 @@ impl McpToolErrorEnvelope {
             None,
         )
     }
+
+    /// Translates the Engine's stable control failures into the equally
+    /// stable recovery contract exposed by every MCP adapter. Keeping this in
+    /// `diri-proto` prevents the stdio bridge and embedded host from assigning
+    /// different codes or retry guidance to the same daemon outcome.
+    pub fn from_control(error: ControlError) -> Self {
+        let lower = error.message.to_ascii_lowercase();
+        match error.code.as_str() {
+            "idempotency_conflict" => Self::new(
+                "idempotency_conflict",
+                error.message,
+                "Use the original arguments for this requestKey, or choose a new requestKey for a different spawn.",
+                false,
+                None,
+            ),
+            "idempotency_requires_caller" => Self::new(
+                "idempotency_requires_caller",
+                error.message,
+                "Run spawn_agent inside a Diri session, or omit requestKey for an unscoped call.",
+                false,
+                Some("whoami"),
+            ),
+            "idempotency_caller_not_found" | "idempotency_caller_retired" => Self::new(
+                error.code,
+                error.message,
+                "The calling session no longer exists. Start or reopen a Diri session before spawning a child.",
+                false,
+                Some("whoami"),
+            ),
+            "idempotency_capacity" => Self::new(
+                "idempotency_capacity",
+                error.message,
+                "Wait for current spawns to settle, then retry the same requestKey.",
+                true,
+                Some("list_agents"),
+            ),
+            "idempotency_outcome_uncertain" => Self::new(
+                "idempotency_outcome_uncertain",
+                error.message,
+                "Do not spawn again with this key. Inspect list_agents and the repository worktrees before deciding how to recover.",
+                false,
+                Some("list_agents"),
+            ),
+            "bad_request" if lower.contains("cwd") && lower.contains("not a directory") => {
+                Self::new(
+                    "cwd_not_found",
+                    error.message,
+                    "Choose an existing project directory and retry with a new requestKey.",
+                    false,
+                    Some("list_agents"),
+                )
+            }
+            "bad_request" => Self::new(
+                "invalid_arguments",
+                error.message,
+                "Correct the requested arguments, then retry with a new requestKey.",
+                false,
+                None,
+            ),
+            "not_found" => Self::new(
+                "resource_not_found",
+                error.message,
+                "Refresh Diri state, choose an existing resource, and retry with a new requestKey.",
+                false,
+                Some("list_agents"),
+            ),
+            "unauthorized" => Self::new(
+                "authorization_denied",
+                error.message,
+                "Reconnect through the current Diri session; do not retry with the same credentials.",
+                false,
+                Some("whoami"),
+            ),
+            "version_mismatch" => Self::new(
+                "version_mismatch",
+                error.message,
+                "Restart or update Diri so the MCP adapter and Engine use the same protocol.",
+                false,
+                None,
+            ),
+            "initial_prompt_delivery_failed" => Self::new(
+                "initial_prompt_delivery_failed",
+                error.message,
+                "The session exists. Inspect list_agents and send_prompt to that session instead of spawning another one.",
+                false,
+                Some("list_agents"),
+            ),
+            "internal" => Self::new(
+                "internal",
+                error.message,
+                "Inspect list_agents before retrying; if no mutation occurred, retry once with the same requestKey.",
+                true,
+                Some("list_agents"),
+            ),
+            code => Self::new(
+                code,
+                error.message,
+                "Inspect current Diri state, then retry only when the operation is safe.",
+                false,
+                Some("list_agents"),
+            ),
+        }
+    }
 }
 
 fn empty_details() -> Value {
@@ -165,5 +270,24 @@ mod tests {
         ))
         .expect("valid JSON");
         assert_eq!(upgraded["error"]["code"], "invalid_arguments");
+    }
+
+    #[test]
+    fn control_mapping_covers_safe_idempotency_recovery() {
+        let uncertain = McpToolErrorEnvelope::from_control(ControlError::new(
+            "idempotency_outcome_uncertain",
+            "the spawn panicked after it may have committed",
+        ));
+        assert_eq!(uncertain.error.code, "idempotency_outcome_uncertain");
+        assert!(!uncertain.error.retryable);
+        assert_eq!(
+            uncertain.error.suggested_tool.as_deref(),
+            Some("list_agents")
+        );
+
+        let validation = McpToolErrorEnvelope::from_control(ControlError::bad_request(
+            "requestKey must be a string containing 1 to 128 bytes",
+        ));
+        assert_eq!(validation.error.code, "invalid_arguments");
     }
 }

--- a/diri/crates/diri-proto/src/mcp.rs
+++ b/diri/crates/diri-proto/src/mcp.rs
@@ -1,0 +1,169 @@
+//! Stable, machine-readable MCP tool failures.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct McpToolErrorEnvelope {
+    pub error: McpToolError,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpToolError {
+    pub code: String,
+    pub message: String,
+    pub model_guidance: String,
+    pub retryable: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suggested_tool: Option<String>,
+    #[serde(default = "empty_details")]
+    pub details: Value,
+}
+
+impl McpToolErrorEnvelope {
+    pub fn new(
+        code: impl Into<String>,
+        message: impl Into<String>,
+        model_guidance: impl Into<String>,
+        retryable: bool,
+        suggested_tool: Option<&str>,
+    ) -> Self {
+        Self {
+            error: McpToolError {
+                code: code.into(),
+                message: message.into(),
+                model_guidance: model_guidance.into(),
+                retryable,
+                suggested_tool: suggested_tool.map(str::to_owned),
+                details: empty_details(),
+            },
+        }
+    }
+
+    pub fn with_details(mut self, details: Value) -> Self {
+        self.error.details = details;
+        self
+    }
+
+    /// Encodes the envelope as the MCP text content. This deliberately stays
+    /// JSON text rather than structuredContent so older clients still show it.
+    pub fn to_text(&self) -> String {
+        serde_json::to_string(self).unwrap_or_else(|_| {
+            "{\"error\":{\"code\":\"internal\",\"message\":\"Could not encode the tool failure.\",\"modelGuidance\":\"Report this Diri error and do not assume the mutation succeeded.\",\"retryable\":false,\"details\":{}}}".to_owned()
+        })
+    }
+
+    /// Preserves an already-typed failure and upgrades legacy prose to a
+    /// conservative envelope.
+    pub fn normalize_text(message: &str) -> String {
+        if serde_json::from_str::<Self>(message).is_ok() {
+            message.to_owned()
+        } else {
+            Self::from_legacy(message).to_text()
+        }
+    }
+
+    pub fn from_legacy(message: &str) -> Self {
+        let lower = message.to_ascii_lowercase();
+        if lower.contains("missing required argument")
+            || lower.contains("requires a tool name")
+            || lower.contains(" is required")
+        {
+            return Self::new(
+                "invalid_arguments",
+                message,
+                "Correct the named arguments, then call the tool again.",
+                false,
+                None,
+            );
+        }
+        if lower.contains("no session") || lower.contains("session not found") {
+            return Self::new(
+                "session_not_found",
+                message,
+                "Call list_agents, choose an existing session ID, and retry with a new requestKey.",
+                false,
+                Some("list_agents"),
+            );
+        }
+        if lower.contains("cannot target")
+            || lower.contains("refuses to kill")
+            || lower.contains("must run inside a diri session")
+        {
+            return Self::new(
+                "authorization_denied",
+                message,
+                "Choose a session allowed by Diri's parent-child policy or answer in the current session.",
+                false,
+                Some("list_agents"),
+            );
+        }
+        if lower.contains("unknown tool") {
+            return Self::new(
+                "tool_not_found",
+                message,
+                "Call tools/list and choose one of the advertised Diri tools.",
+                false,
+                None,
+            );
+        }
+        if lower.contains("idempotency_conflict") {
+            return Self::new(
+                "idempotency_conflict",
+                message,
+                "Use the original arguments for this requestKey, or choose a new requestKey for a different spawn.",
+                false,
+                None,
+            );
+        }
+        Self::new(
+            "tool_failed",
+            message,
+            "Inspect the error, verify current Diri state, and retry only if the operation is safe.",
+            false,
+            None,
+        )
+    }
+}
+
+fn empty_details() -> Value {
+    json!({})
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn envelope_uses_stable_camel_case_json() {
+        let envelope = McpToolErrorEnvelope::new(
+            "cwd_not_found",
+            "The directory is gone.",
+            "Choose an existing project directory.",
+            false,
+            Some("list_agents"),
+        )
+        .with_details(json!({"cwd": "/gone"}));
+        let value: Value = serde_json::from_str(&envelope.to_text()).expect("valid JSON");
+        assert_eq!(value["error"]["code"], "cwd_not_found");
+        assert_eq!(
+            value["error"]["modelGuidance"],
+            "Choose an existing project directory."
+        );
+        assert_eq!(value["error"]["suggestedTool"], "list_agents");
+        assert_eq!(value["error"]["details"]["cwd"], "/gone");
+    }
+
+    #[test]
+    fn normalize_preserves_typed_errors_and_upgrades_prose() {
+        let typed =
+            McpToolErrorEnvelope::new("internal", "boom", "Retry once.", true, None).to_text();
+        assert_eq!(McpToolErrorEnvelope::normalize_text(&typed), typed);
+        let upgraded: Value = serde_json::from_str(&McpToolErrorEnvelope::normalize_text(
+            "missing required argument: cwd",
+        ))
+        .expect("valid JSON");
+        assert_eq!(upgraded["error"]["code"], "invalid_arguments");
+    }
+}

--- a/diri/crates/diri-proto/src/methods.rs
+++ b/diri/crates/diri-proto/src/methods.rs
@@ -358,6 +358,10 @@ pub struct SessionSpawnParams {
     /// `cwd` / the host's defaultCwd when the repo isn't cloned there.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub same_repo_as: Option<SessionId>,
+    /// Optional caller-scoped idempotency key for mutating automation calls.
+    /// The Engine retains successful results; ordinary app spawns omit it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_key: Option<String>,
 }
 
 pub type SessionSpawnResult = SessionRecord;

--- a/diri/crates/diri-proto/tests/control_roundtrip.rs
+++ b/diri/crates/diri-proto/tests/control_roundtrip.rs
@@ -319,6 +319,27 @@ fn spawn_params_host_field_is_wire_compatible() {
 }
 
 #[test]
+fn spawn_request_key_is_additive_and_uses_mcp_spelling() {
+    let legacy: diri_proto::SessionSpawnParams =
+        serde_json::from_value(json!({"kind": {"shell": {}}, "cwd": "/tmp"})).unwrap();
+    assert_eq!(legacy.request_key, None);
+    assert!(
+        serde_json::to_value(&legacy)
+            .unwrap()
+            .get("requestKey")
+            .is_none()
+    );
+
+    let keyed = diri_proto::SessionSpawnParams {
+        request_key: Some("turn-42/spawn-reviewer".into()),
+        ..legacy
+    };
+    let encoded = serde_json::to_value(&keyed).unwrap();
+    assert_eq!(encoded["requestKey"], "turn-42/spawn-reviewer");
+    typed_round_trip(&keyed);
+}
+
+#[test]
 fn migration_and_host_methods_use_the_swift_wire_names() {
     // session.migrate: sessionID spelling, targetHost skip-if-none.
     let to_local = diri_proto::SessionMigrateParams {

--- a/diri/crates/dirijor-mcp/src/bridge.rs
+++ b/diri/crates/dirijor-mcp/src/bridge.rs
@@ -1112,4 +1112,24 @@ mod tests {
             assert!(!envelope.error.retryable);
         }
     }
+
+    #[test]
+    fn real_bridge_prose_paths_normalize_to_stable_codes() {
+        let missing = find_session(&[], "s_gone").expect_err("missing session");
+        let missing: McpToolErrorEnvelope =
+            serde_json::from_str(&McpToolErrorEnvelope::normalize_text(&missing))
+                .expect("typed missing-session error");
+        assert_eq!(missing.error.code, "session_not_found");
+
+        for policy_error in [
+            "release_agent cannot terminate its caller",
+            "release_agent cannot terminate the session waiting on this result",
+        ] {
+            let envelope: McpToolErrorEnvelope =
+                serde_json::from_str(&McpToolErrorEnvelope::normalize_text(policy_error))
+                    .expect("typed authorization error");
+            assert_eq!(envelope.error.code, "authorization_denied");
+            assert!(!envelope.error.retryable);
+        }
+    }
 }

--- a/diri/crates/dirijor-mcp/src/bridge.rs
+++ b/diri/crates/dirijor-mcp/src/bridge.rs
@@ -113,6 +113,9 @@ impl Bridge {
 
     fn spawn_agent(&self, arguments: &Value) -> Result<Value, String> {
         let requested = required_string(arguments, "kind")?;
+        // Presence is significant for a safety feature: malformed keys must
+        // never degrade into the historical non-idempotent path.
+        let request_key = request_key(arguments)?;
         let readiness: AgentReadinessResult =
             self.request_typed(Method::AGENT_READINESS, json!({}), DEFAULT_TIMEOUT)?;
         let kind = resolve_agent_kind(&readiness, &requested);
@@ -129,7 +132,7 @@ impl Bridge {
             initial_rows: None,
             host: optional_string(arguments, "host"),
             same_repo_as: None,
-            request_key: optional_string(arguments, "requestKey"),
+            request_key,
         };
         let params = serde_json::to_value(params).map_err(|error| error.to_string())?;
         self.request(Method::SESSION_SPAWN, params, SPAWN_TIMEOUT)
@@ -606,95 +609,7 @@ fn render_failure(error: ControlFailure) -> String {
 }
 
 fn daemon_tool_error(error: diri_proto::ControlError) -> McpToolErrorEnvelope {
-    let lower = error.message.to_ascii_lowercase();
-    match error.code.as_str() {
-        "idempotency_conflict" => McpToolErrorEnvelope::new(
-            "idempotency_conflict",
-            error.message,
-            "Use the original arguments for this requestKey, or choose a new requestKey for a different spawn.",
-            false,
-            None,
-        ),
-        "idempotency_requires_caller" => McpToolErrorEnvelope::new(
-            "idempotency_requires_caller",
-            error.message,
-            "Run spawn_agent inside a Diri session, or omit requestKey for an unscoped call.",
-            false,
-            Some("whoami"),
-        ),
-        "idempotency_caller_not_found" => McpToolErrorEnvelope::new(
-            "idempotency_caller_not_found",
-            error.message,
-            "The calling session no longer exists. Start a new Diri session before spawning a child.",
-            false,
-            Some("whoami"),
-        ),
-        "idempotency_capacity" => McpToolErrorEnvelope::new(
-            "idempotency_capacity",
-            error.message,
-            "Wait for current spawns to settle, then retry the same requestKey.",
-            true,
-            Some("list_agents"),
-        ),
-        "bad_request" if lower.contains("cwd") && lower.contains("not a directory") => {
-            McpToolErrorEnvelope::new(
-                "cwd_not_found",
-                error.message,
-                "Choose an existing project directory and retry with a new requestKey.",
-                false,
-                Some("list_agents"),
-            )
-        }
-        "bad_request" => McpToolErrorEnvelope::new(
-            "invalid_arguments",
-            error.message,
-            "Correct the requested arguments, then retry with a new requestKey.",
-            false,
-            None,
-        ),
-        "not_found" => McpToolErrorEnvelope::new(
-            "resource_not_found",
-            error.message,
-            "Refresh Diri state, choose an existing resource, and retry with a new requestKey.",
-            false,
-            Some("list_agents"),
-        ),
-        "unauthorized" => McpToolErrorEnvelope::new(
-            "authorization_denied",
-            error.message,
-            "Reconnect through the current Diri session; do not retry with the same credentials.",
-            false,
-            Some("whoami"),
-        ),
-        "version_mismatch" => McpToolErrorEnvelope::new(
-            "version_mismatch",
-            error.message,
-            "Restart or update Diri so the MCP adapter and Engine use the same protocol.",
-            false,
-            None,
-        ),
-        "initial_prompt_delivery_failed" => McpToolErrorEnvelope::new(
-            "initial_prompt_delivery_failed",
-            error.message,
-            "The session exists. Inspect list_agents and send_prompt to that session instead of spawning another one.",
-            false,
-            Some("list_agents"),
-        ),
-        "internal" => McpToolErrorEnvelope::new(
-            "internal",
-            error.message,
-            "Inspect list_agents before retrying; if no mutation occurred, retry once with the same requestKey.",
-            true,
-            Some("list_agents"),
-        ),
-        code => McpToolErrorEnvelope::new(
-            code,
-            error.message,
-            "Inspect current Diri state, then retry only when the operation is safe.",
-            false,
-            Some("list_agents"),
-        ),
-    }
+    McpToolErrorEnvelope::from_control(error)
 }
 
 fn required_string(arguments: &Value, key: &str) -> Result<String, String> {
@@ -712,6 +627,31 @@ fn optional_string(arguments: &Value, key: &str) -> Option<String> {
         .and_then(Value::as_str)
         .filter(|value| !value.is_empty())
         .map(str::to_owned)
+}
+
+fn request_key(arguments: &Value) -> Result<Option<String>, String> {
+    let Some(value) = arguments.get("requestKey") else {
+        return Ok(None);
+    };
+    let Some(value) = value.as_str() else {
+        return Err(
+            McpToolErrorEnvelope::from_control(diri_proto::ControlError::bad_request(
+                "requestKey must be a string containing 1 to 128 bytes",
+            ))
+            .with_details(json!({"argument": "requestKey", "expected": "non-empty string"}))
+            .to_text(),
+        );
+    };
+    if value.trim().is_empty() || value.len() > 128 {
+        return Err(
+            McpToolErrorEnvelope::from_control(diri_proto::ControlError::bad_request(
+                "requestKey must be a string containing 1 to 128 bytes",
+            ))
+            .with_details(json!({"argument": "requestKey", "minBytes": 1, "maxBytes": 128}))
+            .to_text(),
+        );
+    }
+    Ok(Some(value.to_owned()))
 }
 
 fn optional_bool(arguments: &Value, key: &str) -> Option<bool> {
@@ -1148,5 +1088,28 @@ mod tests {
         let timeout: McpToolErrorEnvelope = serde_json::from_str(&timeout).expect("timeout JSON");
         assert_eq!(timeout.error.code, "daemon_timeout");
         assert!(timeout.error.retryable);
+    }
+
+    #[test]
+    fn malformed_request_keys_never_fall_back_to_unkeyed_spawns() {
+        assert_eq!(request_key(&json!({})).expect("absent key"), None);
+        assert_eq!(
+            request_key(&json!({"requestKey": "turn-1/child"})).expect("valid key"),
+            Some("turn-1/child".into())
+        );
+
+        for arguments in [
+            json!({"requestKey": ""}),
+            json!({"requestKey": "   "}),
+            json!({"requestKey": 42}),
+            json!({"requestKey": null}),
+            json!({"requestKey": "x".repeat(129)}),
+        ] {
+            let error = request_key(&arguments).expect_err("malformed key");
+            let envelope: McpToolErrorEnvelope =
+                serde_json::from_str(&error).expect("typed error JSON");
+            assert_eq!(envelope.error.code, "invalid_arguments");
+            assert!(!envelope.error.retryable);
+        }
     }
 }

--- a/diri/crates/dirijor-mcp/src/bridge.rs
+++ b/diri/crates/dirijor-mcp/src/bridge.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use diri_proto::{
-    AgentKind, AgentReadinessResult, Method, ReadScreenResult, SessionId, SessionListResult,
-    SessionRecord, SessionSpawnParams, SessionStatus,
+    AgentKind, AgentReadinessResult, McpToolErrorEnvelope, Method, ReadScreenResult, SessionId,
+    SessionListResult, SessionRecord, SessionSpawnParams, SessionStatus,
 };
 use serde::de::DeserializeOwned;
 use serde_json::{Map, Value, json};
@@ -65,7 +65,7 @@ impl Bridge {
     }
 
     pub fn call(&self, tool: &str, arguments: &Value) -> Result<Value, String> {
-        match tool {
+        let result = match tool {
             "spawn_agent" => self.spawn_agent(arguments),
             "list_agents" => self.list_agents(),
             "get_status" => self.get_status(arguments),
@@ -85,7 +85,8 @@ impl Bridge {
             "summarize_children" => self.summarize_children(arguments),
             "report_to_parent" => self.report_to_parent(arguments),
             other => Err(format!("unknown tool: {other}")),
-        }
+        };
+        result.map_err(|message| McpToolErrorEnvelope::normalize_text(&message))
     }
 
     pub fn request(&self, method: &str, params: Value, timeout: Duration) -> Result<Value, String> {
@@ -128,6 +129,7 @@ impl Bridge {
             initial_rows: None,
             host: optional_string(arguments, "host"),
             same_repo_as: None,
+            request_key: optional_string(arguments, "requestKey"),
         };
         let params = serde_json::to_value(params).map_err(|error| error.to_string())?;
         self.request(Method::SESSION_SPAWN, params, SPAWN_TIMEOUT)
@@ -576,9 +578,122 @@ impl Bridge {
 }
 
 fn render_failure(error: ControlFailure) -> String {
-    match error {
-        ControlFailure::Io(error) => format!("daemon socket: {error}"),
-        other => other.to_string(),
+    let failure = match error {
+        ControlFailure::Daemon(error) => daemon_tool_error(error),
+        ControlFailure::Io(error) => McpToolErrorEnvelope::new(
+            "daemon_unavailable",
+            format!("Diri's Engine is unavailable: {error}"),
+            "Wait briefly for Diri's Engine to start, then retry the same requestKey.",
+            true,
+            None,
+        ),
+        ControlFailure::Timeout => McpToolErrorEnvelope::new(
+            "daemon_timeout",
+            "Diri's Engine did not answer before the tool deadline.",
+            "Inspect list_agents before retrying a mutation; if it did not happen, retry with the same requestKey.",
+            true,
+            Some("list_agents"),
+        ),
+        ControlFailure::Protocol(message) => McpToolErrorEnvelope::new(
+            "daemon_protocol_error",
+            message,
+            "Reconnect to Diri's Engine and retry the same requestKey once.",
+            true,
+            None,
+        ),
+    };
+    failure.to_text()
+}
+
+fn daemon_tool_error(error: diri_proto::ControlError) -> McpToolErrorEnvelope {
+    let lower = error.message.to_ascii_lowercase();
+    match error.code.as_str() {
+        "idempotency_conflict" => McpToolErrorEnvelope::new(
+            "idempotency_conflict",
+            error.message,
+            "Use the original arguments for this requestKey, or choose a new requestKey for a different spawn.",
+            false,
+            None,
+        ),
+        "idempotency_requires_caller" => McpToolErrorEnvelope::new(
+            "idempotency_requires_caller",
+            error.message,
+            "Run spawn_agent inside a Diri session, or omit requestKey for an unscoped call.",
+            false,
+            Some("whoami"),
+        ),
+        "idempotency_caller_not_found" => McpToolErrorEnvelope::new(
+            "idempotency_caller_not_found",
+            error.message,
+            "The calling session no longer exists. Start a new Diri session before spawning a child.",
+            false,
+            Some("whoami"),
+        ),
+        "idempotency_capacity" => McpToolErrorEnvelope::new(
+            "idempotency_capacity",
+            error.message,
+            "Wait for current spawns to settle, then retry the same requestKey.",
+            true,
+            Some("list_agents"),
+        ),
+        "bad_request" if lower.contains("cwd") && lower.contains("not a directory") => {
+            McpToolErrorEnvelope::new(
+                "cwd_not_found",
+                error.message,
+                "Choose an existing project directory and retry with a new requestKey.",
+                false,
+                Some("list_agents"),
+            )
+        }
+        "bad_request" => McpToolErrorEnvelope::new(
+            "invalid_arguments",
+            error.message,
+            "Correct the requested arguments, then retry with a new requestKey.",
+            false,
+            None,
+        ),
+        "not_found" => McpToolErrorEnvelope::new(
+            "resource_not_found",
+            error.message,
+            "Refresh Diri state, choose an existing resource, and retry with a new requestKey.",
+            false,
+            Some("list_agents"),
+        ),
+        "unauthorized" => McpToolErrorEnvelope::new(
+            "authorization_denied",
+            error.message,
+            "Reconnect through the current Diri session; do not retry with the same credentials.",
+            false,
+            Some("whoami"),
+        ),
+        "version_mismatch" => McpToolErrorEnvelope::new(
+            "version_mismatch",
+            error.message,
+            "Restart or update Diri so the MCP adapter and Engine use the same protocol.",
+            false,
+            None,
+        ),
+        "initial_prompt_delivery_failed" => McpToolErrorEnvelope::new(
+            "initial_prompt_delivery_failed",
+            error.message,
+            "The session exists. Inspect list_agents and send_prompt to that session instead of spawning another one.",
+            false,
+            Some("list_agents"),
+        ),
+        "internal" => McpToolErrorEnvelope::new(
+            "internal",
+            error.message,
+            "Inspect list_agents before retrying; if no mutation occurred, retry once with the same requestKey.",
+            true,
+            Some("list_agents"),
+        ),
+        code => McpToolErrorEnvelope::new(
+            code,
+            error.message,
+            "Inspect current Diri state, then retry only when the operation is safe.",
+            false,
+            Some("list_agents"),
+        ),
     }
 }
 
@@ -990,5 +1105,48 @@ mod tests {
         let generic = resolve_agent_kind(&readiness, "htop");
         assert_eq!(generic.id(), AgentKind::GENERIC_ID);
         assert_eq!(generic.command(), Some("htop"));
+    }
+
+    #[test]
+    fn daemon_failures_have_stable_recovery_contracts() {
+        let cases = [
+            (
+                diri_proto::ControlError::bad_request("cwd \"/gone\" is not a directory"),
+                "cwd_not_found",
+                false,
+            ),
+            (
+                diri_proto::ControlError::unauthorized(),
+                "authorization_denied",
+                false,
+            ),
+            (
+                diri_proto::ControlError::not_found("session s_gone"),
+                "resource_not_found",
+                false,
+            ),
+            (
+                diri_proto::ControlError::new("idempotency_conflict", "different arguments"),
+                "idempotency_conflict",
+                false,
+            ),
+            (
+                diri_proto::ControlError::internal("worker stopped"),
+                "internal",
+                true,
+            ),
+        ];
+        for (failure, expected_code, retryable) in cases {
+            let envelope = daemon_tool_error(failure);
+            assert_eq!(envelope.error.code, expected_code);
+            assert_eq!(envelope.error.retryable, retryable);
+            assert!(!envelope.error.model_guidance.is_empty());
+            serde_json::from_str::<Value>(&envelope.to_text()).expect("valid JSON");
+        }
+
+        let timeout = render_failure(ControlFailure::Timeout);
+        let timeout: McpToolErrorEnvelope = serde_json::from_str(&timeout).expect("timeout JSON");
+        assert_eq!(timeout.error.code, "daemon_timeout");
+        assert!(timeout.error.retryable);
     }
 }

--- a/diri/crates/dirijor-mcp/src/bridge.rs
+++ b/diri/crates/dirijor-mcp/src/bridge.rs
@@ -120,6 +120,7 @@ impl Bridge {
             self.request_typed(Method::AGENT_READINESS, json!({}), DEFAULT_TIMEOUT)?;
         let kind = resolve_agent_kind(&readiness, &requested);
 
+        let has_request_key = request_key.is_some();
         let params = SessionSpawnParams {
             kind,
             cwd: required_string(arguments, "cwd")?,
@@ -135,7 +136,19 @@ impl Bridge {
             request_key,
         };
         let params = serde_json::to_value(params).map_err(|error| error.to_string())?;
-        self.request(Method::SESSION_SPAWN, params, SPAWN_TIMEOUT)
+        self.spawn_request(params, has_request_key)
+    }
+
+    /// Keeps transport guidance honest about whether a mutation could have
+    /// committed. A connect failure proves nothing was sent. Once a spawn is
+    /// written, only a requestKey makes an uncertain transport failure safe
+    /// to retry automatically.
+    fn spawn_request(&self, params: Value, has_request_key: bool) -> Result<Value, String> {
+        let mut client = ControlClient::connect(&self.socket_path, SPAWN_TIMEOUT)
+            .map_err(render_pre_send_failure)?;
+        client
+            .request(Method::SESSION_SPAWN, params)
+            .map_err(|error| render_spawn_failure(error, has_request_key))
     }
 
     fn list_agents(&self) -> Result<Value, String> {
@@ -606,6 +619,64 @@ fn render_failure(error: ControlFailure) -> String {
         ),
     };
     failure.to_text()
+}
+
+fn render_pre_send_failure(error: ControlFailure) -> String {
+    let failure = match error {
+        ControlFailure::Daemon(error) => daemon_tool_error(error),
+        ControlFailure::Io(error) => McpToolErrorEnvelope::new(
+            "daemon_unavailable",
+            format!("Diri's Engine is unavailable: {error}"),
+            "No mutation request was sent. Wait briefly for Diri's Engine to start, then retry.",
+            true,
+            None,
+        ),
+        ControlFailure::Timeout => McpToolErrorEnvelope::new(
+            "daemon_timeout",
+            "Diri's Engine was unavailable before the spawn request could be sent.",
+            "No mutation request was sent. Wait briefly, then retry.",
+            true,
+            None,
+        ),
+        ControlFailure::Protocol(message) => McpToolErrorEnvelope::new(
+            "daemon_protocol_error",
+            message,
+            "No mutation request was sent. Reconnect to Diri's Engine, then retry once.",
+            true,
+            None,
+        ),
+    };
+    failure.to_text()
+}
+
+fn render_spawn_failure(error: ControlFailure, has_request_key: bool) -> String {
+    if has_request_key || matches!(&error, ControlFailure::Daemon(_)) {
+        return render_failure(error);
+    }
+
+    let (code, message) = match error {
+        ControlFailure::Io(error) => (
+            "spawn_outcome_uncertain",
+            format!("The Engine connection failed after the spawn request was sent: {error}"),
+        ),
+        ControlFailure::Timeout => (
+            "spawn_outcome_uncertain",
+            "Diri's Engine did not answer after the spawn request was sent.".to_owned(),
+        ),
+        ControlFailure::Protocol(message) => (
+            "spawn_outcome_uncertain",
+            format!("The Engine returned an invalid response after the spawn request: {message}"),
+        ),
+        ControlFailure::Daemon(_) => unreachable!("daemon failures return above"),
+    };
+    McpToolErrorEnvelope::new(
+        code,
+        message,
+        "Do not repeat this unkeyed spawn automatically. Inspect list_agents and list_worktrees to determine whether it committed.",
+        false,
+        Some("list_agents"),
+    )
+    .to_text()
 }
 
 fn daemon_tool_error(error: diri_proto::ControlError) -> McpToolErrorEnvelope {
@@ -1088,6 +1159,45 @@ mod tests {
         let timeout: McpToolErrorEnvelope = serde_json::from_str(&timeout).expect("timeout JSON");
         assert_eq!(timeout.error.code, "daemon_timeout");
         assert!(timeout.error.retryable);
+    }
+
+    #[test]
+    fn spawn_transport_guidance_distinguishes_keyed_unkeyed_and_unsent_requests() {
+        let keyed = render_spawn_failure(ControlFailure::Timeout, true);
+        let keyed: McpToolErrorEnvelope = serde_json::from_str(&keyed).expect("keyed JSON");
+        assert_eq!(keyed.error.code, "daemon_timeout");
+        assert!(keyed.error.retryable);
+        assert!(keyed.error.model_guidance.contains("same requestKey"));
+
+        for failure in [
+            ControlFailure::Timeout,
+            ControlFailure::Io(std::io::Error::new(
+                std::io::ErrorKind::ConnectionReset,
+                "reset after send",
+            )),
+            ControlFailure::Protocol("truncated response".into()),
+        ] {
+            let unkeyed = render_spawn_failure(failure, false);
+            let unkeyed: McpToolErrorEnvelope =
+                serde_json::from_str(&unkeyed).expect("unkeyed JSON");
+            assert_eq!(unkeyed.error.code, "spawn_outcome_uncertain");
+            assert!(!unkeyed.error.retryable);
+            assert!(unkeyed.error.model_guidance.contains("Do not repeat"));
+            assert_eq!(unkeyed.error.suggested_tool.as_deref(), Some("list_agents"));
+        }
+
+        let unsent = render_pre_send_failure(ControlFailure::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "no socket",
+        )));
+        let unsent: McpToolErrorEnvelope = serde_json::from_str(&unsent).expect("unsent JSON");
+        assert!(unsent.error.retryable);
+        assert!(
+            unsent
+                .error
+                .model_guidance
+                .contains("No mutation request was sent")
+        );
     }
 
     #[test]

--- a/diri/crates/dirijor-mcp/src/main.rs
+++ b/diri/crates/dirijor-mcp/src/main.rs
@@ -1,5 +1,6 @@
 use std::io::{self, BufRead, Write};
 
+use diri_proto::McpToolErrorEnvelope;
 use dirijor_mcp::Bridge;
 use serde_json::{Value, json};
 
@@ -55,7 +56,10 @@ fn error(id: Value, code: i64, message: impl Into<String>) -> Value {
 fn tool_content(result: Result<Value, String>) -> Value {
     let (value, is_error) = match result {
         Ok(value) => (value, false),
-        Err(message) => (Value::String(message), true),
+        Err(message) => (
+            Value::String(McpToolErrorEnvelope::normalize_text(&message)),
+            true,
+        ),
     };
     let text = value.as_str().map_or_else(
         || serde_json::to_string(&value).unwrap_or_else(|_| "null".to_owned()),
@@ -206,5 +210,18 @@ mod tests {
         assert!(instructions.contains("native kind"));
         assert!(instructions.contains("Never use `shell` to launch an agent CLI"));
         assert!(instructions.contains("Cmd+J"));
+    }
+
+    #[test]
+    fn failed_tool_text_is_always_parseable_typed_json() {
+        let result = tool_content(Err("missing required argument: cwd".into()));
+        assert_eq!(result["isError"], true);
+        let parsed: Value =
+            serde_json::from_str(result["content"][0]["text"].as_str().expect("text content"))
+                .expect("valid JSON");
+        assert_eq!(parsed["error"]["code"], "invalid_arguments");
+        assert_eq!(parsed["error"]["retryable"], false);
+        assert!(parsed["error"]["modelGuidance"].is_string());
+        assert!(parsed["error"]["details"].is_object());
     }
 }

--- a/diri/crates/dirijor-mcp/src/tools.rs
+++ b/diri/crates/dirijor-mcp/src/tools.rs
@@ -42,7 +42,13 @@ pub fn tool_definitions_for(kinds: &[String]) -> Vec<ToolDefinition> {
                     "worktree": {"type": "boolean"},
                     "branch": {"type": "string"},
                     "prompt": {"type": "string"},
-                    "name": {"type": "string"}
+                    "name": {"type": "string"},
+                    "requestKey": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 128,
+                        "description": "Stable caller-scoped key. Retry the same operation with the same key to receive its original result."
+                    }
                 },
                 "required": ["kind", "cwd"]
             }),
@@ -304,6 +310,10 @@ mod tests {
         assert_eq!(
             spawn.input_schema["properties"]["kind"]["enum"],
             json!(["opencode", "shell"])
+        );
+        assert_eq!(
+            spawn.input_schema["properties"]["requestKey"]["maxLength"],
+            128
         );
     }
 }

--- a/diri/crates/dirijor-mcp/tests/spawn_prompt.rs
+++ b/diri/crates/dirijor-mcp/tests/spawn_prompt.rs
@@ -186,6 +186,40 @@ fn call_spawn_agent_through_mcp(socket: &Path, arguments: serde_json::Value) -> 
 }
 
 #[test]
+fn malformed_request_key_is_typed_and_never_spawns() {
+    let temp = tempfile::tempdir().expect("temp");
+    let fixture = temp.path().join("prompt-fixture");
+    std::fs::write(&fixture, "#!/bin/sh\nsleep 30\n").expect("write fixture");
+    std::fs::set_permissions(&fixture, std::fs::Permissions::from_mode(0o700))
+        .expect("make fixture executable");
+    let server = start_server(temp.path(), &fixture);
+    let bridge = Bridge::new(server.socket_path().to_path_buf(), Some("s_parent".into()));
+
+    for request_key in [json!(""), json!(42), serde_json::Value::Null] {
+        let failure = bridge
+            .call(
+                "spawn_agent",
+                &json!({
+                    "kind": "prompt-fixture",
+                    "cwd": temp.path(),
+                    "requestKey": request_key,
+                }),
+            )
+            .expect_err("malformed key must be rejected");
+        let failure: serde_json::Value = serde_json::from_str(&failure).expect("typed JSON");
+        assert_eq!(failure["error"]["code"], "invalid_arguments");
+        assert_eq!(failure["error"]["retryable"], false);
+    }
+
+    let sessions = bridge.call("list_agents", &json!({})).expect("list agents");
+    assert_eq!(
+        sessions["agents"].as_array().expect("agents").len(),
+        1,
+        "only the parent record should exist"
+    );
+}
+
+#[test]
 fn keyed_spawn_survives_mcp_stdio_recreation_without_duplicate_worktree() {
     let temp = tempfile::tempdir().expect("temp");
     let repo = temp.path().join("repo");

--- a/diri/crates/dirijor-mcp/tests/spawn_prompt.rs
+++ b/diri/crates/dirijor-mcp/tests/spawn_prompt.rs
@@ -10,6 +10,10 @@ use std::time::{Duration, Instant};
 use diri_engine::control::ControlServer;
 use diri_engine::detect::ManifestEngine;
 use diri_engine::registry::Registry;
+use diri_proto::{
+    AgentKind, DateMillis, ProjectId, Resumability, SessionId, SessionRecord, SessionStatus,
+    TitleSource,
+};
 use dirijor_mcp::Bridge;
 use serde_json::json;
 
@@ -79,10 +83,40 @@ fn start_server(temp: &Path, fixture: &Path) -> Arc<ControlServer> {
     let (engine, failures) = ManifestEngine::load_dir(&manifests).expect("load manifests");
     assert!(failures.is_empty(), "manifest failures: {failures:?}");
 
-    let registry = Arc::new(Mutex::new(Registry::new(
-        Arc::new(engine),
-        temp.join("state.json"),
-    )));
+    let mut registry = Registry::new(Arc::new(engine), temp.join("state.json"));
+    registry.insert_record(SessionRecord {
+        id: SessionId::new("s_parent"),
+        kind: AgentKind::CODEX,
+        cwd: temp.to_string_lossy().into_owned(),
+        project_id: ProjectId::new("test-parent"),
+        worktree_path: None,
+        git_branch: None,
+        title: "test parent".into(),
+        title_source: TitleSource::Placeholder,
+        originating_prompt: None,
+        agent_session_id: None,
+        transcript_path: None,
+        status: SessionStatus::Idle,
+        status_evidence: None,
+        needs_input: None,
+        resumability: Resumability::Live,
+        parent: None,
+        created_at: DateMillis(0.0),
+        updated_at: DateMillis(0.0),
+        last_turn_completed_at: None,
+        last_seen_at: None,
+        pinned: false,
+        archived_at: None,
+        host: None,
+        remote_persistence: None,
+        hibernation: None,
+        memory_bytes: None,
+        artifacts: None,
+        pull_requests: None,
+        listening_ports: None,
+        foreground_agent: None,
+    });
+    let registry = Arc::new(Mutex::new(registry));
     let server = Arc::new(
         ControlServer::new(registry, temp.join("daemon.sock")).with_logs_dir(temp.join("logs")),
     );
@@ -149,6 +183,57 @@ fn call_spawn_agent_through_mcp(socket: &Path, arguments: serde_json::Value) -> 
             .expect("MCP text content"),
     )
     .expect("decode spawn result")
+}
+
+#[test]
+fn keyed_spawn_survives_mcp_stdio_recreation_without_duplicate_worktree() {
+    let temp = tempfile::tempdir().expect("temp");
+    let repo = temp.path().join("repo");
+    let fixture = temp.path().join("prompt-fixture");
+    initialize_repository(&repo);
+    std::fs::write(&fixture, "#!/bin/sh\nsleep 30\n").expect("write fixture");
+    std::fs::set_permissions(&fixture, std::fs::Permissions::from_mode(0o700))
+        .expect("make fixture executable");
+
+    let server = start_server(temp.path(), &fixture);
+    let arguments = json!({
+        "kind": "prompt-fixture",
+        "cwd": repo,
+        "worktree": true,
+        "branch": "test/idempotent-spawn",
+        "name": "one child, even after reconnect",
+        "requestKey": "turn-12/idempotent-child",
+    });
+
+    // Each helper invocation launches a brand-new stdio MCP process. The
+    // result survives because the Engine, rather than that process, owns it.
+    let first = call_spawn_agent_through_mcp(server.socket_path(), arguments.clone());
+    let replay = call_spawn_agent_through_mcp(server.socket_path(), arguments.clone());
+    assert_eq!(first["id"], replay["id"]);
+    assert_eq!(first["worktreePath"], replay["worktreePath"]);
+
+    let bridge = Bridge::new(server.socket_path().to_path_buf(), Some("s_parent".into()));
+    let conflict = bridge
+        .call(
+            "spawn_agent",
+            &json!({
+                "kind": "prompt-fixture",
+                "cwd": repo,
+                "name": "different operation",
+                "requestKey": "turn-12/idempotent-child",
+            }),
+        )
+        .expect_err("argument drift must conflict");
+    let conflict: serde_json::Value = serde_json::from_str(&conflict).expect("typed JSON");
+    assert_eq!(conflict["error"]["code"], "idempotency_conflict");
+    assert_eq!(conflict["error"]["retryable"], false);
+
+    bridge
+        .call(
+            "release_agent",
+            &json!({"session_id": first["id"].as_str().expect("session id")}),
+        )
+        .expect("release child");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add strict request keys and a daemon-owned caller-scoped idempotency ledger
- coalesce concurrent duplicate mutations and retire caller generations safely
- preserve sticky outcome-uncertain results across panic, timeout, TTL, and eviction boundaries
- prevalidate embedded mutations and roll back created worktrees, branches, and PTYs on failure
- share typed control-error mapping across embedded and production MCP paths

## Verification

- full diri-proto, diri-engine, and dirijor-mcp suites
- strict all-target Clippy
- concurrent replay, caller replacement, panic, timeout, rollback, and embedded parity tests
- formatting and lockfile checks clean