### PR TITLE
engine: make agent run delivery durable across restarts

### DIFF
--- a/diri/PLAN.md
+++ b/diri/PLAN.md
@@ -115,7 +115,34 @@ Everything below is verified against the Swift source; cite these files in code 
 **Grid codec** (`Grid.swift:100-234`) — must match bit-for-bit, big-endian throughout:
 `cols u16, rows u16, cursorCol u16, cursorRow u16, flags u8 (bit0 cursorVisible, bit1 fullSnapshot), rowCount u16`, then per row: `y u16, runCount u16`, runs of `[repeat u16, scalar u32, fgPacked u32, bgPacked u32, style u16]`. `TermColor` packs default/defaultInverted/ansi(u8)/rgb into u32; `TermStyle` is a u16 bitset (bold, underline, blink, inverse, invisible, dim, italic, crossedOut — SwiftTerm bit layout). The same row codec is reused by `session.read_scrollback_cells` (base64 in JSON).
 
-**Methods** (full list in `Methods.swift`; client wrappers in `DaemonClient.swift:222-399`): `hello`, `session.{spawn,list,kill,remove,rename,resume,send_text,resize,set_owner,read_screen,read_scrollback,read_scrollback_cells,mark_seen,hibernate,wake,archive,unarchive,reopen_last,history,resume_from_history}`, `worktree.{create,list,remove,overview}`, `project.add`, `client.set_active`, `governor.configure`, `agent.readiness`, `events.subscribe`, `events.wait`, `hook.report`, `test.run`. `daemon.shutdown` is scoped to the explicit remote-config reload described in §3; `daemon.prepare_shutdown` remains unused.
+**Methods** (full list in `Methods.swift`; client wrappers in `DaemonClient.swift:222-399`): `hello`, `session.{spawn,list,kill,remove,rename,resume,send_text,run.send,run.interrupt,run.report,resize,set_owner,read_screen,read_scrollback,read_scrollback_cells,mark_seen,hibernate,wake,archive,unarchive,reopen_last,history,resume_from_history}`, `worktree.{create,list,remove,overview}`, `project.add`, `client.set_active`, `governor.configure`, `agent.readiness`, `events.subscribe`, `events.wait`, `hook.report`, `test.run`. `daemon.shutdown` is scoped to the explicit remote-config reload described in §3; `daemon.prepare_shutdown` remains unused.
+
+**Agent runs are explicit.** Child turns carry a monotonic `run.id` and one of
+`starting → running → needsInput | completed | failed | aborted`. Terminal
+`idle` alone is never completion: the Engine records the reducer's lossless
+turn-completion edge. MCP writes may carry `expectedRunId`; stale writes,
+reports, waits, and interrupts are rejected or returned as `superseded` rather
+than landing in a newer turn. Submitted queue entries receive their future run
+identity when acknowledged. Follow-ups and child reports wait FIFO inside a
+durable Engine outbox until the target has a manifest-confirmed safe composer,
+so neither an MCP-proxy reconnect nor an Engine restart loses them. Dispatch is
+two-phase: a crash in the PTY-send window fails the exact run as
+`delivery_outcome_uncertain` rather than silently replaying it, and durable
+output-offset provenance reconciles later holder activity back to that same
+run. Mutating run methods accept an additive caller-generated `requestId`;
+bounded durable replay records make response-loss retries idempotent.
+`run.interrupt` durably records intent before Ctrl-C, leaves the session
+reusable, preserves acknowledged future turns, and never rewrites an
+already-terminal outcome.
+
+`events.wait` is edge-triggered from the session reducer. `done` matches any
+terminal run and preserves its exact completed/failed/aborted outcome;
+`completed` matches success only. `needsInput` remains a distinct paused state,
+and an idle child that has not begun work does not satisfy completion. The
+Engine keeps a bounded durable terminal-run ledger, so a FIFO advancing to the
+next generation cannot erase a pinned wait's result. Control and embedded MCP
+share one wait decision and the same edge-triggered change signal instead of a
+100 ms polling loop.
 
 **Client behaviors to replicate** (`DaemonClient.swift`, `SessionAttachment.swift`):
 - Request correlation by monotonic u64 id; auto-reconnect with 0.5→8 s exponential backoff; idle heartbeat = cheap `hello` every 25 s.

--- a/diri/crates/diri-app/src/delegation.rs
+++ b/diri/crates/diri-app/src/delegation.rs
@@ -424,6 +424,7 @@ mod tests {
             pull_requests: None,
             listening_ports: None,
             foreground_agent: None,
+            run: None,
         }
     }
 

--- a/diri/crates/diri-app/src/menu_inbox.rs
+++ b/diri/crates/diri-app/src/menu_inbox.rs
@@ -163,6 +163,7 @@ mod tests {
             pull_requests: None,
             listening_ports: None,
             foreground_agent: None,
+            run: None,
         })
     }
 

--- a/diri/crates/diri-app/src/notifications.rs
+++ b/diri/crates/diri-app/src/notifications.rs
@@ -622,6 +622,7 @@ mod tests {
             pull_requests: None,
             listening_ports: None,
             foreground_agent: None,
+            run: None,
         }
     }
 

--- a/diri/crates/diri-app/src/palette.rs
+++ b/diri/crates/diri-app/src/palette.rs
@@ -1087,6 +1087,7 @@ mod tests {
             pull_requests: None,
             listening_ports: None,
             foreground_agent: None,
+            run: None,
         }
     }
 

--- a/diri/crates/diri-app/src/session_surfaces.rs
+++ b/diri/crates/diri-app/src/session_surfaces.rs
@@ -1541,6 +1541,7 @@ mod tests {
             pull_requests: None,
             listening_ports: None,
             foreground_agent: None,
+            run: None,
         }
     }
 

--- a/diri/crates/diri-app/src/sidebar/fixture.rs
+++ b/diri/crates/diri-app/src/sidebar/fixture.rs
@@ -511,6 +511,7 @@ fn session(
         pull_requests: None,
         listening_ports: None,
         foreground_agent: None,
+        run: None,
     })
 }
 

--- a/diri/crates/diri-app/src/store/tests.rs
+++ b/diri/crates/diri-app/src/store/tests.rs
@@ -59,6 +59,7 @@ fn session(value: &str, project: &str, created: f64) -> SessionRecord {
         pull_requests: None,
         listening_ports: None,
         foreground_agent: None,
+        run: None,
     }
 }
 

--- a/diri/crates/diri-app/src/switcher.rs
+++ b/diri/crates/diri-app/src/switcher.rs
@@ -614,6 +614,7 @@ mod tests {
             pull_requests: None,
             listening_ports: None,
             foreground_agent: None,
+            run: None,
         }
     }
 

--- a/diri/crates/diri-client/src/client.rs
+++ b/diri/crates/diri-client/src/client.rs
@@ -590,6 +590,29 @@ impl DaemonClient {
         .await
     }
 
+    /// Run-aware MCP/orchestration write. Unlike raw desktop typing, this may
+    /// queue until the target composer is safe and can reject a stale run id.
+    pub async fn send_run_text(
+        &self,
+        params: SessionRunSendParams,
+    ) -> Result<SessionRunSendResult, ClientError> {
+        self.typed(Method::SESSION_RUN_SEND, &params).await
+    }
+
+    pub async fn interrupt_run(
+        &self,
+        params: SessionRunInterruptParams,
+    ) -> Result<SessionRunInterruptResult, ClientError> {
+        self.typed(Method::SESSION_RUN_INTERRUPT, &params).await
+    }
+
+    pub async fn report_run(
+        &self,
+        params: SessionRunReportParams,
+    ) -> Result<SessionRunReportResult, ClientError> {
+        self.typed(Method::SESSION_RUN_REPORT, &params).await
+    }
+
     pub async fn resize(
         &self,
         session_id: &SessionId,

--- a/diri/crates/diri-engine/src/attach.rs
+++ b/diri/crates/diri-engine/src/attach.rs
@@ -135,25 +135,33 @@ impl AttachHub {
             // the race where the governor froze it mid-keystroke.
             let _ = guard.wake_session(session_id);
         }
-        let Some(session) = guard.get(session_id) else {
+        if guard.get(session_id).is_none() {
             return true; // session ended; swallow input quietly, as Swift does
-        };
+        }
         match frame.frame_type {
             FrameType::Input => {
-                let _ = session.write_input(&frame.payload);
+                let _ = guard.write_attached_input(session_id, &frame.payload);
             }
             FrameType::Mouse => {
-                let _ = session.write_mouse(&frame.payload);
+                let _ = guard
+                    .get(session_id)
+                    .expect("session checked above")
+                    .write_mouse(&frame.payload);
             }
             FrameType::Resize => {
                 if let Some((cols, rows)) = frame.resize_payload() {
-                    let _ = session.resize(cols.max(2), rows.max(2));
+                    let _ = guard
+                        .get(session_id)
+                        .expect("session checked above")
+                        .resize(cols.max(2), rows.max(2));
                 }
             }
             FrameType::Scroll => {
                 if let Some((direction, lines, col, row)) = frame.scroll_payload() {
-                    let _ =
-                        session.scroll(direction == 0, lines as usize, col as usize, row as usize);
+                    let _ = guard
+                        .get(session_id)
+                        .expect("session checked above")
+                        .scroll(direction == 0, lines as usize, col as usize, row as usize);
                 }
             }
             FrameType::Ping => {

--- a/diri/crates/diri-engine/src/control.rs
+++ b/diri/crates/diri-engine/src/control.rs
@@ -2999,6 +2999,10 @@ fn run_control_error(error: crate::registry::RegistryRunError) -> ControlError {
             "request_conflict",
             format!("request id {request_id:?} was reused with different input"),
         ),
+        E::ReplayCapacity => ControlError::new(
+            "request_capacity",
+            "active idempotent requests occupy the bounded replay journal",
+        ),
         E::Io(error) => ControlError::internal(error.to_string()),
     }
 }

--- a/diri/crates/diri-engine/src/control.rs
+++ b/diri/crates/diri-engine/src/control.rs
@@ -613,39 +613,45 @@ impl ControlServer {
             ),
         );
 
-        let current = |registry: &Registry| -> Option<diri_proto::SessionRecord> {
-            registry
+        let assess = |registry: &Registry| {
+            let record = registry
                 .records()
                 .into_iter()
-                .find(|record| record.id.0 == p.session_id.0)
-        };
-        let matches = |record: &diri_proto::SessionRecord| {
-            p.until
-                .iter()
-                .any(|target| crate::events::satisfies_wait_target(&record.status, target))
+                .find(|record| record.id.0 == p.session_id.0)?;
+            let decision = registry.wait_decision(&p.session_id.0, p.run_id, &p.until)?;
+            Some((record, decision))
         };
 
-        let mut latest = {
-            let registry = self.registry.lock().map_err(poisoned)?;
-            current(&registry).ok_or_else(|| ControlError::not_found(p.session_id.0.clone()))?
+        let (mut latest, mut decision) = {
+            let mut registry = self.registry.lock().map_err(poisoned)?;
+            registry.sync_orchestration();
+            assess(&registry).ok_or_else(|| ControlError::not_found(p.session_id.0.clone()))?
         };
         loop {
-            if matches(&latest) {
+            if decision.resolved {
                 return encode(&diri_proto::EventsWaitResult {
                     session: latest,
                     timed_out: false,
+                    superseded: decision.superseded,
+                    reached: decision.reached,
+                    run: decision.run,
                 });
             }
             let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now()) else {
                 return encode(&diri_proto::EventsWaitResult {
                     session: latest,
                     timed_out: true,
+                    superseded: false,
+                    reached: false,
+                    run: decision.run,
                 });
             };
             if stream.recv(remaining).is_some() {
-                let registry = self.registry.lock().map_err(poisoned)?;
-                if let Some(record) = current(&registry) {
+                let mut registry = self.registry.lock().map_err(poisoned)?;
+                registry.sync_orchestration();
+                if let Some((record, next_decision)) = assess(&registry) {
                     latest = record;
+                    decision = next_decision;
                 }
             }
         }
@@ -657,6 +663,9 @@ impl ControlServer {
             Method::SESSION_SPAWN => self.session_spawn(params),
             Method::SESSION_LIST | Method::STATE_SNAPSHOT => self.session_list(),
             Method::SESSION_SEND_TEXT => self.session_send_text(params),
+            Method::SESSION_RUN_SEND => self.session_run_send(params),
+            Method::SESSION_RUN_INTERRUPT => self.session_run_interrupt(params),
+            Method::SESSION_RUN_REPORT => self.session_run_report(params),
             Method::SESSION_RESIZE => self.session_resize(params),
             Method::SESSION_READ_SCREEN => self.session_read_screen(params),
             Method::SESSION_READ_SCROLLBACK => self.session_read_scrollback(params),
@@ -855,6 +864,9 @@ impl ControlServer {
         record.worktree_path = worktree_path;
         record.git_branch = git_branch.or_else(|| crate::git::branch(&cwd_path));
         record.parent = p.parent.clone();
+        if record.parent.is_some() {
+            record.run = Some(diri_proto::AgentRun::starting(1, record.created_at));
+        }
         if let (Some(cols), Some(rows)) = (p.initial_cols, p.initial_rows) {
             pty.cols = cols.clamp(2, u16::MAX as i64) as u16;
             pty.rows = rows.clamp(2, u16::MAX as i64) as u16;
@@ -1095,6 +1107,9 @@ impl ControlServer {
         record.project_id = crate::registry::session_project_id(&captured.cwd, Some(&host.id));
         record.remote_persistence = Some(persistence);
         record.parent = p.parent.clone();
+        if record.parent.is_some() {
+            record.run = Some(diri_proto::AgentRun::starting(1, record.created_at));
+        }
         record.agent_session_id = agent_session_id;
         if let Some(title) = &p.title {
             record.title = title.clone();
@@ -1677,7 +1692,8 @@ impl ControlServer {
     /// `session.list` and `state.snapshot` are the same view: every record
     /// plus the project list, exactly as the Swift daemon answers them.
     fn session_list(&self) -> Result<JsonValue, ControlError> {
-        let registry = self.registry.lock().map_err(poisoned)?;
+        let mut registry = self.registry.lock().map_err(poisoned)?;
+        registry.sync_orchestration();
         serde_json::to_value(json!({
             "sessions": registry.records(),
             "projects": registry.projects_raw(),
@@ -1692,13 +1708,68 @@ impl ControlServer {
         // flushed after SIGCONT, so no keystroke is lost.
         let _ = registry.wake_session(&p.session_id.0);
         self.publish_updated(&registry, &p.session_id.0);
-        let session = registry
-            .get(&p.session_id.0)
-            .ok_or_else(|| ControlError::not_found(p.session_id.0.clone()))?;
-        session
-            .send_text(&p.text, p.submit)
-            .map_err(|error| ControlError::internal(error.to_string()))?;
+        registry
+            .send_user_text(&p.session_id.0, p.text, p.submit)
+            .map_err(run_control_error)?;
         Ok(json!({}))
+    }
+
+    fn session_run_send(&self, params: Option<JsonValue>) -> Result<JsonValue, ControlError> {
+        let p: diri_proto::SessionRunSendParams = decode(params)?;
+        let mut registry = self.registry.lock().map_err(poisoned)?;
+        let _ = registry.wake_session(&p.session_id.0);
+        let (queued, run) = registry
+            .send_run_text(
+                &p.session_id.0,
+                p.text,
+                p.submit,
+                p.expected_run_id,
+                true,
+                p.request_id.clone(),
+            )
+            .map_err(run_control_error)?;
+        let _ = registry.persist();
+        self.publish_updated(&registry, &p.session_id.0);
+        encode(&diri_proto::SessionRunSendResult {
+            queued,
+            run,
+            request_id: p.request_id,
+        })
+    }
+
+    fn session_run_interrupt(&self, params: Option<JsonValue>) -> Result<JsonValue, ControlError> {
+        let p: diri_proto::SessionRunInterruptParams = decode(params)?;
+        let mut registry = self.registry.lock().map_err(poisoned)?;
+        let run = registry
+            .interrupt_run(&p.session_id.0, p.expected_run_id, p.request_id.clone())
+            .map_err(run_control_error)?;
+        let _ = registry.persist();
+        self.publish_updated(&registry, &p.session_id.0);
+        encode(&diri_proto::SessionRunInterruptResult {
+            run,
+            request_id: p.request_id,
+        })
+    }
+
+    fn session_run_report(&self, params: Option<JsonValue>) -> Result<JsonValue, ControlError> {
+        let p: diri_proto::SessionRunReportParams = decode(params)?;
+        let mut registry = self.registry.lock().map_err(poisoned)?;
+        let (parent, queued, run) = registry
+            .report_to_parent(
+                &p.reporter_session_id.0,
+                p.text,
+                p.submit,
+                p.expected_run_id,
+                p.request_id.clone(),
+            )
+            .map_err(run_control_error)?;
+        let _ = registry.persist();
+        self.publish_updated(&registry, &parent);
+        encode(&diri_proto::SessionRunReportResult {
+            queued,
+            run,
+            request_id: p.request_id,
+        })
     }
 
     fn session_resize(&self, params: Option<JsonValue>) -> Result<JsonValue, ControlError> {
@@ -2815,6 +2886,7 @@ pub(crate) fn new_record(id: &str, kind: &str, cwd: &str) -> diri_proto::Session
         pull_requests: None,
         listening_ports: None,
         foreground_agent: None,
+        run: None,
     }
 }
 
@@ -2902,6 +2974,32 @@ fn io_control_error(error: std::io::Error) -> ControlError {
     match error.kind() {
         std::io::ErrorKind::NotFound => ControlError::not_found(error.to_string()),
         _ => ControlError::internal(error.to_string()),
+    }
+}
+
+fn run_control_error(error: crate::registry::RegistryRunError) -> ControlError {
+    use crate::registry::RegistryRunError as E;
+    match error {
+        E::NotFound(id) => ControlError::not_found(id),
+        E::NoParent => ControlError::bad_request("this session has no parent"),
+        E::Stale { expected, current } => ControlError::new(
+            "stale_run",
+            format!("run {expected} is stale; current run is {current}"),
+        ),
+        E::Exited => ControlError::new("run_exited", "the session process has exited"),
+        E::AlreadyTerminal { current } => ControlError::new(
+            "run_terminal",
+            format!("run {current} is already terminal; nothing was interrupted"),
+        ),
+        E::OutcomeUncertain(detail) => ControlError::new("outcome_uncertain", detail),
+        E::InvalidRequestId => {
+            ControlError::bad_request("request id must be non-empty and no longer than 256 bytes")
+        }
+        E::RequestConflict(request_id) => ControlError::new(
+            "request_conflict",
+            format!("request id {request_id:?} was reused with different input"),
+        ),
+        E::Io(error) => ControlError::internal(error.to_string()),
     }
 }
 
@@ -3441,6 +3539,7 @@ mod tests {
             pull_requests: None,
             listening_ports: None,
             foreground_agent: None,
+            run: None,
         }
     }
 
@@ -3557,6 +3656,99 @@ mod tests {
             Some(64),
             "the app needs a stable content identity for upgrade coordination"
         );
+    }
+
+    #[test]
+    fn run_wait_distinguishes_a_queued_future_from_a_superseded_generation() {
+        let temp = tempfile::tempdir().expect("temp");
+        let server = server(temp.path());
+        let mut record = test_record("agent");
+        record.kind = diri_proto::AgentKind::CODEX;
+        record.run = Some(diri_proto::AgentRun {
+            id: 1,
+            state: diri_proto::AgentRunState::Completed,
+            started_at: record.created_at,
+            finished_at: Some(record.updated_at),
+            terminal_outcome: Some("completed".into()),
+        });
+        server
+            .registry
+            .lock()
+            .unwrap()
+            .insert_record(record.clone());
+
+        let future = ok_of(call(
+            &server,
+            Method::EVENTS_WAIT,
+            Some(json!({
+                "sessionID": "agent",
+                "until": ["done"],
+                "timeoutMs": 0,
+                "runId": 2,
+            })),
+        ));
+        assert_eq!(future["timedOut"], true);
+        assert_eq!(future["superseded"], false);
+
+        server
+            .registry
+            .lock()
+            .unwrap()
+            .update_record("agent", |record| {
+                record.run = Some(diri_proto::AgentRun::starting(3, record.updated_at));
+            });
+        let stale = ok_of(call(
+            &server,
+            Method::EVENTS_WAIT,
+            Some(json!({
+                "sessionID": "agent",
+                "until": ["done"],
+                "timeoutMs": 0,
+                "runId": 2,
+            })),
+        ));
+        assert_eq!(stale["superseded"], true);
+        assert_eq!(stale["timedOut"], false);
+
+        let exact_old = ok_of(call(
+            &server,
+            Method::EVENTS_WAIT,
+            Some(json!({
+                "sessionID": "agent",
+                "until": ["completed"],
+                "timeoutMs": 0,
+                "runId": 1,
+            })),
+        ));
+        assert_eq!(exact_old["reached"], true);
+        assert_eq!(exact_old["superseded"], false);
+        assert_eq!(exact_old["run"]["id"], 1);
+        assert_eq!(exact_old["run"]["state"], "completed");
+
+        server
+            .registry
+            .lock()
+            .unwrap()
+            .update_record("agent", |record| {
+                record.status = diri_proto::SessionStatus::Exited(diri_proto::ExitInfo {
+                    reason: diri_proto::ExitReason::Exited,
+                    code: Some(0),
+                    signal: None,
+                });
+            });
+        let dead_future = ok_of(call(
+            &server,
+            Method::EVENTS_WAIT,
+            Some(json!({
+                "sessionID": "agent",
+                "until": ["done"],
+                "timeoutMs": 60_000,
+                "runId": 4,
+            })),
+        ));
+        assert_eq!(dead_future["timedOut"], false);
+        assert_eq!(dead_future["reached"], false);
+        assert_eq!(dead_future["superseded"], false);
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/events.rs
+++ b/diri/crates/diri-engine/src/events.rs
@@ -371,6 +371,30 @@ pub fn satisfies_wait_target(status: &diri_proto::SessionStatus, target: &str) -
     }
 }
 
+/// Run-aware wait semantics. In particular `needsInput` is paused—not done—
+/// and a never-started idle terminal cannot satisfy `done`.
+pub fn run_satisfies_wait_target(record: &diri_proto::SessionRecord, target: &str) -> bool {
+    use diri_proto::AgentRunState as R;
+    let Some(run) = record.run.as_ref() else {
+        return satisfies_wait_target(&record.status, target);
+    };
+    match target {
+        "done" | "settled" => run.state.is_terminal(),
+        "completed" => matches!(run.state, R::Completed),
+        "running" | "working" => matches!(run.state, R::Running),
+        "starting" => matches!(run.state, R::Starting),
+        "idle" => matches!(record.status, diri_proto::SessionStatus::Idle),
+        "needsInput" | "needs_input" | "needs-input" | "needs_me" | "blocked" => {
+            matches!(run.state, R::NeedsInput)
+        }
+        "failed" => matches!(run.state, R::Failed),
+        "aborted" => matches!(run.state, R::Aborted),
+        "exited" | "dead" => matches!(record.status, diri_proto::SessionStatus::Exited(_)),
+        "any" => !matches!(run.state, R::Starting),
+        _ => false,
+    }
+}
+
 /// Publishes `session.updated` whenever a live session's observable state
 /// changes, by diffing registry views on a short cadence. The Swift daemon
 /// publishes at each mutation site inside its status engine; this engine's
@@ -388,12 +412,15 @@ pub fn spawn_registry_watcher(
             // integer compare per live session — the previous implementation
             // cloned and JSON-serialized every record (live and archived) on
             // every pass, all under the registry lock.
-            let mut published: HashMap<String, u64> = HashMap::new();
+            let mut published: HashMap<String, (u64, u64)> = HashMap::new();
+            let changes = registry.lock().expect("registry").state_changes();
+            let mut observed = changes.observe();
             while !stop.load(Ordering::SeqCst) {
                 let changed = {
                     let Ok(mut registry) = registry.lock() else {
                         break;
                     };
+                    registry.sync_orchestration();
                     registry.changed_since(&mut published)
                 };
                 for (id, record) in changed {
@@ -403,7 +430,7 @@ pub fn spawn_registry_watcher(
                         Some(&id),
                     );
                 }
-                std::thread::sleep(Duration::from_millis(150));
+                observed = changes.wait_after(observed, Duration::from_millis(250));
             }
         })
         .expect("spawn watcher")
@@ -521,5 +548,40 @@ mod tests {
         assert!(satisfies_wait_target(&exited, "exited"));
         assert!(satisfies_wait_target(&exited, "dead"));
         assert!(!satisfies_wait_target(&exited, "nonsense"));
+    }
+
+    #[test]
+    fn run_waits_distinguish_idle_before_work_pause_and_completion() {
+        use diri_proto::{AgentRun, AgentRunState, SessionStatus};
+
+        let now = std::time::SystemTime::now().into();
+        let mut record = crate::control::new_record("s_run", "codex", "/tmp");
+        record.status = SessionStatus::Idle;
+        record.run = Some(AgentRun::starting(7, now));
+
+        assert!(
+            !run_satisfies_wait_target(&record, "done"),
+            "an idle composer before the prompt starts is not a completed turn"
+        );
+
+        record.run.as_mut().expect("run").state = AgentRunState::NeedsInput;
+        assert!(run_satisfies_wait_target(&record, "needsInput"));
+        assert!(
+            !run_satisfies_wait_target(&record, "done"),
+            "a paused child still owes its caller an outcome"
+        );
+
+        record.run.as_mut().expect("run").state = AgentRunState::Completed;
+        assert!(run_satisfies_wait_target(&record, "done"));
+        assert!(run_satisfies_wait_target(&record, "settled"));
+
+        record.run.as_mut().expect("run").state = AgentRunState::Failed;
+        assert!(run_satisfies_wait_target(&record, "done"));
+        assert!(!run_satisfies_wait_target(&record, "completed"));
+        assert!(run_satisfies_wait_target(&record, "failed"));
+
+        record.run.as_mut().expect("run").state = AgentRunState::Aborted;
+        assert!(run_satisfies_wait_target(&record, "done"));
+        assert!(run_satisfies_wait_target(&record, "aborted"));
     }
 }

--- a/diri/crates/diri-engine/src/holder/client.rs
+++ b/diri/crates/diri-engine/src/holder/client.rs
@@ -56,6 +56,32 @@ impl HolderClient {
         self.write_legacy(data)
     }
 
+    /// Writes one lifecycle submission idempotently. This intentionally uses
+    /// the request lane instead of the legacy binary stream so the Holder can
+    /// retain the operation id before acknowledging it.
+    pub fn write_receipted(&self, data: &[u8], delivery_id: &str) -> HolderResult<()> {
+        let mut request = HolderRequest::op(HolderOperation::WriteReceipt);
+        request.data = Some(base64::engine::general_purpose::STANDARD.encode(data));
+        request.delivery_id = Some(delivery_id.to_owned());
+        match self.request(&request) {
+            Ok(_) => Ok(()),
+            // An explicit rejection proves an older live Holder did not
+            // perform the unknown additive operation, so its acknowledged
+            // legacy write is a safe compatibility fallback. Transport loss
+            // never falls back because the new operation may have landed.
+            Err(HolderError::Rejected(_)) => self.write(data),
+            Err(error) => Err(error),
+        }
+    }
+
+    pub fn accepted_delivery(&self, delivery_id: &str) -> HolderResult<bool> {
+        Ok(self
+            .stat()?
+            .accepted_delivery_ids
+            .iter()
+            .any(|accepted| accepted == delivery_id))
+    }
+
     fn write_legacy(&self, data: &[u8]) -> HolderResult<()> {
         let mut request = HolderRequest::op(HolderOperation::Write);
         request.data = Some(base64::engine::general_purpose::STANDARD.encode(data));

--- a/diri/crates/diri-engine/src/holder/client.rs
+++ b/diri/crates/diri-engine/src/holder/client.rs
@@ -60,18 +60,16 @@ impl HolderClient {
     /// the request lane instead of the legacy binary stream so the Holder can
     /// retain the operation id before acknowledging it.
     pub fn write_receipted(&self, data: &[u8], delivery_id: &str) -> HolderResult<()> {
+        if !self.stat()?.delivery_receipts {
+            // Capability absence is observed before the receipted operation,
+            // so an old Holder's acknowledged legacy write cannot duplicate
+            // a partially successful new operation.
+            return self.write(data);
+        }
         let mut request = HolderRequest::op(HolderOperation::WriteReceipt);
         request.data = Some(base64::engine::general_purpose::STANDARD.encode(data));
         request.delivery_id = Some(delivery_id.to_owned());
-        match self.request(&request) {
-            Ok(_) => Ok(()),
-            // An explicit rejection proves an older live Holder did not
-            // perform the unknown additive operation, so its acknowledged
-            // legacy write is a safe compatibility fallback. Transport loss
-            // never falls back because the new operation may have landed.
-            Err(HolderError::Rejected(_)) => self.write(data),
-            Err(error) => Err(error),
-        }
+        self.request(&request).map(drop)
     }
 
     pub fn accepted_delivery(&self, delivery_id: &str) -> HolderResult<bool> {

--- a/diri/crates/diri-engine/src/holder/protocol.rs
+++ b/diri/crates/diri-engine/src/holder/protocol.rs
@@ -93,6 +93,11 @@ pub struct HolderStat {
         skip_serializing_if = "Vec::is_empty"
     )]
     pub accepted_delivery_ids: Vec<String>,
+    /// Explicit negotiation bit for the additive receipt operation. Older
+    /// Swift/Rust Holders omit it and decode to false, allowing the client to
+    /// choose the legacy write before attempting any side effect.
+    #[serde(rename = "deliveryReceipts", default)]
+    pub delivery_receipts: bool,
 }
 
 /// How the held child ended.
@@ -433,12 +438,14 @@ mod tests {
         .expect("full stat");
         assert_eq!(full.child_pid, 123);
         assert_eq!(full.epoch_offset, Some(1024));
+        assert!(!full.delivery_receipts);
 
         // …and with them omitted, as a pre-epoch holder would send.
         let sparse: HolderStat =
             serde_json::from_str(r#"{"childPID":9,"alive":false,"logOffset":0}"#).expect("sparse");
         assert_eq!(sparse.foreground_pid, None);
         assert_eq!(sparse.epoch_offset, None);
+        assert!(!sparse.delivery_receipts);
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/holder/protocol.rs
+++ b/diri/crates/diri-engine/src/holder/protocol.rs
@@ -44,6 +44,7 @@ pub const HOLDER_STREAM_INPUT: u8 = 1;
 pub const HOLDER_STREAM_RESIZE: u8 = 2;
 pub const HOLDER_STREAM_ACK: u8 = 0;
 pub const HOLDER_STREAM_MAX_PAYLOAD: usize = 1 << 20;
+pub const HOLDER_DELIVERY_RECEIPT_LIMIT: usize = 64;
 
 /// A (pid, start time) pair. The start time is the identity check that makes
 /// signalling a recycled pid safe.
@@ -83,6 +84,15 @@ pub struct HolderStat {
         skip_serializing_if = "Option::is_none"
     )]
     pub epoch_offset: Option<u64>,
+    /// Bounded Holder-owned provenance for lifecycle submission operations.
+    /// The Holder outlives an Engine daemon restart, so these ids distinguish
+    /// a landed Enter from a paste that merely echoed before a crash.
+    #[serde(
+        rename = "acceptedDeliveryIDs",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub accepted_delivery_ids: Vec<String>,
 }
 
 /// How the held child ended.
@@ -112,6 +122,8 @@ pub enum HolderOperation {
     Stream,
     #[serde(rename = "write")]
     Write,
+    #[serde(rename = "write-receipt")]
+    WriteReceipt,
     #[serde(rename = "resize")]
     Resize,
     #[serde(rename = "signal")]
@@ -140,6 +152,12 @@ pub struct HolderRequest {
     pub rows: Option<u16>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sig: Option<i32>,
+    #[serde(
+        rename = "deliveryID",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub delivery_id: Option<String>,
 }
 
 impl HolderRequest {
@@ -151,6 +169,7 @@ impl HolderRequest {
             cols: None,
             rows: None,
             sig: None,
+            delivery_id: None,
         }
     }
 }

--- a/diri/crates/diri-engine/src/holder/server.rs
+++ b/diri/crates/diri-engine/src/holder/server.rs
@@ -563,6 +563,7 @@ fn current_stat(shared: &Shared) -> HolderStat {
             .iter()
             .cloned()
             .collect(),
+        delivery_receipts: true,
     }
 }
 

--- a/diri/crates/diri-engine/src/holder/server.rs
+++ b/diri/crates/diri-engine/src/holder/server.rs
@@ -7,6 +7,7 @@
 //! that wasn't running at the time still learns how the child died — then
 //! removes its control files and stops serving.
 
+use std::collections::VecDeque;
 use std::io::{Read, Write};
 use std::net::Shutdown;
 use std::path::Path;
@@ -22,9 +23,10 @@ use crate::pty::{Pty, PtySpec};
 use super::client::HolderClient;
 use super::process_tree;
 use super::protocol::{
-    HOLDER_STREAM_ACK, HOLDER_STREAM_INPUT, HOLDER_STREAM_MAX_PAYLOAD, HOLDER_STREAM_RESIZE,
-    HOLDER_STREAM_VERSION, HolderExitMarker, HolderExitReason, HolderExitStatus, HolderLaunchSpec,
-    HolderOperation, HolderRequest, HolderResponse, HolderStat,
+    HOLDER_DELIVERY_RECEIPT_LIMIT, HOLDER_STREAM_ACK, HOLDER_STREAM_INPUT,
+    HOLDER_STREAM_MAX_PAYLOAD, HOLDER_STREAM_RESIZE, HOLDER_STREAM_VERSION, HolderExitMarker,
+    HolderExitReason, HolderExitStatus, HolderLaunchSpec, HolderOperation, HolderRequest,
+    HolderResponse, HolderStat,
 };
 use super::socket;
 use super::{HolderError, HolderResult};
@@ -53,6 +55,7 @@ struct Shared {
     /// Weak handles let the exit path interrupt blocking input reads without
     /// making idle Holder streams wake on a timer.
     input_streams: Mutex<Vec<Weak<std::os::unix::net::UnixStream>>>,
+    accepted_deliveries: Mutex<VecDeque<String>>,
 }
 
 impl HolderServer {
@@ -124,6 +127,7 @@ impl HolderServer {
             finished: AtomicBool::new(false),
             listen_fd: AtomicI32::new(listen_fd),
             input_streams: Mutex::new(Vec::new()),
+            accepted_deliveries: Mutex::new(VecDeque::new()),
             spec,
         });
 
@@ -331,6 +335,47 @@ fn handle(shared: &Shared, request: &HolderRequest) -> HolderResult<HolderRespon
             Ok(HolderResponse::success())
         }
 
+        HolderOperation::WriteReceipt => {
+            let delivery_id = request.delivery_id.as_deref().ok_or_else(|| {
+                HolderError::InvalidRequest("write-receipt requires deliveryID".into())
+            })?;
+            if delivery_id.is_empty() || delivery_id.len() > 256 {
+                return Err(HolderError::InvalidRequest(
+                    "deliveryID must contain 1 through 256 bytes".into(),
+                ));
+            }
+            if shared
+                .accepted_deliveries
+                .lock()
+                .expect("accepted deliveries")
+                .iter()
+                .any(|accepted| accepted == delivery_id)
+            {
+                return Ok(HolderResponse::success());
+            }
+            let data = request
+                .data
+                .as_deref()
+                .and_then(|encoded| {
+                    base64::engine::general_purpose::STANDARD
+                        .decode(encoded)
+                        .ok()
+                })
+                .ok_or_else(|| {
+                    HolderError::InvalidRequest("write-receipt requires base64 data".into())
+                })?;
+            write_pty(shared, &data)?;
+            let mut accepted = shared
+                .accepted_deliveries
+                .lock()
+                .expect("accepted deliveries");
+            accepted.push_back(delivery_id.to_owned());
+            while accepted.len() > HOLDER_DELIVERY_RECEIPT_LIMIT {
+                accepted.pop_front();
+            }
+            Ok(HolderResponse::success())
+        }
+
         HolderOperation::Resize => {
             let (Some(cols), Some(rows)) = (request.cols, request.rows) else {
                 return Err(HolderError::InvalidRequest(
@@ -511,6 +556,13 @@ fn current_stat(shared: &Shared) -> HolderStat {
         cols: size.map(|(cols, _)| cols),
         rows: size.map(|(_, rows)| rows),
         epoch_offset: Some(shared.epoch_offset),
+        accepted_delivery_ids: shared
+            .accepted_deliveries
+            .lock()
+            .expect("accepted deliveries")
+            .iter()
+            .cloned()
+            .collect(),
     }
 }
 

--- a/diri/crates/diri-engine/src/lib.rs
+++ b/diri/crates/diri-engine/src/lib.rs
@@ -40,6 +40,7 @@ pub mod legacy_remote;
 pub mod log;
 pub mod mcp;
 pub mod migrate;
+pub mod orchestration;
 pub mod pr_monitor;
 pub mod pty;
 pub mod registry;

--- a/diri/crates/diri-engine/src/mcp/host.rs
+++ b/diri/crates/diri-engine/src/mcp/host.rs
@@ -21,9 +21,6 @@ pub const SESSION_ID_ENV: &str = "DIRIJOR_SESSION_ID";
 const DEFAULT_READ_BYTES: usize = 8_000;
 const DEFAULT_WAIT_SECONDS: f64 = 300.0;
 const DEFAULT_CHILDREN_WAIT_SECONDS: f64 = 600.0;
-/// How often a wait re-checks. Long enough not to spin, short enough that a
-/// state change is noticed promptly.
-const WAIT_POLL: Duration = Duration::from_millis(100);
 
 pub struct RegistryHost {
     registry: Arc<Mutex<Registry>>,
@@ -86,7 +83,8 @@ impl ToolHost for RegistryHost {
     fn call(&self, tool: &str, arguments: &Value) -> Result<Value, String> {
         match tool {
             "list_agents" => {
-                let registry = self.registry()?;
+                let mut registry = self.registry()?;
+                registry.sync_orchestration();
                 let agents: Vec<Value> = registry
                     .records()
                     .into_iter()
@@ -98,6 +96,7 @@ impl ToolHost for RegistryHost {
                             "status": status_word(&record.status),
                             "cwd": record.cwd,
                             "parent": record.parent.map(|parent| parent.0),
+                            "run": record.run,
                         })
                     })
                     .collect();
@@ -106,7 +105,8 @@ impl ToolHost for RegistryHost {
 
             "get_status" => {
                 let id = required_str(arguments, "session_id")?;
-                let registry = self.registry()?;
+                let mut registry = self.registry()?;
+                registry.sync_orchestration();
                 let record = registry
                     .records()
                     .into_iter()
@@ -122,6 +122,7 @@ impl ToolHost for RegistryHost {
                         "summary": detail.summary,
                         "options": detail.options,
                     })),
+                    "run": record.run,
                 }))
             }
 
@@ -133,19 +134,43 @@ impl ToolHost for RegistryHost {
                     .and_then(Value::as_bool)
                     .unwrap_or(true);
 
-                let registry = self.registry()?;
-                let session = registry
-                    .get(&id)
-                    .ok_or_else(|| format!("no session {id}"))?;
-                let payload = if submit {
-                    format!("{text}\r")
-                } else {
-                    text.clone()
-                };
-                session
-                    .write_input(payload.as_bytes())
+                let expected = arguments.get("run_id").and_then(Value::as_u64);
+                let request_id = arguments
+                    .get("request_id")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned);
+                let mut registry = self.registry()?;
+                let (queued, run) = registry
+                    .send_run_text(
+                        &id,
+                        text.clone(),
+                        submit,
+                        expected,
+                        true,
+                        request_id.clone(),
+                    )
                     .map_err(|error| error.to_string())?;
-                Ok(json!({ "sent": text.len(), "submitted": submit }))
+                Ok(json!({
+                    "sent": text.len(),
+                    "submitted": submit,
+                    "queued": queued,
+                    "run": run,
+                    "requestId": request_id,
+                }))
+            }
+
+            "interrupt_agent" => {
+                let id = required_str(arguments, "session_id")?;
+                let expected = arguments.get("run_id").and_then(Value::as_u64);
+                let request_id = arguments
+                    .get("request_id")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned);
+                let mut registry = self.registry()?;
+                let run = registry
+                    .interrupt_run(&id, expected, request_id.clone())
+                    .map_err(|error| error.to_string())?;
+                Ok(json!({"run": run, "requestId": request_id}))
             }
 
             "read_output" => {
@@ -195,7 +220,8 @@ impl ToolHost for RegistryHost {
                     .get("timeout_seconds")
                     .and_then(Value::as_f64)
                     .unwrap_or(DEFAULT_WAIT_SECONDS);
-                self.wait_for(&id, &until, timeout)
+                let run_id = arguments.get("run_id").and_then(Value::as_u64);
+                self.wait_for(&id, &until, timeout, run_id)
             }
 
             "create_worktree" => {
@@ -233,7 +259,8 @@ impl ToolHost for RegistryHost {
                 let caller = self.caller.clone().ok_or_else(|| {
                     format!("this session did not identify itself; {SESSION_ID_ENV} is unset")
                 })?;
-                let registry = self.registry()?;
+                let mut registry = self.registry()?;
+                registry.sync_orchestration();
                 let record = registry
                     .records()
                     .into_iter()
@@ -245,6 +272,7 @@ impl ToolHost for RegistryHost {
                     "title": record.title,
                     "cwd": record.cwd,
                     "parent": record.parent.map(|parent| parent.0),
+                    "run": record.run,
                 }))
             }
 
@@ -252,7 +280,8 @@ impl ToolHost for RegistryHost {
                 let caller = self.caller.clone().ok_or_else(|| {
                     format!("this session did not identify itself; {SESSION_ID_ENV} is unset")
                 })?;
-                let registry = self.registry()?;
+                let mut registry = self.registry()?;
+                registry.sync_orchestration();
                 let children: Vec<Value> = registry
                     .records()
                     .into_iter()
@@ -263,6 +292,7 @@ impl ToolHost for RegistryHost {
                             "kind": record.kind.id(),
                             "title": record.title,
                             "status": status_word(&record.status),
+                            "run": record.run,
                         })
                     })
                     .collect();
@@ -357,6 +387,9 @@ impl RegistryHost {
         let id = crate::control::next_session_id();
         let mut record = crate::control::new_record(&id, &kind, &working_dir.to_string_lossy());
         record.parent = self.caller.clone().map(SessionId);
+        if record.parent.is_some() {
+            record.run = Some(diri_proto::AgentRun::starting(1, record.created_at));
+        }
         record.worktree_path = worktree_path.clone();
         record.git_branch = branch.clone();
         if let Some(title) = title {
@@ -440,85 +473,117 @@ impl RegistryHost {
         ))
     }
 
-    fn wait_for(&self, id: &str, until: &str, timeout_seconds: f64) -> Result<Value, String> {
+    fn wait_for(
+        &self,
+        id: &str,
+        until: &str,
+        timeout_seconds: f64,
+        run_id: Option<u64>,
+    ) -> Result<Value, String> {
         let deadline = Instant::now() + Duration::from_secs_f64(timeout_seconds.max(0.0));
-        // "done" means a turn finished: idle *after* having worked. Treating a
-        // session that is merely idle as done would return instantly for one
-        // that has not started yet.
-        let mut has_worked = false;
+        let changes = self.registry()?.state_changes();
+        let mut observed = changes.observe();
 
         loop {
-            let status = {
-                let registry = self.registry()?;
-                let session = registry.get(id).ok_or_else(|| format!("no session {id}"))?;
-                session.status()
+            let targets = vec![until.to_owned()];
+            let (record, decision) = {
+                let mut registry = self.registry()?;
+                registry.sync_orchestration();
+                let record = registry
+                    .records()
+                    .into_iter()
+                    .find(|record| record.id.0 == id)
+                    .ok_or_else(|| format!("no session {id}"))?;
+                let decision = registry
+                    .wait_decision(id, run_id, &targets)
+                    .ok_or_else(|| format!("no session {id}"))?;
+                (record, decision)
             };
-            if matches!(status, SessionStatus::Working) {
-                has_worked = true;
-            }
-
-            let reached = match until {
-                "done" => has_worked && matches!(status, SessionStatus::Idle),
-                "needsInput" => matches!(status, SessionStatus::NeedsInput(_)),
-                "exited" => matches!(status, SessionStatus::Exited(_)),
-                "any" => !matches!(status, SessionStatus::Starting),
-                other => return Err(format!("unknown wait target {other:?}")),
-            };
-            // A dead session will never reach anything else.
-            let dead = matches!(status, SessionStatus::Exited(_));
-
-            if reached || dead {
+            if decision.resolved {
                 return Ok(json!({
                     "id": id,
-                    "status": status_word(&status),
-                    "reached": reached,
+                    "status": status_word(&record.status),
+                    "reached": decision.reached,
+                    "superseded": decision.superseded,
+                    "run": decision.run,
                 }));
             }
             if Instant::now() >= deadline {
                 return Ok(json!({
                     "id": id,
-                    "status": status_word(&status),
+                    "status": status_word(&record.status),
                     "reached": false,
                     "timedOut": true,
+                    "run": decision.run,
                 }));
             }
-            std::thread::sleep(WAIT_POLL);
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            observed = changes.wait_after(observed, remaining);
         }
     }
 
     fn wait_for_children(&self, caller: &str, timeout_seconds: f64) -> Result<Value, String> {
         let deadline = Instant::now() + Duration::from_secs_f64(timeout_seconds.max(0.0));
         let parent = SessionId(caller.to_string());
+        let changes = self.registry()?.state_changes();
+        let mut observed = changes.observe();
 
         loop {
-            let statuses: Vec<(String, SessionStatus)> = {
-                let registry = self.registry()?;
+            let records: Vec<diri_proto::SessionRecord> = {
+                let mut registry = self.registry()?;
+                registry.sync_orchestration();
                 registry
                     .records()
                     .into_iter()
                     .filter(|record| record.parent.as_ref() == Some(&parent))
-                    .map(|record| (record.id.0, record.status))
                     .collect()
             };
 
-            let pending: Vec<&String> = statuses
+            let pending: Vec<&String> = records
                 .iter()
-                .filter(|(_, status)| {
-                    matches!(status, SessionStatus::Working | SessionStatus::Starting)
+                .filter(|record| {
+                    record.run.as_ref().map_or_else(
+                        || {
+                            !matches!(
+                                record.status,
+                                SessionStatus::Idle | SessionStatus::Exited(_)
+                            )
+                        },
+                        |run| !run.state.is_terminal(),
+                    )
                 })
-                .map(|(id, _)| id)
+                .map(|record| &record.id.0)
                 .collect();
+            let unsettled = records.iter().any(|record| {
+                record.run.as_ref().map_or_else(
+                    || {
+                        !matches!(
+                            record.status,
+                            SessionStatus::Idle
+                                | SessionStatus::NeedsInput(_)
+                                | SessionStatus::Exited(_)
+                        )
+                    },
+                    |run| {
+                        !run.state.is_terminal()
+                            && !matches!(run.state, diri_proto::AgentRunState::NeedsInput)
+                    },
+                )
+            });
 
-            if pending.is_empty() || Instant::now() >= deadline {
+            if !unsettled || Instant::now() >= deadline {
                 return Ok(json!({
-                    "children": statuses.iter().map(|(id, status)| json!({
-                        "id": id,
-                        "status": status_word(status),
+                    "children": records.iter().map(|record| json!({
+                        "id": record.id.0,
+                        "status": status_word(&record.status),
+                        "run": record.run,
                     })).collect::<Vec<_>>(),
                     "allDone": pending.is_empty(),
+                    "needsInput": records.iter().any(|record| record.run.as_ref().is_some_and(|run| matches!(run.state, diri_proto::AgentRunState::NeedsInput))),
                 }));
             }
-            std::thread::sleep(WAIT_POLL);
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            observed = changes.wait_after(observed, remaining);
         }
     }
 

--- a/diri/crates/diri-engine/src/mcp/mod.rs
+++ b/diri/crates/diri-engine/src/mcp/mod.rs
@@ -239,6 +239,7 @@ mod tests {
             "list_agents",
             "get_status",
             "send_prompt",
+            "interrupt_agent",
             "read_output",
             "release_agent",
             "create_worktree",

--- a/diri/crates/diri-engine/src/mcp/tools.rs
+++ b/diri/crates/diri-engine/src/mcp/tools.rs
@@ -89,21 +89,25 @@ pub fn tool_definitions_for(kinds: &[String]) -> Vec<ToolDefinition> {
                 "properties": {
                     "session_id": { "type": "string" },
                     "text": { "type": "string", "description": "The text to send." },
-                    "submit": { "type": "boolean", "description": "Press return afterwards. Defaults to true." }
+                    "submit": { "type": "boolean", "description": "Press return afterwards. Defaults to true." },
+                    "run_id": { "type": "integer", "minimum": 1, "description": "Reject if this run is no longer current." },
+                    "request_id": { "type": "string", "minLength": 1, "maxLength": 256, "description": "Stable idempotency key. Reuse it when retrying after a lost response." }
                 },
                 "required": ["session_id", "text"]
             }),
         ),
         tool(
             "wait_for_agent",
-            "Block until a session reaches a state: done (idle after working), needsInput, or \
-             exited. Returns as soon as the state is reached or the timeout elapses.",
+            "Block until a specific agent run reaches a state. done means any terminal outcome; \
+             completed means success only; needsInput is paused, not done. A pinned future run \
+             waits until it starts, while a newer run returns superseded.",
             json!({
                 "type": "object",
                 "properties": {
                     "session_id": { "type": "string" },
-                    "until": { "type": "string", "enum": ["done", "needsInput", "exited", "any"], "description": "What to wait for. Defaults to done." },
-                    "timeout_seconds": { "type": "number", "description": "Give up after this long. Defaults to 300." }
+                    "until": { "type": "string", "enum": ["done", "completed", "failed", "aborted", "needsInput", "idle", "exited", "any"], "description": "What to wait for. Defaults to done." },
+                    "timeout_seconds": { "type": "number", "description": "Give up after this long. Defaults to 300." },
+                    "run_id": { "type": "integer", "minimum": 1, "description": "Pin the wait to this current or queued future run." }
                 },
                 "required": ["session_id"]
             }),
@@ -116,6 +120,19 @@ pub fn tool_definitions_for(kinds: &[String]) -> Vec<ToolDefinition> {
                 "properties": {
                     "session_id": { "type": "string" },
                     "max_bytes": { "type": "number", "description": "How much to read from the end. Defaults to 8000." }
+                },
+                "required": ["session_id"]
+            }),
+        ),
+        tool(
+            "interrupt_agent",
+            "Abort the current run with Ctrl-C but keep the session available for a later prompt.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "session_id": { "type": "string" },
+                    "run_id": { "type": "integer", "minimum": 1 },
+                    "request_id": { "type": "string", "minLength": 1, "maxLength": 256, "description": "Stable idempotency key. Reuse it when retrying after a lost response." }
                 },
                 "required": ["session_id"]
             }),

--- a/diri/crates/diri-engine/src/orchestration.rs
+++ b/diri/crates/diri-engine/src/orchestration.rs
@@ -67,6 +67,15 @@ pub(crate) struct PendingDelivery {
     /// Engine acknowledges it, even while an older run is still active.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub assigned_run: Option<AgentRun>,
+    /// Stable Holder-side idempotency/provenance key for the submitting Enter.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operation_id: Option<String>,
+    /// Request provenance must travel with queued work so a bounded replay
+    /// journal can never evict a key whose side effect is still pending.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_fingerprint: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
@@ -113,6 +122,8 @@ struct DispatchIntent {
     request_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     request_fingerprint: Option<String>,
+    #[serde(default)]
+    queued: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -135,9 +146,13 @@ struct UncertainDelivery {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     prepared_blocker: Option<BlockerIdentity>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    operation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     request_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     request_fingerprint: Option<String>,
+    #[serde(default)]
+    queued: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -199,6 +214,7 @@ pub(crate) struct WaitDecision {
 pub(crate) struct DeliveryPlan {
     pub queued: bool,
     pub run: Option<AgentRun>,
+    pub operation_id: Option<String>,
 }
 
 pub(crate) struct DeliveryRequest<'a> {
@@ -221,6 +237,7 @@ pub(crate) enum RunError {
     AlreadyTerminal { current: u64 },
     InvalidRequestId,
     RequestConflict { request_id: String },
+    ReplayCapacity,
 }
 
 /// Only durable fields are serialized. Completion counters and the last
@@ -339,14 +356,16 @@ impl Orchestration {
                         run_id: intent.run_id.unwrap_or(run.id),
                         prepared_output_offset: intent.prepared_output_offset,
                         prepared_blocker: intent.prepared_blocker,
+                        operation_id: intent.delivery.operation_id,
                         request_id: intent.request_id.clone(),
                         request_fingerprint: intent.request_fingerprint.clone(),
+                        queued: intent.queued,
                     },
                 );
                 if let (Some(request_id), Some(fingerprint)) =
                     (intent.request_id, intent.request_fingerprint)
                 {
-                    self.remember_replay_unchecked(
+                    let _ = self.remember_replay_unchecked(
                         &id,
                         ReplayEntry {
                             operation: ReplayOperation::Delivery,
@@ -383,7 +402,7 @@ impl Orchestration {
             if let (Some(request_id), Some(fingerprint)) =
                 (intent.request_id, intent.request_fingerprint)
             {
-                self.remember_replay_unchecked(
+                let _ = self.remember_replay_unchecked(
                     &id,
                     ReplayEntry {
                         operation: ReplayOperation::Interrupt,
@@ -456,7 +475,7 @@ impl Orchestration {
                 if let (Some(request_id), Some(fingerprint)) =
                     (uncertain.request_id, uncertain.request_fingerprint)
                 {
-                    self.remember_replay_unchecked(
+                    let _ = self.remember_replay_unchecked(
                         &id,
                         ReplayEntry {
                             operation: ReplayOperation::Delivery,
@@ -630,6 +649,37 @@ impl Orchestration {
         Ok(Some(entry.outcome.clone()))
     }
 
+    /// Ensures a new request can be journaled before any associated state or
+    /// PTY side effect is accepted. Entries that still own pending work,
+    /// in-flight intent, or an uncertain tombstone are pinned and ineligible
+    /// for bounded-journal eviction.
+    pub fn ensure_replay_capacity(
+        &self,
+        scope: &str,
+        operation: ReplayOperation,
+        request_id: Option<&str>,
+    ) -> Result<(), RunError> {
+        let Some(request_id) = request_id else {
+            return Ok(());
+        };
+        validate_request_id(request_id)?;
+        let entries = self.request_replays.get(scope);
+        if entries
+            .into_iter()
+            .flatten()
+            .any(|entry| entry.operation == operation && entry.request_id == request_id)
+            || entries.is_none_or(|entries| entries.len() < REQUEST_REPLAY_LIMIT)
+            || entries
+                .into_iter()
+                .flatten()
+                .any(|entry| !self.replay_is_pinned(scope, entry))
+        {
+            Ok(())
+        } else {
+            Err(RunError::ReplayCapacity)
+        }
+    }
+
     pub fn remember_replay(
         &mut self,
         scope: &str,
@@ -651,22 +701,71 @@ impl Orchestration {
                 fingerprint: fingerprint.to_owned(),
                 outcome,
             },
-        );
-        Ok(())
+        )
     }
 
-    fn remember_replay_unchecked(&mut self, scope: &str, entry: ReplayEntry) {
+    fn remember_replay_unchecked(
+        &mut self,
+        scope: &str,
+        entry: ReplayEntry,
+    ) -> Result<(), RunError> {
+        let eviction = self.request_replays.get(scope).and_then(|entries| {
+            (entries.len() >= REQUEST_REPLAY_LIMIT).then(|| {
+                entries
+                    .iter()
+                    .position(|existing| !self.replay_is_pinned(scope, existing))
+            })
+        });
         let entries = self.request_replays.entry(scope.to_owned()).or_default();
         if let Some(existing) = entries.iter_mut().find(|existing| {
             existing.operation == entry.operation && existing.request_id == entry.request_id
         }) {
             *existing = entry;
-            return;
+            return Ok(());
+        }
+        if let Some(eviction) = eviction {
+            let Some(index) = eviction else {
+                return Err(RunError::ReplayCapacity);
+            };
+            entries.remove(index);
         }
         entries.push_back(entry);
-        while entries.len() > REQUEST_REPLAY_LIMIT {
-            entries.pop_front();
-        }
+        Ok(())
+    }
+
+    fn replay_is_pinned(&self, scope: &str, entry: &ReplayEntry) -> bool {
+        let matches = |request_id: Option<&String>, fingerprint: Option<&String>| {
+            request_id.is_some_and(|request_id| request_id == &entry.request_id)
+                && fingerprint.is_some_and(|fingerprint| fingerprint == &entry.fingerprint)
+        };
+        self.pending
+            .get(scope)
+            .into_iter()
+            .flatten()
+            .any(|delivery| {
+                matches(
+                    delivery.request_id.as_ref(),
+                    delivery.request_fingerprint.as_ref(),
+                )
+            })
+            || self.dispatching.get(scope).is_some_and(|intent| {
+                matches(
+                    intent.request_id.as_ref(),
+                    intent.request_fingerprint.as_ref(),
+                )
+            })
+            || self.uncertain_deliveries.get(scope).is_some_and(|intent| {
+                matches(
+                    intent.request_id.as_ref(),
+                    intent.request_fingerprint.as_ref(),
+                )
+            })
+            || self.interrupting.get(scope).is_some_and(|intent| {
+                matches(
+                    intent.request_id.as_ref(),
+                    intent.request_fingerprint.as_ref(),
+                )
+            })
     }
 
     pub fn remember_current_terminal(&mut self, record: &SessionRecord) {
@@ -789,21 +888,28 @@ impl Orchestration {
         if let Some(request_id) = request_id {
             validate_request_id(request_id)?;
         }
-        Self::validate_expected(record, expected_run_id)?;
         if matches!(status, SessionStatus::Exited(_)) {
             return Err(RunError::Exited);
         }
+        // Fold the supplied authoritative snapshot before comparing the
+        // caller's generation. A raw PTY turn can start between registry
+        // snapshots; validating first would acknowledge a stale run and then
+        // silently queue against its successor.
         let _ = self.observe(record, status, needs_input, completion_seq, output_offset);
+        Self::validate_expected(record, expected_run_id)?;
+        self.ensure_replay_capacity(&record.id.0, ReplayOperation::Delivery, request_id)?;
         let next_run_id = self.next_run_id(record);
         let Some(run) = record.run.as_mut() else {
             return Ok(DeliveryPlan {
                 queued: false,
                 run: None,
+                operation_id: None,
             });
         };
         let id = record.id.0.clone();
         let queue_occupied = self.pending.get(&id).is_some_and(|queue| !queue.is_empty())
-            || self.dispatching.contains_key(&id);
+            || self.dispatching.contains_key(&id)
+            || self.uncertain_deliveries.contains_key(&id);
         let safe = !queue_occupied
             && match run.state {
                 AgentRunState::Completed | AgentRunState::Failed | AgentRunState::Aborted => {
@@ -828,6 +934,7 @@ impl Orchestration {
                 run.state = AgentRunState::Running;
             }
             let response_run = Some(run.clone());
+            let operation_id = submit.then(|| delivery_operation_id(&id, run.id, &text));
             self.dispatching.insert(
                 id,
                 DispatchIntent {
@@ -835,22 +942,30 @@ impl Orchestration {
                         text,
                         submit,
                         assigned_run: submit.then(|| run.clone()),
+                        operation_id: operation_id.clone(),
+                        request_id: request_id.map(str::to_owned),
+                        request_fingerprint: request_fingerprint.map(str::to_owned),
                     },
                     run_id: Some(run.id),
                     prepared_output_offset: output_offset,
                     prepared_blocker: needs_input.map(BlockerIdentity::from),
                     request_id: request_id.map(str::to_owned),
                     request_fingerprint: request_fingerprint.map(str::to_owned),
+                    queued: false,
                 },
             );
             return Ok(DeliveryPlan {
                 queued: false,
                 run: response_run,
+                operation_id,
             });
         }
 
         let assigned_run = submit.then(|| AgentRun::starting(next_run_id, now()));
         let response_run = assigned_run.clone().or_else(|| Some(run.clone()));
+        let operation_id = assigned_run
+            .as_ref()
+            .map(|run| delivery_operation_id(&id, run.id, &text));
         self.pending
             .entry(id)
             .or_default()
@@ -858,10 +973,14 @@ impl Orchestration {
                 text,
                 submit,
                 assigned_run,
+                operation_id: operation_id.clone(),
+                request_id: request_id.map(str::to_owned),
+                request_fingerprint: request_fingerprint.map(str::to_owned),
             });
         Ok(DeliveryPlan {
             queued: true,
             run: response_run,
+            operation_id,
         })
     }
 
@@ -880,6 +999,7 @@ impl Orchestration {
         if !matches!(status, SessionStatus::Idle)
             || self.awaiting_work.contains_key(&id)
             || self.dispatching.contains_key(&id)
+            || self.uncertain_deliveries.contains_key(&id)
         {
             return None;
         }
@@ -907,8 +1027,9 @@ impl Orchestration {
                 run_id: record.run.as_ref().map(|run| run.id),
                 prepared_output_offset: output_offset,
                 prepared_blocker: needs_input.map(BlockerIdentity::from),
-                request_id: None,
-                request_fingerprint: None,
+                request_id: delivery.request_id.clone(),
+                request_fingerprint: delivery.request_fingerprint.clone(),
+                queued: true,
                 delivery: delivery.clone(),
             },
         );
@@ -936,6 +1057,134 @@ impl Orchestration {
         }
     }
 
+    /// Converts the still-present durable dispatch intent into a tombstone.
+    /// This is used both for acknowledgement loss and for a failed final
+    /// commit: neither case is allowed to discard the operation identity.
+    pub fn mark_dispatch_uncertain(
+        &mut self,
+        record: &mut SessionRecord,
+        detail: String,
+    ) -> Result<(), RunError> {
+        let id = record.id.0.clone();
+        let Some(intent) = self.dispatching.remove(&id) else {
+            return Ok(());
+        };
+        let run = record
+            .run
+            .get_or_insert_with(|| AgentRun::starting(intent.run_id.unwrap_or(1), now()));
+        run.state = AgentRunState::Failed;
+        run.finished_at = Some(now());
+        run.terminal_outcome = Some("delivery_outcome_uncertain".into());
+        self.awaiting_work.remove(&id);
+        self.remember_terminal(&id, run.clone());
+        self.uncertain_deliveries.insert(
+            id.clone(),
+            UncertainDelivery {
+                run_id: intent.run_id.unwrap_or(run.id),
+                prepared_output_offset: intent.prepared_output_offset,
+                prepared_blocker: intent.prepared_blocker,
+                operation_id: intent.delivery.operation_id,
+                request_id: intent.request_id.clone(),
+                request_fingerprint: intent.request_fingerprint.clone(),
+                queued: intent.queued,
+            },
+        );
+        if let (Some(request_id), Some(fingerprint)) =
+            (intent.request_id, intent.request_fingerprint)
+        {
+            self.remember_replay_unchecked(
+                &id,
+                ReplayEntry {
+                    operation: ReplayOperation::Delivery,
+                    request_id,
+                    fingerprint,
+                    outcome: ReplayOutcome::OutcomeUncertain { detail },
+                },
+            )?;
+        }
+        Ok(())
+    }
+
+    pub fn uncertain_operation_id(&self, id: &str) -> Option<&str> {
+        self.uncertain_deliveries
+            .get(id)
+            .and_then(|delivery| delivery.operation_id.as_deref())
+    }
+
+    /// Reconciles an uncertain pre-send tombstone with the Holder's durable
+    /// receipt for the submitting Enter. The receipt proves the entire prior
+    /// ordered paste reached the same PTY, so an adopted Idle/output edge can
+    /// safely close the original generation instead of leaving it failed.
+    pub fn confirm_uncertain_delivery(
+        &mut self,
+        record: &mut SessionRecord,
+        status: &SessionStatus,
+        needs_input: Option<&NeedsInputDetail>,
+        completion_seq: u64,
+        output_offset: u64,
+    ) -> bool {
+        let id = record.id.0.clone();
+        let Some(uncertain) = self.uncertain_deliveries.get(&id).cloned() else {
+            return false;
+        };
+        let Some(run) = record.run.as_mut().filter(|run| run.id == uncertain.run_id) else {
+            return false;
+        };
+        let output_advanced = output_offset > uncertain.prepared_output_offset;
+        let same_blocker =
+            needs_input.map(BlockerIdentity::from).as_ref() == uncertain.prepared_blocker.as_ref();
+        run.state = match status {
+            SessionStatus::Idle if output_advanced => AgentRunState::Completed,
+            SessionStatus::NeedsInput(_) if !same_blocker => AgentRunState::NeedsInput,
+            SessionStatus::Exited(_) => AgentRunState::Failed,
+            SessionStatus::Starting
+            | SessionStatus::Idle
+            | SessionStatus::Working
+            | SessionStatus::NeedsInput(_)
+            | SessionStatus::Unknown => AgentRunState::Running,
+        };
+        run.finished_at = run.state.is_terminal().then(now);
+        run.terminal_outcome = match run.state {
+            AgentRunState::Completed => Some("completed".into()),
+            AgentRunState::Failed => Some("process_exited".into()),
+            _ => None,
+        };
+        let accepted_run = run.clone();
+        self.remove_terminal(&id, accepted_run.id);
+        if accepted_run.state.is_terminal() {
+            self.remember_terminal(&id, accepted_run.clone());
+        } else {
+            self.awaiting_work.insert(
+                id.clone(),
+                AwaitingWork {
+                    run_id: accepted_run.id,
+                    accepted_output_offset: uncertain.prepared_output_offset,
+                    answered_blocker: uncertain.prepared_blocker.clone(),
+                },
+            );
+        }
+        self.uncertain_deliveries.remove(&id);
+        self.adoption_pending.remove(&id);
+        self.completion_baselines.insert(id.clone(), completion_seq);
+        if let (Some(request_id), Some(fingerprint)) =
+            (uncertain.request_id, uncertain.request_fingerprint)
+        {
+            let _ = self.remember_replay_unchecked(
+                &id,
+                ReplayEntry {
+                    operation: ReplayOperation::Delivery,
+                    request_id,
+                    fingerprint,
+                    outcome: ReplayOutcome::Delivery {
+                        queued: uncertain.queued,
+                        run: Some(accepted_run),
+                    },
+                },
+            );
+        }
+        true
+    }
+
     pub fn prepare_interrupt(
         &mut self,
         record: &mut SessionRecord,
@@ -946,6 +1195,7 @@ impl Orchestration {
         if let Some(request_id) = request_id {
             validate_request_id(request_id)?;
         }
+        self.ensure_replay_capacity(&record.id.0, ReplayOperation::Interrupt, request_id)?;
         Self::validate_expected(record, expected)?;
         let run = record
             .run
@@ -977,6 +1227,38 @@ impl Orchestration {
         self.interrupting.remove(&record.id.0);
         self.remember_terminal(&record.id.0, run.clone());
         run.clone()
+    }
+
+    pub fn mark_interrupt_uncertain(
+        &mut self,
+        record: &mut SessionRecord,
+        detail: String,
+    ) -> Result<AgentRun, RunError> {
+        let id = record.id.0.clone();
+        let intent = self.interrupting.remove(&id);
+        let run = record
+            .run
+            .get_or_insert_with(|| AgentRun::starting(1, now()));
+        run.state = AgentRunState::Aborted;
+        run.finished_at = Some(now());
+        run.terminal_outcome = Some("interrupt_outcome_uncertain".into());
+        self.awaiting_work.remove(&id);
+        self.remember_terminal(&id, run.clone());
+        if let Some(intent) = intent
+            && let (Some(request_id), Some(fingerprint)) =
+                (intent.request_id, intent.request_fingerprint)
+        {
+            self.remember_replay_unchecked(
+                &id,
+                ReplayEntry {
+                    operation: ReplayOperation::Interrupt,
+                    request_id,
+                    fingerprint,
+                    outcome: ReplayOutcome::OutcomeUncertain { detail },
+                },
+            )?;
+        }
+        Ok(run.clone())
     }
 
     fn next_run_id(&self, record: &SessionRecord) -> u64 {
@@ -1017,6 +1299,11 @@ fn validate_request_id(request_id: &str) -> Result<(), RunError> {
     } else {
         Ok(())
     }
+}
+
+fn delivery_operation_id(session_id: &str, run_id: u64, text: &str) -> String {
+    let fingerprint = request_fingerprint(&(session_id, run_id, text));
+    format!("run-{run_id}-{}", &fingerprint[..24])
 }
 
 fn run_satisfies_target(run: &AgentRun, status: &SessionStatus, target: &str) -> bool {
@@ -1646,6 +1933,331 @@ mod tests {
         assert_eq!(run.id, 1);
         assert_eq!(run.state, AgentRunState::Running);
         assert!(run.terminal_outcome.is_none());
+    }
+
+    #[test]
+    fn expected_generation_is_checked_after_the_fresh_raw_turn_snapshot() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        record.run.as_mut().unwrap().state = AgentRunState::Completed;
+        lifecycle.register(&record, 0, &SessionStatus::Idle);
+
+        let error = lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::Working,
+                    needs_input: None,
+                    completion_seq: 0,
+                    output_offset: 10,
+                    expected_run_id: Some(1),
+                    text: "must not target the successor".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: None,
+                    request_fingerprint: None,
+                },
+            )
+            .unwrap_err();
+        assert_eq!(
+            error,
+            RunError::Stale {
+                expected: 1,
+                current: 2
+            }
+        );
+        assert_eq!(record.run.as_ref().unwrap().id, 2);
+        assert!(!lifecycle.pending.contains_key("child"));
+    }
+
+    #[test]
+    fn acknowledgement_loss_retains_the_exact_dispatch_tombstone() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        lifecycle.register(&record, 0, &SessionStatus::Idle);
+        let plan = lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::Idle,
+                    needs_input: None,
+                    completion_seq: 0,
+                    output_offset: 10,
+                    expected_run_id: Some(1),
+                    text: "land once".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: Some("delivery-1"),
+                    request_fingerprint: Some("fingerprint-1"),
+                },
+            )
+            .unwrap();
+        let operation_id = plan.operation_id.expect("receipt id");
+        lifecycle
+            .mark_dispatch_uncertain(&mut record, "ack lost".into())
+            .unwrap();
+
+        assert_eq!(
+            lifecycle.uncertain_operation_id("child"),
+            Some(operation_id.as_str())
+        );
+        assert_eq!(record.run.as_ref().unwrap().state, AgentRunState::Failed);
+        assert!(matches!(
+            lifecycle
+                .lookup_replay(
+                    "child",
+                    ReplayOperation::Delivery,
+                    Some("delivery-1"),
+                    Some("fingerprint-1")
+                )
+                .unwrap(),
+            Some(ReplayOutcome::OutcomeUncertain { .. })
+        ));
+        let queued = lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::Idle,
+                    needs_input: None,
+                    completion_seq: 0,
+                    output_offset: 11,
+                    expected_run_id: Some(1),
+                    text: "must wait for reconciliation".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: None,
+                    request_fingerprint: None,
+                },
+            )
+            .unwrap();
+        assert!(queued.queued);
+        assert!(
+            lifecycle
+                .begin_ready(&mut record, &SessionStatus::Idle, None, 0, 11)
+                .is_none(),
+            "an unresolved tombstone must gate its queued successor"
+        );
+    }
+
+    #[test]
+    fn holder_receipt_reconciles_idle_restart_window_to_completion() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        lifecycle.register(&record, 0, &SessionStatus::Idle);
+        lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::Idle,
+                    needs_input: None,
+                    completion_seq: 0,
+                    output_offset: 10,
+                    expected_run_id: Some(1),
+                    text: "finish while absent".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: Some("restart-1"),
+                    request_fingerprint: Some("restart-fingerprint"),
+                },
+            )
+            .unwrap();
+        lifecycle
+            .mark_dispatch_uncertain(&mut record, "daemon restarted".into())
+            .unwrap();
+        lifecycle.register_adopted(&record, 0, &SessionStatus::Idle);
+
+        assert!(lifecycle.confirm_uncertain_delivery(
+            &mut record,
+            &SessionStatus::Idle,
+            None,
+            0,
+            20,
+        ));
+        let run = record.run.as_ref().unwrap();
+        assert_eq!(run.id, 1);
+        assert_eq!(run.state, AgentRunState::Completed);
+        assert_eq!(run.terminal_outcome.as_deref(), Some("completed"));
+        assert!(matches!(
+            lifecycle
+                .lookup_replay(
+                    "child",
+                    ReplayOperation::Delivery,
+                    Some("restart-1"),
+                    Some("restart-fingerprint")
+                )
+                .unwrap(),
+            Some(ReplayOutcome::Delivery { queued: false, .. })
+        ));
+    }
+
+    #[test]
+    fn active_request_keys_are_pinned_in_the_bounded_replay_journal() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        record.run.as_mut().unwrap().state = AgentRunState::Running;
+        lifecycle.register(&record, 0, &SessionStatus::Working);
+        for index in 0..REQUEST_REPLAY_LIMIT {
+            let request_id = format!("queued-{index}");
+            let fingerprint = format!("fingerprint-{index}");
+            let plan = lifecycle
+                .prepare_delivery(
+                    &mut record,
+                    DeliveryRequest {
+                        status: &SessionStatus::Working,
+                        needs_input: None,
+                        completion_seq: 0,
+                        output_offset: 0,
+                        expected_run_id: Some(1),
+                        text: format!("queued {index}"),
+                        submit: true,
+                        allow_needs_input: true,
+                        request_id: Some(&request_id),
+                        request_fingerprint: Some(&fingerprint),
+                    },
+                )
+                .unwrap();
+            lifecycle
+                .remember_replay(
+                    "child",
+                    ReplayOperation::Delivery,
+                    Some(&request_id),
+                    Some(&fingerprint),
+                    ReplayOutcome::Delivery {
+                        queued: true,
+                        run: plan.run,
+                    },
+                )
+                .unwrap();
+        }
+        let error = lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::Working,
+                    needs_input: None,
+                    completion_seq: 0,
+                    output_offset: 0,
+                    expected_run_id: Some(1),
+                    text: "one too many".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: Some("queued-overflow"),
+                    request_fingerprint: Some("overflow-fingerprint"),
+                },
+            )
+            .unwrap_err();
+        assert_eq!(error, RunError::ReplayCapacity);
+        assert_eq!(lifecycle.pending["child"].len(), REQUEST_REPLAY_LIMIT);
+        assert!(
+            lifecycle
+                .lookup_replay(
+                    "child",
+                    ReplayOperation::Delivery,
+                    Some("queued-0"),
+                    Some("fingerprint-0")
+                )
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn final_commit_failure_replaces_delivery_success_with_uncertainty_in_memory() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        lifecycle.register(&record, 0, &SessionStatus::Idle);
+        lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::Idle,
+                    needs_input: None,
+                    completion_seq: 0,
+                    output_offset: 0,
+                    expected_run_id: Some(1),
+                    text: "commit window".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: Some("commit-1"),
+                    request_fingerprint: Some("commit-fingerprint"),
+                },
+            )
+            .unwrap();
+        let durable_intent = lifecycle.clone();
+        lifecycle.finish_dispatch("child", Some(1), true, None, 0);
+        lifecycle
+            .remember_replay(
+                "child",
+                ReplayOperation::Delivery,
+                Some("commit-1"),
+                Some("commit-fingerprint"),
+                ReplayOutcome::Delivery {
+                    queued: false,
+                    run: record.run.clone(),
+                },
+            )
+            .unwrap();
+
+        lifecycle = durable_intent;
+        lifecycle
+            .mark_dispatch_uncertain(&mut record, "commit failed".into())
+            .unwrap();
+        assert!(matches!(
+            lifecycle
+                .lookup_replay(
+                    "child",
+                    ReplayOperation::Delivery,
+                    Some("commit-1"),
+                    Some("commit-fingerprint")
+                )
+                .unwrap(),
+            Some(ReplayOutcome::OutcomeUncertain { .. })
+        ));
+    }
+
+    #[test]
+    fn final_commit_failure_replaces_interrupt_success_with_uncertainty_in_memory() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        record.run.as_mut().unwrap().state = AgentRunState::Running;
+        lifecycle.register(&record, 0, &SessionStatus::Working);
+        lifecycle
+            .prepare_interrupt(
+                &mut record,
+                Some(1),
+                Some("interrupt-commit-1"),
+                Some("interrupt-fingerprint"),
+            )
+            .unwrap();
+        let durable_intent = lifecycle.clone();
+        lifecycle.finish_interrupt(&mut record);
+        lifecycle
+            .remember_replay(
+                "child",
+                ReplayOperation::Interrupt,
+                Some("interrupt-commit-1"),
+                Some("interrupt-fingerprint"),
+                ReplayOutcome::Interrupt {
+                    run: record.run.clone().unwrap(),
+                },
+            )
+            .unwrap();
+
+        lifecycle = durable_intent;
+        lifecycle
+            .mark_interrupt_uncertain(&mut record, "commit failed".into())
+            .unwrap();
+        assert!(matches!(
+            lifecycle
+                .lookup_replay(
+                    "child",
+                    ReplayOperation::Interrupt,
+                    Some("interrupt-commit-1"),
+                    Some("interrupt-fingerprint")
+                )
+                .unwrap(),
+            Some(ReplayOutcome::OutcomeUncertain { .. })
+        ));
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/orchestration.rs
+++ b/diri/crates/diri-engine/src/orchestration.rs
@@ -1,0 +1,1738 @@
+//! Durable, explicit agent-turn orchestration layered over terminal status.
+//!
+//! A terminal being `Idle` is ambiguous: it may not have begun a turn yet or
+//! it may just have completed one. This module owns the deeper contract used
+//! by MCP callers: monotonic run identities, terminal outcomes, stale-event
+//! rejection, and an Engine-owned durable FIFO that waits for a safe composer.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::Duration;
+
+use diri_proto::{
+    AgentRun, AgentRunState, DateMillis, NeedsInputDetail, NeedsInputKind, NeedsInputSource,
+    SessionRecord, SessionStatus,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+const TERMINAL_HISTORY_LIMIT: usize = 32;
+const REQUEST_REPLAY_LIMIT: usize = 64;
+const REQUEST_ID_LIMIT: usize = 256;
+
+#[derive(Clone, Default)]
+pub struct StateChanges {
+    inner: Arc<StateChangesInner>,
+}
+
+#[derive(Default)]
+struct StateChangesInner {
+    revision: Mutex<u64>,
+    changed: Condvar,
+}
+
+impl StateChanges {
+    pub fn observe(&self) -> u64 {
+        *self.inner.revision.lock().expect("state changes")
+    }
+
+    pub fn notify(&self) {
+        let mut revision = self.inner.revision.lock().expect("state changes");
+        *revision = revision.saturating_add(1);
+        self.inner.changed.notify_all();
+    }
+
+    /// Waits without polling. Returns the latest revision; a different value
+    /// means at least one session changed.
+    pub fn wait_after(&self, observed: u64, timeout: Duration) -> u64 {
+        let revision = self.inner.revision.lock().expect("state changes");
+        if *revision != observed {
+            return *revision;
+        }
+        let (revision, _) = self
+            .inner
+            .changed
+            .wait_timeout_while(revision, timeout, |revision| *revision == observed)
+            .expect("state changes");
+        *revision
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PendingDelivery {
+    pub text: String,
+    pub submit: bool,
+    /// A submitted delivery owns its future identity from the moment the
+    /// Engine acknowledges it, even while an older run is still active.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assigned_run: Option<AgentRun>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BlockerIdentity {
+    kind: NeedsInputKind,
+    source: NeedsInputSource,
+    tool_name: Option<String>,
+    /// The summary is the stable human-visible question. Prompt excerpts are
+    /// intentionally excluded: screen echoes and selection cursors make them
+    /// change while the same blocker remains visible.
+    summary: String,
+    options: Option<Vec<String>>,
+}
+
+impl From<&NeedsInputDetail> for BlockerIdentity {
+    fn from(detail: &NeedsInputDetail) -> Self {
+        Self {
+            kind: detail.kind,
+            source: detail.source,
+            tool_name: detail.tool_name.clone(),
+            summary: detail
+                .summary
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join(" "),
+            options: detail.options.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DispatchIntent {
+    #[serde(flatten)]
+    delivery: PendingDelivery,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    run_id: Option<u64>,
+    #[serde(default)]
+    prepared_output_offset: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    prepared_blocker: Option<BlockerIdentity>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    request_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    request_fingerprint: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AwaitingWork {
+    run_id: u64,
+    /// Output tail at the accepted PTY write. A holder can advance this while
+    /// the daemon is absent, giving adoption durable evidence that work ran.
+    #[serde(default)]
+    accepted_output_offset: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    answered_blocker: Option<BlockerIdentity>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UncertainDelivery {
+    run_id: u64,
+    prepared_output_offset: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    prepared_blocker: Option<BlockerIdentity>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    request_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    request_fingerprint: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InterruptIntent {
+    run_id: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    request_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    request_fingerprint: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum ReplayOperation {
+    Delivery,
+    Interrupt,
+    Report,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub(crate) enum ReplayOutcome {
+    Delivery {
+        queued: bool,
+        run: Option<AgentRun>,
+    },
+    Interrupt {
+        run: AgentRun,
+    },
+    Report {
+        parent: String,
+        queued: bool,
+        run: Option<AgentRun>,
+    },
+    OutcomeUncertain {
+        detail: String,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ReplayEntry {
+    operation: ReplayOperation,
+    request_id: String,
+    fingerprint: String,
+    outcome: ReplayOutcome,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct WaitDecision {
+    pub reached: bool,
+    pub superseded: bool,
+    pub resolved: bool,
+    pub run: Option<AgentRun>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct DeliveryPlan {
+    pub queued: bool,
+    pub run: Option<AgentRun>,
+}
+
+pub(crate) struct DeliveryRequest<'a> {
+    pub status: &'a SessionStatus,
+    pub needs_input: Option<&'a NeedsInputDetail>,
+    pub completion_seq: u64,
+    pub output_offset: u64,
+    pub expected_run_id: Option<u64>,
+    pub text: String,
+    pub submit: bool,
+    pub allow_needs_input: bool,
+    pub request_id: Option<&'a str>,
+    pub request_fingerprint: Option<&'a str>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum RunError {
+    Stale { expected: u64, current: u64 },
+    Exited,
+    AlreadyTerminal { current: u64 },
+    InvalidRequestId,
+    RequestConflict { request_id: String },
+}
+
+/// Only durable fields are serialized. Completion counters and the last
+/// observed low-level status belong to one Engine process and are rebound when
+/// a Holder is adopted.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct Orchestration {
+    #[serde(skip)]
+    completion_baselines: HashMap<String, u64>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pending: HashMap<String, VecDeque<PendingDelivery>>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    awaiting_work: HashMap<String, AwaitingWork>,
+    /// Dispatch is a two-phase outbox. It is persisted before touching the
+    /// PTY. A crash in the tiny send/commit window is surfaced as uncertain,
+    /// never silently replayed into an agent composer.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    dispatching: HashMap<String, DispatchIntent>,
+    /// Dispatches found in the pre-send phase after a restart remain tied to
+    /// their original generation until holder output proves what happened.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    uncertain_deliveries: HashMap<String, UncertainDelivery>,
+    /// Interrupt is also a two-phase operation: intent lands before Ctrl-C.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    interrupting: HashMap<String, InterruptIntent>,
+    /// Bounded exact outcomes make FIFO advancement lossless to pinned waits.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    terminal_runs: HashMap<String, VecDeque<AgentRun>>,
+    /// Bounded idempotency results survive daemon and MCP reconnects.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    request_replays: HashMap<String, VecDeque<ReplayEntry>>,
+    #[serde(skip)]
+    last_status: HashMap<String, SessionStatus>,
+    /// Set only while rebinding holder sessions after load. It permits durable
+    /// output offsets to close an awaiting run without weakening live Idle
+    /// semantics immediately after a prompt echo.
+    #[serde(skip)]
+    adoption_pending: HashSet<String>,
+}
+
+impl Orchestration {
+    pub fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+            && self.awaiting_work.is_empty()
+            && self.dispatching.is_empty()
+            && self.uncertain_deliveries.is_empty()
+            && self.interrupting.is_empty()
+            && self.terminal_runs.is_empty()
+            && self.request_replays.is_empty()
+    }
+
+    pub fn register(
+        &mut self,
+        record: &SessionRecord,
+        completion_seq: u64,
+        status: &SessionStatus,
+    ) {
+        if record.run.is_some() {
+            self.completion_baselines
+                .insert(record.id.0.clone(), completion_seq);
+            self.last_status.insert(record.id.0.clone(), status.clone());
+        }
+    }
+
+    pub fn register_adopted(
+        &mut self,
+        record: &SessionRecord,
+        completion_seq: u64,
+        status: &SessionStatus,
+    ) {
+        self.register(record, completion_seq, status);
+        let id = &record.id.0;
+        if self.awaiting_work.contains_key(id) || self.uncertain_deliveries.contains_key(id) {
+            self.adoption_pending.insert(id.clone());
+        }
+    }
+
+    pub fn forget(&mut self, id: &str) {
+        self.completion_baselines.remove(id);
+        self.pending.remove(id);
+        self.awaiting_work.remove(id);
+        self.dispatching.remove(id);
+        self.uncertain_deliveries.remove(id);
+        self.interrupting.remove(id);
+        self.terminal_runs.remove(id);
+        self.request_replays.remove(id);
+        self.last_status.remove(id);
+        self.adoption_pending.remove(id);
+    }
+
+    /// A persisted dispatch means the Engine crashed after durably reserving
+    /// the delivery but before durably committing its outcome. Retrying could
+    /// duplicate a prompt; forgetting could hide loss. Fail closed and expose
+    /// the uncertainty on the exact run instead.
+    pub fn recover_inflight(&mut self, records: &mut HashMap<String, SessionRecord>) -> bool {
+        let mut recovered = false;
+        let uncertain: Vec<String> = self.dispatching.keys().cloned().collect();
+        for id in uncertain {
+            let Some(intent) = self.dispatching.remove(&id) else {
+                continue;
+            };
+            if let Some(record) = records.get_mut(&id)
+                && let Some(run) = record.run.as_mut()
+            {
+                run.state = AgentRunState::Failed;
+                run.finished_at = Some(now());
+                run.terminal_outcome = Some("delivery_outcome_uncertain".into());
+                record.updated_at = now();
+                record.last_turn_completed_at = run.finished_at;
+                let terminal = run.clone();
+                self.remember_terminal(&id, terminal);
+                self.uncertain_deliveries.insert(
+                    id.clone(),
+                    UncertainDelivery {
+                        run_id: intent.run_id.unwrap_or(run.id),
+                        prepared_output_offset: intent.prepared_output_offset,
+                        prepared_blocker: intent.prepared_blocker,
+                        request_id: intent.request_id.clone(),
+                        request_fingerprint: intent.request_fingerprint.clone(),
+                    },
+                );
+                if let (Some(request_id), Some(fingerprint)) =
+                    (intent.request_id, intent.request_fingerprint)
+                {
+                    self.remember_replay_unchecked(
+                        &id,
+                        ReplayEntry {
+                            operation: ReplayOperation::Delivery,
+                            request_id,
+                            fingerprint,
+                            outcome: ReplayOutcome::OutcomeUncertain {
+                                detail: "daemon restarted during delivery".into(),
+                            },
+                        },
+                    );
+                }
+            }
+            self.awaiting_work.remove(&id);
+            recovered = true;
+        }
+
+        let interrupts: Vec<String> = self.interrupting.keys().cloned().collect();
+        for id in interrupts {
+            let Some(intent) = self.interrupting.remove(&id) else {
+                continue;
+            };
+            if let Some(record) = records.get_mut(&id)
+                && let Some(run) = record.run.as_mut()
+                && run.id == intent.run_id
+                && !run.state.is_terminal()
+            {
+                run.state = AgentRunState::Aborted;
+                run.finished_at = Some(now());
+                run.terminal_outcome = Some("interrupt_outcome_uncertain".into());
+                record.updated_at = now();
+                record.last_turn_completed_at = run.finished_at;
+                self.remember_terminal(&id, run.clone());
+            }
+            if let (Some(request_id), Some(fingerprint)) =
+                (intent.request_id, intent.request_fingerprint)
+            {
+                self.remember_replay_unchecked(
+                    &id,
+                    ReplayEntry {
+                        operation: ReplayOperation::Interrupt,
+                        request_id,
+                        fingerprint,
+                        outcome: ReplayOutcome::OutcomeUncertain {
+                            detail: "daemon restarted during interrupt".into(),
+                        },
+                    },
+                );
+            }
+            recovered = true;
+        }
+        recovered
+    }
+
+    /// Folds a low-level status snapshot into the explicit run state. The
+    /// completion sequence prevents a short Working→Idle edge from being lost
+    /// when both transitions occur between registry/event snapshots.
+    pub fn observe(
+        &mut self,
+        record: &mut SessionRecord,
+        status: &SessionStatus,
+        needs_input: Option<&NeedsInputDetail>,
+        completion_seq: u64,
+        output_offset: u64,
+    ) -> bool {
+        let next_run_id = self.next_run_id(record);
+        let Some(current_run) = record.run.as_ref() else {
+            return false;
+        };
+        let id = record.id.0.clone();
+        let previous_status = self.last_status.insert(id.clone(), status.clone());
+        let baseline = *self
+            .completion_baselines
+            .entry(id.clone())
+            .or_insert(completion_seq);
+
+        // Intent is already durable and the caller has not yet committed its
+        // PTY side effect. Persistence itself must never consume that marker.
+        if self.dispatching.contains_key(&id) || self.interrupting.contains_key(&id) {
+            return false;
+        }
+
+        let uncertain = self.uncertain_deliveries.get(&id).cloned();
+        if current_run.state.is_terminal()
+            && let Some(uncertain) = uncertain
+            && current_run.id == uncertain.run_id
+        {
+            let output_advanced = output_offset > uncertain.prepared_output_offset;
+            let blocker_changed = needs_input.map(BlockerIdentity::from).as_ref()
+                != uncertain.prepared_blocker.as_ref();
+            let accepted = output_advanced
+                && (matches!(status, SessionStatus::Working)
+                    || matches!(status, SessionStatus::NeedsInput(_)) && blocker_changed);
+            if accepted {
+                let run = record.run.as_mut().expect("checked above");
+                run.state = if matches!(status, SessionStatus::NeedsInput(_)) {
+                    AgentRunState::NeedsInput
+                } else {
+                    AgentRunState::Running
+                };
+                run.finished_at = None;
+                run.terminal_outcome = None;
+                let accepted_run = run.clone();
+                self.remove_terminal(&id, accepted_run.id);
+                self.uncertain_deliveries.remove(&id);
+                self.adoption_pending.remove(&id);
+                self.completion_baselines.insert(id.clone(), completion_seq);
+                if let (Some(request_id), Some(fingerprint)) =
+                    (uncertain.request_id, uncertain.request_fingerprint)
+                {
+                    self.remember_replay_unchecked(
+                        &id,
+                        ReplayEntry {
+                            operation: ReplayOperation::Delivery,
+                            request_id,
+                            fingerprint,
+                            outcome: ReplayOutcome::Delivery {
+                                queued: false,
+                                run: Some(accepted_run),
+                            },
+                        },
+                    );
+                }
+                return true;
+            }
+        }
+
+        // A raw terminal submission (the app's attached PTY path) is still a
+        // real turn. Allocate it only on a new transition into Working, not on
+        // the stale Working frame that can coexist with a completion hook.
+        if current_run.state.is_terminal() {
+            if matches!(status, SessionStatus::Working)
+                && !matches!(previous_status, Some(SessionStatus::Working))
+            {
+                self.remember_terminal(&id, current_run.clone());
+                record.run = Some(AgentRun {
+                    id: next_run_id,
+                    state: AgentRunState::Running,
+                    started_at: now(),
+                    finished_at: None,
+                    terminal_outcome: None,
+                });
+                self.completion_baselines.insert(id.clone(), completion_seq);
+                return true;
+            }
+            return false;
+        }
+
+        let awaiting = self.awaiting_work.get(&id).cloned();
+        let awaiting = match awaiting {
+            Some(awaiting) if awaiting.run_id == current_run.id => Some(awaiting),
+            Some(_) => {
+                self.awaiting_work.remove(&id);
+                self.adoption_pending.remove(&id);
+                None
+            }
+            None => None,
+        };
+        let next = if matches!(status, SessionStatus::Exited(_)) {
+            AgentRunState::Failed
+        } else if completion_seq > baseline {
+            self.completion_baselines.insert(id.clone(), completion_seq);
+            AgentRunState::Completed
+        } else if let Some(awaiting) = awaiting {
+            let output_advanced = output_offset > awaiting.accepted_output_offset;
+            match status {
+                SessionStatus::Working => {
+                    self.awaiting_work.remove(&id);
+                    self.adoption_pending.remove(&id);
+                    AgentRunState::Running
+                }
+                SessionStatus::NeedsInput(_)
+                    if awaiting.answered_blocker.as_ref()
+                        == needs_input.map(BlockerIdentity::from).as_ref() =>
+                {
+                    // The reducer has not yet observed the answer. Keep the
+                    // guard and never reopen the same dialog to a duplicate.
+                    AgentRunState::Running
+                }
+                SessionStatus::NeedsInput(_) => {
+                    self.awaiting_work.remove(&id);
+                    self.adoption_pending.remove(&id);
+                    AgentRunState::NeedsInput
+                }
+                SessionStatus::Idle
+                    if matches!(previous_status, Some(SessionStatus::Working))
+                        || self.adoption_pending.contains(&id) && output_advanced =>
+                {
+                    self.awaiting_work.remove(&id);
+                    self.adoption_pending.remove(&id);
+                    AgentRunState::Completed
+                }
+                SessionStatus::Idle | SessionStatus::Starting | SessionStatus::Unknown => {
+                    AgentRunState::Running
+                }
+                SessionStatus::Exited(_) => unreachable!(),
+            }
+        } else {
+            match status {
+                SessionStatus::Working => AgentRunState::Running,
+                SessionStatus::NeedsInput(_) => AgentRunState::NeedsInput,
+                // On adoption the reducer's completion counter starts at
+                // zero. A persisted Running→authoritative Idle transition is
+                // therefore the missing completion edge.
+                SessionStatus::Idle
+                    if matches!(current_run.state, AgentRunState::Running)
+                        && matches!(previous_status, Some(SessionStatus::Working)) =>
+                {
+                    AgentRunState::Completed
+                }
+                SessionStatus::Starting | SessionStatus::Idle | SessionStatus::Unknown => {
+                    current_run.state
+                }
+                SessionStatus::Exited(_) => unreachable!(),
+            }
+        };
+
+        if next == current_run.state {
+            return false;
+        }
+        let run = record.run.as_mut().expect("checked above");
+        run.state = next;
+        if next.is_terminal() {
+            self.awaiting_work.remove(&id);
+            run.finished_at = Some(now());
+            if run.terminal_outcome.is_none() {
+                run.terminal_outcome = Some(
+                    match next {
+                        AgentRunState::Completed => "completed",
+                        AgentRunState::Failed => "process_exited",
+                        AgentRunState::Aborted => "interrupted",
+                        _ => unreachable!(),
+                    }
+                    .into(),
+                );
+            }
+            self.remember_terminal(&id, run.clone());
+        }
+        true
+    }
+
+    pub fn validate_expected(
+        record: &SessionRecord,
+        expected: Option<u64>,
+    ) -> Result<(), RunError> {
+        let Some(expected) = expected else {
+            return Ok(());
+        };
+        let current = record.run.as_ref().map_or(0, |run| run.id);
+        if expected == current {
+            Ok(())
+        } else {
+            Err(RunError::Stale { expected, current })
+        }
+    }
+
+    pub fn lookup_replay(
+        &self,
+        scope: &str,
+        operation: ReplayOperation,
+        request_id: Option<&str>,
+        fingerprint: Option<&str>,
+    ) -> Result<Option<ReplayOutcome>, RunError> {
+        let Some(request_id) = request_id else {
+            return Ok(None);
+        };
+        validate_request_id(request_id)?;
+        let Some(entry) = self
+            .request_replays
+            .get(scope)
+            .into_iter()
+            .flatten()
+            .find(|entry| entry.operation == operation && entry.request_id == request_id)
+        else {
+            return Ok(None);
+        };
+        if Some(entry.fingerprint.as_str()) != fingerprint {
+            return Err(RunError::RequestConflict {
+                request_id: request_id.to_owned(),
+            });
+        }
+        Ok(Some(entry.outcome.clone()))
+    }
+
+    pub fn remember_replay(
+        &mut self,
+        scope: &str,
+        operation: ReplayOperation,
+        request_id: Option<&str>,
+        fingerprint: Option<&str>,
+        outcome: ReplayOutcome,
+    ) -> Result<(), RunError> {
+        let Some(request_id) = request_id else {
+            return Ok(());
+        };
+        validate_request_id(request_id)?;
+        let fingerprint = fingerprint.ok_or(RunError::InvalidRequestId)?;
+        self.remember_replay_unchecked(
+            scope,
+            ReplayEntry {
+                operation,
+                request_id: request_id.to_owned(),
+                fingerprint: fingerprint.to_owned(),
+                outcome,
+            },
+        );
+        Ok(())
+    }
+
+    fn remember_replay_unchecked(&mut self, scope: &str, entry: ReplayEntry) {
+        let entries = self.request_replays.entry(scope.to_owned()).or_default();
+        if let Some(existing) = entries.iter_mut().find(|existing| {
+            existing.operation == entry.operation && existing.request_id == entry.request_id
+        }) {
+            *existing = entry;
+            return;
+        }
+        entries.push_back(entry);
+        while entries.len() > REQUEST_REPLAY_LIMIT {
+            entries.pop_front();
+        }
+    }
+
+    pub fn remember_current_terminal(&mut self, record: &SessionRecord) {
+        if let Some(run) = record.run.as_ref().filter(|run| run.state.is_terminal()) {
+            self.remember_terminal(&record.id.0, run.clone());
+        }
+    }
+
+    pub fn remember_terminal(&mut self, id: &str, run: AgentRun) {
+        if !run.state.is_terminal() {
+            return;
+        }
+        let history = self.terminal_runs.entry(id.to_owned()).or_default();
+        if let Some(existing) = history.iter_mut().find(|existing| existing.id == run.id) {
+            *existing = run;
+        } else {
+            history.push_back(run);
+        }
+        while history.len() > TERMINAL_HISTORY_LIMIT {
+            history.pop_front();
+        }
+    }
+
+    fn remove_terminal(&mut self, id: &str, run_id: u64) {
+        if let Some(history) = self.terminal_runs.get_mut(id) {
+            history.retain(|run| run.id != run_id);
+            if history.is_empty() {
+                self.terminal_runs.remove(id);
+            }
+        }
+    }
+
+    pub fn wait_decision(
+        &self,
+        record: &SessionRecord,
+        run_id: Option<u64>,
+        targets: &[String],
+    ) -> WaitDecision {
+        let current = record.run.as_ref();
+        let current_id = current.map_or(0, |run| run.id);
+        if let Some(expected) = run_id {
+            if let Some(run) = self
+                .terminal_runs
+                .get(&record.id.0)
+                .into_iter()
+                .flatten()
+                .find(|run| run.id == expected && expected != current_id)
+            {
+                return WaitDecision {
+                    reached: targets
+                        .iter()
+                        .any(|target| historical_run_satisfies_target(run, target)),
+                    superseded: false,
+                    resolved: true,
+                    run: Some(run.clone()),
+                };
+            }
+            if expected < current_id {
+                return WaitDecision {
+                    reached: false,
+                    superseded: true,
+                    resolved: true,
+                    run: current.cloned(),
+                };
+            }
+            if expected > current_id {
+                return WaitDecision {
+                    reached: false,
+                    superseded: false,
+                    resolved: matches!(record.status, SessionStatus::Exited(_)),
+                    run: None,
+                };
+            }
+        }
+
+        let run = current.cloned();
+        let reached = targets.iter().any(|target| {
+            run.as_ref().map_or_else(
+                || status_satisfies_target(&record.status, target),
+                |run| run_satisfies_target(run, &record.status, target),
+            )
+        });
+        let resolved = reached
+            || matches!(record.status, SessionStatus::Exited(_))
+            || run.as_ref().is_some_and(|run| run.state.is_terminal());
+        WaitDecision {
+            reached,
+            superseded: false,
+            resolved,
+            run,
+        }
+    }
+
+    /// Highest generation the Engine has durably accepted for this target,
+    /// including a queued future turn not yet installed on the live record.
+    #[cfg(test)]
+    pub fn latest_run_id(&self, record: &SessionRecord) -> u64 {
+        self.next_run_id(record).saturating_sub(1)
+    }
+
+    /// Prepares an MCP prompt. A queued submitted prompt receives its future
+    /// run id now, so callers can immediately pin a wait to that exact turn.
+    pub fn prepare_delivery(
+        &mut self,
+        record: &mut SessionRecord,
+        request: DeliveryRequest<'_>,
+    ) -> Result<DeliveryPlan, RunError> {
+        let DeliveryRequest {
+            status,
+            needs_input,
+            completion_seq,
+            output_offset,
+            expected_run_id,
+            text,
+            submit,
+            allow_needs_input,
+            request_id,
+            request_fingerprint,
+        } = request;
+        if let Some(request_id) = request_id {
+            validate_request_id(request_id)?;
+        }
+        Self::validate_expected(record, expected_run_id)?;
+        if matches!(status, SessionStatus::Exited(_)) {
+            return Err(RunError::Exited);
+        }
+        let _ = self.observe(record, status, needs_input, completion_seq, output_offset);
+        let next_run_id = self.next_run_id(record);
+        let Some(run) = record.run.as_mut() else {
+            return Ok(DeliveryPlan {
+                queued: false,
+                run: None,
+            });
+        };
+        let id = record.id.0.clone();
+        let queue_occupied = self.pending.get(&id).is_some_and(|queue| !queue.is_empty())
+            || self.dispatching.contains_key(&id);
+        let safe = !queue_occupied
+            && match run.state {
+                AgentRunState::Completed | AgentRunState::Failed | AgentRunState::Aborted => {
+                    matches!(status, SessionStatus::Idle)
+                }
+                AgentRunState::NeedsInput if allow_needs_input => {
+                    !self.awaiting_work.contains_key(&id)
+                }
+                AgentRunState::Starting => matches!(status, SessionStatus::Idle),
+                AgentRunState::Running | AgentRunState::NeedsInput => false,
+            };
+
+        if safe {
+            if run.state.is_terminal() {
+                let previous = run.clone();
+                *run = AgentRun::starting(next_run_id, now());
+                self.remember_terminal(&id, previous);
+                self.uncertain_deliveries.remove(&id);
+                self.adoption_pending.remove(&id);
+                self.completion_baselines.insert(id.clone(), completion_seq);
+            } else if matches!(run.state, AgentRunState::NeedsInput) {
+                run.state = AgentRunState::Running;
+            }
+            let response_run = Some(run.clone());
+            self.dispatching.insert(
+                id,
+                DispatchIntent {
+                    delivery: PendingDelivery {
+                        text,
+                        submit,
+                        assigned_run: submit.then(|| run.clone()),
+                    },
+                    run_id: Some(run.id),
+                    prepared_output_offset: output_offset,
+                    prepared_blocker: needs_input.map(BlockerIdentity::from),
+                    request_id: request_id.map(str::to_owned),
+                    request_fingerprint: request_fingerprint.map(str::to_owned),
+                },
+            );
+            return Ok(DeliveryPlan {
+                queued: false,
+                run: response_run,
+            });
+        }
+
+        let assigned_run = submit.then(|| AgentRun::starting(next_run_id, now()));
+        let response_run = assigned_run.clone().or_else(|| Some(run.clone()));
+        self.pending
+            .entry(id)
+            .or_default()
+            .push_back(PendingDelivery {
+                text,
+                submit,
+                assigned_run,
+            });
+        Ok(DeliveryPlan {
+            queued: true,
+            run: response_run,
+        })
+    }
+
+    /// Moves one ready item into the durable dispatch phase. The caller must
+    /// persist this state before touching the PTY.
+    pub fn begin_ready(
+        &mut self,
+        record: &mut SessionRecord,
+        status: &SessionStatus,
+        needs_input: Option<&NeedsInputDetail>,
+        completion_seq: u64,
+        output_offset: u64,
+    ) -> Option<PendingDelivery> {
+        let _ = self.observe(record, status, needs_input, completion_seq, output_offset);
+        let id = record.id.0.clone();
+        if !matches!(status, SessionStatus::Idle)
+            || self.awaiting_work.contains_key(&id)
+            || self.dispatching.contains_key(&id)
+        {
+            return None;
+        }
+        let delivery = self.pending.get_mut(&id)?.pop_front()?;
+        if self.pending.get(&id).is_some_and(VecDeque::is_empty) {
+            self.pending.remove(&id);
+        }
+        if let Some(assigned) = &delivery.assigned_run {
+            if let Some(previous) = record
+                .run
+                .as_ref()
+                .filter(|run| run.state.is_terminal())
+                .cloned()
+            {
+                self.remember_terminal(&id, previous);
+            }
+            record.run = Some(assigned.clone());
+            self.uncertain_deliveries.remove(&id);
+            self.adoption_pending.remove(&id);
+            self.completion_baselines.insert(id.clone(), completion_seq);
+        }
+        self.dispatching.insert(
+            id,
+            DispatchIntent {
+                run_id: record.run.as_ref().map(|run| run.id),
+                prepared_output_offset: output_offset,
+                prepared_blocker: needs_input.map(BlockerIdentity::from),
+                request_id: None,
+                request_fingerprint: None,
+                delivery: delivery.clone(),
+            },
+        );
+        Some(delivery)
+    }
+
+    pub fn finish_dispatch(
+        &mut self,
+        id: &str,
+        run_id: Option<u64>,
+        submit: bool,
+        answered_blocker: Option<NeedsInputDetail>,
+        accepted_output_offset: u64,
+    ) {
+        self.dispatching.remove(id);
+        if submit {
+            self.awaiting_work.insert(
+                id.to_owned(),
+                AwaitingWork {
+                    run_id: run_id.unwrap_or(0),
+                    accepted_output_offset,
+                    answered_blocker: answered_blocker.as_ref().map(BlockerIdentity::from),
+                },
+            );
+        }
+    }
+
+    pub fn prepare_interrupt(
+        &mut self,
+        record: &mut SessionRecord,
+        expected: Option<u64>,
+        request_id: Option<&str>,
+        request_fingerprint: Option<&str>,
+    ) -> Result<AgentRun, RunError> {
+        if let Some(request_id) = request_id {
+            validate_request_id(request_id)?;
+        }
+        Self::validate_expected(record, expected)?;
+        let run = record
+            .run
+            .get_or_insert_with(|| AgentRun::starting(1, now()));
+        if run.state.is_terminal() {
+            return Err(RunError::AlreadyTerminal { current: run.id });
+        }
+        self.interrupting.insert(
+            record.id.0.clone(),
+            InterruptIntent {
+                run_id: run.id,
+                request_id: request_id.map(str::to_owned),
+                request_fingerprint: request_fingerprint.map(str::to_owned),
+            },
+        );
+        Ok(run.clone())
+    }
+
+    pub fn finish_interrupt(&mut self, record: &mut SessionRecord) -> AgentRun {
+        let run = record
+            .run
+            .get_or_insert_with(|| AgentRun::starting(1, now()));
+        run.state = AgentRunState::Aborted;
+        run.finished_at = Some(now());
+        run.terminal_outcome = Some("interrupted".into());
+        // Future acknowledged turns stay queued. Only the current turn's
+        // acceptance guard is retired by Ctrl-C.
+        self.awaiting_work.remove(&record.id.0);
+        self.interrupting.remove(&record.id.0);
+        self.remember_terminal(&record.id.0, run.clone());
+        run.clone()
+    }
+
+    fn next_run_id(&self, record: &SessionRecord) -> u64 {
+        let id = &record.id.0;
+        let current = record.run.as_ref().map_or(0, |run| run.id);
+        self.pending
+            .get(id)
+            .into_iter()
+            .flatten()
+            .filter_map(|delivery| delivery.assigned_run.as_ref().map(|run| run.id))
+            .chain(
+                self.dispatching
+                    .get(id)
+                    .and_then(|intent| intent.delivery.assigned_run.as_ref())
+                    .map(|run| run.id),
+            )
+            .chain(
+                self.terminal_runs
+                    .get(id)
+                    .into_iter()
+                    .flatten()
+                    .map(|run| run.id),
+            )
+            .fold(current, u64::max)
+            .saturating_add(1)
+    }
+}
+
+pub(crate) fn request_fingerprint(value: &impl Serialize) -> String {
+    let bytes = serde_json::to_vec(value).expect("request fingerprint serialization");
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn validate_request_id(request_id: &str) -> Result<(), RunError> {
+    if request_id.is_empty() || request_id.len() > REQUEST_ID_LIMIT {
+        Err(RunError::InvalidRequestId)
+    } else {
+        Ok(())
+    }
+}
+
+fn run_satisfies_target(run: &AgentRun, status: &SessionStatus, target: &str) -> bool {
+    match target {
+        "done" | "settled" => run.state.is_terminal(),
+        "completed" => matches!(run.state, AgentRunState::Completed),
+        "running" | "working" => matches!(run.state, AgentRunState::Running),
+        "starting" => matches!(run.state, AgentRunState::Starting),
+        "idle" => matches!(status, SessionStatus::Idle),
+        "needsInput" | "needs_input" | "needs-input" | "needs_me" | "blocked" => {
+            matches!(run.state, AgentRunState::NeedsInput)
+        }
+        "failed" => matches!(run.state, AgentRunState::Failed),
+        "aborted" => matches!(run.state, AgentRunState::Aborted),
+        "exited" | "dead" => matches!(status, SessionStatus::Exited(_)),
+        "any" => !matches!(run.state, AgentRunState::Starting),
+        _ => false,
+    }
+}
+
+fn historical_run_satisfies_target(run: &AgentRun, target: &str) -> bool {
+    match target {
+        "done" | "settled" | "any" => run.state.is_terminal(),
+        "completed" => matches!(run.state, AgentRunState::Completed),
+        "failed" => matches!(run.state, AgentRunState::Failed),
+        "aborted" => matches!(run.state, AgentRunState::Aborted),
+        _ => false,
+    }
+}
+
+fn status_satisfies_target(status: &SessionStatus, target: &str) -> bool {
+    match target {
+        "idle" | "done" => matches!(status, SessionStatus::Idle),
+        "working" | "running" => matches!(status, SessionStatus::Working),
+        "starting" => matches!(status, SessionStatus::Starting),
+        "unknown" => matches!(status, SessionStatus::Unknown),
+        "needsInput" | "needs_input" | "needs-input" | "needs_me" | "blocked" => {
+            matches!(status, SessionStatus::NeedsInput(_))
+        }
+        "exited" | "dead" => matches!(status, SessionStatus::Exited(_)),
+        "any" => !matches!(status, SessionStatus::Starting),
+        _ => false,
+    }
+}
+
+fn now() -> DateMillis {
+    std::time::SystemTime::now().into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use diri_proto::{AgentKind, ProjectId, Resumability, SessionId, TitleSource};
+
+    fn record() -> SessionRecord {
+        let now = now();
+        SessionRecord {
+            id: SessionId::new("child"),
+            kind: AgentKind::CODEX,
+            cwd: "/tmp".into(),
+            project_id: ProjectId::new("p"),
+            worktree_path: None,
+            git_branch: None,
+            title: "child".into(),
+            title_source: TitleSource::Placeholder,
+            originating_prompt: None,
+            agent_session_id: None,
+            transcript_path: None,
+            status: SessionStatus::Starting,
+            status_evidence: None,
+            needs_input: None,
+            resumability: Resumability::Live,
+            parent: Some(SessionId::new("parent")),
+            created_at: now,
+            updated_at: now,
+            last_turn_completed_at: None,
+            last_seen_at: None,
+            pinned: false,
+            archived_at: None,
+            host: None,
+            remote_persistence: None,
+            hibernation: None,
+            memory_bytes: None,
+            artifacts: None,
+            pull_requests: None,
+            listening_ports: None,
+            foreground_agent: None,
+            run: Some(AgentRun::starting(1, now)),
+        }
+    }
+
+    #[test]
+    fn idle_before_work_is_not_completed_but_completion_edge_is_lossless() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        lifecycle.register(&record, 0, &SessionStatus::Starting);
+        assert!(!lifecycle.observe(&mut record, &SessionStatus::Idle, None, 0, 0));
+        assert_eq!(record.run.as_ref().unwrap().state, AgentRunState::Starting);
+        assert!(lifecycle.observe(&mut record, &SessionStatus::Idle, None, 1, 0));
+        assert_eq!(record.run.as_ref().unwrap().state, AgentRunState::Completed);
+    }
+
+    #[test]
+    fn queued_turns_receive_stable_future_ids_and_release_fifo() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        lifecycle.register(&record, 0, &SessionStatus::Working);
+        lifecycle.observe(&mut record, &SessionStatus::Working, None, 0, 0);
+        let first = lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::Working,
+                    needs_input: None,
+                    completion_seq: 0,
+                    output_offset: 0,
+                    expected_run_id: Some(1),
+                    text: "first".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: None,
+                    request_fingerprint: None,
+                },
+            )
+            .unwrap();
+        let second = lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::Working,
+                    needs_input: None,
+                    completion_seq: 0,
+                    output_offset: 0,
+                    expected_run_id: Some(1),
+                    text: "second".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: None,
+                    request_fingerprint: None,
+                },
+            )
+            .unwrap();
+        assert_eq!(first.run.unwrap().id, 2);
+        assert_eq!(second.run.unwrap().id, 3);
+        assert_eq!(record.run.as_ref().unwrap().id, 1);
+
+        let first = lifecycle
+            .begin_ready(&mut record, &SessionStatus::Idle, None, 1, 0)
+            .unwrap();
+        assert_eq!(first.text, "first");
+        assert_eq!(record.run.as_ref().unwrap().id, 2);
+        lifecycle.finish_dispatch("child", Some(2), true, None, 0);
+        assert!(
+            lifecycle
+                .begin_ready(&mut record, &SessionStatus::Idle, None, 1, 0)
+                .is_none(),
+            "one submitted prompt must begin work before the next is released"
+        );
+        lifecycle.observe(&mut record, &SessionStatus::Working, None, 1, 0);
+        lifecycle.observe(&mut record, &SessionStatus::Idle, None, 2, 0);
+        let second = lifecycle
+            .begin_ready(&mut record, &SessionStatus::Idle, None, 2, 0)
+            .unwrap();
+        assert_eq!(second.text, "second");
+        assert_eq!(record.run.as_ref().unwrap().id, 3);
+    }
+
+    #[test]
+    fn answered_blocker_cannot_regress_and_accept_a_duplicate() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        let detail = NeedsInputDetail {
+            kind: diri_proto::NeedsInputKind::Question,
+            source: diri_proto::NeedsInputSource::ScreenScrape,
+            tool_name: None,
+            summary: "choose".into(),
+            prompt_excerpt: None,
+            options: None,
+            risk_hint: diri_proto::RiskHint::Neutral,
+            occurred_at: now(),
+        };
+        record.run.as_mut().unwrap().state = AgentRunState::NeedsInput;
+        lifecycle.register(&record, 0, &SessionStatus::NeedsInput(detail.kind));
+        let answer = lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::NeedsInput(detail.kind),
+                    needs_input: Some(&detail),
+                    completion_seq: 0,
+                    output_offset: 0,
+                    expected_run_id: Some(1),
+                    text: "yes".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: None,
+                    request_fingerprint: None,
+                },
+            )
+            .unwrap();
+        lifecycle.finish_dispatch("child", Some(1), true, Some(detail.clone()), 0);
+        assert!(!answer.queued);
+        lifecycle.observe(
+            &mut record,
+            &SessionStatus::NeedsInput(detail.kind),
+            Some(&detail),
+            0,
+            0,
+        );
+        assert_eq!(record.run.as_ref().unwrap().state, AgentRunState::Running);
+        let duplicate = lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::NeedsInput(detail.kind),
+                    needs_input: Some(&detail),
+                    completion_seq: 0,
+                    output_offset: 0,
+                    expected_run_id: Some(1),
+                    text: "yes again".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: None,
+                    request_fingerprint: None,
+                },
+            )
+            .unwrap();
+        assert!(duplicate.queued);
+        assert_eq!(duplicate.run.unwrap().id, 2);
+    }
+
+    #[test]
+    fn interrupt_preserves_acknowledged_future_turns_and_rejects_terminal_runs() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        lifecycle.register(&record, 0, &SessionStatus::Working);
+        lifecycle.observe(&mut record, &SessionStatus::Working, None, 0, 0);
+        let queued = lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::Working,
+                    needs_input: None,
+                    completion_seq: 0,
+                    output_offset: 0,
+                    expected_run_id: Some(1),
+                    text: "next".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: None,
+                    request_fingerprint: None,
+                },
+            )
+            .unwrap();
+        assert_eq!(queued.run.unwrap().id, 2);
+        assert_eq!(
+            lifecycle
+                .prepare_interrupt(&mut record, Some(1), None, None)
+                .unwrap()
+                .id,
+            1
+        );
+        assert_eq!(lifecycle.finish_interrupt(&mut record).id, 1);
+        assert_eq!(
+            lifecycle.prepare_interrupt(&mut record, Some(1), None, None),
+            Err(RunError::AlreadyTerminal { current: 1 })
+        );
+        let next = lifecycle
+            .begin_ready(&mut record, &SessionStatus::Idle, None, 1, 0)
+            .unwrap();
+        assert_eq!(next.assigned_run.unwrap().id, 2);
+    }
+
+    #[test]
+    fn adopted_working_run_completes_on_authoritative_idle_without_an_old_counter() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        record.run.as_mut().unwrap().state = AgentRunState::Running;
+        lifecycle.register(&record, 0, &SessionStatus::Working);
+
+        assert!(lifecycle.observe(&mut record, &SessionStatus::Idle, None, 0, 0));
+        assert_eq!(record.run.as_ref().unwrap().state, AgentRunState::Completed);
+    }
+
+    #[test]
+    fn state_wait_is_edge_triggered_and_cannot_miss_a_pre_wait_change() {
+        let changes = StateChanges::default();
+        let observed = changes.observe();
+        changes.notify();
+        let start = std::time::Instant::now();
+        let latest = changes.wait_after(observed, Duration::from_secs(5));
+        assert_ne!(latest, observed);
+        assert!(
+            start.elapsed() < Duration::from_millis(20),
+            "a buffered edge must not wait for a polling interval"
+        );
+    }
+
+    #[test]
+    fn fifo_advancement_preserves_the_exact_terminal_run_for_waiters() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        record.run.as_mut().unwrap().state = AgentRunState::Running;
+        lifecycle.register(&record, 0, &SessionStatus::Working);
+        let queued = lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::Working,
+                    needs_input: None,
+                    completion_seq: 0,
+                    output_offset: 10,
+                    expected_run_id: Some(1),
+                    text: "next".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: None,
+                    request_fingerprint: None,
+                },
+            )
+            .unwrap();
+        assert_eq!(queued.run.unwrap().id, 2);
+
+        assert!(lifecycle.observe(&mut record, &SessionStatus::Idle, None, 1, 20));
+        lifecycle
+            .begin_ready(&mut record, &SessionStatus::Idle, None, 1, 20)
+            .expect("queued run advances");
+        assert_eq!(record.run.as_ref().unwrap().id, 2);
+
+        let decision = lifecycle.wait_decision(&record, Some(1), &["completed".into()]);
+        assert!(decision.reached);
+        assert!(decision.resolved);
+        assert!(!decision.superseded);
+        let completed = decision.run.expect("historical run");
+        assert_eq!(completed.id, 1);
+        assert_eq!(completed.state, AgentRunState::Completed);
+    }
+
+    #[test]
+    fn same_needs_input_snapshot_cannot_consume_the_pre_send_intent() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        let detail = NeedsInputDetail {
+            kind: diri_proto::NeedsInputKind::Question,
+            source: diri_proto::NeedsInputSource::ScreenScrape,
+            tool_name: None,
+            summary: "choose".into(),
+            prompt_excerpt: Some("choose\n> yes".into()),
+            options: Some(vec!["yes".into(), "no".into()]),
+            risk_hint: diri_proto::RiskHint::Neutral,
+            occurred_at: now(),
+        };
+        record.run.as_mut().unwrap().state = AgentRunState::NeedsInput;
+        lifecycle.register(&record, 0, &SessionStatus::NeedsInput(detail.kind));
+        lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::NeedsInput(detail.kind),
+                    needs_input: Some(&detail),
+                    completion_seq: 0,
+                    output_offset: 50,
+                    expected_run_id: Some(1),
+                    text: "yes".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: Some("answer-1"),
+                    request_fingerprint: Some("fingerprint"),
+                },
+            )
+            .unwrap();
+
+        assert!(!lifecycle.observe(
+            &mut record,
+            &SessionStatus::NeedsInput(detail.kind),
+            Some(&detail),
+            0,
+            50,
+        ));
+        let encoded = serde_json::to_value(&lifecycle).unwrap();
+        assert!(encoded["dispatching"]["child"].is_object());
+
+        let mut restored: Orchestration = serde_json::from_value(encoded).unwrap();
+        let mut records = HashMap::from([("child".into(), record)]);
+        assert!(restored.recover_inflight(&mut records));
+        assert_eq!(
+            records["child"]
+                .run
+                .as_ref()
+                .unwrap()
+                .terminal_outcome
+                .as_deref(),
+            Some("delivery_outcome_uncertain")
+        );
+    }
+
+    #[test]
+    fn blocker_identity_ignores_timestamp_and_volatile_screen_echo() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        let detail = NeedsInputDetail {
+            kind: diri_proto::NeedsInputKind::Question,
+            source: diri_proto::NeedsInputSource::ScreenScrape,
+            tool_name: None,
+            summary: "Choose one".into(),
+            prompt_excerpt: Some("Choose one\n> A".into()),
+            options: Some(vec!["A".into(), "B".into()]),
+            risk_hint: diri_proto::RiskHint::Neutral,
+            occurred_at: DateMillis(1.0),
+        };
+        record.run.as_mut().unwrap().state = AgentRunState::NeedsInput;
+        lifecycle.register(&record, 0, &SessionStatus::NeedsInput(detail.kind));
+        lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::NeedsInput(detail.kind),
+                    needs_input: Some(&detail),
+                    completion_seq: 0,
+                    output_offset: 10,
+                    expected_run_id: Some(1),
+                    text: "A".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: None,
+                    request_fingerprint: None,
+                },
+            )
+            .unwrap();
+        lifecycle.finish_dispatch("child", Some(1), true, Some(detail.clone()), 10);
+
+        let mut refreshed = detail.clone();
+        refreshed.occurred_at = DateMillis(2.0);
+        refreshed.prompt_excerpt = Some("Choose one\nA█".into());
+        assert!(!lifecycle.observe(
+            &mut record,
+            &SessionStatus::NeedsInput(detail.kind),
+            Some(&refreshed),
+            0,
+            11,
+        ));
+        assert_eq!(record.run.as_ref().unwrap().state, AgentRunState::Running);
+        let duplicate = lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::NeedsInput(detail.kind),
+                    needs_input: Some(&refreshed),
+                    completion_seq: 0,
+                    output_offset: 11,
+                    expected_run_id: Some(1),
+                    text: "A".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: None,
+                    request_fingerprint: None,
+                },
+            )
+            .unwrap();
+        assert!(duplicate.queued);
+    }
+
+    #[test]
+    fn adoption_uses_durable_output_provenance_to_close_awaiting_work() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        record.run.as_mut().unwrap().state = AgentRunState::Starting;
+        lifecycle.register(&record, 0, &SessionStatus::Idle);
+        lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::Idle,
+                    needs_input: None,
+                    completion_seq: 0,
+                    output_offset: 100,
+                    expected_run_id: Some(1),
+                    text: "work".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: None,
+                    request_fingerprint: None,
+                },
+            )
+            .unwrap();
+        lifecycle.finish_dispatch("child", Some(1), true, None, 100);
+        let encoded = serde_json::to_value(&lifecycle).unwrap();
+        let mut restored: Orchestration = serde_json::from_value(encoded).unwrap();
+        restored.register_adopted(&record, 0, &SessionStatus::Idle);
+
+        assert!(restored.observe(&mut record, &SessionStatus::Idle, None, 0, 120));
+        assert_eq!(record.run.as_ref().unwrap().state, AgentRunState::Completed);
+    }
+
+    #[test]
+    fn adoption_closes_an_answered_blocker_that_finished_while_daemon_was_down() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        let detail = NeedsInputDetail {
+            kind: diri_proto::NeedsInputKind::Question,
+            source: diri_proto::NeedsInputSource::ScreenScrape,
+            tool_name: None,
+            summary: "Continue?".into(),
+            prompt_excerpt: None,
+            options: Some(vec!["yes".into(), "no".into()]),
+            risk_hint: diri_proto::RiskHint::Neutral,
+            occurred_at: DateMillis(1.0),
+        };
+        record.run.as_mut().unwrap().state = AgentRunState::NeedsInput;
+        lifecycle.register(&record, 0, &SessionStatus::NeedsInput(detail.kind));
+        lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::NeedsInput(detail.kind),
+                    needs_input: Some(&detail),
+                    completion_seq: 0,
+                    output_offset: 100,
+                    expected_run_id: Some(1),
+                    text: "yes".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: None,
+                    request_fingerprint: None,
+                },
+            )
+            .unwrap();
+        lifecycle.finish_dispatch("child", Some(1), true, Some(detail), 100);
+        let mut restored: Orchestration =
+            serde_json::from_value(serde_json::to_value(&lifecycle).unwrap()).unwrap();
+        restored.register_adopted(
+            &record,
+            0,
+            &SessionStatus::NeedsInput(diri_proto::NeedsInputKind::Question),
+        );
+
+        assert!(restored.observe(&mut record, &SessionStatus::Idle, None, 0, 120));
+        assert_eq!(record.run.as_ref().unwrap().state, AgentRunState::Completed);
+    }
+
+    #[test]
+    fn interrupt_intent_recovers_uncertain_without_losing_future_fifo() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        record.run.as_mut().unwrap().state = AgentRunState::Running;
+        lifecycle.register(&record, 0, &SessionStatus::Working);
+        lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::Working,
+                    needs_input: None,
+                    completion_seq: 0,
+                    output_offset: 10,
+                    expected_run_id: Some(1),
+                    text: "future".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: None,
+                    request_fingerprint: None,
+                },
+            )
+            .unwrap();
+        lifecycle
+            .prepare_interrupt(
+                &mut record,
+                Some(1),
+                Some("interrupt-1"),
+                Some("fingerprint"),
+            )
+            .unwrap();
+
+        let mut restored: Orchestration =
+            serde_json::from_value(serde_json::to_value(&lifecycle).unwrap()).unwrap();
+        let mut records = HashMap::from([("child".into(), record)]);
+        assert!(restored.recover_inflight(&mut records));
+        let run = records["child"].run.as_ref().unwrap();
+        assert_eq!(run.state, AgentRunState::Aborted);
+        assert_eq!(
+            run.terminal_outcome.as_deref(),
+            Some("interrupt_outcome_uncertain")
+        );
+        assert_eq!(restored.latest_run_id(&records["child"]), 2);
+        assert!(matches!(
+            restored
+                .lookup_replay(
+                    "child",
+                    ReplayOperation::Interrupt,
+                    Some("interrupt-1"),
+                    Some("fingerprint")
+                )
+                .unwrap(),
+            Some(ReplayOutcome::OutcomeUncertain { .. })
+        ));
+    }
+
+    #[test]
+    fn uncertain_delivery_reconciles_activity_to_the_original_generation() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        lifecycle.register(&record, 0, &SessionStatus::Idle);
+        lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::Idle,
+                    needs_input: None,
+                    completion_seq: 0,
+                    output_offset: 10,
+                    expected_run_id: Some(1),
+                    text: "maybe".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: None,
+                    request_fingerprint: None,
+                },
+            )
+            .unwrap();
+        let mut records = HashMap::from([("child".into(), record)]);
+        assert!(lifecycle.recover_inflight(&mut records));
+        let mut record = records.remove("child").unwrap();
+        assert_eq!(record.run.as_ref().unwrap().state, AgentRunState::Failed);
+        lifecycle.register_adopted(&record, 0, &SessionStatus::Idle);
+
+        assert!(lifecycle.observe(&mut record, &SessionStatus::Working, None, 0, 20,));
+        let run = record.run.as_ref().unwrap();
+        assert_eq!(run.id, 1);
+        assert_eq!(run.state, AgentRunState::Running);
+        assert!(run.terminal_outcome.is_none());
+    }
+
+    #[test]
+    fn dead_future_wait_resolves_without_timeout_or_false_supersession() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        record.status = SessionStatus::Exited(diri_proto::ExitInfo {
+            reason: diri_proto::ExitReason::Exited,
+            code: Some(0),
+            signal: None,
+        });
+        let run = record.run.as_mut().unwrap();
+        run.state = AgentRunState::Failed;
+        run.finished_at = Some(now());
+        run.terminal_outcome = Some("process_exited".into());
+        lifecycle.remember_current_terminal(&record);
+
+        let decision = lifecycle.wait_decision(&record, Some(2), &["done".into()]);
+        assert!(decision.resolved);
+        assert!(!decision.reached);
+        assert!(!decision.superseded);
+        assert!(decision.run.is_none());
+    }
+
+    #[test]
+    fn durable_journals_are_bounded() {
+        let mut lifecycle = Orchestration::default();
+        for id in 1..=40 {
+            lifecycle.remember_terminal(
+                "child",
+                AgentRun {
+                    id,
+                    state: AgentRunState::Completed,
+                    started_at: DateMillis(id as f64),
+                    finished_at: Some(DateMillis(id as f64)),
+                    terminal_outcome: Some("completed".into()),
+                },
+            );
+        }
+        assert_eq!(
+            lifecycle.terminal_runs["child"].len(),
+            TERMINAL_HISTORY_LIMIT
+        );
+        assert_eq!(lifecycle.terminal_runs["child"].front().unwrap().id, 9);
+
+        for id in 1..=70 {
+            let request_id = format!("request-{id}");
+            lifecycle
+                .remember_replay(
+                    "child",
+                    ReplayOperation::Delivery,
+                    Some(&request_id),
+                    Some("fingerprint"),
+                    ReplayOutcome::Delivery {
+                        queued: true,
+                        run: None,
+                    },
+                )
+                .unwrap();
+        }
+        assert_eq!(
+            lifecycle.request_replays["child"].len(),
+            REQUEST_REPLAY_LIMIT
+        );
+        let restored: Orchestration =
+            serde_json::from_value(serde_json::to_value(&lifecycle).unwrap()).unwrap();
+        assert!(matches!(
+            restored
+                .lookup_replay(
+                    "child",
+                    ReplayOperation::Delivery,
+                    Some("request-70"),
+                    Some("fingerprint")
+                )
+                .unwrap(),
+            Some(ReplayOutcome::Delivery { queued: true, .. })
+        ));
+        assert_eq!(
+            restored.lookup_replay(
+                "child",
+                ReplayOperation::Delivery,
+                Some("request-70"),
+                Some("different")
+            ),
+            Err(RunError::RequestConflict {
+                request_id: "request-70".into()
+            })
+        );
+    }
+}

--- a/diri/crates/diri-engine/src/orchestration.rs
+++ b/diri/crates/diri-engine/src/orchestration.rs
@@ -140,6 +140,14 @@ struct AwaitingWork {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+struct ActiveReplayIdentity {
+    run_id: u64,
+    request_id: String,
+    fingerprint: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct UncertainDelivery {
     run_id: u64,
     prepared_output_offset: u64,
@@ -153,6 +161,10 @@ struct UncertainDelivery {
     request_fingerprint: Option<String>,
     #[serde(default)]
     queued: bool,
+    /// A durable Holder tombstone is stronger than heuristic PTY activity:
+    /// once observed, only an exact accepted receipt may resolve this send.
+    #[serde(default)]
+    explicitly_uncertain: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -217,6 +229,13 @@ pub(crate) struct DeliveryPlan {
     pub operation_id: Option<String>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RawSubmissionDecision {
+    pub changed: bool,
+    pub claimed: bool,
+    pub blocked: bool,
+}
+
 pub(crate) struct DeliveryRequest<'a> {
     pub status: &'a SessionStatus,
     pub needs_input: Option<&'a NeedsInputDetail>,
@@ -252,6 +271,11 @@ pub(crate) struct Orchestration {
     pending: HashMap<String, VecDeque<PendingDelivery>>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     awaiting_work: HashMap<String, AwaitingWork>,
+    /// Successful request ids stay replayable for as long as their accepted
+    /// run can still produce another blocker. Retiring the dispatch guard must
+    /// not make a lost-response retry eligible for journal eviction.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    active_replays: HashMap<String, Vec<ActiveReplayIdentity>>,
     /// Dispatch is a two-phase outbox. It is persisted before touching the
     /// PTY. A crash in the tiny send/commit window is surfaced as uncertain,
     /// never silently replayed into an agent composer.
@@ -283,6 +307,7 @@ impl Orchestration {
     pub fn is_empty(&self) -> bool {
         self.pending.is_empty()
             && self.awaiting_work.is_empty()
+            && self.active_replays.is_empty()
             && self.dispatching.is_empty()
             && self.uncertain_deliveries.is_empty()
             && self.interrupting.is_empty()
@@ -320,6 +345,7 @@ impl Orchestration {
         self.completion_baselines.remove(id);
         self.pending.remove(id);
         self.awaiting_work.remove(id);
+        self.active_replays.remove(id);
         self.dispatching.remove(id);
         self.uncertain_deliveries.remove(id);
         self.interrupting.remove(id);
@@ -360,6 +386,7 @@ impl Orchestration {
                         request_id: intent.request_id.clone(),
                         request_fingerprint: intent.request_fingerprint.clone(),
                         queued: intent.queued,
+                        explicitly_uncertain: false,
                     },
                 );
                 if let (Some(request_id), Some(fingerprint)) =
@@ -451,6 +478,7 @@ impl Orchestration {
         if current_run.state.is_terminal()
             && let Some(uncertain) = uncertain
             && current_run.id == uncertain.run_id
+            && !uncertain.explicitly_uncertain
         {
             let output_advanced = output_offset > uncertain.prepared_output_offset;
             let blocker_changed = needs_input.map(BlockerIdentity::from).as_ref()
@@ -472,9 +500,11 @@ impl Orchestration {
                 self.uncertain_deliveries.remove(&id);
                 self.adoption_pending.remove(&id);
                 self.completion_baselines.insert(id.clone(), completion_seq);
-                if let (Some(request_id), Some(fingerprint)) =
-                    (uncertain.request_id, uncertain.request_fingerprint)
-                {
+                if let (Some(request_id), Some(fingerprint)) = (
+                    uncertain.request_id.clone(),
+                    uncertain.request_fingerprint.clone(),
+                ) {
+                    self.pin_active_replay(&id, accepted_run.id, &request_id, &fingerprint);
                     let _ = self.remember_replay_unchecked(
                         &id,
                         ReplayEntry {
@@ -490,6 +520,14 @@ impl Orchestration {
                 }
                 return true;
             }
+        }
+        if current_run.state.is_terminal()
+            && self
+                .uncertain_deliveries
+                .get(&id)
+                .is_some_and(|uncertain| uncertain.run_id == current_run.id)
+        {
+            return false;
         }
 
         // A raw terminal submission (the app's attached PTY path) is still a
@@ -603,6 +641,112 @@ impl Orchestration {
             }
             self.remember_terminal(&id, run.clone());
         }
+        true
+    }
+
+    /// Claims an attached terminal's raw Enter before the PTY side effect.
+    /// This closes the interval where the process has accepted a new turn but
+    /// the status reducer still reports the preceding terminal generation.
+    pub fn claim_raw_submission(
+        &mut self,
+        record: &mut SessionRecord,
+        status: &SessionStatus,
+        needs_input: Option<&NeedsInputDetail>,
+        completion_seq: u64,
+        output_offset: u64,
+    ) -> RawSubmissionDecision {
+        if matches!(status, SessionStatus::Exited(_)) {
+            return RawSubmissionDecision {
+                changed: false,
+                claimed: false,
+                blocked: true,
+            };
+        }
+        let observed = self.observe(record, status, needs_input, completion_seq, output_offset);
+        let id = record.id.0.clone();
+        if self.pending.get(&id).is_some_and(|queue| !queue.is_empty())
+            || self.dispatching.contains_key(&id)
+            || self.uncertain_deliveries.contains_key(&id)
+            || self.interrupting.contains_key(&id)
+        {
+            return RawSubmissionDecision {
+                changed: observed,
+                claimed: false,
+                blocked: true,
+            };
+        }
+        let next_run_id = self.next_run_id(record);
+        let Some(current) = record.run.as_ref() else {
+            return RawSubmissionDecision {
+                changed: observed,
+                claimed: false,
+                blocked: false,
+            };
+        };
+        let (run_id, previous) = match current.state {
+            AgentRunState::Completed | AgentRunState::Failed | AgentRunState::Aborted
+                if matches!(status, SessionStatus::Idle) =>
+            {
+                (next_run_id, Some(current.clone()))
+            }
+            AgentRunState::NeedsInput if !self.awaiting_work.contains_key(&id) => {
+                (current.id, None)
+            }
+            AgentRunState::Starting if matches!(status, SessionStatus::Idle) => (current.id, None),
+            AgentRunState::Starting
+            | AgentRunState::Running
+            | AgentRunState::NeedsInput
+            | AgentRunState::Completed
+            | AgentRunState::Failed
+            | AgentRunState::Aborted => {
+                return RawSubmissionDecision {
+                    changed: observed,
+                    claimed: false,
+                    blocked: false,
+                };
+            }
+        };
+        if let Some(previous) = previous {
+            self.remember_terminal(&id, previous);
+            record.run = Some(AgentRun {
+                id: run_id,
+                state: AgentRunState::Running,
+                started_at: now(),
+                finished_at: None,
+                terminal_outcome: None,
+            });
+        } else if let Some(run) = record.run.as_mut() {
+            run.state = AgentRunState::Running;
+        }
+        self.awaiting_work.insert(
+            id.clone(),
+            AwaitingWork {
+                run_id,
+                accepted_output_offset: output_offset,
+                answered_blocker: needs_input.map(BlockerIdentity::from),
+            },
+        );
+        self.adoption_pending.remove(&id);
+        self.completion_baselines.insert(id, completion_seq);
+        RawSubmissionDecision {
+            changed: true,
+            claimed: true,
+            blocked: false,
+        }
+    }
+
+    /// A raw Enter failed after its durable generation claim. The underlying
+    /// write may have been partial, so neither rollback nor retry is safe.
+    pub fn mark_raw_submission_uncertain(&mut self, record: &mut SessionRecord) -> bool {
+        let id = record.id.0.clone();
+        let Some(run) = record.run.as_mut().filter(|run| !run.state.is_terminal()) else {
+            return false;
+        };
+        run.state = AgentRunState::Failed;
+        run.finished_at = Some(now());
+        run.terminal_outcome = Some("delivery_outcome_uncertain".into());
+        self.awaiting_work.remove(&id);
+        self.remember_terminal(&id, run.clone());
         true
     }
 
@@ -766,6 +910,41 @@ impl Orchestration {
                     intent.request_fingerprint.as_ref(),
                 )
             })
+            || entry.operation == ReplayOperation::Delivery
+                && self.active_replays.get(scope).is_some_and(|identities| {
+                    identities.iter().any(|identity| {
+                        identity.request_id == entry.request_id
+                            && identity.fingerprint == entry.fingerprint
+                    })
+                })
+    }
+
+    fn pin_active_replay(&mut self, id: &str, run_id: u64, request_id: &str, fingerprint: &str) {
+        let identities = self.active_replays.entry(id.to_owned()).or_default();
+        if identities.iter().any(|identity| {
+            identity.run_id == run_id
+                && identity.request_id == request_id
+                && identity.fingerprint == fingerprint
+        }) {
+            return;
+        }
+        identities.push(ActiveReplayIdentity {
+            run_id,
+            request_id: request_id.to_owned(),
+            fingerprint: fingerprint.to_owned(),
+        });
+    }
+
+    fn clear_active_replays(&mut self, id: &str, run_id: u64) {
+        let remove_scope = if let Some(identities) = self.active_replays.get_mut(id) {
+            identities.retain(|identity| identity.run_id != run_id);
+            identities.is_empty()
+        } else {
+            false
+        };
+        if remove_scope {
+            self.active_replays.remove(id);
+        }
     }
 
     pub fn remember_current_terminal(&mut self, record: &SessionRecord) {
@@ -778,6 +957,7 @@ impl Orchestration {
         if !run.state.is_terminal() {
             return;
         }
+        self.clear_active_replays(id, run.id);
         let history = self.terminal_runs.entry(id.to_owned()).or_default();
         if let Some(existing) = history.iter_mut().find(|existing| existing.id == run.id) {
             *existing = run;
@@ -1044,8 +1224,16 @@ impl Orchestration {
         answered_blocker: Option<NeedsInputDetail>,
         accepted_output_offset: u64,
     ) {
-        self.dispatching.remove(id);
+        let intent = self.dispatching.remove(id);
         if submit {
+            if let Some(intent) = intent.as_ref()
+                && let (Some(request_id), Some(fingerprint)) = (
+                    intent.request_id.as_deref(),
+                    intent.request_fingerprint.as_deref(),
+                )
+            {
+                self.pin_active_replay(id, run_id.unwrap_or(0), request_id, fingerprint);
+            }
             self.awaiting_work.insert(
                 id.to_owned(),
                 AwaitingWork {
@@ -1087,6 +1275,7 @@ impl Orchestration {
                 request_id: intent.request_id.clone(),
                 request_fingerprint: intent.request_fingerprint.clone(),
                 queued: intent.queued,
+                explicitly_uncertain: false,
             },
         );
         if let (Some(request_id), Some(fingerprint)) =
@@ -1109,6 +1298,19 @@ impl Orchestration {
         self.uncertain_deliveries
             .get(id)
             .and_then(|delivery| delivery.operation_id.as_deref())
+    }
+
+    /// Records the Holder's explicit two-phase tombstone. Generic output or
+    /// status activity can no longer infer acceptance for this operation.
+    pub fn mark_delivery_explicitly_uncertain(&mut self, id: &str, operation_id: &str) -> bool {
+        let Some(delivery) = self.uncertain_deliveries.get_mut(id) else {
+            return false;
+        };
+        if delivery.operation_id.as_deref() != Some(operation_id) || delivery.explicitly_uncertain {
+            return false;
+        }
+        delivery.explicitly_uncertain = true;
+        true
     }
 
     /// Reconciles an uncertain pre-send tombstone with the Holder's durable
@@ -1154,6 +1356,12 @@ impl Orchestration {
         if accepted_run.state.is_terminal() {
             self.remember_terminal(&id, accepted_run.clone());
         } else {
+            if let (Some(request_id), Some(fingerprint)) = (
+                uncertain.request_id.as_deref(),
+                uncertain.request_fingerprint.as_deref(),
+            ) {
+                self.pin_active_replay(&id, accepted_run.id, request_id, fingerprint);
+            }
             self.awaiting_work.insert(
                 id.clone(),
                 AwaitingWork {
@@ -1936,6 +2144,108 @@ mod tests {
     }
 
     #[test]
+    fn explicit_uncertain_receipt_suppresses_all_activity_inference_after_restart() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        lifecycle.register(&record, 0, &SessionStatus::Idle);
+        lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::Idle,
+                    needs_input: None,
+                    completion_seq: 0,
+                    output_offset: 10,
+                    expected_run_id: Some(1),
+                    text: "maybe accepted".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: Some("uncertain-1"),
+                    request_fingerprint: Some("uncertain-fingerprint"),
+                },
+            )
+            .unwrap();
+        lifecycle
+            .mark_dispatch_uncertain(&mut record, "connection lost".into())
+            .unwrap();
+        let operation_id = lifecycle
+            .uncertain_operation_id("child")
+            .unwrap()
+            .to_owned();
+        assert!(lifecycle.mark_delivery_explicitly_uncertain("child", &operation_id));
+
+        let mut lifecycle: Orchestration =
+            serde_json::from_value(serde_json::to_value(&lifecycle).unwrap()).unwrap();
+        lifecycle.register_adopted(&record, 0, &SessionStatus::Idle);
+        assert!(!lifecycle.observe(&mut record, &SessionStatus::Working, None, 0, 20));
+        let run = record.run.as_ref().unwrap();
+        assert_eq!(run.id, 1, "activity must not allocate a raw successor");
+        assert_eq!(run.state, AgentRunState::Failed);
+        assert_eq!(
+            run.terminal_outcome.as_deref(),
+            Some("delivery_outcome_uncertain")
+        );
+        assert_eq!(
+            lifecycle.uncertain_operation_id("child"),
+            Some(operation_id.as_str())
+        );
+        assert_eq!(
+            lifecycle.claim_raw_submission(&mut record, &SessionStatus::Working, None, 0, 20),
+            RawSubmissionDecision {
+                changed: false,
+                claimed: false,
+                blocked: true,
+            },
+            "attached Enter must not bypass the unresolved tombstone"
+        );
+    }
+
+    #[test]
+    fn attached_enter_claims_the_successor_before_status_changes() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        record.run.as_mut().unwrap().state = AgentRunState::Completed;
+        lifecycle.register(&record, 0, &SessionStatus::Idle);
+
+        assert_eq!(
+            lifecycle.claim_raw_submission(&mut record, &SessionStatus::Idle, None, 0, 10),
+            RawSubmissionDecision {
+                changed: true,
+                claimed: true,
+                blocked: false,
+            }
+        );
+        let claimed = record.run.as_ref().unwrap();
+        assert_eq!(claimed.id, 2);
+        assert_eq!(claimed.state, AgentRunState::Running);
+
+        let error = lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::Idle,
+                    needs_input: None,
+                    completion_seq: 0,
+                    output_offset: 10,
+                    expected_run_id: Some(1),
+                    text: "cannot cross the attached Enter".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: None,
+                    request_fingerprint: None,
+                },
+            )
+            .unwrap_err();
+        assert_eq!(
+            error,
+            RunError::Stale {
+                expected: 1,
+                current: 2
+            }
+        );
+    }
+
+    #[test]
     fn expected_generation_is_checked_after_the_fresh_raw_turn_snapshot() {
         let mut lifecycle = Orchestration::default();
         let mut record = record();
@@ -2158,6 +2468,101 @@ mod tests {
                 )
                 .unwrap()
                 .is_some()
+        );
+    }
+
+    #[test]
+    fn accepted_request_replay_stays_pinned_until_its_run_is_terminal() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        lifecycle.register(&record, 0, &SessionStatus::Idle);
+        let plan = lifecycle
+            .prepare_delivery(
+                &mut record,
+                DeliveryRequest {
+                    status: &SessionStatus::Idle,
+                    needs_input: None,
+                    completion_seq: 0,
+                    output_offset: 0,
+                    expected_run_id: Some(1),
+                    text: "accepted".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: Some("accepted-1"),
+                    request_fingerprint: Some("accepted-fingerprint"),
+                },
+            )
+            .unwrap();
+        lifecycle.finish_dispatch("child", Some(1), true, None, 0);
+        lifecycle
+            .remember_replay(
+                "child",
+                ReplayOperation::Delivery,
+                Some("accepted-1"),
+                Some("accepted-fingerprint"),
+                ReplayOutcome::Delivery {
+                    queued: false,
+                    run: plan.run,
+                },
+            )
+            .unwrap();
+        lifecycle.observe(&mut record, &SessionStatus::Working, None, 0, 1);
+
+        for index in 0..REQUEST_REPLAY_LIMIT {
+            let request_id = format!("filler-{index}");
+            lifecycle
+                .remember_replay(
+                    "child",
+                    ReplayOperation::Delivery,
+                    Some(&request_id),
+                    Some("filler-fingerprint"),
+                    ReplayOutcome::Delivery {
+                        queued: false,
+                        run: None,
+                    },
+                )
+                .unwrap();
+        }
+        let mut lifecycle: Orchestration =
+            serde_json::from_value(serde_json::to_value(&lifecycle).unwrap()).unwrap();
+        lifecycle.register_adopted(&record, 0, &SessionStatus::Working);
+        assert!(
+            lifecycle
+                .lookup_replay(
+                    "child",
+                    ReplayOperation::Delivery,
+                    Some("accepted-1"),
+                    Some("accepted-fingerprint")
+                )
+                .unwrap()
+                .is_some(),
+            "a lost response must remain replayable throughout active work"
+        );
+
+        assert!(lifecycle.observe(&mut record, &SessionStatus::Idle, None, 1, 2));
+        lifecycle
+            .remember_replay(
+                "child",
+                ReplayOperation::Delivery,
+                Some("after-terminal"),
+                Some("after-terminal-fingerprint"),
+                ReplayOutcome::Delivery {
+                    queued: false,
+                    run: None,
+                },
+            )
+            .unwrap();
+        assert!(
+            lifecycle
+                .lookup_replay(
+                    "child",
+                    ReplayOperation::Delivery,
+                    Some("accepted-1"),
+                    Some("accepted-fingerprint")
+                )
+                .unwrap()
+                .is_none(),
+            "terminal resolution releases replay provenance for eviction"
         );
     }
 

--- a/diri/crates/diri-engine/src/orchestration.rs
+++ b/diri/crates/diri-engine/src/orchestration.rs
@@ -665,6 +665,7 @@ impl Orchestration {
         let observed = self.observe(record, status, needs_input, completion_seq, output_offset);
         let id = record.id.0.clone();
         if self.pending.get(&id).is_some_and(|queue| !queue.is_empty())
+            || self.awaiting_work.contains_key(&id)
             || self.dispatching.contains_key(&id)
             || self.uncertain_deliveries.contains_key(&id)
             || self.interrupting.contains_key(&id)
@@ -693,16 +694,18 @@ impl Orchestration {
                 (current.id, None)
             }
             AgentRunState::Starting if matches!(status, SessionStatus::Idle) => (current.id, None),
-            AgentRunState::Starting
-            | AgentRunState::Running
-            | AgentRunState::NeedsInput
-            | AgentRunState::Completed
-            | AgentRunState::Failed
-            | AgentRunState::Aborted => {
+            AgentRunState::Starting | AgentRunState::Running | AgentRunState::NeedsInput => {
                 return RawSubmissionDecision {
                     changed: observed,
                     claimed: false,
                     blocked: false,
+                };
+            }
+            AgentRunState::Completed | AgentRunState::Failed | AgentRunState::Aborted => {
+                return RawSubmissionDecision {
+                    changed: observed,
+                    claimed: false,
+                    blocked: true,
                 };
             }
         };
@@ -2218,6 +2221,15 @@ mod tests {
         let claimed = record.run.as_ref().unwrap();
         assert_eq!(claimed.id, 2);
         assert_eq!(claimed.state, AgentRunState::Running);
+        assert_eq!(
+            lifecycle.claim_raw_submission(&mut record, &SessionStatus::Idle, None, 0, 10),
+            RawSubmissionDecision {
+                changed: false,
+                claimed: false,
+                blocked: true,
+            },
+            "a second Enter before the first status edge must be rejected"
+        );
 
         let error = lifecycle
             .prepare_delivery(
@@ -2243,6 +2255,25 @@ mod tests {
                 current: 2
             }
         );
+    }
+
+    #[test]
+    fn attached_enter_fails_closed_for_a_terminal_non_idle_snapshot() {
+        let mut lifecycle = Orchestration::default();
+        let mut record = record();
+        record.run.as_mut().unwrap().state = AgentRunState::Completed;
+        lifecycle.register(&record, 0, &SessionStatus::Unknown);
+
+        assert_eq!(
+            lifecycle.claim_raw_submission(&mut record, &SessionStatus::Unknown, None, 0, 10),
+            RawSubmissionDecision {
+                changed: false,
+                claimed: false,
+                blocked: true,
+            }
+        );
+        assert_eq!(record.run.as_ref().unwrap().id, 1);
+        assert_eq!(record.run.as_ref().unwrap().state, AgentRunState::Completed);
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/registry.rs
+++ b/diri/crates/diri-engine/src/registry.rs
@@ -4,7 +4,7 @@
 //! It also owns the additive `{ version, projects, sessions }` persistence
 //! envelope. Unknown project fields survive a read/write cycle.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -69,6 +69,10 @@ pub struct Registry {
     /// Mutations to run metadata do not necessarily change terminal status.
     /// This parallel version keeps lifecycle-only updates event-visible.
     record_versions: HashMap<String, u64>,
+    /// Live observations that changed a run but have not yet reached the
+    /// atomic state snapshot. This survives a failed write in memory so a
+    /// retry cannot mistake an already-consumed edge for durable state.
+    pending_lifecycle_persistence: HashSet<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -193,6 +197,7 @@ impl Registry {
             orchestration: Orchestration::default(),
             state_changes: StateChanges::default(),
             record_versions: HashMap::new(),
+            pending_lifecycle_persistence: HashSet::new(),
         }
     }
 
@@ -217,6 +222,7 @@ impl Registry {
                 } = state;
                 self.projects = projects;
                 self.orchestration = orchestration;
+                self.pending_lifecycle_persistence.clear();
                 let project_roots = self
                     .projects
                     .iter()
@@ -329,7 +335,15 @@ impl Registry {
         // Rename is atomic, so a crash mid-write cannot truncate the real file.
         std::fs::rename(&temp, &self.state_file)?;
         self.dirty = false;
+        self.pending_lifecycle_persistence.clear();
         self.last_persist = Some(std::time::Instant::now());
+        Ok(())
+    }
+
+    fn persist_lifecycle_observation_for(&mut self, id: &str) -> std::io::Result<()> {
+        if self.pending_lifecycle_persistence.contains(id) {
+            self.persist_intent_now()?;
+        }
         Ok(())
     }
 
@@ -615,15 +629,15 @@ impl Registry {
     /// Reconciles the current run without releasing its queued successor.
     /// Reports validate against this state so the report that closes run N is
     /// not made stale merely by starting acknowledged run N+1 first.
-    fn sync_run_state_for(&mut self, id: &str) -> bool {
+    fn sync_run_state_for(&mut self, id: &str) {
         let Some((view, completion_seq)) = self
             .sessions
             .get(id)
             .map(|session| (session.view(), session.turn_completion_seq()))
         else {
-            return false;
+            return;
         };
-        self.observe_run_state_for_view(id, &view, completion_seq)
+        self.observe_run_state_for_view(id, &view, completion_seq);
     }
 
     /// Every authoritative status fold first consumes Holder receipt
@@ -662,6 +676,7 @@ impl Registry {
         });
         if run_changed || receipt_changed {
             self.dirty = true;
+            self.pending_lifecycle_persistence.insert(id.to_owned());
             self.bump_record_version(id);
             self.state_changes.notify();
         }
@@ -732,21 +747,21 @@ impl Registry {
         })
     }
 
-    fn sync_orchestration_for(&mut self, id: &str) -> bool {
+    fn sync_orchestration_for(&mut self, id: &str) {
         let Some((view, completion_seq)) = self
             .sessions
             .get(id)
             .map(|session| (session.view(), session.turn_completion_seq()))
         else {
-            return false;
+            return;
         };
-        let observation_changed = self.observe_run_state_for_view(id, &view, completion_seq);
+        self.observe_run_state_for_view(id, &view, completion_seq);
         let orchestration_before = self.orchestration.clone();
         let run_before = self.records.get(id).and_then(|record| record.run.clone());
         let dirty_before = self.dirty;
         let (delivery, mut run_changed) = {
             let Some(record) = self.records.get_mut(id) else {
-                return observation_changed;
+                return;
             };
             let previous_run = record.run.clone();
             let delivery = self.orchestration.begin_ready(
@@ -773,7 +788,7 @@ impl Registry {
                     record.run = run_before;
                 }
                 self.dirty = dirty_before;
-                return observation_changed;
+                return;
             }
             let orchestration_intent = self.orchestration.clone();
             let run_intent = self.records.get(id).and_then(|record| record.run.clone());
@@ -829,7 +844,6 @@ impl Registry {
         if run_changed {
             self.bump_record_version(id);
         }
-        observation_changed || run_changed
     }
 
     fn run_transaction_snapshot(&self, id: &str) -> RunTransactionSnapshot {
@@ -876,9 +890,9 @@ impl Registry {
         request_fingerprint: Option<&str>,
     ) -> Result<(crate::orchestration::DeliveryPlan, RunTransactionSnapshot), RegistryRunError>
     {
-        if self.observe_run_state_for_view(id, view, completion_seq) {
-            self.persist_intent_now().map_err(RegistryRunError::Io)?;
-        }
+        self.observe_run_state_for_view(id, view, completion_seq);
+        self.persist_lifecycle_observation_for(id)
+            .map_err(RegistryRunError::Io)?;
         let snapshot = self.run_transaction_snapshot(id);
         let result = self
             .records
@@ -927,9 +941,9 @@ impl Registry {
         request_id: Option<&str>,
         request_fingerprint: Option<&str>,
     ) -> Result<RunTransactionSnapshot, RegistryRunError> {
-        if self.observe_run_state_for_view(id, view, completion_seq) {
-            self.persist_intent_now().map_err(RegistryRunError::Io)?;
-        }
+        self.observe_run_state_for_view(id, view, completion_seq);
+        self.persist_lifecycle_observation_for(id)
+            .map_err(RegistryRunError::Io)?;
         let snapshot = self.run_transaction_snapshot(id);
         let result = self
             .records
@@ -975,9 +989,9 @@ impl Registry {
         {
             // A response-loss retry is also a reconciliation opportunity: a
             // surviving Holder may now prove the original Enter was accepted.
-            if self.sync_run_state_for(id) {
-                self.persist_intent_now().map_err(RegistryRunError::Io)?;
-            }
+            self.sync_run_state_for(id);
+            self.persist_lifecycle_observation_for(id)
+                .map_err(RegistryRunError::Io)?;
         }
         match self.orchestration.lookup_replay(
             id,
@@ -1003,13 +1017,12 @@ impl Registry {
             ));
         }
         self.ensure_run(id)?;
-        if self.sync_orchestration_for(id) {
-            // This is the first fold that can discover a raw successor. Land
-            // it before expected-generation validation is allowed to reject
-            // the request; the transaction's second fold is intentionally
-            // idempotent and cannot carry this durability obligation.
-            self.persist_intent_now().map_err(RegistryRunError::Io)?;
-        }
+        self.sync_orchestration_for(id);
+        // This may be a retry after the first write failed. Consult the
+        // durable-observation watermark even when this sync did not create a
+        // transition: the raw successor edge has already been consumed.
+        self.persist_lifecycle_observation_for(id)
+            .map_err(RegistryRunError::Io)?;
         let (view, completion_seq) = self
             .sessions
             .get(id)
@@ -1149,7 +1162,7 @@ impl Registry {
             .get(id)
             .map(|session| (session.view(), session.turn_completion_seq()))
             .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))?;
-        let observation_changed = self.observe_run_state_for_view(id, &view, completion_seq);
+        self.observe_run_state_for_view(id, &view, completion_seq);
         let transaction_before = self.run_transaction_snapshot(id);
         let RawSubmissionDecision {
             changed,
@@ -1176,9 +1189,11 @@ impl Registry {
             self.bump_record_version(id);
             self.state_changes.notify();
         }
-        if (changed || observation_changed)
-            && let Err(error) = self.persist_intent_now()
-        {
+        if changed && let Err(error) = self.persist_intent_now() {
+            self.restore_run_transaction(id, transaction_before);
+            return Err(RegistryRunError::Io(error));
+        }
+        if let Err(error) = self.persist_lifecycle_observation_for(id) {
             self.restore_run_transaction(id, transaction_before);
             return Err(RegistryRunError::Io(error));
         }
@@ -1299,9 +1314,9 @@ impl Registry {
             None => {}
         }
 
-        if self.sync_run_state_for(reporter) {
-            self.persist_intent_now().map_err(RegistryRunError::Io)?;
-        }
+        self.sync_run_state_for(reporter);
+        self.persist_lifecycle_observation_for(reporter)
+            .map_err(RegistryRunError::Io)?;
         let record = self
             .records
             .get(reporter)
@@ -1354,9 +1369,9 @@ impl Registry {
             Some(_) => unreachable!("operation-scoped replay variant"),
             None => {}
         }
-        if self.sync_orchestration_for(id) {
-            self.persist_intent_now().map_err(RegistryRunError::Io)?;
-        }
+        self.sync_orchestration_for(id);
+        self.persist_lifecycle_observation_for(id)
+            .map_err(RegistryRunError::Io)?;
         let (view, completion_seq) = self
             .sessions
             .get(id)

--- a/diri/crates/diri-engine/src/registry.rs
+++ b/diri/crates/diri-engine/src/registry.rs
@@ -71,6 +71,14 @@ pub struct Registry {
     record_versions: HashMap<String, u64>,
 }
 
+#[derive(Clone, Debug)]
+struct RunTransactionSnapshot {
+    orchestration: Orchestration,
+    record: Option<SessionRecord>,
+    dirty: bool,
+    version: Option<u64>,
+}
+
 /// How long consecutive persists coalesce. Matches the Swift daemon's
 /// `PersistenceStore` debounce.
 const PERSIST_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(500);
@@ -657,6 +665,17 @@ impl Registry {
         else {
             return false;
         };
+        // A replacement remote Holder can prove only that the predecessor
+        // prepared this operation before its PTY side effect. Preserve the
+        // failed tombstone forever; in particular, output activity must not
+        // promote an explicitly uncertain restart window to accepted.
+        if self
+            .sessions
+            .get(id)
+            .is_some_and(|session| session.uncertain_delivery(&operation_id))
+        {
+            return false;
+        }
         if !self
             .sessions
             .get(id)
@@ -790,6 +809,127 @@ impl Registry {
         }
     }
 
+    fn run_transaction_snapshot(&self, id: &str) -> RunTransactionSnapshot {
+        RunTransactionSnapshot {
+            orchestration: self.orchestration.clone(),
+            record: self.records.get(id).cloned(),
+            dirty: self.dirty,
+            version: self.record_versions.get(id).copied(),
+        }
+    }
+
+    fn restore_run_transaction(&mut self, id: &str, snapshot: RunTransactionSnapshot) {
+        self.orchestration = snapshot.orchestration;
+        match snapshot.record {
+            Some(record) => {
+                self.records.insert(id.to_owned(), record);
+            }
+            None => {
+                self.records.remove(id);
+            }
+        }
+        self.dirty = snapshot.dirty;
+        match snapshot.version {
+            Some(version) => {
+                self.record_versions.insert(id.to_owned(), version);
+            }
+            None => {
+                self.record_versions.remove(id);
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn prepare_delivery_transaction(
+        &mut self,
+        id: &str,
+        view: &SessionView,
+        completion_seq: u64,
+        text: String,
+        submit: bool,
+        expected_run_id: Option<u64>,
+        allow_needs_input: bool,
+        request_id: Option<&str>,
+        request_fingerprint: Option<&str>,
+    ) -> Result<(crate::orchestration::DeliveryPlan, RunTransactionSnapshot), RegistryRunError>
+    {
+        let snapshot = self.run_transaction_snapshot(id);
+        let result = self
+            .records
+            .get_mut(id)
+            .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))
+            .and_then(|record| {
+                let previous_run = record.run.clone();
+                let result = self
+                    .orchestration
+                    .prepare_delivery(
+                        record,
+                        DeliveryRequest {
+                            status: &view.status,
+                            needs_input: view.needs_input.as_ref(),
+                            completion_seq,
+                            output_offset: view.tail_offset,
+                            expected_run_id,
+                            text,
+                            submit,
+                            allow_needs_input,
+                            request_id,
+                            request_fingerprint,
+                        },
+                    )
+                    .map_err(RegistryRunError::from);
+                if result.is_ok() && record.run != previous_run {
+                    apply_run_transition_metadata(record);
+                }
+                result
+            });
+        match result {
+            Ok(plan) => Ok((plan, snapshot)),
+            Err(error) => {
+                self.restore_run_transaction(id, snapshot);
+                Err(error)
+            }
+        }
+    }
+
+    fn prepare_interrupt_transaction(
+        &mut self,
+        id: &str,
+        view: &SessionView,
+        completion_seq: u64,
+        expected_run_id: Option<u64>,
+        request_id: Option<&str>,
+        request_fingerprint: Option<&str>,
+    ) -> Result<RunTransactionSnapshot, RegistryRunError> {
+        let snapshot = self.run_transaction_snapshot(id);
+        let result = self
+            .records
+            .get_mut(id)
+            .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))
+            .and_then(|record| {
+                if self.orchestration.observe(
+                    record,
+                    &view.status,
+                    view.needs_input.as_ref(),
+                    completion_seq,
+                    view.tail_offset,
+                ) {
+                    apply_run_transition_metadata(record);
+                }
+                self.orchestration
+                    .prepare_interrupt(record, expected_run_id, request_id, request_fingerprint)
+                    .map(drop)
+                    .map_err(RegistryRunError::from)
+            });
+        match result {
+            Ok(()) => Ok(snapshot),
+            Err(error) => {
+                self.restore_run_transaction(id, snapshot);
+                Err(error)
+            }
+        }
+    }
+
     /// Sends now only at a manifest-derived safe input state; otherwise keeps
     /// the message FIFO inside the Engine across MCP process reconnects.
     pub fn send_run_text(
@@ -837,31 +977,17 @@ impl Registry {
             .get(id)
             .map(|session| (session.view(), session.turn_completion_seq()))
             .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))?;
-        let orchestration_before = self.orchestration.clone();
-        let run_before = self.records.get(id).and_then(|record| record.run.clone());
-        let dirty_before = self.dirty;
-        let version_before = self.record_versions.get(id).copied();
-        let plan = {
-            let record = self
-                .records
-                .get_mut(id)
-                .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))?;
-            self.orchestration.prepare_delivery(
-                record,
-                DeliveryRequest {
-                    status: &view.status,
-                    needs_input: view.needs_input.as_ref(),
-                    completion_seq,
-                    output_offset: view.tail_offset,
-                    expected_run_id,
-                    text: text.clone(),
-                    submit,
-                    allow_needs_input,
-                    request_id: request_id.as_deref(),
-                    request_fingerprint: fingerprint.as_deref(),
-                },
-            )?
-        };
+        let (plan, transaction_before) = self.prepare_delivery_transaction(
+            id,
+            &view,
+            completion_seq,
+            text.clone(),
+            submit,
+            expected_run_id,
+            allow_needs_input,
+            request_id.as_deref(),
+            fingerprint.as_deref(),
+        )?;
         let mut intent_snapshot = None;
         if !plan.queued {
             // All agent deliveries use the same two-phase outbox as queued
@@ -869,19 +995,7 @@ impl Registry {
             // uncertainty but can never silently forget or duplicate it.
             self.dirty = true;
             if let Err(error) = self.persist_intent_now() {
-                self.orchestration = orchestration_before;
-                if let Some(record) = self.records.get_mut(id) {
-                    record.run = run_before;
-                }
-                self.dirty = dirty_before;
-                match version_before {
-                    Some(version) => {
-                        self.record_versions.insert(id.to_owned(), version);
-                    }
-                    None => {
-                        self.record_versions.remove(id);
-                    }
-                }
+                self.restore_run_transaction(id, transaction_before);
                 return Err(RegistryRunError::Io(error));
             }
             intent_snapshot = Some((
@@ -929,19 +1043,7 @@ impl Registry {
         // an MCP process or daemon restart.
         if let Err(error) = self.persist_intent_now() {
             if plan.queued {
-                self.orchestration = orchestration_before;
-                if let Some(record) = self.records.get_mut(id) {
-                    record.run = run_before;
-                }
-                self.dirty = dirty_before;
-                match version_before {
-                    Some(version) => {
-                        self.record_versions.insert(id.to_owned(), version);
-                    }
-                    None => {
-                        self.record_versions.remove(id);
-                    }
-                }
+                self.restore_run_transaction(id, transaction_before);
                 return Err(RegistryRunError::Io(error));
             }
             // Disk still contains the pre-side-effect intent. Mirror that
@@ -1129,51 +1231,22 @@ impl Registry {
             None => {}
         }
         self.sync_orchestration_for(id);
-        let orchestration_before = self.orchestration.clone();
-        let run_before = self.records.get(id).and_then(|record| record.run.clone());
-        let dirty_before = self.dirty;
-        let version_before = self.record_versions.get(id).copied();
         let (view, completion_seq) = self
             .sessions
             .get(id)
             .map(|session| (session.view(), session.turn_completion_seq()))
             .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))?;
-        {
-            let record = self
-                .records
-                .get_mut(id)
-                .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))?;
-            if self.orchestration.observe(
-                record,
-                &view.status,
-                view.needs_input.as_ref(),
-                completion_seq,
-                view.tail_offset,
-            ) {
-                apply_run_transition_metadata(record);
-            }
-            self.orchestration.prepare_interrupt(
-                record,
-                expected_run_id,
-                request_id.as_deref(),
-                fingerprint.as_deref(),
-            )?;
-        }
+        let transaction_before = self.prepare_interrupt_transaction(
+            id,
+            &view,
+            completion_seq,
+            expected_run_id,
+            request_id.as_deref(),
+            fingerprint.as_deref(),
+        )?;
         self.dirty = true;
         if let Err(error) = self.persist_intent_now() {
-            self.orchestration = orchestration_before;
-            if let Some(record) = self.records.get_mut(id) {
-                record.run = run_before;
-            }
-            self.dirty = dirty_before;
-            match version_before {
-                Some(version) => {
-                    self.record_versions.insert(id.to_owned(), version);
-                }
-                None => {
-                    self.record_versions.remove(id);
-                }
-            }
+            self.restore_run_transaction(id, transaction_before);
             return Err(RegistryRunError::Io(error));
         }
         let orchestration_intent = self.orchestration.clone();
@@ -2111,6 +2184,180 @@ mod tests {
             .expect("manifests");
         let (engine, _) = ManifestEngine::load_dir(&dir).expect("load");
         Arc::new(engine)
+    }
+
+    fn view(id: &str, status: SessionStatus, tail_offset: u64) -> SessionView {
+        SessionView {
+            id: id.into(),
+            status,
+            status_evidence: None,
+            needs_input: None,
+            title: None,
+            title_source: None,
+            tail_offset,
+            exited: false,
+        }
+    }
+
+    #[test]
+    fn stale_delivery_rolls_back_a_fresh_raw_successor_for_the_event_sync() {
+        let temp = tempfile::tempdir().expect("temp");
+        let mut registry = Registry::new(engine(), temp.path().join("state.json"));
+        let mut agent = record("s_agent");
+        agent.kind = AgentKind::CODEX;
+        agent.status = SessionStatus::Idle;
+        agent.run = Some(AgentRun {
+            id: 1,
+            state: AgentRunState::Completed,
+            started_at: DateMillis(1.0),
+            finished_at: Some(DateMillis(2.0)),
+            terminal_outcome: Some("completed".into()),
+        });
+        registry.records.insert("s_agent".into(), agent.clone());
+        registry
+            .orchestration
+            .register(&agent, 0, &SessionStatus::Idle);
+        let working = view("s_agent", SessionStatus::Working, 10);
+
+        let error = registry
+            .prepare_delivery_transaction(
+                "s_agent",
+                &working,
+                0,
+                "stale".into(),
+                true,
+                Some(1),
+                true,
+                None,
+                None,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            RegistryRunError::Stale {
+                expected: 1,
+                current: 2
+            }
+        ));
+        assert_eq!(registry.records["s_agent"].run.as_ref().unwrap().id, 1);
+        assert!(registry.orchestration.observe(
+            registry.records.get_mut("s_agent").unwrap(),
+            &working.status,
+            None,
+            0,
+            working.tail_offset,
+        ));
+        assert_eq!(registry.records["s_agent"].run.as_ref().unwrap().id, 2);
+    }
+
+    #[test]
+    fn stale_interrupt_rolls_back_a_fresh_raw_successor_for_the_event_sync() {
+        let temp = tempfile::tempdir().expect("temp");
+        let mut registry = Registry::new(engine(), temp.path().join("state.json"));
+        let mut agent = record("s_agent");
+        agent.kind = AgentKind::CODEX;
+        agent.status = SessionStatus::Idle;
+        agent.run = Some(AgentRun {
+            id: 1,
+            state: AgentRunState::Completed,
+            started_at: DateMillis(1.0),
+            finished_at: Some(DateMillis(2.0)),
+            terminal_outcome: Some("completed".into()),
+        });
+        registry.records.insert("s_agent".into(), agent.clone());
+        registry
+            .orchestration
+            .register(&agent, 0, &SessionStatus::Idle);
+        let working = view("s_agent", SessionStatus::Working, 10);
+
+        let error = registry
+            .prepare_interrupt_transaction("s_agent", &working, 0, Some(1), None, None)
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            RegistryRunError::Stale {
+                expected: 1,
+                current: 2
+            }
+        ));
+        assert_eq!(registry.records["s_agent"].run.as_ref().unwrap().id, 1);
+        assert!(registry.orchestration.observe(
+            registry.records.get_mut("s_agent").unwrap(),
+            &working.status,
+            None,
+            0,
+            working.tail_offset,
+        ));
+        assert_eq!(registry.records["s_agent"].run.as_ref().unwrap().id, 2);
+    }
+
+    #[test]
+    fn failed_report_replay_commit_keeps_only_the_durable_parent_evidence() {
+        let temp = tempfile::tempdir().expect("temp");
+        let blocked_parent = temp.path().join("not-a-directory");
+        std::fs::write(&blocked_parent, b"file").expect("blocking file");
+        let mut registry = Registry::new(engine(), blocked_parent.join("state.json"));
+        let mut reporter = record("reporter");
+        reporter.kind = AgentKind::CODEX;
+        reporter.parent = Some(SessionId::new("parent"));
+        registry.records.insert("reporter".into(), reporter);
+
+        let request_id = "report-1";
+        let text = "finished";
+        let internal_request_id =
+            format!("report:{}", request_fingerprint(&("reporter", request_id)));
+        let internal_fingerprint =
+            request_fingerprint(&("parent", text, true, Option::<u64>::None, false));
+        registry
+            .orchestration
+            .remember_replay(
+                "parent",
+                ReplayOperation::Delivery,
+                Some(&internal_request_id),
+                Some(&internal_fingerprint),
+                ReplayOutcome::Delivery {
+                    queued: true,
+                    run: Some(AgentRun::starting(2, DateMillis(3.0))),
+                },
+            )
+            .unwrap();
+
+        assert!(matches!(
+            registry.report_to_parent(
+                "reporter",
+                text.into(),
+                true,
+                Some(1),
+                Some(request_id.into())
+            ),
+            Err(RegistryRunError::Io(_))
+        ));
+        let outer_fingerprint = request_fingerprint(&("reporter", text, true, Some(1_u64)));
+        assert!(
+            registry
+                .orchestration
+                .lookup_replay(
+                    "reporter",
+                    ReplayOperation::Report,
+                    Some(request_id),
+                    Some(&outer_fingerprint)
+                )
+                .unwrap()
+                .is_none(),
+            "an uncommitted success must not replay in this process"
+        );
+        assert!(matches!(
+            registry
+                .orchestration
+                .lookup_replay(
+                    "parent",
+                    ReplayOperation::Delivery,
+                    Some(&internal_request_id),
+                    Some(&internal_fingerprint)
+                )
+                .unwrap(),
+            Some(ReplayOutcome::Delivery { queued: true, .. })
+        ));
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/registry.rs
+++ b/diri/crates/diri-engine/src/registry.rs
@@ -79,6 +79,14 @@ struct RunTransactionSnapshot {
     version: Option<u64>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum DeliveryReceiptEvidence {
+    None,
+    Authoritative(String),
+    Accepted(String),
+    Uncertain(String),
+}
+
 /// How long consecutive persists coalesce. Matches the Swift daemon's
 /// `PersistenceStore` debounce.
 const PERSIST_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(500);
@@ -335,23 +343,7 @@ impl Registry {
             .map(|(id, session)| (id.clone(), session.view(), session.turn_completion_seq()))
             .collect::<Vec<_>>();
         for (id, view, completion_seq) in live {
-            if let Some(record) = self.records.get_mut(&id) {
-                let previous = record.run.clone();
-                let changed = self.orchestration.observe(
-                    record,
-                    &view.status,
-                    view.needs_input.as_ref(),
-                    completion_seq,
-                    view.tail_offset,
-                );
-                if changed {
-                    apply_run_transition_metadata(record);
-                    if previous != record.run {
-                        let version = self.record_versions.entry(id).or_default();
-                        *version = version.saturating_add(1);
-                    }
-                }
-            }
+            self.observe_run_state_for_view(&id, &view, completion_seq);
         }
         let mut records: Vec<SessionRecord> = self.records.values().cloned().collect();
         for record in &mut records {
@@ -631,8 +623,31 @@ impl Registry {
         else {
             return;
         };
-        let receipt_changed = self.reconcile_delivery_receipt(id, &view, completion_seq);
-        let changed = self.records.get_mut(id).is_some_and(|record| {
+        self.observe_run_state_for_view(id, &view, completion_seq);
+    }
+
+    /// Every authoritative status fold first consumes Holder receipt
+    /// evidence. This ordering makes an explicit uncertainty tombstone
+    /// stronger than generic output activity at every Registry seam.
+    fn observe_run_state_for_view(
+        &mut self,
+        id: &str,
+        view: &SessionView,
+        completion_seq: u64,
+    ) -> bool {
+        let evidence = self.delivery_receipt_evidence(id);
+        self.observe_run_state_with_receipt(id, view, completion_seq, evidence)
+    }
+
+    fn observe_run_state_with_receipt(
+        &mut self,
+        id: &str,
+        view: &SessionView,
+        completion_seq: u64,
+        evidence: DeliveryReceiptEvidence,
+    ) -> bool {
+        let receipt_changed = self.reconcile_delivery_receipt(id, view, completion_seq, evidence);
+        let run_changed = self.records.get_mut(id).is_some_and(|record| {
             let changed = self.orchestration.observe(
                 record,
                 &view.status,
@@ -645,10 +660,36 @@ impl Registry {
             }
             changed
         });
-        if changed || receipt_changed {
+        if run_changed || receipt_changed {
             self.dirty = true;
             self.bump_record_version(id);
             self.state_changes.notify();
+        }
+        run_changed || receipt_changed
+    }
+
+    fn delivery_receipt_evidence(&self, id: &str) -> DeliveryReceiptEvidence {
+        let Some(operation_id) = self
+            .orchestration
+            .uncertain_operation_id(id)
+            .map(str::to_owned)
+        else {
+            return DeliveryReceiptEvidence::None;
+        };
+        let Some(session) = self.sessions.get(id) else {
+            return DeliveryReceiptEvidence::None;
+        };
+        if session.uncertain_delivery(&operation_id) {
+            DeliveryReceiptEvidence::Uncertain(operation_id)
+        } else if session.accepted_delivery(&operation_id) {
+            DeliveryReceiptEvidence::Accepted(operation_id)
+        } else if session.remote_delivery_receipts_supported().is_some() {
+            // A remote transport can reconnect or publish a HelloAck outcome
+            // immediately after this snapshot. Never race that exact evidence
+            // with heuristic output reconciliation.
+            DeliveryReceiptEvidence::Authoritative(operation_id)
+        } else {
+            DeliveryReceiptEvidence::None
         }
     }
 
@@ -657,32 +698,23 @@ impl Registry {
         id: &str,
         view: &SessionView,
         completion_seq: u64,
+        evidence: DeliveryReceiptEvidence,
     ) -> bool {
-        let Some(operation_id) = self
-            .orchestration
-            .uncertain_operation_id(id)
-            .map(str::to_owned)
-        else {
-            return false;
-        };
         // A replacement remote Holder can prove only that the predecessor
         // prepared this operation before its PTY side effect. Preserve the
         // failed tombstone forever; in particular, output activity must not
         // promote an explicitly uncertain restart window to accepted.
-        if self
-            .sessions
-            .get(id)
-            .is_some_and(|session| session.uncertain_delivery(&operation_id))
+        if let DeliveryReceiptEvidence::Authoritative(operation_id)
+        | DeliveryReceiptEvidence::Uncertain(operation_id) = &evidence
         {
             return self
                 .orchestration
-                .mark_delivery_explicitly_uncertain(id, &operation_id);
+                .mark_delivery_explicitly_uncertain(id, operation_id);
         }
-        if !self
-            .sessions
-            .get(id)
-            .is_some_and(|session| session.accepted_delivery(&operation_id))
-        {
+        let DeliveryReceiptEvidence::Accepted(operation_id) = evidence else {
+            return false;
+        };
+        if self.orchestration.uncertain_operation_id(id) != Some(operation_id.as_str()) {
             return false;
         }
         self.records.get_mut(id).is_some_and(|record| {
@@ -708,12 +740,7 @@ impl Registry {
         else {
             return;
         };
-        let receipt_changed = self.reconcile_delivery_receipt(id, &view, completion_seq);
-        if receipt_changed {
-            self.dirty = true;
-            self.bump_record_version(id);
-            self.state_changes.notify();
-        }
+        self.observe_run_state_for_view(id, &view, completion_seq);
         let orchestration_before = self.orchestration.clone();
         let run_before = self.records.get(id).and_then(|record| record.run.clone());
         let dirty_before = self.dirty;
@@ -722,17 +749,6 @@ impl Registry {
                 return;
             };
             let previous_run = record.run.clone();
-            let changed = self.orchestration.observe(
-                record,
-                &view.status,
-                view.needs_input.as_ref(),
-                completion_seq,
-                view.tail_offset,
-            );
-            if changed {
-                apply_run_transition_metadata(record);
-                self.dirty = true;
-            }
             let delivery = self.orchestration.begin_ready(
                 record,
                 &view.status,
@@ -740,7 +756,11 @@ impl Registry {
                 completion_seq,
                 view.tail_offset,
             );
-            (delivery, previous_run != record.run)
+            let run_changed = previous_run != record.run;
+            if run_changed {
+                apply_run_transition_metadata(record);
+            }
+            (delivery, run_changed)
         };
         if let Some(delivery) = delivery {
             // Persist the outbox's dispatch phase before touching the PTY. If
@@ -855,6 +875,9 @@ impl Registry {
         request_fingerprint: Option<&str>,
     ) -> Result<(crate::orchestration::DeliveryPlan, RunTransactionSnapshot), RegistryRunError>
     {
+        if self.observe_run_state_for_view(id, view, completion_seq) {
+            self.persist_intent_now().map_err(RegistryRunError::Io)?;
+        }
         let snapshot = self.run_transaction_snapshot(id);
         let result = self
             .records
@@ -903,21 +926,15 @@ impl Registry {
         request_id: Option<&str>,
         request_fingerprint: Option<&str>,
     ) -> Result<RunTransactionSnapshot, RegistryRunError> {
+        if self.observe_run_state_for_view(id, view, completion_seq) {
+            self.persist_intent_now().map_err(RegistryRunError::Io)?;
+        }
         let snapshot = self.run_transaction_snapshot(id);
         let result = self
             .records
             .get_mut(id)
             .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))
             .and_then(|record| {
-                if self.orchestration.observe(
-                    record,
-                    &view.status,
-                    view.needs_input.as_ref(),
-                    completion_seq,
-                    view.tail_offset,
-                ) {
-                    apply_run_transition_metadata(record);
-                }
                 self.orchestration
                     .prepare_interrupt(record, expected_run_id, request_id, request_fingerprint)
                     .map(drop)
@@ -1123,6 +1140,7 @@ impl Registry {
             .get(id)
             .map(|session| (session.view(), session.turn_completion_seq()))
             .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))?;
+        let observation_changed = self.observe_run_state_for_view(id, &view, completion_seq);
         let transaction_before = self.run_transaction_snapshot(id);
         let RawSubmissionDecision {
             changed,
@@ -1147,11 +1165,13 @@ impl Registry {
             }
             self.dirty = true;
             self.bump_record_version(id);
-            if let Err(error) = self.persist_intent_now() {
-                self.restore_run_transaction(id, transaction_before);
-                return Err(RegistryRunError::Io(error));
-            }
             self.state_changes.notify();
+        }
+        if (changed || observation_changed)
+            && let Err(error) = self.persist_intent_now()
+        {
+            self.restore_run_transaction(id, transaction_before);
+            return Err(RegistryRunError::Io(error));
         }
         if blocked {
             return Err(RegistryRunError::OutcomeUncertain(
@@ -1485,36 +1505,23 @@ impl Registry {
             .collect::<Vec<_>>();
         let mut title_changed = false;
         for (id, session_version, view) in changed_views {
-            let mut lifecycle_changed = false;
+            let completion_seq = self
+                .sessions
+                .get(&id)
+                .map_or(0, Session::turn_completion_seq);
+            let lifecycle_changed = self.observe_run_state_for_view(&id, &view, completion_seq);
             if let Some(record) = self.records.get_mut(&id) {
                 let previous_title = (record.title.clone(), record.title_source);
                 fold_session_view(record, &view);
-                let completion_seq = self
-                    .sessions
-                    .get(&id)
-                    .map_or(0, Session::turn_completion_seq);
-                let run_changed = self.orchestration.observe(
-                    record,
-                    &view.status,
-                    view.needs_input.as_ref(),
-                    completion_seq,
-                    view.tail_offset,
-                );
-                lifecycle_changed = run_changed;
                 let record_title_changed =
                     previous_title != (record.title.clone(), record.title_source);
-                if run_changed {
-                    apply_run_transition_metadata(record);
-                } else if record_title_changed {
+                if record_title_changed && !lifecycle_changed {
                     record.updated_at = DateMillis::from(std::time::SystemTime::now());
                 }
-                if record_title_changed || run_changed {
+                if record_title_changed || lifecycle_changed {
                     title_changed = true;
                 }
                 changed.push((id.clone(), record.clone()));
-            }
-            if lifecycle_changed {
-                self.bump_record_version(&id);
             }
             published.insert(
                 id.clone(),
@@ -2297,9 +2304,10 @@ mod tests {
     }
 
     #[test]
-    fn stale_delivery_rolls_back_a_fresh_raw_successor_for_the_event_sync() {
+    fn stale_delivery_commits_a_fresh_raw_successor_before_returning() {
         let temp = tempfile::tempdir().expect("temp");
-        let mut registry = Registry::new(engine(), temp.path().join("state.json"));
+        let state_file = temp.path().join("state.json");
+        let mut registry = Registry::new(engine(), &state_file);
         let mut agent = record("s_agent");
         agent.kind = AgentKind::CODEX;
         agent.status = SessionStatus::Idle;
@@ -2336,21 +2344,26 @@ mod tests {
                 current: 2
             }
         ));
-        assert_eq!(registry.records["s_agent"].run.as_ref().unwrap().id, 1);
-        assert!(registry.orchestration.observe(
+        assert_eq!(registry.records["s_agent"].run.as_ref().unwrap().id, 2);
+        assert!(!registry.orchestration.observe(
             registry.records.get_mut("s_agent").unwrap(),
             &working.status,
             None,
             0,
             working.tail_offset,
         ));
-        assert_eq!(registry.records["s_agent"].run.as_ref().unwrap().id, 2);
+        assert!(!registry.dirty);
+        assert!(registry.record_versions["s_agent"] > 0);
+        let mut restored = Registry::new(engine(), &state_file);
+        restored.load().expect("reload committed observation");
+        assert_eq!(restored.records["s_agent"].run.as_ref().unwrap().id, 2);
     }
 
     #[test]
-    fn stale_interrupt_rolls_back_a_fresh_raw_successor_for_the_event_sync() {
+    fn stale_interrupt_commits_a_fresh_raw_successor_before_returning() {
         let temp = tempfile::tempdir().expect("temp");
-        let mut registry = Registry::new(engine(), temp.path().join("state.json"));
+        let state_file = temp.path().join("state.json");
+        let mut registry = Registry::new(engine(), &state_file);
         let mut agent = record("s_agent");
         agent.kind = AgentKind::CODEX;
         agent.status = SessionStatus::Idle;
@@ -2377,15 +2390,19 @@ mod tests {
                 current: 2
             }
         ));
-        assert_eq!(registry.records["s_agent"].run.as_ref().unwrap().id, 1);
-        assert!(registry.orchestration.observe(
+        assert_eq!(registry.records["s_agent"].run.as_ref().unwrap().id, 2);
+        assert!(!registry.orchestration.observe(
             registry.records.get_mut("s_agent").unwrap(),
             &working.status,
             None,
             0,
             working.tail_offset,
         ));
-        assert_eq!(registry.records["s_agent"].run.as_ref().unwrap().id, 2);
+        assert!(!registry.dirty);
+        assert!(registry.record_versions["s_agent"] > 0);
+        let mut restored = Registry::new(engine(), &state_file);
+        restored.load().expect("reload committed observation");
+        assert_eq!(restored.records["s_agent"].run.as_ref().unwrap().id, 2);
     }
 
     #[test]
@@ -2451,6 +2468,80 @@ mod tests {
         assert_eq!(restored.records["s_agent"].run.as_ref().unwrap().id, 2);
         assert!(is_attached_submit(b"\r"));
         assert!(!is_attached_submit(b"pasted\ntext"));
+    }
+
+    #[test]
+    fn holder_uncertainty_is_folded_before_concurrent_working_activity() {
+        let temp = tempfile::tempdir().expect("temp");
+        let state_file = temp.path().join("state.json");
+        let mut registry = Registry::new(engine(), &state_file);
+        let mut agent = record("s_agent");
+        agent.kind = AgentKind::CODEX;
+        agent.status = SessionStatus::Idle;
+        agent.run = Some(AgentRun::starting(1, DateMillis(1.0)));
+        registry.records.insert("s_agent".into(), agent.clone());
+        registry
+            .orchestration
+            .register(&agent, 0, &SessionStatus::Idle);
+        registry
+            .orchestration
+            .prepare_delivery(
+                registry.records.get_mut("s_agent").unwrap(),
+                DeliveryRequest {
+                    status: &SessionStatus::Idle,
+                    needs_input: None,
+                    completion_seq: 0,
+                    output_offset: 10,
+                    expected_run_id: Some(1),
+                    text: "receipt race".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: Some("receipt-race"),
+                    request_fingerprint: Some("receipt-fingerprint"),
+                },
+            )
+            .unwrap();
+        registry
+            .orchestration
+            .mark_dispatch_uncertain(
+                registry.records.get_mut("s_agent").unwrap(),
+                "response lost".into(),
+            )
+            .unwrap();
+        let operation_id = registry
+            .orchestration
+            .uncertain_operation_id("s_agent")
+            .unwrap()
+            .to_owned();
+        let working = view("s_agent", SessionStatus::Working, 20);
+
+        assert!(registry.observe_run_state_with_receipt(
+            "s_agent",
+            &working,
+            0,
+            DeliveryReceiptEvidence::Uncertain(operation_id.clone()),
+        ));
+        let run = registry.records["s_agent"].run.as_ref().unwrap();
+        assert_eq!(run.id, 1);
+        assert_eq!(run.state, AgentRunState::Failed);
+        assert_eq!(
+            registry.orchestration.uncertain_operation_id("s_agent"),
+            Some(operation_id.as_str())
+        );
+        assert!(registry.dirty);
+        assert!(registry.record_versions["s_agent"] > 0);
+        registry.persist_intent_now().expect("persist tombstone");
+
+        let mut restored = Registry::new(engine(), &state_file);
+        restored.load().expect("reload tombstone");
+        assert_eq!(
+            restored.records["s_agent"].run.as_ref().unwrap().state,
+            AgentRunState::Failed
+        );
+        assert_eq!(
+            restored.orchestration.uncertain_operation_id("s_agent"),
+            Some(operation_id.as_str())
+        );
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/registry.rs
+++ b/diri/crates/diri-engine/src/registry.rs
@@ -14,8 +14,8 @@ use serde::{Deserialize, Serialize};
 use crate::detect::ManifestEngine;
 use crate::holder::{HolderClient, HolderManagerPaths, HolderPaths};
 use crate::orchestration::{
-    DeliveryRequest, Orchestration, ReplayOperation, ReplayOutcome, RunError, StateChanges,
-    WaitDecision, request_fingerprint,
+    DeliveryRequest, Orchestration, RawSubmissionDecision, ReplayOperation, ReplayOutcome,
+    RunError, StateChanges, WaitDecision, request_fingerprint,
 };
 use crate::session::{HolderConfig, RemoteAdoptSpec, Session, SessionSpec, SessionView};
 
@@ -674,7 +674,9 @@ impl Registry {
             .get(id)
             .is_some_and(|session| session.uncertain_delivery(&operation_id))
         {
-            return false;
+            return self
+                .orchestration
+                .mark_delivery_explicitly_uncertain(id, &operation_id);
         }
         if !self
             .sessions
@@ -970,6 +972,16 @@ impl Registry {
             Some(_) => unreachable!("operation-scoped replay variant"),
             None => {}
         }
+        if submit
+            && self
+                .sessions
+                .get(id)
+                .is_some_and(|session| session.remote_delivery_receipts_supported() == Some(false))
+        {
+            return Err(RegistryRunError::OutcomeUncertain(
+                "remote Holder cannot acknowledge run delivery (protocol 1.6 required)".into(),
+            ));
+        }
         self.ensure_run(id)?;
         self.sync_orchestration_for(id);
         let (view, completion_seq) = self
@@ -1086,6 +1098,87 @@ impl Registry {
             .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))?
             .send_text(&text, submit)
             .map_err(RegistryRunError::Io)
+    }
+
+    /// Raw input seam for attached terminals. A standalone Enter into an
+    /// agent session claims its run generation durably while the Registry
+    /// lock still excludes run.send, before the PTY can accept the byte.
+    pub fn write_attached_input(&mut self, id: &str, bytes: &[u8]) -> Result<(), RegistryRunError> {
+        let is_agent = self
+            .records
+            .get(id)
+            .is_some_and(|record| record.kind != diri_proto::AgentKind::SHELL);
+        if !is_agent || !is_attached_submit(bytes) {
+            return self
+                .sessions
+                .get(id)
+                .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))?
+                .write_input(bytes)
+                .map_err(RegistryRunError::Io);
+        }
+
+        self.ensure_run(id)?;
+        let (view, completion_seq) = self
+            .sessions
+            .get(id)
+            .map(|session| (session.view(), session.turn_completion_seq()))
+            .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))?;
+        let transaction_before = self.run_transaction_snapshot(id);
+        let RawSubmissionDecision {
+            changed,
+            claimed,
+            blocked,
+        } = {
+            let record = self
+                .records
+                .get_mut(id)
+                .expect("ensure_run validated the record");
+            self.orchestration.claim_raw_submission(
+                record,
+                &view.status,
+                view.needs_input.as_ref(),
+                completion_seq,
+                view.tail_offset,
+            )
+        };
+        if changed {
+            if let Some(record) = self.records.get_mut(id) {
+                apply_run_transition_metadata(record);
+            }
+            self.dirty = true;
+            self.bump_record_version(id);
+            if let Err(error) = self.persist_intent_now() {
+                self.restore_run_transaction(id, transaction_before);
+                return Err(RegistryRunError::Io(error));
+            }
+            self.state_changes.notify();
+        }
+        if blocked {
+            return Err(RegistryRunError::OutcomeUncertain(
+                "attached submission cannot bypass unresolved lifecycle work".into(),
+            ));
+        }
+
+        if let Err(error) = self
+            .sessions
+            .get(id)
+            .expect("session remained live while Registry is locked")
+            .write_input(bytes)
+        {
+            if claimed {
+                if let Some(record) = self.records.get_mut(id) {
+                    self.orchestration.mark_raw_submission_uncertain(record);
+                    apply_run_transition_metadata(record);
+                }
+                self.dirty = true;
+                self.bump_record_version(id);
+                let _ = self.persist_intent_now();
+                self.state_changes.notify();
+                return Err(RegistryRunError::OutcomeUncertain(error.to_string()));
+            }
+            return Err(RegistryRunError::Io(error));
+        }
+        Ok(())
     }
 
     pub fn report_to_parent(
@@ -2110,6 +2203,10 @@ fn is_generic_terminal_title(title: &str, record: &SessionRecord) -> bool {
         )
 }
 
+fn is_attached_submit(bytes: &[u8]) -> bool {
+    matches!(bytes, b"\r" | b"\n" | b"\r\n")
+}
+
 fn not_found(id: &str) -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::NotFound, format!("no session {id}"))
 }
@@ -2289,6 +2386,71 @@ mod tests {
             working.tail_offset,
         ));
         assert_eq!(registry.records["s_agent"].run.as_ref().unwrap().id, 2);
+    }
+
+    #[test]
+    fn attached_enter_claim_is_durable_before_the_status_transition() {
+        let temp = tempfile::tempdir().expect("temp");
+        let state_file = temp.path().join("state.json");
+        let mut registry = Registry::new(engine(), &state_file);
+        let mut agent = record("s_agent");
+        agent.kind = AgentKind::CODEX;
+        agent.status = SessionStatus::Idle;
+        agent.run = Some(AgentRun {
+            id: 1,
+            state: AgentRunState::Completed,
+            started_at: DateMillis(1.0),
+            finished_at: Some(DateMillis(2.0)),
+            terminal_outcome: Some("completed".into()),
+        });
+        registry.records.insert("s_agent".into(), agent.clone());
+        registry
+            .orchestration
+            .register(&agent, 0, &SessionStatus::Idle);
+        let idle = view("s_agent", SessionStatus::Idle, 10);
+        assert_eq!(
+            registry.orchestration.claim_raw_submission(
+                registry.records.get_mut("s_agent").unwrap(),
+                &idle.status,
+                None,
+                0,
+                idle.tail_offset,
+            ),
+            RawSubmissionDecision {
+                changed: true,
+                claimed: true,
+                blocked: false,
+            }
+        );
+        apply_run_transition_metadata(registry.records.get_mut("s_agent").unwrap());
+        registry.dirty = true;
+        registry.persist_intent_now().expect("persist raw claim");
+
+        let mut restored = Registry::new(engine(), &state_file);
+        restored.load().expect("reload raw claim");
+        let error = restored
+            .prepare_delivery_transaction(
+                "s_agent",
+                &idle,
+                0,
+                "must be stale".into(),
+                true,
+                Some(1),
+                true,
+                None,
+                None,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            RegistryRunError::Stale {
+                expected: 1,
+                current: 2
+            }
+        ));
+        assert_eq!(restored.records["s_agent"].run.as_ref().unwrap().id, 2);
+        assert!(is_attached_submit(b"\r"));
+        assert!(!is_attached_submit(b"pasted\ntext"));
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/registry.rs
+++ b/diri/crates/diri-engine/src/registry.rs
@@ -85,6 +85,7 @@ pub enum RegistryRunError {
     OutcomeUncertain(String),
     InvalidRequestId,
     RequestConflict(String),
+    ReplayCapacity,
     Io(std::io::Error),
 }
 
@@ -96,6 +97,7 @@ impl From<RunError> for RegistryRunError {
             RunError::AlreadyTerminal { current } => Self::AlreadyTerminal { current },
             RunError::InvalidRequestId => Self::InvalidRequestId,
             RunError::RequestConflict { request_id } => Self::RequestConflict(request_id),
+            RunError::ReplayCapacity => Self::ReplayCapacity,
         }
     }
 }
@@ -122,6 +124,9 @@ impl std::fmt::Display for RegistryRunError {
             Self::RequestConflict(request_id) => write!(
                 formatter,
                 "request id {request_id:?} was already used with a different operation payload"
+            ),
+            Self::ReplayCapacity => formatter.write_str(
+                "request replay capacity is occupied by active operations; retry after one resolves",
             ),
             Self::Io(error) => error.fmt(formatter),
         }
@@ -618,6 +623,7 @@ impl Registry {
         else {
             return;
         };
+        let receipt_changed = self.reconcile_delivery_receipt(id, &view, completion_seq);
         let changed = self.records.get_mut(id).is_some_and(|record| {
             let changed = self.orchestration.observe(
                 record,
@@ -631,11 +637,46 @@ impl Registry {
             }
             changed
         });
-        if changed {
+        if changed || receipt_changed {
             self.dirty = true;
             self.bump_record_version(id);
             self.state_changes.notify();
         }
+    }
+
+    fn reconcile_delivery_receipt(
+        &mut self,
+        id: &str,
+        view: &SessionView,
+        completion_seq: u64,
+    ) -> bool {
+        let Some(operation_id) = self
+            .orchestration
+            .uncertain_operation_id(id)
+            .map(str::to_owned)
+        else {
+            return false;
+        };
+        if !self
+            .sessions
+            .get(id)
+            .is_some_and(|session| session.accepted_delivery(&operation_id))
+        {
+            return false;
+        }
+        self.records.get_mut(id).is_some_and(|record| {
+            let changed = self.orchestration.confirm_uncertain_delivery(
+                record,
+                &view.status,
+                view.needs_input.as_ref(),
+                completion_seq,
+                view.tail_offset,
+            );
+            if changed {
+                apply_run_transition_metadata(record);
+            }
+            changed
+        })
     }
 
     fn sync_orchestration_for(&mut self, id: &str) {
@@ -646,6 +687,12 @@ impl Registry {
         else {
             return;
         };
+        let receipt_changed = self.reconcile_delivery_receipt(id, &view, completion_seq);
+        if receipt_changed {
+            self.dirty = true;
+            self.bump_record_version(id);
+            self.state_changes.notify();
+        }
         let orchestration_before = self.orchestration.clone();
         let run_before = self.records.get(id).and_then(|record| record.run.clone());
         let dirty_before = self.dirty;
@@ -687,36 +734,55 @@ impl Registry {
                 self.dirty = dirty_before;
                 return;
             }
+            let orchestration_intent = self.orchestration.clone();
+            let run_intent = self.records.get(id).and_then(|record| record.run.clone());
             let result = self
                 .sessions
                 .get(id)
                 .expect("session remained live")
-                .send_text(&delivery.text, delivery.submit);
+                .send_text_receipted(
+                    &delivery.text,
+                    delivery.submit,
+                    delivery.operation_id.as_deref(),
+                );
             let run_id = self
                 .records
                 .get(id)
                 .and_then(|record| record.run.as_ref().map(|run| run.id));
             let blocker = view.needs_input.clone();
-            self.orchestration.finish_dispatch(
-                id,
-                run_id,
-                delivery.submit,
-                blocker,
-                view.tail_offset,
-            );
-            if result.is_err()
-                && let Some(record) = self.records.get_mut(id)
-                && let Some(run) = record.run.as_mut()
-            {
-                run.state = diri_proto::AgentRunState::Failed;
-                run.finished_at = Some(DateMillis::from(std::time::SystemTime::now()));
-                run.terminal_outcome = Some("delivery_failed".into());
-                self.orchestration.remember_terminal(id, run.clone());
-                apply_run_transition_metadata(record);
-                run_changed = true;
+            let delivered = result.is_ok();
+            match result {
+                Ok(()) => self.orchestration.finish_dispatch(
+                    id,
+                    run_id,
+                    delivery.submit,
+                    blocker,
+                    view.tail_offset,
+                ),
+                Err(error) => {
+                    if let Some(record) = self.records.get_mut(id) {
+                        let _ = self
+                            .orchestration
+                            .mark_dispatch_uncertain(record, error.to_string());
+                        apply_run_transition_metadata(record);
+                        run_changed = true;
+                    }
+                }
             }
             self.dirty = true;
-            let _ = self.persist_now();
+            if self.persist_now().is_err() && delivered {
+                self.orchestration = orchestration_intent;
+                if let Some(record) = self.records.get_mut(id) {
+                    record.run = run_intent;
+                    let _ = self.orchestration.mark_dispatch_uncertain(
+                        record,
+                        "failed to commit queued delivery outcome".into(),
+                    );
+                    apply_run_transition_metadata(record);
+                    run_changed = true;
+                }
+                self.dirty = true;
+            }
             self.state_changes.notify();
         }
         if run_changed {
@@ -738,6 +804,19 @@ impl Registry {
         let fingerprint = request_id
             .as_ref()
             .map(|_| request_fingerprint(&(id, &text, submit, expected_run_id, allow_needs_input)));
+        let replay = self.orchestration.lookup_replay(
+            id,
+            ReplayOperation::Delivery,
+            request_id.as_deref(),
+            fingerprint.as_deref(),
+        )?;
+        if matches!(replay, Some(ReplayOutcome::OutcomeUncertain { .. }))
+            && self.sessions.contains_key(id)
+        {
+            // A response-loss retry is also a reconciliation opportunity: a
+            // surviving Holder may now prove the original Enter was accepted.
+            self.sync_run_state_for(id);
+        }
         match self.orchestration.lookup_replay(
             id,
             ReplayOperation::Delivery,
@@ -783,6 +862,7 @@ impl Registry {
                 },
             )?
         };
+        let mut intent_snapshot = None;
         if !plan.queued {
             // All agent deliveries use the same two-phase outbox as queued
             // turns. Persist before the PTY write; a restart can then expose
@@ -804,37 +884,21 @@ impl Registry {
                 }
                 return Err(RegistryRunError::Io(error));
             }
+            intent_snapshot = Some((
+                self.orchestration.clone(),
+                self.records.get(id).and_then(|record| record.run.clone()),
+            ));
             if let Err(error) = self
                 .sessions
                 .get(id)
                 .expect("checked above")
-                .send_text(&text, submit)
+                .send_text_receipted(&text, submit, plan.operation_id.as_deref())
             {
-                if let Some(record) = self.records.get_mut(id)
-                    && let Some(run) = record.run.as_mut()
-                {
-                    run.state = diri_proto::AgentRunState::Failed;
-                    run.finished_at = Some(DateMillis::from(std::time::SystemTime::now()));
-                    run.terminal_outcome = Some("delivery_failed".into());
-                    self.orchestration.remember_terminal(id, run.clone());
+                if let Some(record) = self.records.get_mut(id) {
+                    self.orchestration
+                        .mark_dispatch_uncertain(record, error.to_string())?;
                     apply_run_transition_metadata(record);
                 }
-                self.orchestration.finish_dispatch(
-                    id,
-                    plan.run.as_ref().map(|run| run.id),
-                    false,
-                    None,
-                    view.tail_offset,
-                );
-                self.orchestration.remember_replay(
-                    id,
-                    ReplayOperation::Delivery,
-                    request_id.as_deref(),
-                    fingerprint.as_deref(),
-                    ReplayOutcome::OutcomeUncertain {
-                        detail: error.to_string(),
-                    },
-                )?;
                 self.dirty = true;
                 let _ = self.persist_now();
                 return Err(RegistryRunError::OutcomeUncertain(error.to_string()));
@@ -880,6 +944,19 @@ impl Registry {
                 }
                 return Err(RegistryRunError::Io(error));
             }
+            // Disk still contains the pre-side-effect intent. Mirror that
+            // exact state in memory, then expose one uncertain result instead
+            // of replaying a success that would disappear on restart.
+            let (orchestration_intent, run_intent) =
+                intent_snapshot.expect("immediate delivery retained its durable intent");
+            self.orchestration = orchestration_intent;
+            if let Some(record) = self.records.get_mut(id) {
+                record.run = run_intent;
+                self.orchestration
+                    .mark_dispatch_uncertain(record, error.to_string())?;
+                apply_run_transition_metadata(record);
+            }
+            self.dirty = true;
             return Err(RegistryRunError::OutcomeUncertain(error.to_string()));
         }
         Ok((plan.queued, plan.run))
@@ -937,6 +1014,11 @@ impl Registry {
             Some(_) => unreachable!("operation-scoped replay variant"),
             None => {}
         }
+        self.orchestration.ensure_replay_capacity(
+            reporter,
+            ReplayOperation::Report,
+            request_id.as_deref(),
+        )?;
 
         let record = self
             .records
@@ -966,6 +1048,7 @@ impl Registry {
             internal_fingerprint.as_deref(),
         )? {
             Some(ReplayOutcome::Delivery { queued, run }) => {
+                let before_report_replay = self.orchestration.clone();
                 self.orchestration.remember_replay(
                     reporter,
                     ReplayOperation::Report,
@@ -978,7 +1061,11 @@ impl Registry {
                     },
                 )?;
                 self.dirty = true;
-                self.persist_now().map_err(RegistryRunError::Io)?;
+                if let Err(error) = self.persist_now() {
+                    self.orchestration = before_report_replay;
+                    self.dirty = true;
+                    return Err(RegistryRunError::Io(error));
+                }
                 return Ok((parent, queued, run));
             }
             Some(ReplayOutcome::OutcomeUncertain { detail }) => {
@@ -998,6 +1085,7 @@ impl Registry {
         let (queued, run) =
             self.send_run_text(&parent, text, submit, None, false, internal_request_id)?;
         self.sync_orchestration_for(reporter);
+        let before_report_replay = self.orchestration.clone();
         self.orchestration.remember_replay(
             reporter,
             ReplayOperation::Report,
@@ -1010,7 +1098,11 @@ impl Registry {
             },
         )?;
         self.dirty = true;
-        self.persist_now().map_err(RegistryRunError::Io)?;
+        if let Err(error) = self.persist_now() {
+            self.orchestration = before_report_replay;
+            self.dirty = true;
+            return Err(RegistryRunError::Io(error));
+        }
         Ok((parent, queued, run))
     }
 
@@ -1041,11 +1133,25 @@ impl Registry {
         let run_before = self.records.get(id).and_then(|record| record.run.clone());
         let dirty_before = self.dirty;
         let version_before = self.record_versions.get(id).copied();
+        let (view, completion_seq) = self
+            .sessions
+            .get(id)
+            .map(|session| (session.view(), session.turn_completion_seq()))
+            .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))?;
         {
             let record = self
                 .records
                 .get_mut(id)
                 .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))?;
+            if self.orchestration.observe(
+                record,
+                &view.status,
+                view.needs_input.as_ref(),
+                completion_seq,
+                view.tail_offset,
+            ) {
+                apply_run_transition_metadata(record);
+            }
             self.orchestration.prepare_interrupt(
                 record,
                 expected_run_id,
@@ -1070,35 +1176,31 @@ impl Registry {
             }
             return Err(RegistryRunError::Io(error));
         }
+        let orchestration_intent = self.orchestration.clone();
+        let run_intent = self.records.get(id).and_then(|record| record.run.clone());
         let write_result = self
             .sessions
             .get(id)
             .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))?
             .write_input(&[0x03]);
+        if let Err(error) = write_result {
+            let record = self
+                .records
+                .get_mut(id)
+                .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))?;
+            self.orchestration
+                .mark_interrupt_uncertain(record, error.to_string())?;
+            apply_run_transition_metadata(record);
+            self.dirty = true;
+            let _ = self.persist_now();
+            return Err(RegistryRunError::OutcomeUncertain(error.to_string()));
+        }
         let record = self
             .records
             .get_mut(id)
             .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))?;
         let run = self.orchestration.finish_interrupt(record);
         record.updated_at = DateMillis::from(std::time::SystemTime::now());
-        if let Err(error) = write_result {
-            if let Some(run) = record.run.as_mut() {
-                run.terminal_outcome = Some("interrupt_outcome_uncertain".into());
-                self.orchestration.remember_terminal(id, run.clone());
-            }
-            self.orchestration.remember_replay(
-                id,
-                ReplayOperation::Interrupt,
-                request_id.as_deref(),
-                fingerprint.as_deref(),
-                ReplayOutcome::OutcomeUncertain {
-                    detail: error.to_string(),
-                },
-            )?;
-            self.dirty = true;
-            let _ = self.persist_now();
-            return Err(RegistryRunError::OutcomeUncertain(error.to_string()));
-        }
         self.orchestration.remember_replay(
             id,
             ReplayOperation::Interrupt,
@@ -1110,6 +1212,14 @@ impl Registry {
         self.bump_record_version(id);
         self.state_changes.notify();
         if let Err(error) = self.persist_now() {
+            self.orchestration = orchestration_intent;
+            if let Some(record) = self.records.get_mut(id) {
+                record.run = run_intent;
+                self.orchestration
+                    .mark_interrupt_uncertain(record, error.to_string())?;
+                apply_run_transition_metadata(record);
+            }
+            self.dirty = true;
             return Err(RegistryRunError::OutcomeUncertain(error.to_string()));
         }
         Ok(run)

--- a/diri/crates/diri-engine/src/registry.rs
+++ b/diri/crates/diri-engine/src/registry.rs
@@ -615,15 +615,15 @@ impl Registry {
     /// Reconciles the current run without releasing its queued successor.
     /// Reports validate against this state so the report that closes run N is
     /// not made stale merely by starting acknowledged run N+1 first.
-    fn sync_run_state_for(&mut self, id: &str) {
+    fn sync_run_state_for(&mut self, id: &str) -> bool {
         let Some((view, completion_seq)) = self
             .sessions
             .get(id)
             .map(|session| (session.view(), session.turn_completion_seq()))
         else {
-            return;
+            return false;
         };
-        self.observe_run_state_for_view(id, &view, completion_seq);
+        self.observe_run_state_for_view(id, &view, completion_seq)
     }
 
     /// Every authoritative status fold first consumes Holder receipt
@@ -732,21 +732,21 @@ impl Registry {
         })
     }
 
-    fn sync_orchestration_for(&mut self, id: &str) {
+    fn sync_orchestration_for(&mut self, id: &str) -> bool {
         let Some((view, completion_seq)) = self
             .sessions
             .get(id)
             .map(|session| (session.view(), session.turn_completion_seq()))
         else {
-            return;
+            return false;
         };
-        self.observe_run_state_for_view(id, &view, completion_seq);
+        let observation_changed = self.observe_run_state_for_view(id, &view, completion_seq);
         let orchestration_before = self.orchestration.clone();
         let run_before = self.records.get(id).and_then(|record| record.run.clone());
         let dirty_before = self.dirty;
         let (delivery, mut run_changed) = {
             let Some(record) = self.records.get_mut(id) else {
-                return;
+                return observation_changed;
             };
             let previous_run = record.run.clone();
             let delivery = self.orchestration.begin_ready(
@@ -773,7 +773,7 @@ impl Registry {
                     record.run = run_before;
                 }
                 self.dirty = dirty_before;
-                return;
+                return observation_changed;
             }
             let orchestration_intent = self.orchestration.clone();
             let run_intent = self.records.get(id).and_then(|record| record.run.clone());
@@ -829,6 +829,7 @@ impl Registry {
         if run_changed {
             self.bump_record_version(id);
         }
+        observation_changed || run_changed
     }
 
     fn run_transaction_snapshot(&self, id: &str) -> RunTransactionSnapshot {
@@ -974,7 +975,9 @@ impl Registry {
         {
             // A response-loss retry is also a reconciliation opportunity: a
             // surviving Holder may now prove the original Enter was accepted.
-            self.sync_run_state_for(id);
+            if self.sync_run_state_for(id) {
+                self.persist_intent_now().map_err(RegistryRunError::Io)?;
+            }
         }
         match self.orchestration.lookup_replay(
             id,
@@ -1000,7 +1003,13 @@ impl Registry {
             ));
         }
         self.ensure_run(id)?;
-        self.sync_orchestration_for(id);
+        if self.sync_orchestration_for(id) {
+            // This is the first fold that can discover a raw successor. Land
+            // it before expected-generation validation is allowed to reject
+            // the request; the transaction's second fold is intentionally
+            // idempotent and cannot carry this durability obligation.
+            self.persist_intent_now().map_err(RegistryRunError::Io)?;
+        }
         let (view, completion_seq) = self
             .sessions
             .get(id)
@@ -1290,7 +1299,9 @@ impl Registry {
             None => {}
         }
 
-        self.sync_run_state_for(reporter);
+        if self.sync_run_state_for(reporter) {
+            self.persist_intent_now().map_err(RegistryRunError::Io)?;
+        }
         let record = self
             .records
             .get(reporter)
@@ -1343,7 +1354,9 @@ impl Registry {
             Some(_) => unreachable!("operation-scoped replay variant"),
             None => {}
         }
-        self.sync_orchestration_for(id);
+        if self.sync_orchestration_for(id) {
+            self.persist_intent_now().map_err(RegistryRunError::Io)?;
+        }
         let (view, completion_seq) = self
             .sessions
             .get(id)

--- a/diri/crates/diri-engine/src/registry.rs
+++ b/diri/crates/diri-engine/src/registry.rs
@@ -13,6 +13,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::detect::ManifestEngine;
 use crate::holder::{HolderClient, HolderManagerPaths, HolderPaths};
+use crate::orchestration::{
+    DeliveryRequest, Orchestration, ReplayOperation, ReplayOutcome, RunError, StateChanges,
+    WaitDecision, request_fingerprint,
+};
 use crate::session::{HolderConfig, RemoteAdoptSpec, Session, SessionSpec, SessionView};
 
 /// The versioned on-disk snapshot.
@@ -23,14 +27,23 @@ pub struct PersistedState {
     pub projects: Vec<serde_json::Value>,
     #[serde(default)]
     pub sessions: Vec<SessionRecord>,
+    /// Durable agent-turn outbox and acceptance guards. Older state files omit
+    /// it and migrate conservatively from their session records.
+    #[serde(default, skip_serializing_if = "Orchestration::is_empty")]
+    orchestration: Orchestration,
 }
 
 impl PersistedState {
-    fn current(sessions: Vec<SessionRecord>, projects: Vec<serde_json::Value>) -> Self {
+    fn current(
+        sessions: Vec<SessionRecord>,
+        projects: Vec<serde_json::Value>,
+        orchestration: Orchestration,
+    ) -> Self {
         Self {
             version: 1,
             projects,
             sessions,
+            orchestration,
         }
     }
 }
@@ -51,11 +64,71 @@ pub struct Registry {
     /// tab switch), and the flusher or the next persist call writes it out.
     dirty: bool,
     last_persist: Option<std::time::Instant>,
+    orchestration: Orchestration,
+    state_changes: StateChanges,
+    /// Mutations to run metadata do not necessarily change terminal status.
+    /// This parallel version keeps lifecycle-only updates event-visible.
+    record_versions: HashMap<String, u64>,
 }
 
 /// How long consecutive persists coalesce. Matches the Swift daemon's
 /// `PersistenceStore` debounce.
 const PERSIST_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(500);
+
+#[derive(Debug)]
+pub enum RegistryRunError {
+    NotFound(String),
+    NoParent,
+    Stale { expected: u64, current: u64 },
+    Exited,
+    AlreadyTerminal { current: u64 },
+    OutcomeUncertain(String),
+    InvalidRequestId,
+    RequestConflict(String),
+    Io(std::io::Error),
+}
+
+impl From<RunError> for RegistryRunError {
+    fn from(error: RunError) -> Self {
+        match error {
+            RunError::Stale { expected, current } => Self::Stale { expected, current },
+            RunError::Exited => Self::Exited,
+            RunError::AlreadyTerminal { current } => Self::AlreadyTerminal { current },
+            RunError::InvalidRequestId => Self::InvalidRequestId,
+            RunError::RequestConflict { request_id } => Self::RequestConflict(request_id),
+        }
+    }
+}
+
+impl std::fmt::Display for RegistryRunError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound(id) => write!(formatter, "no live session {id}"),
+            Self::NoParent => formatter.write_str("this session has no parent"),
+            Self::Stale { expected, current } => write!(
+                formatter,
+                "run {expected} is stale; the current run is {current}"
+            ),
+            Self::Exited => formatter.write_str("the session process has exited"),
+            Self::AlreadyTerminal { current } => {
+                write!(formatter, "run {current} is already terminal")
+            }
+            Self::OutcomeUncertain(detail) => {
+                write!(formatter, "delivery outcome is uncertain: {detail}")
+            }
+            Self::InvalidRequestId => {
+                formatter.write_str("request id must be non-empty and no longer than 256 bytes")
+            }
+            Self::RequestConflict(request_id) => write!(
+                formatter,
+                "request id {request_id:?} was already used with a different operation payload"
+            ),
+            Self::Io(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for RegistryRunError {}
 
 impl Drop for Registry {
     fn drop(&mut self) {
@@ -96,6 +169,9 @@ impl Registry {
             state_file: state_file.into(),
             dirty: false,
             last_persist: None,
+            orchestration: Orchestration::default(),
+            state_changes: StateChanges::default(),
+            record_versions: HashMap::new(),
         }
     }
 
@@ -112,7 +188,14 @@ impl Registry {
         };
         match serde_json::from_slice::<PersistedState>(&bytes) {
             Ok(state) => {
-                self.projects = state.projects;
+                let PersistedState {
+                    projects,
+                    sessions,
+                    orchestration,
+                    ..
+                } = state;
+                self.projects = projects;
+                self.orchestration = orchestration;
                 let project_roots = self
                     .projects
                     .iter()
@@ -123,9 +206,10 @@ impl Registry {
                         ))
                     })
                     .collect::<HashMap<_, _>>();
-                let mut locations = Vec::with_capacity(state.sessions.len());
-                for mut record in state.sessions {
+                let mut locations = Vec::with_capacity(sessions.len());
+                for mut record in sessions {
                     repair_persisted_agent_title(&mut record);
+                    migrate_run_lifecycle(&mut record);
                     // Resolve the owning project before repairing its
                     // location namespace. In particular, a linked worktree's
                     // cwd is not its first-level project root.
@@ -137,8 +221,20 @@ impl Registry {
                     locations.push((project_root, record.host.clone()));
                     self.records.insert(record.id.0.clone(), record);
                 }
+                let terminal_records = self.records.values().cloned().collect::<Vec<_>>();
+                for record in &terminal_records {
+                    self.orchestration.remember_current_terminal(record);
+                }
+                let recovered = self.orchestration.recover_inflight(&mut self.records);
                 for (root, host) in locations {
                     self.ensure_session_project(&root, host.as_deref());
+                }
+                // Recovery changes externally visible run outcomes. Land it
+                // before serving state so another crash cannot resurrect the
+                // original in-flight marker or regenerate timestamps.
+                if recovered {
+                    self.dirty = true;
+                    self.persist_now()?;
                 }
                 Ok(self.records.len())
             }
@@ -181,7 +277,28 @@ impl Registry {
 
     /// Writes the current state atomically, unconditionally.
     fn persist_now(&mut self) -> std::io::Result<()> {
-        let state = PersistedState::current(self.records_for_persistence(), self.projects.clone());
+        let records = self.records_for_persistence();
+        self.write_state(records)
+    }
+
+    /// Persists an operation intent without running lifecycle reconciliation
+    /// inside the write. The intent and its exact pre-side-effect run snapshot
+    /// must reach disk together; folding another live observation here could
+    /// consume the marker before the PTY write or make rollback cross-session.
+    fn persist_intent_now(&mut self) -> std::io::Result<()> {
+        let mut records: Vec<SessionRecord> = self.records.values().cloned().collect();
+        for record in &mut records {
+            if let Some(session) = self.sessions.get(&record.id.0) {
+                fold_session_status(record, &session.view());
+            }
+        }
+        records.sort_by(|a, b| a.id.0.cmp(&b.id.0));
+        self.write_state(records)
+    }
+
+    fn write_state(&mut self, records: Vec<SessionRecord>) -> std::io::Result<()> {
+        let state =
+            PersistedState::current(records, self.projects.clone(), self.orchestration.clone());
         let bytes = serde_json::to_vec(&state)?;
         let temp = self.state_file.with_extension("json.tmp");
         if let Some(parent) = self.state_file.parent() {
@@ -195,7 +312,34 @@ impl Registry {
         Ok(())
     }
 
-    fn records_for_persistence(&self) -> Vec<SessionRecord> {
+    fn records_for_persistence(&mut self) -> Vec<SessionRecord> {
+        // Fold completion edges synchronously before a durable shutdown write.
+        // The event watcher normally does this immediately, but durability
+        // must not depend on winning a scheduling race with that thread.
+        let live = self
+            .sessions
+            .iter()
+            .map(|(id, session)| (id.clone(), session.view(), session.turn_completion_seq()))
+            .collect::<Vec<_>>();
+        for (id, view, completion_seq) in live {
+            if let Some(record) = self.records.get_mut(&id) {
+                let previous = record.run.clone();
+                let changed = self.orchestration.observe(
+                    record,
+                    &view.status,
+                    view.needs_input.as_ref(),
+                    completion_seq,
+                    view.tail_offset,
+                );
+                if changed {
+                    apply_run_transition_metadata(record);
+                    if previous != record.run {
+                        let version = self.record_versions.entry(id).or_default();
+                        *version = version.saturating_add(1);
+                    }
+                }
+            }
+        }
         let mut records: Vec<SessionRecord> = self.records.values().cloned().collect();
         for record in &mut records {
             if let Some(session) = self.sessions.get(&record.id.0) {
@@ -210,14 +354,24 @@ impl Registry {
     /// imports, and tests use this; live sessions come from [`spawn`].
     ///
     /// [`spawn`]: Registry::spawn
-    pub fn insert_record(&mut self, record: SessionRecord) {
+    pub fn insert_record(&mut self, mut record: SessionRecord) {
+        migrate_run_lifecycle(&mut record);
+        self.orchestration.remember_current_terminal(&record);
         self.records.insert(record.id.0.clone(), record);
     }
 
     /// Starts a session and takes ownership of it.
-    pub fn spawn(&mut self, spec: SessionSpec, record: SessionRecord) -> std::io::Result<String> {
+    pub fn spawn(
+        &mut self,
+        spec: SessionSpec,
+        mut record: SessionRecord,
+    ) -> std::io::Result<String> {
         let id = spec.id.clone();
+        migrate_run_lifecycle(&mut record);
         let session = Session::spawn(spec, Arc::clone(&self.engine))?;
+        session.bind_state_changes(self.state_changes.clone());
+        self.orchestration
+            .register(&record, session.turn_completion_seq(), &session.status());
         self.records.insert(id.clone(), record);
         self.sessions.insert(id.clone(), session);
         Ok(id)
@@ -243,6 +397,12 @@ impl Registry {
             Arc::clone(&self.engine),
             initial_status,
         )?;
+        session.bind_state_changes(self.state_changes.clone());
+        self.orchestration.register_adopted(
+            self.records.get(&id).expect("checked above"),
+            session.turn_completion_seq(),
+            &session.status(),
+        );
         self.sessions.insert(id.clone(), session);
         Ok(id)
     }
@@ -290,6 +450,7 @@ impl Registry {
             return;
         }
         for id in &orphaned {
+            let mut terminal = None;
             if let Some(record) = self.records.get_mut(id) {
                 record.status = SessionStatus::Exited(ExitInfo {
                     reason: ExitReason::DaemonRestart,
@@ -297,6 +458,18 @@ impl Registry {
                     signal: None,
                 });
                 record.needs_input = None;
+                if let Some(run) = record.run.as_mut()
+                    && !run.state.is_terminal()
+                {
+                    run.state = diri_proto::AgentRunState::Failed;
+                    run.finished_at = Some(DateMillis::from(std::time::SystemTime::now()));
+                    run.terminal_outcome = Some("daemon_restart".into());
+                    terminal = Some(run.clone());
+                    apply_run_transition_metadata(record);
+                }
+            }
+            if let Some(run) = terminal {
+                self.orchestration.remember_terminal(id, run);
             }
         }
         let _ = self.persist();
@@ -364,6 +537,12 @@ impl Registry {
                     if was_hibernated {
                         let _ = session.set_hibernated(true);
                     }
+                    session.bind_state_changes(self.state_changes.clone());
+                    self.orchestration.register_adopted(
+                        self.records.get(&session_id).expect("record exists"),
+                        session.turn_completion_seq(),
+                        &session.status(),
+                    );
                     self.sessions.insert(session_id.clone(), session);
                     adopted.push(session_id);
                 }
@@ -398,6 +577,569 @@ impl Registry {
         }
         records.sort_by(|a, b| a.id.0.cmp(&b.id.0));
         records
+    }
+
+    /// Shared edge-triggered wake source for event and embedded MCP waits.
+    pub fn state_changes(&self) -> StateChanges {
+        self.state_changes.clone()
+    }
+
+    /// Single run-aware wait decision used by every transport. Historical
+    /// terminal outcomes, queued futures, and dead sessions therefore cannot
+    /// diverge between control and embedded MCP.
+    pub(crate) fn wait_decision(
+        &self,
+        id: &str,
+        run_id: Option<u64>,
+        targets: &[String],
+    ) -> Option<WaitDecision> {
+        let mut record = self.records.get(id)?.clone();
+        self.fold_live(&mut record);
+        Some(self.orchestration.wait_decision(&record, run_id, targets))
+    }
+
+    /// Reconciles explicit run states and releases at most one queued message
+    /// for each session whose composer is now safe.
+    pub fn sync_orchestration(&mut self) {
+        let ids: Vec<String> = self.sessions.keys().cloned().collect();
+        for id in ids {
+            self.sync_orchestration_for(&id);
+        }
+    }
+
+    /// Reconciles the current run without releasing its queued successor.
+    /// Reports validate against this state so the report that closes run N is
+    /// not made stale merely by starting acknowledged run N+1 first.
+    fn sync_run_state_for(&mut self, id: &str) {
+        let Some((view, completion_seq)) = self
+            .sessions
+            .get(id)
+            .map(|session| (session.view(), session.turn_completion_seq()))
+        else {
+            return;
+        };
+        let changed = self.records.get_mut(id).is_some_and(|record| {
+            let changed = self.orchestration.observe(
+                record,
+                &view.status,
+                view.needs_input.as_ref(),
+                completion_seq,
+                view.tail_offset,
+            );
+            if changed {
+                apply_run_transition_metadata(record);
+            }
+            changed
+        });
+        if changed {
+            self.dirty = true;
+            self.bump_record_version(id);
+            self.state_changes.notify();
+        }
+    }
+
+    fn sync_orchestration_for(&mut self, id: &str) {
+        let Some((view, completion_seq)) = self
+            .sessions
+            .get(id)
+            .map(|session| (session.view(), session.turn_completion_seq()))
+        else {
+            return;
+        };
+        let orchestration_before = self.orchestration.clone();
+        let run_before = self.records.get(id).and_then(|record| record.run.clone());
+        let dirty_before = self.dirty;
+        let (delivery, mut run_changed) = {
+            let Some(record) = self.records.get_mut(id) else {
+                return;
+            };
+            let previous_run = record.run.clone();
+            let changed = self.orchestration.observe(
+                record,
+                &view.status,
+                view.needs_input.as_ref(),
+                completion_seq,
+                view.tail_offset,
+            );
+            if changed {
+                apply_run_transition_metadata(record);
+                self.dirty = true;
+            }
+            let delivery = self.orchestration.begin_ready(
+                record,
+                &view.status,
+                view.needs_input.as_ref(),
+                completion_seq,
+                view.tail_offset,
+            );
+            (delivery, previous_run != record.run)
+        };
+        if let Some(delivery) = delivery {
+            // Persist the outbox's dispatch phase before touching the PTY. If
+            // the process dies after this write, restart fails the run closed
+            // rather than silently replaying an acknowledged turn.
+            self.dirty = true;
+            if let Err(_error) = self.persist_intent_now() {
+                self.orchestration = orchestration_before;
+                if let Some(record) = self.records.get_mut(id) {
+                    record.run = run_before;
+                }
+                self.dirty = dirty_before;
+                return;
+            }
+            let result = self
+                .sessions
+                .get(id)
+                .expect("session remained live")
+                .send_text(&delivery.text, delivery.submit);
+            let run_id = self
+                .records
+                .get(id)
+                .and_then(|record| record.run.as_ref().map(|run| run.id));
+            let blocker = view.needs_input.clone();
+            self.orchestration.finish_dispatch(
+                id,
+                run_id,
+                delivery.submit,
+                blocker,
+                view.tail_offset,
+            );
+            if result.is_err()
+                && let Some(record) = self.records.get_mut(id)
+                && let Some(run) = record.run.as_mut()
+            {
+                run.state = diri_proto::AgentRunState::Failed;
+                run.finished_at = Some(DateMillis::from(std::time::SystemTime::now()));
+                run.terminal_outcome = Some("delivery_failed".into());
+                self.orchestration.remember_terminal(id, run.clone());
+                apply_run_transition_metadata(record);
+                run_changed = true;
+            }
+            self.dirty = true;
+            let _ = self.persist_now();
+            self.state_changes.notify();
+        }
+        if run_changed {
+            self.bump_record_version(id);
+        }
+    }
+
+    /// Sends now only at a manifest-derived safe input state; otherwise keeps
+    /// the message FIFO inside the Engine across MCP process reconnects.
+    pub fn send_run_text(
+        &mut self,
+        id: &str,
+        text: String,
+        submit: bool,
+        expected_run_id: Option<u64>,
+        allow_needs_input: bool,
+        request_id: Option<String>,
+    ) -> Result<(bool, Option<diri_proto::AgentRun>), RegistryRunError> {
+        let fingerprint = request_id
+            .as_ref()
+            .map(|_| request_fingerprint(&(id, &text, submit, expected_run_id, allow_needs_input)));
+        match self.orchestration.lookup_replay(
+            id,
+            ReplayOperation::Delivery,
+            request_id.as_deref(),
+            fingerprint.as_deref(),
+        )? {
+            Some(ReplayOutcome::Delivery { queued, run }) => return Ok((queued, run)),
+            Some(ReplayOutcome::OutcomeUncertain { detail }) => {
+                return Err(RegistryRunError::OutcomeUncertain(detail));
+            }
+            Some(_) => unreachable!("operation-scoped replay variant"),
+            None => {}
+        }
+        self.ensure_run(id)?;
+        self.sync_orchestration_for(id);
+        let (view, completion_seq) = self
+            .sessions
+            .get(id)
+            .map(|session| (session.view(), session.turn_completion_seq()))
+            .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))?;
+        let orchestration_before = self.orchestration.clone();
+        let run_before = self.records.get(id).and_then(|record| record.run.clone());
+        let dirty_before = self.dirty;
+        let version_before = self.record_versions.get(id).copied();
+        let plan = {
+            let record = self
+                .records
+                .get_mut(id)
+                .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))?;
+            self.orchestration.prepare_delivery(
+                record,
+                DeliveryRequest {
+                    status: &view.status,
+                    needs_input: view.needs_input.as_ref(),
+                    completion_seq,
+                    output_offset: view.tail_offset,
+                    expected_run_id,
+                    text: text.clone(),
+                    submit,
+                    allow_needs_input,
+                    request_id: request_id.as_deref(),
+                    request_fingerprint: fingerprint.as_deref(),
+                },
+            )?
+        };
+        if !plan.queued {
+            // All agent deliveries use the same two-phase outbox as queued
+            // turns. Persist before the PTY write; a restart can then expose
+            // uncertainty but can never silently forget or duplicate it.
+            self.dirty = true;
+            if let Err(error) = self.persist_intent_now() {
+                self.orchestration = orchestration_before;
+                if let Some(record) = self.records.get_mut(id) {
+                    record.run = run_before;
+                }
+                self.dirty = dirty_before;
+                match version_before {
+                    Some(version) => {
+                        self.record_versions.insert(id.to_owned(), version);
+                    }
+                    None => {
+                        self.record_versions.remove(id);
+                    }
+                }
+                return Err(RegistryRunError::Io(error));
+            }
+            if let Err(error) = self
+                .sessions
+                .get(id)
+                .expect("checked above")
+                .send_text(&text, submit)
+            {
+                if let Some(record) = self.records.get_mut(id)
+                    && let Some(run) = record.run.as_mut()
+                {
+                    run.state = diri_proto::AgentRunState::Failed;
+                    run.finished_at = Some(DateMillis::from(std::time::SystemTime::now()));
+                    run.terminal_outcome = Some("delivery_failed".into());
+                    self.orchestration.remember_terminal(id, run.clone());
+                    apply_run_transition_metadata(record);
+                }
+                self.orchestration.finish_dispatch(
+                    id,
+                    plan.run.as_ref().map(|run| run.id),
+                    false,
+                    None,
+                    view.tail_offset,
+                );
+                self.orchestration.remember_replay(
+                    id,
+                    ReplayOperation::Delivery,
+                    request_id.as_deref(),
+                    fingerprint.as_deref(),
+                    ReplayOutcome::OutcomeUncertain {
+                        detail: error.to_string(),
+                    },
+                )?;
+                self.dirty = true;
+                let _ = self.persist_now();
+                return Err(RegistryRunError::OutcomeUncertain(error.to_string()));
+            }
+            self.orchestration.finish_dispatch(
+                id,
+                plan.run.as_ref().map(|run| run.id),
+                submit,
+                view.needs_input,
+                view.tail_offset,
+            );
+        }
+        self.orchestration.remember_replay(
+            id,
+            ReplayOperation::Delivery,
+            request_id.as_deref(),
+            fingerprint.as_deref(),
+            ReplayOutcome::Delivery {
+                queued: plan.queued,
+                run: plan.run.clone(),
+            },
+        )?;
+        self.dirty = true;
+        self.bump_record_version(id);
+        self.state_changes.notify();
+        // A queued acknowledgement is durable before it leaves the Engine.
+        // Immediate delivery is also landed so its acceptance guard survives
+        // an MCP process or daemon restart.
+        if let Err(error) = self.persist_intent_now() {
+            if plan.queued {
+                self.orchestration = orchestration_before;
+                if let Some(record) = self.records.get_mut(id) {
+                    record.run = run_before;
+                }
+                self.dirty = dirty_before;
+                match version_before {
+                    Some(version) => {
+                        self.record_versions.insert(id.to_owned(), version);
+                    }
+                    None => {
+                        self.record_versions.remove(id);
+                    }
+                }
+                return Err(RegistryRunError::Io(error));
+            }
+            return Err(RegistryRunError::OutcomeUncertain(error.to_string()));
+        }
+        Ok((plan.queued, plan.run))
+    }
+
+    /// Compatibility input seam for existing app/CLI callers. Submitted
+    /// prompts into agent sessions enter the same durable run coordinator;
+    /// shell commands and unsubmitted composer edits retain raw PTY behavior.
+    pub fn send_user_text(
+        &mut self,
+        id: &str,
+        text: String,
+        submit: bool,
+    ) -> Result<(), RegistryRunError> {
+        let is_agent = self
+            .records
+            .get(id)
+            .is_some_and(|record| record.kind != diri_proto::AgentKind::SHELL);
+        if submit && is_agent {
+            let _ = self.send_run_text(id, text, true, None, true, None)?;
+            return Ok(());
+        }
+        self.sessions
+            .get(id)
+            .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))?
+            .send_text(&text, submit)
+            .map_err(RegistryRunError::Io)
+    }
+
+    pub fn report_to_parent(
+        &mut self,
+        reporter: &str,
+        text: String,
+        submit: bool,
+        expected_run_id: Option<u64>,
+        request_id: Option<String>,
+    ) -> Result<(String, bool, Option<diri_proto::AgentRun>), RegistryRunError> {
+        let fingerprint = request_id
+            .as_ref()
+            .map(|_| request_fingerprint(&(reporter, &text, submit, expected_run_id)));
+        match self.orchestration.lookup_replay(
+            reporter,
+            ReplayOperation::Report,
+            request_id.as_deref(),
+            fingerprint.as_deref(),
+        )? {
+            Some(ReplayOutcome::Report {
+                parent,
+                queued,
+                run,
+            }) => return Ok((parent, queued, run)),
+            Some(ReplayOutcome::OutcomeUncertain { detail }) => {
+                return Err(RegistryRunError::OutcomeUncertain(detail));
+            }
+            Some(_) => unreachable!("operation-scoped replay variant"),
+            None => {}
+        }
+
+        let record = self
+            .records
+            .get(reporter)
+            .ok_or_else(|| RegistryRunError::NotFound(reporter.to_owned()))?;
+        let parent = record
+            .parent
+            .as_ref()
+            .map(|parent| parent.0.clone())
+            .ok_or(RegistryRunError::NoParent)?;
+        let internal_request_id = request_id.as_ref().map(|request_id| {
+            format!(
+                "report:{}",
+                request_fingerprint(&(reporter, request_id.as_str()))
+            )
+        });
+        let internal_fingerprint = internal_request_id.as_ref().map(|_| {
+            request_fingerprint(&(parent.as_str(), &text, submit, Option::<u64>::None, false))
+        });
+        // If the parent delivery committed but the daemon died before the
+        // reporter replay record landed, the parent's internal replay is the
+        // atomic evidence needed to reconstruct the original response.
+        match self.orchestration.lookup_replay(
+            &parent,
+            ReplayOperation::Delivery,
+            internal_request_id.as_deref(),
+            internal_fingerprint.as_deref(),
+        )? {
+            Some(ReplayOutcome::Delivery { queued, run }) => {
+                self.orchestration.remember_replay(
+                    reporter,
+                    ReplayOperation::Report,
+                    request_id.as_deref(),
+                    fingerprint.as_deref(),
+                    ReplayOutcome::Report {
+                        parent: parent.clone(),
+                        queued,
+                        run: run.clone(),
+                    },
+                )?;
+                self.dirty = true;
+                self.persist_now().map_err(RegistryRunError::Io)?;
+                return Ok((parent, queued, run));
+            }
+            Some(ReplayOutcome::OutcomeUncertain { detail }) => {
+                return Err(RegistryRunError::OutcomeUncertain(detail));
+            }
+            Some(_) => unreachable!("operation-scoped replay variant"),
+            None => {}
+        }
+
+        self.sync_run_state_for(reporter);
+        let record = self
+            .records
+            .get(reporter)
+            .ok_or_else(|| RegistryRunError::NotFound(reporter.to_owned()))?;
+        Orchestration::validate_expected(record, expected_run_id)?;
+        self.ensure_run(&parent)?;
+        let (queued, run) =
+            self.send_run_text(&parent, text, submit, None, false, internal_request_id)?;
+        self.sync_orchestration_for(reporter);
+        self.orchestration.remember_replay(
+            reporter,
+            ReplayOperation::Report,
+            request_id.as_deref(),
+            fingerprint.as_deref(),
+            ReplayOutcome::Report {
+                parent: parent.clone(),
+                queued,
+                run: run.clone(),
+            },
+        )?;
+        self.dirty = true;
+        self.persist_now().map_err(RegistryRunError::Io)?;
+        Ok((parent, queued, run))
+    }
+
+    pub fn interrupt_run(
+        &mut self,
+        id: &str,
+        expected_run_id: Option<u64>,
+        request_id: Option<String>,
+    ) -> Result<diri_proto::AgentRun, RegistryRunError> {
+        let fingerprint = request_id
+            .as_ref()
+            .map(|_| request_fingerprint(&(id, expected_run_id)));
+        match self.orchestration.lookup_replay(
+            id,
+            ReplayOperation::Interrupt,
+            request_id.as_deref(),
+            fingerprint.as_deref(),
+        )? {
+            Some(ReplayOutcome::Interrupt { run }) => return Ok(run),
+            Some(ReplayOutcome::OutcomeUncertain { detail }) => {
+                return Err(RegistryRunError::OutcomeUncertain(detail));
+            }
+            Some(_) => unreachable!("operation-scoped replay variant"),
+            None => {}
+        }
+        self.sync_orchestration_for(id);
+        let orchestration_before = self.orchestration.clone();
+        let run_before = self.records.get(id).and_then(|record| record.run.clone());
+        let dirty_before = self.dirty;
+        let version_before = self.record_versions.get(id).copied();
+        {
+            let record = self
+                .records
+                .get_mut(id)
+                .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))?;
+            self.orchestration.prepare_interrupt(
+                record,
+                expected_run_id,
+                request_id.as_deref(),
+                fingerprint.as_deref(),
+            )?;
+        }
+        self.dirty = true;
+        if let Err(error) = self.persist_intent_now() {
+            self.orchestration = orchestration_before;
+            if let Some(record) = self.records.get_mut(id) {
+                record.run = run_before;
+            }
+            self.dirty = dirty_before;
+            match version_before {
+                Some(version) => {
+                    self.record_versions.insert(id.to_owned(), version);
+                }
+                None => {
+                    self.record_versions.remove(id);
+                }
+            }
+            return Err(RegistryRunError::Io(error));
+        }
+        let write_result = self
+            .sessions
+            .get(id)
+            .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))?
+            .write_input(&[0x03]);
+        let record = self
+            .records
+            .get_mut(id)
+            .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))?;
+        let run = self.orchestration.finish_interrupt(record);
+        record.updated_at = DateMillis::from(std::time::SystemTime::now());
+        if let Err(error) = write_result {
+            if let Some(run) = record.run.as_mut() {
+                run.terminal_outcome = Some("interrupt_outcome_uncertain".into());
+                self.orchestration.remember_terminal(id, run.clone());
+            }
+            self.orchestration.remember_replay(
+                id,
+                ReplayOperation::Interrupt,
+                request_id.as_deref(),
+                fingerprint.as_deref(),
+                ReplayOutcome::OutcomeUncertain {
+                    detail: error.to_string(),
+                },
+            )?;
+            self.dirty = true;
+            let _ = self.persist_now();
+            return Err(RegistryRunError::OutcomeUncertain(error.to_string()));
+        }
+        self.orchestration.remember_replay(
+            id,
+            ReplayOperation::Interrupt,
+            request_id.as_deref(),
+            fingerprint.as_deref(),
+            ReplayOutcome::Interrupt { run: run.clone() },
+        )?;
+        self.dirty = true;
+        self.bump_record_version(id);
+        self.state_changes.notify();
+        if let Err(error) = self.persist_now() {
+            return Err(RegistryRunError::OutcomeUncertain(error.to_string()));
+        }
+        Ok(run)
+    }
+
+    /// Ensures any agent session observed through orchestration has a run,
+    /// including roots and records loaded from a pre-lifecycle state file.
+    fn ensure_run(&mut self, id: &str) -> Result<(), RegistryRunError> {
+        let changed = {
+            let record = self
+                .records
+                .get_mut(id)
+                .ok_or_else(|| RegistryRunError::NotFound(id.to_owned()))?;
+            if record.kind != diri_proto::AgentKind::SHELL && record.run.is_none() {
+                record.run = Some(run_from_legacy_record(record));
+                true
+            } else {
+                false
+            }
+        };
+        if changed {
+            self.bump_record_version(id);
+            self.dirty = true;
+        }
+        Ok(())
+    }
+
+    fn bump_record_version(&mut self, id: &str) {
+        let version = self.record_versions.entry(id.to_owned()).or_default();
+        *version = version.saturating_add(1);
     }
 
     /// One record with live status folded in, without cloning the whole table.
@@ -451,7 +1193,7 @@ impl Registry {
     /// serialization.
     pub fn changed_since(
         &mut self,
-        published: &mut HashMap<String, u64>,
+        published: &mut HashMap<String, (u64, u64)>,
     ) -> Vec<(String, SessionRecord)> {
         published.retain(|id, _| self.sessions.contains_key(id));
         let mut changed = Vec::new();
@@ -459,24 +1201,52 @@ impl Registry {
             .sessions
             .iter()
             .filter_map(|(id, session)| {
-                let version = session.state_version();
-                (published.get(id) != Some(&version)).then(|| (id.clone(), version, session.view()))
+                let session_version = session.state_version();
+                let record_version = self.record_versions.get(id).copied().unwrap_or(0);
+                (published.get(id) != Some(&(session_version, record_version)))
+                    .then(|| (id.clone(), session_version, session.view()))
             })
             .collect::<Vec<_>>();
         let mut title_changed = false;
-        for (id, version, view) in changed_views {
-            published.insert(id.clone(), version);
+        for (id, session_version, view) in changed_views {
+            let mut lifecycle_changed = false;
             if let Some(record) = self.records.get_mut(&id) {
                 let previous_title = (record.title.clone(), record.title_source);
                 fold_session_view(record, &view);
+                let completion_seq = self
+                    .sessions
+                    .get(&id)
+                    .map_or(0, Session::turn_completion_seq);
+                let run_changed = self.orchestration.observe(
+                    record,
+                    &view.status,
+                    view.needs_input.as_ref(),
+                    completion_seq,
+                    view.tail_offset,
+                );
+                lifecycle_changed = run_changed;
                 let record_title_changed =
                     previous_title != (record.title.clone(), record.title_source);
-                if record_title_changed {
+                if run_changed {
+                    apply_run_transition_metadata(record);
+                } else if record_title_changed {
                     record.updated_at = DateMillis::from(std::time::SystemTime::now());
+                }
+                if record_title_changed || run_changed {
                     title_changed = true;
                 }
-                changed.push((id, record.clone()));
+                changed.push((id.clone(), record.clone()));
             }
+            if lifecycle_changed {
+                self.bump_record_version(&id);
+            }
+            published.insert(
+                id.clone(),
+                (
+                    session_version,
+                    self.record_versions.get(&id).copied().unwrap_or(0),
+                ),
+            );
         }
         if title_changed {
             self.dirty = true;
@@ -493,9 +1263,11 @@ impl Registry {
         let Some(mut session) = self.sessions.remove(id) else {
             return Ok(None);
         };
+        let completion_seq = session.turn_completion_seq();
+        let output_offset = session.view().tail_offset;
         let exit = session.terminate(grace)?;
         if let Some(record) = self.records.get_mut(id) {
-            record.status = SessionStatus::Exited(diri_proto::ExitInfo {
+            let status = SessionStatus::Exited(diri_proto::ExitInfo {
                 reason: match exit {
                     crate::pty::Exit::Signal(_) => diri_proto::ExitReason::Signaled,
                     crate::pty::Exit::Code(_) => diri_proto::ExitReason::Exited,
@@ -509,7 +1281,14 @@ impl Registry {
                     crate::pty::Exit::Code(_) => None,
                 },
             });
+            record.status.clone_from(&status);
+            let _ =
+                self.orchestration
+                    .observe(record, &status, None, completion_seq, output_offset);
+            apply_run_transition_metadata(record);
+            record.updated_at = DateMillis::from(std::time::SystemTime::now());
         }
+        self.state_changes.notify();
         Ok(Some(exit))
     }
 
@@ -517,6 +1296,8 @@ impl Registry {
     pub fn forget(&mut self, id: &str) {
         self.sessions.remove(id);
         self.records.remove(id);
+        self.orchestration.forget(id);
+        self.record_versions.remove(id);
     }
 
     /// Ends the session (if live), deletes its record AND its output log.
@@ -533,6 +1314,8 @@ impl Registry {
             self.recently_closed.remove(0);
         }
         self.sessions.remove(id);
+        self.orchestration.forget(id);
+        self.record_versions.remove(id);
         let _ = std::fs::remove_file(logs_dir.join(format!("{id}.bin")));
         Ok(())
     }
@@ -545,6 +1328,7 @@ impl Registry {
             if record.host.is_none() && !Path::new(&record.cwd).exists() {
                 continue; // the folder is gone; try the next candidate
             }
+            self.orchestration.remember_current_terminal(&record);
             self.records.insert(record.id.0.clone(), record.clone());
             return Some(record);
         }
@@ -558,11 +1342,27 @@ impl Registry {
             return Err(not_found(&id));
         }
         let session = Session::spawn(spec, Arc::clone(&self.engine))?;
-        self.sessions.insert(id.clone(), session);
+        session.bind_state_changes(self.state_changes.clone());
+        if let Some(previous) = self.records.get(&id).cloned() {
+            self.orchestration.remember_current_terminal(&previous);
+        }
         let record = self.records.get_mut(&id).expect("checked above");
         record.status = SessionStatus::Starting;
         record.needs_input = None;
+        if let Some(run) = record.run.as_mut()
+            && run.state.is_terminal()
+        {
+            *run = diri_proto::AgentRun::starting(
+                run.id.saturating_add(1),
+                DateMillis::from(std::time::SystemTime::now()),
+            );
+        }
         record.updated_at = DateMillis::from(std::time::SystemTime::now());
+        self.orchestration
+            .register(record, session.turn_completion_seq(), &session.status());
+        self.sessions.insert(id.clone(), session);
+        self.bump_record_version(&id);
+        self.state_changes.notify();
         Ok(())
     }
 
@@ -1028,6 +1828,62 @@ fn repair_persisted_agent_title(record: &mut SessionRecord) -> bool {
     }
 }
 
+/// Additive migration for records created before explicit runs existed. Agent
+/// roots participate too: they are the usual destination for child reports,
+/// so leaving them untracked would bypass safe-composer/FIFO guarantees.
+fn migrate_run_lifecycle(record: &mut SessionRecord) {
+    if record.kind == diri_proto::AgentKind::SHELL || record.run.is_some() {
+        return;
+    }
+    use diri_proto::{AgentRun, AgentRunState};
+    let state = match &record.status {
+        SessionStatus::Working => AgentRunState::Running,
+        SessionStatus::NeedsInput(_) => AgentRunState::NeedsInput,
+        SessionStatus::Exited(_) => AgentRunState::Failed,
+        SessionStatus::Idle if record.last_turn_completed_at.is_some() => AgentRunState::Completed,
+        SessionStatus::Starting | SessionStatus::Idle | SessionStatus::Unknown => {
+            AgentRunState::Starting
+        }
+    };
+    let terminal = state.is_terminal();
+    record.run = Some(AgentRun {
+        id: 1,
+        state,
+        started_at: record.created_at,
+        finished_at: terminal.then_some(record.updated_at),
+        terminal_outcome: terminal.then(|| {
+            if matches!(state, AgentRunState::Completed) {
+                "completed"
+            } else {
+                "process_exited"
+            }
+            .into()
+        }),
+    });
+}
+
+fn run_from_legacy_record(record: &SessionRecord) -> diri_proto::AgentRun {
+    let mut migrated = record.clone();
+    migrate_run_lifecycle(&mut migrated);
+    migrated
+        .run
+        .unwrap_or_else(|| diri_proto::AgentRun::starting(1, record.created_at))
+}
+
+/// Every run transition updates the same metadata regardless of whether the
+/// event watcher, shutdown persistence, or an explicit control mutation saw
+/// it first.
+fn apply_run_transition_metadata(record: &mut SessionRecord) {
+    record.updated_at = DateMillis::from(std::time::SystemTime::now());
+    if record
+        .run
+        .as_ref()
+        .is_some_and(|run| run.state.is_terminal())
+    {
+        record.last_turn_completed_at = record.run.as_ref().and_then(|run| run.finished_at);
+    }
+}
+
 fn fold_session_status(record: &mut SessionRecord, view: &SessionView) {
     record.status.clone_from(&view.status);
     // Keep evidence only when it explains this exact canonical state. This is
@@ -1098,7 +1954,10 @@ pub(crate) fn session_project_id(root: &str, host: Option<&str>) -> diri_proto::
 #[cfg(test)]
 mod tests {
     use super::*;
-    use diri_proto::{AgentKind, DateMillis, ProjectId, Resumability, SessionId, TitleSource};
+    use diri_proto::{
+        AgentKind, AgentRun, AgentRunState, DateMillis, ProjectId, Resumability, SessionId,
+        TitleSource,
+    };
 
     fn record(id: &str) -> SessionRecord {
         SessionRecord {
@@ -1132,6 +1991,7 @@ mod tests {
             pull_requests: None,
             listening_ports: None,
             foreground_agent: None,
+            run: None,
         }
     }
 
@@ -1149,7 +2009,15 @@ mod tests {
         let state_file = temp.path().join("state.json");
 
         let mut registry = Registry::new(engine(), &state_file);
-        registry.records.insert("s_1".into(), record("s_1"));
+        let mut original = record("s_1");
+        original.run = Some(AgentRun {
+            id: 9,
+            state: AgentRunState::NeedsInput,
+            started_at: DateMillis(10.0),
+            finished_at: None,
+            terminal_outcome: None,
+        });
+        registry.records.insert("s_1".into(), original);
         registry.persist().expect("persist");
 
         // The shape on disk is what the Swift daemon expects.
@@ -1162,7 +2030,146 @@ mod tests {
 
         let mut reloaded = Registry::new(engine(), &state_file);
         assert_eq!(reloaded.load().expect("load"), 1);
-        assert_eq!(reloaded.records()[0].id.0, "s_1");
+        let reloaded = reloaded.records().pop().expect("session");
+        assert_eq!(reloaded.id.0, "s_1");
+        assert_eq!(reloaded.run.expect("run").state, AgentRunState::NeedsInput);
+    }
+
+    #[test]
+    fn acknowledged_future_turns_survive_an_engine_restart() {
+        let temp = tempfile::tempdir().expect("temp");
+        let state_file = temp.path().join("state.json");
+        let mut registry = Registry::new(engine(), &state_file);
+        let mut agent = record("s_agent");
+        agent.kind = AgentKind::CODEX;
+        agent.status = SessionStatus::Working;
+        agent.run = Some(AgentRun {
+            id: 1,
+            state: AgentRunState::Running,
+            started_at: DateMillis(1.0),
+            finished_at: None,
+            terminal_outcome: None,
+        });
+        registry.records.insert("s_agent".into(), agent.clone());
+        registry
+            .orchestration
+            .register(&agent, 0, &SessionStatus::Working);
+        let plan = registry
+            .orchestration
+            .prepare_delivery(
+                registry.records.get_mut("s_agent").unwrap(),
+                DeliveryRequest {
+                    status: &SessionStatus::Working,
+                    needs_input: None,
+                    completion_seq: 0,
+                    output_offset: 0,
+                    expected_run_id: Some(1),
+                    text: "survive restart".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: None,
+                    request_fingerprint: None,
+                },
+            )
+            .unwrap();
+        assert!(plan.queued);
+        assert_eq!(plan.run.as_ref().unwrap().id, 2);
+        registry.persist().expect("persist queue");
+
+        let raw: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&state_file).unwrap()).unwrap();
+        assert_eq!(
+            raw["orchestration"]["pending"]["s_agent"][0]["text"],
+            "survive restart"
+        );
+
+        let mut reloaded = Registry::new(engine(), &state_file);
+        reloaded.load().expect("reload");
+        let record = reloaded.records.get("s_agent").unwrap();
+        assert_eq!(reloaded.orchestration.latest_run_id(record), 2);
+        assert_eq!(record.run.as_ref().unwrap().id, 1);
+    }
+
+    #[test]
+    fn a_crash_during_dispatch_fails_closed_instead_of_replaying() {
+        let temp = tempfile::tempdir().expect("temp");
+        let state_file = temp.path().join("state.json");
+        let mut registry = Registry::new(engine(), &state_file);
+        let mut agent = record("s_agent");
+        agent.kind = AgentKind::CODEX;
+        agent.status = SessionStatus::Idle;
+        agent.run = Some(AgentRun::starting(1, DateMillis(1.0)));
+        registry.records.insert("s_agent".into(), agent.clone());
+        registry
+            .orchestration
+            .register(&agent, 0, &SessionStatus::Idle);
+        let plan = registry
+            .orchestration
+            .prepare_delivery(
+                registry.records.get_mut("s_agent").unwrap(),
+                DeliveryRequest {
+                    status: &SessionStatus::Idle,
+                    needs_input: None,
+                    completion_seq: 0,
+                    output_offset: 0,
+                    expected_run_id: Some(1),
+                    text: "maybe sent".into(),
+                    submit: true,
+                    allow_needs_input: true,
+                    request_id: None,
+                    request_fingerprint: None,
+                },
+            )
+            .unwrap();
+        assert!(!plan.queued, "safe sends enter dispatch directly");
+        registry.persist().expect("persist dispatch");
+
+        let mut reloaded = Registry::new(engine(), &state_file);
+        reloaded.load().expect("reload");
+        let run = reloaded
+            .records
+            .get("s_agent")
+            .unwrap()
+            .run
+            .as_ref()
+            .unwrap();
+        assert_eq!(run.state, AgentRunState::Failed);
+        assert_eq!(
+            run.terminal_outcome.as_deref(),
+            Some("delivery_outcome_uncertain")
+        );
+        let first_finished_at = run.finished_at;
+        let recovered: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&state_file).unwrap()).unwrap();
+        assert!(recovered["orchestration"]["dispatching"].is_null());
+        assert!(recovered["orchestration"]["uncertainDeliveries"]["s_agent"].is_object());
+
+        let mut reloaded_again = Registry::new(engine(), &state_file);
+        reloaded_again.load().expect("second reload");
+        let second_finished_at = reloaded_again.records["s_agent"]
+            .run
+            .as_ref()
+            .unwrap()
+            .finished_at
+            .unwrap();
+        assert!(
+            (second_finished_at.0 - first_finished_at.unwrap().0).abs() < 0.001,
+            "recovery must be landed once rather than regenerated every restart"
+        );
+    }
+
+    #[test]
+    fn legacy_agent_records_gain_a_conservative_explicit_run() {
+        let mut child = record("legacy");
+        child.kind = AgentKind::CODEX;
+        child.parent = Some(SessionId::new("parent"));
+        child.status = SessionStatus::NeedsInput(diri_proto::NeedsInputKind::Question);
+        migrate_run_lifecycle(&mut child);
+        assert_eq!(child.run.unwrap().state, AgentRunState::NeedsInput);
+
+        let mut shell = record("shell");
+        migrate_run_lifecycle(&mut shell);
+        assert!(shell.run.is_none(), "raw terminals have no agent turn");
     }
 
     #[test]
@@ -1207,7 +2214,8 @@ mod tests {
         let mut build = record("build");
         build.cwd = "/srv/app".into();
         build.host = Some("build".into());
-        let state = PersistedState::current(vec![forge, build], Vec::new());
+        let state =
+            PersistedState::current(vec![forge, build], Vec::new(), Orchestration::default());
         std::fs::write(&state_file, serde_json::to_vec(&state).expect("encode")).expect("write");
 
         let mut registry = Registry::new(engine(), &state_file);
@@ -1259,7 +2267,8 @@ mod tests {
         hashed.project_id = session_project_id(root, None);
         let expected = hashed.project_id.clone();
 
-        let state = PersistedState::current(vec![legacy, hashed], Vec::new());
+        let state =
+            PersistedState::current(vec![legacy, hashed], Vec::new(), Orchestration::default());
         std::fs::write(&state_file, serde_json::to_vec(&state).expect("encode")).expect("write");
 
         let mut registry = Registry::new(engine(), &state_file);
@@ -1297,6 +2306,7 @@ mod tests {
                 "root": project_root,
                 "name": "app"
             })],
+            Orchestration::default(),
         );
         std::fs::write(&state_file, serde_json::to_vec(&state).expect("encode")).expect("write");
 

--- a/diri/crates/diri-engine/src/remote/client.rs
+++ b/diri/crates/diri-engine/src/remote/client.rs
@@ -1,6 +1,6 @@
 //! One Engine-side controller for one remote Holder.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, VecDeque};
 use std::io::{self, Write};
 use std::process::{Child, ChildStdin, ChildStdout};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -10,9 +10,10 @@ use std::time::Duration;
 
 use diri_proto::frames::Frame;
 use diri_proto::remote_pty::{
-    DeliveryInput, Hello, HelloAck, PHASE_ONE_HOLDER_CAPABILITIES, ProtocolVersion, RemoteCodec,
-    RemoteMessage, RemoteRole, ScrollbackRequest, ScrollbackResponse, SessionInspection,
-    SessionSelector, SessionToken, Signal, validate_terminal_dimensions,
+    DELIVERY_RECEIPT_PROTOCOL_MINOR, DeliveryInput, Hello, HelloAck, PHASE_ONE_HOLDER_CAPABILITIES,
+    ProtocolVersion, RemoteCapability, RemoteCodec, RemoteMessage, RemoteRole, ScrollbackRequest,
+    ScrollbackResponse, SessionInspection, SessionSelector, SessionToken, Signal,
+    validate_terminal_dimensions,
 };
 
 use super::binding::RemoteBindingStore;
@@ -33,6 +34,53 @@ struct WriterState {
     delivery_receipts: bool,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DeliveryOutcome {
+    Accepted,
+    Uncertain,
+}
+
+#[derive(Debug, Default)]
+struct DeliveryOutcomes {
+    entries: VecDeque<(String, DeliveryOutcome)>,
+}
+
+impl DeliveryOutcomes {
+    fn get(&self, delivery_id: &str) -> Option<DeliveryOutcome> {
+        self.entries
+            .iter()
+            .find_map(|(candidate, outcome)| (candidate == delivery_id).then_some(*outcome))
+    }
+
+    fn contains(&self, delivery_id: &str) -> bool {
+        self.get(delivery_id).is_some()
+    }
+
+    fn record(&mut self, delivery_id: String, outcome: DeliveryOutcome) {
+        if let Some((_, existing)) = self
+            .entries
+            .iter_mut()
+            .find(|(candidate, _)| candidate == &delivery_id)
+        {
+            if *existing != DeliveryOutcome::Accepted {
+                *existing = outcome;
+            }
+            return;
+        }
+        if self.entries.len() >= 64 {
+            let Some(eviction) = self
+                .entries
+                .iter()
+                .position(|(_, outcome)| *outcome == DeliveryOutcome::Accepted)
+            else {
+                return;
+            };
+            self.entries.remove(eviction);
+        }
+        self.entries.push_back((delivery_id, outcome));
+    }
+}
+
 /// The pump owns SSH stdout. Interactive callers share this small writer
 /// state; no terminal/parser lock is on the input hot path.
 pub struct RemoteSessionClient {
@@ -47,7 +95,7 @@ pub struct RemoteSessionClient {
     persisted_output_offset: AtomicU64,
     next_request_id: AtomicU64,
     scrollback_requests: Mutex<HashMap<u64, mpsc::Sender<diri_proto::ReadScrollbackCellsResult>>>,
-    delivery_receipts: Mutex<HashSet<String>>,
+    delivery_outcomes: Mutex<DeliveryOutcomes>,
     delivery_changed: Condvar,
 }
 
@@ -82,7 +130,7 @@ impl RemoteSessionClient {
             persisted_output_offset: AtomicU64::new(initial_output_offset),
             next_request_id: AtomicU64::new(1),
             scrollback_requests: Mutex::new(HashMap::new()),
-            delivery_receipts: Mutex::new(HashSet::new()),
+            delivery_outcomes: Mutex::new(DeliveryOutcomes::default()),
             delivery_changed: Condvar::new(),
         }
     }
@@ -119,21 +167,23 @@ impl RemoteSessionClient {
         Ok((writer.generation, channel.output))
     }
 
-    pub fn accept_hello(
-        &self,
-        generation: u64,
-        epoch: u64,
-        accepted_delivery_ids: &[String],
-        delivery_receipts: bool,
-    ) -> io::Result<()> {
+    pub fn accept_hello(&self, generation: u64, acknowledgement: &HelloAck) -> io::Result<()> {
+        let delivery_receipts = delivery_receipts_negotiated(acknowledgement);
         let mut writer = self.writer.lock().expect("remote writer");
         require_generation(&writer, generation)?;
-        writer.controller_epoch = Some(epoch);
+        writer.controller_epoch = Some(acknowledgement.controller_epoch);
         writer.delivery_receipts = delivery_receipts;
         drop(writer);
-        let mut receipts = self.delivery_receipts.lock().expect("delivery receipts");
-        receipts.extend(accepted_delivery_ids.iter().cloned());
-        self.delivery_changed.notify_all();
+        if delivery_receipts {
+            let mut outcomes = self.delivery_outcomes.lock().expect("delivery outcomes");
+            for delivery_id in &acknowledgement.uncertain_delivery_ids {
+                outcomes.record(delivery_id.clone(), DeliveryOutcome::Uncertain);
+            }
+            for delivery_id in &acknowledgement.accepted_delivery_ids {
+                outcomes.record(delivery_id.clone(), DeliveryOutcome::Accepted);
+            }
+            self.delivery_changed.notify_all();
+        }
         Ok(())
     }
 
@@ -194,6 +244,11 @@ impl RemoteSessionClient {
         if self.accepted_delivery(delivery_id) {
             return Ok(());
         }
+        if self.uncertain_delivery(delivery_id) {
+            return Err(io::Error::other(
+                "remote Holder reports the delivery outcome is uncertain",
+            ));
+        }
         {
             let mut writer = self.writer.lock().expect("remote writer");
             if !writer.delivery_receipts {
@@ -216,42 +271,56 @@ impl RemoteSessionClient {
                 }),
             )?;
         }
-        let receipts = self.delivery_receipts.lock().expect("delivery receipts");
-        let (receipts, timeout) = self
+        let outcomes = self.delivery_outcomes.lock().expect("delivery outcomes");
+        let (outcomes, timeout) = self
             .delivery_changed
-            .wait_timeout_while(receipts, Duration::from_secs(5), |receipts| {
-                !receipts.contains(delivery_id)
+            .wait_timeout_while(outcomes, Duration::from_secs(5), |outcomes| {
+                !outcomes.contains(delivery_id)
             })
-            .expect("delivery receipts");
-        if receipts.contains(delivery_id) {
-            Ok(())
-        } else {
-            Err(io::Error::new(
+            .expect("delivery outcomes");
+        match outcomes.get(delivery_id) {
+            Some(DeliveryOutcome::Accepted) => Ok(()),
+            Some(DeliveryOutcome::Uncertain) => Err(io::Error::other(
+                "remote Holder reports the delivery outcome is uncertain",
+            )),
+            None => Err(io::Error::new(
                 if timeout.timed_out() {
                     io::ErrorKind::TimedOut
                 } else {
                     io::ErrorKind::BrokenPipe
                 },
                 "remote delivery acknowledgement was not observed",
-            ))
+            )),
         }
     }
 
     pub fn complete_delivery(&self, delivery_id: String) {
-        self.delivery_receipts
+        self.delivery_outcomes
             .lock()
-            .expect("delivery receipts")
-            .insert(delivery_id);
+            .expect("delivery outcomes")
+            .record(delivery_id, DeliveryOutcome::Accepted);
+        self.delivery_changed.notify_all();
+    }
+
+    pub fn mark_delivery_uncertain(&self, delivery_id: String) {
+        self.delivery_outcomes
+            .lock()
+            .expect("delivery outcomes")
+            .record(delivery_id, DeliveryOutcome::Uncertain);
         self.delivery_changed.notify_all();
     }
 
     pub fn accepted_delivery(&self, delivery_id: &str) -> bool {
-        if self
-            .delivery_receipts
-            .lock()
-            .expect("delivery receipts")
-            .contains(delivery_id)
-        {
+        if !self.writer.lock().expect("remote writer").delivery_receipts {
+            return false;
+        }
+        if matches!(
+            self.delivery_outcomes
+                .lock()
+                .expect("delivery outcomes")
+                .get(delivery_id),
+            Some(DeliveryOutcome::Accepted)
+        ) {
             return true;
         }
         self.inspect().is_ok_and(|inspection| {
@@ -259,6 +328,27 @@ impl RemoteSessionClient {
                 .accepted_delivery_ids
                 .iter()
                 .any(|accepted| accepted == delivery_id)
+        })
+    }
+
+    pub fn uncertain_delivery(&self, delivery_id: &str) -> bool {
+        if !self.writer.lock().expect("remote writer").delivery_receipts {
+            return false;
+        }
+        if matches!(
+            self.delivery_outcomes
+                .lock()
+                .expect("delivery outcomes")
+                .get(delivery_id),
+            Some(DeliveryOutcome::Uncertain)
+        ) {
+            return true;
+        }
+        self.inspect().is_ok_and(|inspection| {
+            inspection
+                .uncertain_delivery_ids
+                .iter()
+                .any(|uncertain| uncertain == delivery_id)
         })
     }
 
@@ -486,6 +576,14 @@ impl RemoteSessionClient {
     }
 }
 
+fn delivery_receipts_negotiated(acknowledgement: &HelloAck) -> bool {
+    acknowledgement.protocol.major == ProtocolVersion::CURRENT.major
+        && acknowledgement.protocol.minor >= DELIVERY_RECEIPT_PROTOCOL_MINOR
+        && acknowledgement
+            .capabilities
+            .contains(&RemoteCapability::DeliveryReceipts)
+}
+
 fn write_message(writer: &mut WriterState, message: &RemoteMessage) -> io::Result<()> {
     let encoded = RemoteCodec::encode(message).map_err(io::Error::other)?;
     let input = writer
@@ -556,6 +654,7 @@ impl Drop for RemoteSessionClient {
 #[cfg(test)]
 mod tests {
     use diri_proto::frames::FrameType;
+    use diri_proto::remote_pty::RemoteProcessState;
 
     use super::*;
 
@@ -574,5 +673,43 @@ mod tests {
             terminal_input_frame(ProtocolVersion::CURRENT, b"key", false).frame_type,
             FrameType::Input
         );
+    }
+
+    #[test]
+    fn protocol_1_5_cannot_activate_delivery_receipts_with_a_false_capability() {
+        let acknowledgement = HelloAck {
+            protocol: ProtocolVersion { major: 1, minor: 5 },
+            holder_build_id: "holder".into(),
+            session_incarnation: "incarnation".into(),
+            capabilities: vec![RemoteCapability::DeliveryReceipts],
+            controller_epoch: 1,
+            process_state: RemoteProcessState::Running { pid: 1 },
+            output_offset: 0,
+            snapshot_sequence: 0,
+            accepted_delivery_ids: vec!["false-positive".into()],
+            uncertain_delivery_ids: vec!["also-false".into()],
+        };
+        assert!(!delivery_receipts_negotiated(&acknowledgement));
+
+        let mut current = acknowledgement;
+        current.protocol.minor = DELIVERY_RECEIPT_PROTOCOL_MINOR;
+        assert!(delivery_receipts_negotiated(&current));
+        current.capabilities.clear();
+        assert!(!delivery_receipts_negotiated(&current));
+    }
+
+    #[test]
+    fn bounded_delivery_outcomes_never_evict_an_uncertain_tombstone() {
+        let mut outcomes = DeliveryOutcomes::default();
+        outcomes.record("uncertain".into(), DeliveryOutcome::Uncertain);
+        for index in 0..100 {
+            outcomes.record(format!("accepted-{index}"), DeliveryOutcome::Accepted);
+        }
+        assert_eq!(outcomes.entries.len(), 64);
+        assert_eq!(outcomes.get("uncertain"), Some(DeliveryOutcome::Uncertain));
+
+        outcomes.record("uncertain".into(), DeliveryOutcome::Accepted);
+        outcomes.record("uncertain".into(), DeliveryOutcome::Uncertain);
+        assert_eq!(outcomes.get("uncertain"), Some(DeliveryOutcome::Accepted));
     }
 }

--- a/diri/crates/diri-engine/src/remote/client.rs
+++ b/diri/crates/diri-engine/src/remote/client.rs
@@ -171,9 +171,6 @@ impl RemoteSessionClient {
         let delivery_receipts = delivery_receipts_negotiated(acknowledgement);
         let mut writer = self.writer.lock().expect("remote writer");
         require_generation(&writer, generation)?;
-        writer.controller_epoch = Some(acknowledgement.controller_epoch);
-        writer.delivery_receipts = delivery_receipts;
-        drop(writer);
         if delivery_receipts {
             let mut outcomes = self.delivery_outcomes.lock().expect("delivery outcomes");
             for delivery_id in &acknowledgement.uncertain_delivery_ids {
@@ -182,6 +179,14 @@ impl RemoteSessionClient {
             for delivery_id in &acknowledgement.accepted_delivery_ids {
                 outcomes.record(delivery_id.clone(), DeliveryOutcome::Accepted);
             }
+        }
+        // Publish the capability only after the corresponding receipt sets
+        // are visible. Receipt-first Registry observation can then never see
+        // a capable generation without its HelloAck tombstones.
+        writer.controller_epoch = Some(acknowledgement.controller_epoch);
+        writer.delivery_receipts = delivery_receipts;
+        drop(writer);
+        if delivery_receipts {
             self.delivery_changed.notify_all();
         }
         Ok(())
@@ -241,6 +246,21 @@ impl RemoteSessionClient {
     }
 
     pub fn write_delivery(&self, bytes: &[u8], delivery_id: &str) -> io::Result<()> {
+        self.write_receipted_sequence(&[], bytes, delivery_id)
+    }
+
+    /// Sends the prompt bytes and their receipted Enter on one controller
+    /// generation. Prompt bytes never enter the generic reconnect queue.
+    pub fn write_delivery_submission(&self, prompt: &[u8], delivery_id: &str) -> io::Result<()> {
+        self.write_receipted_sequence(prompt, b"\r", delivery_id)
+    }
+
+    fn write_receipted_sequence(
+        &self,
+        prompt: &[u8],
+        submit: &[u8],
+        delivery_id: &str,
+    ) -> io::Result<()> {
         if self.accepted_delivery(delivery_id) {
             return Ok(());
         }
@@ -251,14 +271,30 @@ impl RemoteSessionClient {
         }
         {
             let mut writer = self.writer.lock().expect("remote writer");
-            let message = receipted_delivery_message(writer.delivery_receipts, bytes, delivery_id)?;
+            let message =
+                receipted_delivery_message(writer.delivery_receipts, submit, delivery_id)?;
             if writer.controller_epoch.is_none() || writer.input.is_none() {
                 return Err(io::Error::new(
                     io::ErrorKind::NotConnected,
                     "remote controller is reconnecting",
                 ));
             }
-            write_message(&mut writer, &message)?;
+            if !prompt.is_empty() {
+                if let Err(error) = write_message(
+                    &mut writer,
+                    &RemoteMessage::Terminal(Frame::input(prompt.to_vec())),
+                ) {
+                    terminate_current(&mut writer);
+                    writer.controller_epoch = None;
+                    return Err(error);
+                }
+                std::thread::sleep(Duration::from_millis(30));
+            }
+            if let Err(error) = write_message(&mut writer, &message) {
+                terminate_current(&mut writer);
+                writer.controller_epoch = None;
+                return Err(error);
+            }
         }
         let outcomes = self.delivery_outcomes.lock().expect("delivery outcomes");
         let (outcomes, timeout) = self
@@ -717,6 +753,30 @@ mod tests {
         ));
         current.capabilities.clear();
         assert!(!delivery_receipts_negotiated(&current));
+    }
+
+    #[test]
+    fn capability_flip_is_rejected_before_any_prompt_frame_can_be_written() {
+        let preflight_supported = true;
+        assert!(preflight_supported);
+
+        // The controller reconnects to an older Holder after Registry's
+        // preflight but before the send obtains WriterState. Production builds
+        // the receipted Enter while holding that writer lock and only then
+        // writes the prompt frame, so this error precedes every raw byte.
+        let actual_generation_supports_receipts = false;
+        let mut prompt_written = false;
+        let result = (|| -> io::Result<()> {
+            let _message = receipted_delivery_message(
+                actual_generation_supports_receipts,
+                b"\r",
+                "generation-flipped",
+            )?;
+            prompt_written = true;
+            Ok(())
+        })();
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::Unsupported);
+        assert!(!prompt_written);
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/remote/client.rs
+++ b/diri/crates/diri-engine/src/remote/client.rs
@@ -251,25 +251,14 @@ impl RemoteSessionClient {
         }
         {
             let mut writer = self.writer.lock().expect("remote writer");
-            if !writer.delivery_receipts {
-                // Capability absence is an authoritative old-peer answer: no
-                // receipted operation was sent, so the legacy terminal frame
-                // is a safe compatibility fallback.
-                return write_message(&mut writer, &RemoteMessage::Terminal(Frame::input(bytes)));
-            }
+            let message = receipted_delivery_message(writer.delivery_receipts, bytes, delivery_id)?;
             if writer.controller_epoch.is_none() || writer.input.is_none() {
                 return Err(io::Error::new(
                     io::ErrorKind::NotConnected,
                     "remote controller is reconnecting",
                 ));
             }
-            write_message(
-                &mut writer,
-                &RemoteMessage::DeliveryInput(DeliveryInput {
-                    delivery_id: delivery_id.to_owned(),
-                    data: bytes.to_vec(),
-                }),
-            )?;
+            write_message(&mut writer, &message)?;
         }
         let outcomes = self.delivery_outcomes.lock().expect("delivery outcomes");
         let (outcomes, timeout) = self
@@ -329,6 +318,10 @@ impl RemoteSessionClient {
                 .iter()
                 .any(|accepted| accepted == delivery_id)
         })
+    }
+
+    pub fn delivery_receipts_supported(&self) -> bool {
+        self.writer.lock().expect("remote writer").delivery_receipts
     }
 
     pub fn uncertain_delivery(&self, delivery_id: &str) -> bool {
@@ -584,6 +577,23 @@ fn delivery_receipts_negotiated(acknowledgement: &HelloAck) -> bool {
             .contains(&RemoteCapability::DeliveryReceipts)
 }
 
+fn receipted_delivery_message(
+    delivery_receipts: bool,
+    bytes: &[u8],
+    delivery_id: &str,
+) -> io::Result<RemoteMessage> {
+    if !delivery_receipts {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "remote Holder does not support receipted delivery (protocol 1.6 required)",
+        ));
+    }
+    Ok(RemoteMessage::DeliveryInput(DeliveryInput {
+        delivery_id: delivery_id.to_owned(),
+        data: bytes.to_vec(),
+    }))
+}
+
 fn write_message(writer: &mut WriterState, message: &RemoteMessage) -> io::Result<()> {
     let encoded = RemoteCodec::encode(message).map_err(io::Error::other)?;
     let input = writer
@@ -690,10 +700,21 @@ mod tests {
             uncertain_delivery_ids: vec!["also-false".into()],
         };
         assert!(!delivery_receipts_negotiated(&acknowledgement));
+        let error = receipted_delivery_message(
+            delivery_receipts_negotiated(&acknowledgement),
+            b"\r",
+            "must-not-send",
+        )
+        .expect_err("an old peer must not receive an unreceipted fallback");
+        assert_eq!(error.kind(), io::ErrorKind::Unsupported);
 
         let mut current = acknowledgement;
         current.protocol.minor = DELIVERY_RECEIPT_PROTOCOL_MINOR;
         assert!(delivery_receipts_negotiated(&current));
+        assert!(matches!(
+            receipted_delivery_message(true, b"\r", "accepted"),
+            Ok(RemoteMessage::DeliveryInput(_))
+        ));
         current.capabilities.clear();
         assert!(!delivery_receipts_negotiated(&current));
     }

--- a/diri/crates/diri-engine/src/remote/client.rs
+++ b/diri/crates/diri-engine/src/remote/client.rs
@@ -1,17 +1,18 @@
 //! One Engine-side controller for one remote Holder.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{self, Write};
 use std::process::{Child, ChildStdin, ChildStdout};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::Duration;
 
 use diri_proto::frames::Frame;
 use diri_proto::remote_pty::{
-    Hello, HelloAck, PHASE_ONE_HOLDER_CAPABILITIES, ProtocolVersion, RemoteCodec, RemoteMessage,
-    RemoteRole, ScrollbackRequest, ScrollbackResponse, SessionInspection, SessionSelector,
-    SessionToken, Signal, validate_terminal_dimensions,
+    DeliveryInput, Hello, HelloAck, PHASE_ONE_HOLDER_CAPABILITIES, ProtocolVersion, RemoteCodec,
+    RemoteMessage, RemoteRole, ScrollbackRequest, ScrollbackResponse, SessionInspection,
+    SessionSelector, SessionToken, Signal, validate_terminal_dimensions,
 };
 
 use super::binding::RemoteBindingStore;
@@ -29,6 +30,7 @@ struct WriterState {
     controller_epoch: Option<u64>,
     queued_input: Vec<u8>,
     queued_resize: Option<(u16, u16)>,
+    delivery_receipts: bool,
 }
 
 /// The pump owns SSH stdout. Interactive callers share this small writer
@@ -45,6 +47,8 @@ pub struct RemoteSessionClient {
     persisted_output_offset: AtomicU64,
     next_request_id: AtomicU64,
     scrollback_requests: Mutex<HashMap<u64, mpsc::Sender<diri_proto::ReadScrollbackCellsResult>>>,
+    delivery_receipts: Mutex<HashSet<String>>,
+    delivery_changed: Condvar,
 }
 
 impl RemoteSessionClient {
@@ -72,11 +76,14 @@ impl RemoteSessionClient {
                 controller_epoch: None,
                 queued_input: Vec::new(),
                 queued_resize: None,
+                delivery_receipts: false,
             }),
             observed_output_offset: AtomicU64::new(initial_output_offset),
             persisted_output_offset: AtomicU64::new(initial_output_offset),
             next_request_id: AtomicU64::new(1),
             scrollback_requests: Mutex::new(HashMap::new()),
+            delivery_receipts: Mutex::new(HashSet::new()),
+            delivery_changed: Condvar::new(),
         }
     }
 
@@ -106,15 +113,27 @@ impl RemoteSessionClient {
         terminate_current(&mut writer);
         writer.generation = writer.generation.saturating_add(1);
         writer.controller_epoch = None;
+        writer.delivery_receipts = false;
         writer.child = Some(channel.child);
         writer.input = Some(channel.input);
         Ok((writer.generation, channel.output))
     }
 
-    pub fn accept_hello(&self, generation: u64, epoch: u64) -> io::Result<()> {
+    pub fn accept_hello(
+        &self,
+        generation: u64,
+        epoch: u64,
+        accepted_delivery_ids: &[String],
+        delivery_receipts: bool,
+    ) -> io::Result<()> {
         let mut writer = self.writer.lock().expect("remote writer");
         require_generation(&writer, generation)?;
         writer.controller_epoch = Some(epoch);
+        writer.delivery_receipts = delivery_receipts;
+        drop(writer);
+        let mut receipts = self.delivery_receipts.lock().expect("delivery receipts");
+        receipts.extend(accepted_delivery_ids.iter().cloned());
+        self.delivery_changed.notify_all();
         Ok(())
     }
 
@@ -169,6 +188,78 @@ impl RemoteSessionClient {
 
     pub fn write_mouse(&self, bytes: &[u8]) -> io::Result<()> {
         self.write_terminal(bytes, true)
+    }
+
+    pub fn write_delivery(&self, bytes: &[u8], delivery_id: &str) -> io::Result<()> {
+        if self.accepted_delivery(delivery_id) {
+            return Ok(());
+        }
+        {
+            let mut writer = self.writer.lock().expect("remote writer");
+            if !writer.delivery_receipts {
+                // Capability absence is an authoritative old-peer answer: no
+                // receipted operation was sent, so the legacy terminal frame
+                // is a safe compatibility fallback.
+                return write_message(&mut writer, &RemoteMessage::Terminal(Frame::input(bytes)));
+            }
+            if writer.controller_epoch.is_none() || writer.input.is_none() {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotConnected,
+                    "remote controller is reconnecting",
+                ));
+            }
+            write_message(
+                &mut writer,
+                &RemoteMessage::DeliveryInput(DeliveryInput {
+                    delivery_id: delivery_id.to_owned(),
+                    data: bytes.to_vec(),
+                }),
+            )?;
+        }
+        let receipts = self.delivery_receipts.lock().expect("delivery receipts");
+        let (receipts, timeout) = self
+            .delivery_changed
+            .wait_timeout_while(receipts, Duration::from_secs(5), |receipts| {
+                !receipts.contains(delivery_id)
+            })
+            .expect("delivery receipts");
+        if receipts.contains(delivery_id) {
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                if timeout.timed_out() {
+                    io::ErrorKind::TimedOut
+                } else {
+                    io::ErrorKind::BrokenPipe
+                },
+                "remote delivery acknowledgement was not observed",
+            ))
+        }
+    }
+
+    pub fn complete_delivery(&self, delivery_id: String) {
+        self.delivery_receipts
+            .lock()
+            .expect("delivery receipts")
+            .insert(delivery_id);
+        self.delivery_changed.notify_all();
+    }
+
+    pub fn accepted_delivery(&self, delivery_id: &str) -> bool {
+        if self
+            .delivery_receipts
+            .lock()
+            .expect("delivery receipts")
+            .contains(delivery_id)
+        {
+            return true;
+        }
+        self.inspect().is_ok_and(|inspection| {
+            inspection
+                .accepted_delivery_ids
+                .iter()
+                .any(|accepted| accepted == delivery_id)
+        })
     }
 
     /// Routes wheel intent to the Holder that owns the authoritative parser.

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -1451,6 +1451,15 @@ impl Session {
         }
     }
 
+    /// `Some(false)` is an authoritative remote compatibility answer. Local
+    /// and direct transports retain their existing delivery guarantees.
+    pub fn remote_delivery_receipts_supported(&self) -> Option<bool> {
+        match &self.transport {
+            Transport::Remote(client) => Some(client.delivery_receipts_supported()),
+            Transport::Direct(_) | Transport::Held(_) => None,
+        }
+    }
+
     fn write_delivery_input(&self, bytes: &[u8], operation_id: &str) -> std::io::Result<()> {
         self.shared.note_hot();
         self.shared.grid_wake.prioritize_interactive_changes();

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -1428,6 +1428,18 @@ impl Session {
         if !submit {
             return self.write_input(text.as_bytes());
         }
+        if let (Some(operation_id), Transport::Remote(client)) = (operation_id, &self.transport) {
+            self.capture_prompt_title(text);
+            let framed = self.framed_paste_text(text);
+            self.shared.note_hot();
+            self.shared.grid_wake.prioritize_interactive_changes();
+            self.observe_prompt_input(framed.as_bytes());
+            self.observe_prompt_input(b"\r");
+            client.write_delivery_submission(framed.as_bytes(), operation_id)?;
+            self.feed_signal(StatusSignal::UserKeystroke);
+            self.feed_signal(StatusSignal::UserKeystroke);
+            return Ok(());
+        }
         self.paste_text(text)?;
         std::thread::sleep(Duration::from_millis(30));
         let Some(operation_id) = operation_id else {
@@ -1486,12 +1498,16 @@ impl Session {
     /// idempotent, which matters because the injector may retype.
     pub fn paste_text(&self, text: &str) -> std::io::Result<()> {
         self.capture_prompt_title(text);
-        let framed = if self.bracketed_paste() {
+        let framed = self.framed_paste_text(text);
+        self.write_input(framed.as_bytes())
+    }
+
+    fn framed_paste_text(&self, text: &str) -> String {
+        if self.bracketed_paste() {
             format!("\x1b[200~{text}\x1b[201~")
         } else {
             text.to_owned()
-        };
-        self.write_input(framed.as_bytes())
+        }
     }
 
     /// The Enter that submits whatever is in the composer.

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -1444,6 +1444,13 @@ impl Session {
         }
     }
 
+    pub fn uncertain_delivery(&self, operation_id: &str) -> bool {
+        match &self.transport {
+            Transport::Remote(client) => client.uncertain_delivery(operation_id),
+            Transport::Direct(_) | Transport::Held(_) => false,
+        }
+    }
+
     fn write_delivery_input(&self, bytes: &[u8], operation_id: &str) -> std::io::Result<()> {
         self.shared.note_hot();
         self.shared.grid_wake.prioritize_interactive_changes();
@@ -2071,16 +2078,7 @@ fn handle_remote_message(
         RemoteMessage::HelloAck(acknowledgement) => {
             if *hello_accepted
                 || client.validate_hello(&acknowledgement).is_err()
-                || client
-                    .accept_hello(
-                        generation,
-                        acknowledgement.controller_epoch,
-                        &acknowledgement.accepted_delivery_ids,
-                        acknowledgement
-                            .capabilities
-                            .contains(&diri_proto::remote_pty::RemoteCapability::DeliveryReceipts),
-                    )
-                    .is_err()
+                || client.accept_hello(generation, &acknowledgement).is_err()
             {
                 return RemoteConnectionDisposition::Fatal;
             }
@@ -2156,6 +2154,10 @@ fn handle_remote_message(
         }
         RemoteMessage::DeliveryAccepted(accepted) => {
             client.complete_delivery(accepted.delivery_id);
+            RemoteConnectionDisposition::Continue
+        }
+        RemoteMessage::DeliveryUncertain(uncertain) => {
+            client.mark_delivery_uncertain(uncertain.delivery_id);
             RemoteConnectionDisposition::Continue
         }
         RemoteMessage::Error(error) if error.fatal => RemoteConnectionDisposition::Fatal,

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -1417,6 +1417,48 @@ impl Session {
         self.submit_input()
     }
 
+    /// Lifecycle submission variant whose final Enter is acknowledged under
+    /// a stable operation id by transports that outlive this daemon.
+    pub fn send_text_receipted(
+        &self,
+        text: &str,
+        submit: bool,
+        operation_id: Option<&str>,
+    ) -> std::io::Result<()> {
+        if !submit {
+            return self.write_input(text.as_bytes());
+        }
+        self.paste_text(text)?;
+        std::thread::sleep(Duration::from_millis(30));
+        let Some(operation_id) = operation_id else {
+            return self.submit_input();
+        };
+        self.write_delivery_input(b"\r", operation_id)
+    }
+
+    pub fn accepted_delivery(&self, operation_id: &str) -> bool {
+        match &self.transport {
+            Transport::Direct(_) => false,
+            Transport::Held(client) => client.accepted_delivery(operation_id).unwrap_or(false),
+            Transport::Remote(client) => client.accepted_delivery(operation_id),
+        }
+    }
+
+    fn write_delivery_input(&self, bytes: &[u8], operation_id: &str) -> std::io::Result<()> {
+        self.shared.note_hot();
+        self.shared.grid_wake.prioritize_interactive_changes();
+        self.observe_prompt_input(bytes);
+        match &self.transport {
+            Transport::Direct(_) => self.write_input(bytes),
+            Transport::Held(client) => client
+                .write_receipted(bytes, operation_id)
+                .map_err(holder_io_error),
+            Transport::Remote(client) => client.write_delivery(bytes, operation_id),
+        }?;
+        self.feed_signal(StatusSignal::UserKeystroke);
+        Ok(())
+    }
+
     /// Types `text` into the composer WITHOUT submitting it, framed as a
     /// bracketed paste when the child has that mode on. Separated from
     /// [`Self::send_text`] so a caller that cannot see the composer — the
@@ -2030,7 +2072,14 @@ fn handle_remote_message(
             if *hello_accepted
                 || client.validate_hello(&acknowledgement).is_err()
                 || client
-                    .accept_hello(generation, acknowledgement.controller_epoch)
+                    .accept_hello(
+                        generation,
+                        acknowledgement.controller_epoch,
+                        &acknowledgement.accepted_delivery_ids,
+                        acknowledgement
+                            .capabilities
+                            .contains(&diri_proto::remote_pty::RemoteCapability::DeliveryReceipts),
+                    )
                     .is_err()
             {
                 return RemoteConnectionDisposition::Fatal;
@@ -2103,6 +2152,10 @@ fn handle_remote_message(
         }
         RemoteMessage::ScrollbackResponse(response) => {
             client.complete_scrollback(response);
+            RemoteConnectionDisposition::Continue
+        }
+        RemoteMessage::DeliveryAccepted(accepted) => {
+            client.complete_delivery(accepted.delivery_id);
             RemoteConnectionDisposition::Continue
         }
         RemoteMessage::Error(error) if error.fatal => RemoteConnectionDisposition::Fatal,

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -220,6 +220,12 @@ struct Shared {
     /// registry watcher compares this instead of cloning and JSON-serializing
     /// every record on every poll.
     state_version: AtomicU64,
+    /// Lossless turn-completion edge count. Status can move Working→Idle
+    /// between registry snapshots; the counter makes that edge observable.
+    turn_completion_seq: AtomicU64,
+    /// Registry-wide wake source used by event waiters. Kept optional because
+    /// a Session can be constructed directly in low-level tests.
+    state_changes: Mutex<Option<crate::orchestration::StateChanges>>,
     /// Seconds since UNIX_EPOCH of the last attach-pump poll or input write.
     /// Keeps interactive sessions on the fast quiet-tick.
     last_hot: AtomicU64,
@@ -252,6 +258,9 @@ struct RemoteGridState {
 impl Shared {
     fn bump_state_version(&self) {
         self.state_version.fetch_add(1, Ordering::SeqCst);
+        if let Some(changes) = self.state_changes.lock().expect("state changes").as_ref() {
+            changes.notify();
+        }
     }
 
     fn note_hot(&self) {
@@ -1068,6 +1077,14 @@ impl Session {
         self.shared.state_version.load(Ordering::SeqCst)
     }
 
+    pub fn turn_completion_seq(&self) -> u64 {
+        self.shared.turn_completion_seq.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn bind_state_changes(&self, changes: crate::orchestration::StateChanges) {
+        *self.shared.state_changes.lock().expect("state changes") = Some(changes);
+    }
+
     pub fn status(&self) -> SessionStatus {
         self.shared.status.lock().expect("status").clone()
     }
@@ -1695,6 +1712,8 @@ fn new_shared(spec: &SessionSpec, log: OutputLog, engine: &ManifestEngine) -> Ar
         exited: AtomicBool::new(false),
         stop: AtomicBool::new(false),
         state_version: AtomicU64::new(0),
+        turn_completion_seq: AtomicU64::new(0),
+        state_changes: Mutex::new(None),
         last_hot: AtomicU64::new(unix_secs()),
         last_interaction: AtomicU64::new(0),
         artifacts: Mutex::new(Vec::new()),
@@ -1780,6 +1799,10 @@ fn apply(shared: &Shared, outcome: &ReducerOutcome) {
             *current = None;
             changed = true;
         }
+    }
+    if outcome.turn_completed {
+        shared.turn_completion_seq.fetch_add(1, Ordering::SeqCst);
+        changed = true;
     }
     if changed {
         shared.bump_state_version();

--- a/diri/crates/diri-engine/tests/checkpoint.rs
+++ b/diri/crates/diri-engine/tests/checkpoint.rs
@@ -90,6 +90,7 @@ fn record(id: &str) -> diri_proto::SessionRecord {
         pull_requests: None,
         listening_ports: None,
         foreground_agent: None,
+        run: None,
     }
 }
 

--- a/diri/crates/diri-engine/tests/holder.rs
+++ b/diri/crates/diri-engine/tests/holder.rs
@@ -149,6 +149,39 @@ fn a_holder_owns_a_session_end_to_end() {
 }
 
 #[test]
+fn holder_delivery_receipts_are_idempotent_and_queryable_after_ack_loss() {
+    let root = holders_dir("receipt");
+    let logs = root.join("logs");
+    let paths = HolderPaths::new(&root, "s_receipt");
+    let launch = spec(
+        &paths,
+        &logs,
+        &["/bin/sh", "-c", "stty -echo; exec /bin/cat"],
+    );
+    let server = std::thread::spawn(move || HolderServer::run(launch));
+    let client = HolderClient::new(paths.socket());
+    wait_until("holder ready", Duration::from_secs(5), || client.is_alive());
+
+    client
+        .write_receipted(b"landed once\n", "delivery-1")
+        .expect("first delivery");
+    assert!(client.accepted_delivery("delivery-1").expect("receipt"));
+    client
+        .write_receipted(b"landed once\n", "delivery-1")
+        .expect("idempotent retry");
+    wait_until("echo in log", Duration::from_secs(5), || {
+        log_bytes(&logs, "s_receipt")
+            .windows(b"landed once".len())
+            .filter(|window| *window == b"landed once")
+            .count()
+            == 1
+    });
+
+    client.kill_tree().expect("kill-tree");
+    server.join().expect("join").expect("clean holder exit");
+}
+
+#[test]
 #[ignore = "release-only local UDS input latency benchmark"]
 fn holder_input_latency_is_reported() {
     let root = holders_dir("lat");

--- a/diri/crates/diri-engine/tests/holder_session.rs
+++ b/diri/crates/diri-engine/tests/holder_session.rs
@@ -229,6 +229,7 @@ fn record(id: &str) -> diri_proto::SessionRecord {
         pull_requests: None,
         listening_ports: None,
         foreground_agent: None,
+        run: None,
     }
 }
 

--- a/diri/crates/diri-engine/tests/legacy_remote.rs
+++ b/diri/crates/diri-engine/tests/legacy_remote.rs
@@ -72,6 +72,7 @@ fn record(id: &str, host: Option<&str>, agent_session_id: Option<&str>) -> Sessi
         pull_requests: None,
         listening_ports: None,
         foreground_agent: None,
+        run: None,
     }
 }
 

--- a/diri/crates/diri-engine/tests/mcp_tools.rs
+++ b/diri/crates/diri-engine/tests/mcp_tools.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use diri_engine::detect::ManifestEngine;
 use diri_engine::mcp::{McpServer, RegistryHost, tool_definitions};
 use diri_engine::pty::PtySpec;
-use diri_engine::registry::Registry;
+use diri_engine::registry::{Registry, RegistryRunError};
 use diri_engine::session::SessionSpec;
 use diri_engine::status::Authority;
 use diri_engine::status::ClaudeHook;
@@ -119,6 +119,69 @@ fn output_contains(registry: &Arc<Mutex<Registry>>, id: &str, needle: &str) -> b
         return false;
     };
     session.screen_lines().join("\n").contains(needle)
+}
+
+#[test]
+fn stale_public_mutations_durably_commit_a_raw_successor_before_rejecting() {
+    for interrupt in [false, true] {
+        let temp = tempfile::tempdir().expect("temp");
+        let state_file = temp.path().join("state.json");
+        let logs = temp.path().join("logs");
+        let id = if interrupt { "interrupt" } else { "send" };
+        let mut registry = Registry::new(engine(), &state_file);
+        let mut child = record(id, None);
+        child.kind = AgentKind::CODEX;
+        child.status = SessionStatus::Idle;
+        child.run = Some(diri_proto::AgentRun {
+            id: 1,
+            state: diri_proto::AgentRunState::Completed,
+            started_at: DateMillis(1.0),
+            finished_at: Some(DateMillis(2.0)),
+            terminal_outcome: Some("completed".into()),
+        });
+        registry
+            .spawn(
+                hook_spec(
+                    id,
+                    "trap '' INT; while IFS= read -r line; do printf 'GOT:%s\\n' \"$line\"; done",
+                    &logs,
+                ),
+                child,
+            )
+            .expect("spawn child");
+
+        // This models an attached/raw Enter that reached the PTY between the
+        // last Registry fold and the public mutation. The first public sync
+        // observes run 2; expected generation 1 must be rejected only after
+        // that successor is durable.
+        registry
+            .get(id)
+            .expect("live child")
+            .claude_hook(ClaudeHook::UserPromptSubmit, false);
+        let error = if interrupt {
+            registry.interrupt_run(id, Some(1), None).unwrap_err()
+        } else {
+            registry
+                .send_run_text(id, "stale".into(), true, Some(1), true, None)
+                .unwrap_err()
+        };
+        assert!(matches!(
+            error,
+            RegistryRunError::Stale {
+                expected: 1,
+                current: 2
+            }
+        ));
+
+        let mut restored = Registry::new(engine(), &state_file);
+        restored.load().expect("reload committed successor");
+        let run = restored
+            .record(id)
+            .and_then(|record| record.run)
+            .expect("restored run");
+        assert_eq!(run.id, 2);
+        assert_eq!(run.state, diri_proto::AgentRunState::Running);
+    }
 }
 
 #[test]

--- a/diri/crates/diri-engine/tests/mcp_tools.rs
+++ b/diri/crates/diri-engine/tests/mcp_tools.rs
@@ -125,7 +125,9 @@ fn output_contains(registry: &Arc<Mutex<Registry>>, id: &str, needle: &str) -> b
 fn stale_public_mutations_durably_commit_a_raw_successor_before_rejecting() {
     for interrupt in [false, true] {
         let temp = tempfile::tempdir().expect("temp");
-        let state_file = temp.path().join("state.json");
+        let blocked_parent = temp.path().join("blocked-state-parent");
+        std::fs::write(&blocked_parent, b"not a directory").expect("blocking file");
+        let state_file = blocked_parent.join("state.json");
         let logs = temp.path().join("logs");
         let id = if interrupt { "interrupt" } else { "send" };
         let mut registry = Registry::new(engine(), &state_file);
@@ -158,6 +160,20 @@ fn stale_public_mutations_durably_commit_a_raw_successor_before_rejecting() {
             .get(id)
             .expect("live child")
             .claude_hook(ClaudeHook::UserPromptSubmit, false);
+        let first_error = if interrupt {
+            registry.interrupt_run(id, Some(1), None).unwrap_err()
+        } else {
+            registry
+                .send_run_text(id, "stale".into(), true, Some(1), true, None)
+                .unwrap_err()
+        };
+        assert!(
+            matches!(first_error, RegistryRunError::Io(_)),
+            "the first lifecycle write must fail before stale is returned: {first_error}"
+        );
+
+        std::fs::remove_file(&blocked_parent).expect("remove blocking file");
+        std::fs::create_dir(&blocked_parent).expect("restore state directory");
         let error = if interrupt {
             registry.interrupt_run(id, Some(1), None).unwrap_err()
         } else {

--- a/diri/crates/diri-engine/tests/mcp_tools.rs
+++ b/diri/crates/diri-engine/tests/mcp_tools.rs
@@ -16,6 +16,7 @@ use diri_engine::pty::PtySpec;
 use diri_engine::registry::Registry;
 use diri_engine::session::SessionSpec;
 use diri_engine::status::Authority;
+use diri_engine::status::ClaudeHook;
 use diri_proto::{
     AgentKind, DateMillis, ProjectId, Resumability, SessionId, SessionRecord, SessionStatus,
     TitleSource,
@@ -65,6 +66,7 @@ fn record(id: &str, parent: Option<&str>) -> SessionRecord {
         pull_requests: None,
         listening_ports: None,
         foreground_agent: None,
+        run: None,
     }
 }
 
@@ -82,6 +84,12 @@ fn spec(id: &str, script: &str, logs: &Path) -> SessionSpec {
         remote: None,
         defer_launch: false,
     }
+}
+
+fn hook_spec(id: &str, script: &str, logs: &Path) -> SessionSpec {
+    let mut spec = spec(id, script, logs);
+    spec.authority = Authority::HooksPrimary;
+    spec
 }
 
 /// Calls a tool through the full MCP server and returns the parsed result.
@@ -103,6 +111,259 @@ fn call(server: &McpServer<RegistryHost>, tool: &str, arguments: Value) -> Resul
         return Err(text);
     }
     Ok(serde_json::from_str(&text).unwrap_or(Value::String(text)))
+}
+
+fn output_contains(registry: &Arc<Mutex<Registry>>, id: &str, needle: &str) -> bool {
+    let registry = registry.lock().expect("registry");
+    let Some(session) = registry.get(id) else {
+        return false;
+    };
+    session.screen_lines().join("\n").contains(needle)
+}
+
+#[test]
+fn queued_followups_survive_mcp_reconnect_and_interrupt_keeps_session_reusable() {
+    let temp = tempfile::tempdir().expect("temp");
+    let logs = temp.path().join("logs");
+    let mut registry = Registry::new(engine(), temp.path().join("state.json"));
+    let mut child = record("child", Some("parent"));
+    child.run = Some(diri_proto::AgentRun::starting(1, child.created_at));
+    registry
+        .spawn(
+            hook_spec(
+                "child",
+                "trap '' INT; while IFS= read -r line; do printf 'GOT:%s\\n' \"$line\"; done",
+                &logs,
+            ),
+            child,
+        )
+        .expect("spawn child");
+    let registry = Arc::new(Mutex::new(registry));
+    {
+        let registry = registry.lock().expect("registry");
+        registry
+            .get("child")
+            .unwrap()
+            .claude_hook(ClaudeHook::UserPromptSubmit, false);
+    }
+
+    // The first MCP process queues two follow-ups while run 1 is working.
+    {
+        let server = McpServer::new(
+            tool_definitions(),
+            RegistryHost::new(Arc::clone(&registry), &logs).with_caller(Some("parent".into())),
+        );
+        for text in ["first", "second"] {
+            let sent = call(
+                &server,
+                "send_prompt",
+                json!({"session_id": "child", "text": text, "run_id": 1}),
+            )
+            .expect("queue follow-up");
+            assert_eq!(sent["queued"], true);
+        }
+    }
+    assert!(!output_contains(&registry, "child", "GOT:first"));
+
+    // The MCP process reconnects. One completion boundary releases exactly
+    // one FIFO item and starts run 2; the second remains queued.
+    {
+        let mut registry = registry.lock().expect("registry");
+        registry
+            .get("child")
+            .unwrap()
+            .claude_hook(ClaudeHook::UserPromptSubmit, false);
+        registry
+            .get("child")
+            .unwrap()
+            .claude_hook(ClaudeHook::Stop, false);
+        std::thread::sleep(Duration::from_millis(150));
+        registry
+            .get("child")
+            .unwrap()
+            .feed_signal(diri_engine::status::StatusSignal::Tick);
+        registry.sync_orchestration();
+    }
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    while std::time::Instant::now() < deadline && !output_contains(&registry, "child", "GOT:first")
+    {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(output_contains(&registry, "child", "GOT:first"));
+    assert!(!output_contains(&registry, "child", "GOT:second"));
+
+    // A delayed command carrying run 1 cannot land in run 2.
+    let reconnected = McpServer::new(
+        tool_definitions(),
+        RegistryHost::new(Arc::clone(&registry), &logs).with_caller(Some("parent".into())),
+    );
+    let stale = call(
+        &reconnected,
+        "send_prompt",
+        json!({"session_id": "child", "text": "stale", "run_id": 1}),
+    )
+    .expect_err("stale generation");
+    assert!(stale.contains("stale"), "{stale}");
+
+    {
+        let mut registry = registry.lock().expect("registry");
+        registry
+            .get("child")
+            .unwrap()
+            .claude_hook(ClaudeHook::UserPromptSubmit, false);
+        registry
+            .get("child")
+            .unwrap()
+            .claude_hook(ClaudeHook::Stop, false);
+        std::thread::sleep(Duration::from_millis(150));
+        registry
+            .get("child")
+            .unwrap()
+            .feed_signal(diri_engine::status::StatusSignal::Tick);
+        registry.sync_orchestration();
+    }
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    while std::time::Instant::now() < deadline && !output_contains(&registry, "child", "GOT:second")
+    {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(output_contains(&registry, "child", "GOT:second"));
+
+    let interrupted = call(
+        &reconnected,
+        "interrupt_agent",
+        json!({
+            "session_id": "child",
+            "run_id": 3,
+            "request_id": "interrupt-response-loss-1"
+        }),
+    )
+    .expect("interrupt current run");
+    assert_eq!(interrupted["run"]["state"], "aborted");
+    let replayed_interrupt = call(
+        &reconnected,
+        "interrupt_agent",
+        json!({
+            "session_id": "child",
+            "run_id": 3,
+            "request_id": "interrupt-response-loss-1"
+        }),
+    )
+    .expect("replay interrupt response");
+    assert_eq!(replayed_interrupt["run"], interrupted["run"]);
+    let next = call(
+        &reconnected,
+        "send_prompt",
+        json!({"session_id": "child", "text": "after-abort", "run_id": 3}),
+    )
+    .expect("reuse after abort");
+    assert_eq!(next["run"]["id"], 4);
+}
+
+#[test]
+fn reports_wait_for_the_parent_composer_and_preserve_fifo_order() {
+    let temp = tempfile::tempdir().expect("temp");
+    let logs = temp.path().join("logs");
+    let mut registry = Registry::new(engine(), temp.path().join("state.json"));
+    let mut parent = record("parent", None);
+    parent.kind = AgentKind::CODEX;
+    let mut reporter = record("reporter", Some("parent"));
+    reporter.kind = AgentKind::CODEX;
+    for (record, script) in [
+        (
+            parent,
+            "trap '' INT; while IFS= read -r line; do printf 'PARENT:%s\\n' \"$line\"; done",
+        ),
+        (
+            reporter,
+            "trap '' INT; while IFS= read -r line; do printf 'REPORTER:%s\\n' \"$line\"; done",
+        ),
+    ] {
+        let id = record.id.0.clone();
+        registry
+            .spawn(hook_spec(&id, script, &logs), record)
+            .expect("spawn");
+    }
+    registry
+        .get("parent")
+        .unwrap()
+        .claude_hook(ClaudeHook::UserPromptSubmit, false);
+    let first = registry
+        .report_to_parent(
+            "reporter",
+            "report-one".into(),
+            true,
+            Some(1),
+            Some("report-response-loss-1".into()),
+        )
+        .expect("queue first report");
+    let replay = registry
+        .report_to_parent(
+            "reporter",
+            "report-one".into(),
+            true,
+            Some(1),
+            Some("report-response-loss-1".into()),
+        )
+        .expect("replay first report");
+    assert_eq!(replay, first);
+    let (parent, queued, _) = registry
+        .report_to_parent("reporter", "report-two".into(), true, Some(1), None)
+        .expect("queue report");
+    assert_eq!(parent, "parent");
+    assert!(queued);
+    let registry = Arc::new(Mutex::new(registry));
+    assert!(!output_contains(&registry, "parent", "PARENT:report-one"));
+
+    for (completion, absent) in [
+        ("PARENT:report-one", "PARENT:report-two"),
+        ("PARENT:report-two", "PARENT:never"),
+    ] {
+        {
+            let mut registry = registry.lock().expect("registry");
+            registry
+                .get("parent")
+                .unwrap()
+                .claude_hook(ClaudeHook::Stop, false);
+            std::thread::sleep(Duration::from_millis(150));
+            registry
+                .get("parent")
+                .unwrap()
+                .feed_signal(diri_engine::status::StatusSignal::Tick);
+            registry.sync_orchestration();
+        }
+        let deadline = std::time::Instant::now() + Duration::from_secs(3);
+        while std::time::Instant::now() < deadline
+            && !output_contains(&registry, "parent", completion)
+        {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(output_contains(&registry, "parent", completion));
+        assert!(!output_contains(&registry, "parent", absent));
+        if completion.ends_with("one") {
+            registry
+                .lock()
+                .expect("registry")
+                .get("parent")
+                .unwrap()
+                .claude_hook(ClaudeHook::UserPromptSubmit, false);
+        }
+    }
+
+    // Merely acknowledging reporter run 2 must not stale the still-current
+    // run 1: that run must remain able to deliver its final report until the
+    // future generation actually becomes active.
+    let mut registry = registry.lock().expect("registry");
+    registry
+        .interrupt_run("reporter", Some(1), None)
+        .expect("abort");
+    registry
+        .send_run_text("reporter", "next".into(), true, Some(1), true, None)
+        .expect("start next run");
+    let accepted = registry
+        .report_to_parent("reporter", "late".into(), true, Some(1), None)
+        .expect("current report remains valid while run 2 is only queued");
+    assert_eq!(accepted.0, "parent");
 }
 
 #[test]
@@ -193,7 +454,7 @@ fn send_prompt_types_into_a_session_and_submits() {
         .spawn(
             spec(
                 "s_ask",
-                "read answer; printf 'got:%s\\n' \"$answer\"; sleep 30",
+                "for i in 1 2; do read answer; printf 'got:%s\\n' \"$answer\"; done; sleep 30",
                 &logs,
             ),
             record("s_ask", None),
@@ -206,30 +467,63 @@ fn send_prompt_types_into_a_session_and_submits() {
         RegistryHost::new(Arc::clone(&registry), &logs),
     );
 
-    call(
+    let first = call(
         &server,
         "send_prompt",
-        json!({ "session_id": "s_ask", "text": "hello-there" }),
+        json!({
+            "session_id": "s_ask",
+            "text": "hello-there",
+            "request_id": "lost-response-retry-1"
+        }),
     )
     .expect("send");
+    // Model a response lost after the daemon committed delivery: the caller
+    // retries the same request id and must receive the original result without
+    // another PTY write.
+    let replay = call(
+        &server,
+        "send_prompt",
+        json!({
+            "session_id": "s_ask",
+            "text": "hello-there",
+            "request_id": "lost-response-retry-1"
+        }),
+    )
+    .expect("replay");
+    assert_eq!(replay["queued"], first["queued"]);
+    assert_eq!(replay["run"], first["run"]);
 
     let deadline = std::time::Instant::now() + Duration::from_secs(10);
-    let mut seen = false;
-    while std::time::Instant::now() < deadline && !seen {
+    let mut output = String::new();
+    while std::time::Instant::now() < deadline && !output.contains("got:hello-there") {
         let read = call(
             &server,
             "read_output",
             json!({ "session_id": "s_ask", "max_bytes": 4096 }),
         )
         .expect("read");
-        seen = read["output"]
-            .as_str()
-            .is_some_and(|text| text.contains("got:hello-there"));
-        if !seen {
+        output = read["output"].as_str().unwrap_or_default().to_owned();
+        if !output.contains("got:hello-there") {
             std::thread::sleep(Duration::from_millis(50));
         }
     }
-    assert!(seen, "the session never received the submitted prompt");
+    assert!(
+        output.contains("got:hello-there"),
+        "the session never received the submitted prompt"
+    );
+    std::thread::sleep(Duration::from_millis(100));
+    let read = call(
+        &server,
+        "read_output",
+        json!({ "session_id": "s_ask", "max_bytes": 4096 }),
+    )
+    .expect("read after replay");
+    let output = read["output"].as_str().unwrap_or_default();
+    assert_eq!(
+        output.matches("got:hello-there").count(),
+        1,
+        "a response-loss retry must not submit the prompt twice: {output:?}"
+    );
 }
 
 #[test]
@@ -261,10 +555,78 @@ fn waiting_on_an_exited_session_returns_immediately() {
     .expect("wait");
 
     assert_eq!(waited["status"], "exited");
+    assert_eq!(waited["reached"], false);
     assert!(
         started.elapsed() < Duration::from_secs(20),
         "waiting on a dead session must not run to the timeout"
     );
+}
+
+#[test]
+fn embedded_waits_match_run_generation_and_idle_semantics() {
+    let temp = tempfile::tempdir().expect("temp");
+    let logs = temp.path().join("logs");
+    let mut registry = Registry::new(engine(), temp.path().join("state.json"));
+    let mut agent = record("agent", None);
+    agent.kind = AgentKind::CODEX;
+    agent.status = SessionStatus::Idle;
+    agent.run = Some(diri_proto::AgentRun::starting(3, agent.created_at));
+    registry.insert_record(agent);
+    let mut dead = record("dead", None);
+    dead.kind = AgentKind::CODEX;
+    dead.status = SessionStatus::Exited(diri_proto::ExitInfo {
+        reason: diri_proto::ExitReason::Exited,
+        code: Some(0),
+        signal: None,
+    });
+    dead.run = Some(diri_proto::AgentRun {
+        id: 1,
+        state: diri_proto::AgentRunState::Failed,
+        started_at: dead.created_at,
+        finished_at: Some(dead.updated_at),
+        terminal_outcome: Some("process_exited".into()),
+    });
+    registry.insert_record(dead);
+    let server = McpServer::new(
+        tool_definitions(),
+        RegistryHost::new(Arc::new(Mutex::new(registry)), &logs),
+    );
+
+    let stale = call(
+        &server,
+        "wait_for_agent",
+        json!({"session_id": "agent", "run_id": 2, "timeout_seconds": 0}),
+    )
+    .expect("stale wait");
+    assert_eq!(stale["superseded"], true);
+
+    let idle = call(
+        &server,
+        "wait_for_agent",
+        json!({"session_id": "agent", "run_id": 3, "until": "idle", "timeout_seconds": 0}),
+    )
+    .expect("idle wait");
+    assert_eq!(idle["reached"], true);
+
+    let future = call(
+        &server,
+        "wait_for_agent",
+        json!({"session_id": "agent", "run_id": 4, "timeout_seconds": 0}),
+    )
+    .expect("future wait");
+    assert_eq!(future["timedOut"], true);
+    assert_ne!(future["reached"], true);
+
+    let started = std::time::Instant::now();
+    let dead_future = call(
+        &server,
+        "wait_for_agent",
+        json!({"session_id": "dead", "run_id": 2, "timeout_seconds": 60}),
+    )
+    .expect("dead future wait");
+    assert_eq!(dead_future["reached"], false);
+    assert_eq!(dead_future["superseded"], false);
+    assert!(started.elapsed() < Duration::from_secs(1));
 }
 
 #[test]

--- a/diri/crates/diri-proto/src/methods.rs
+++ b/diri/crates/diri-proto/src/methods.rs
@@ -2,7 +2,7 @@
 
 use crate::control::{JsonValue, WIRE_VERSION};
 use crate::model::{
-    AgentKind, DateMillis, PortInfo, Project, SessionArtifact, SessionId, SessionRecord,
+    AgentKind, AgentRun, DateMillis, PortInfo, Project, SessionArtifact, SessionId, SessionRecord,
     SessionStatus, WorktreeInfo,
 };
 use serde::{Deserialize, Serialize};
@@ -24,6 +24,9 @@ impl Method {
     pub const SESSION_RENAME: &'static str = "session.rename";
     pub const SESSION_RESUME: &'static str = "session.resume";
     pub const SESSION_SEND_TEXT: &'static str = "session.send_text";
+    pub const SESSION_RUN_SEND: &'static str = "session.run.send";
+    pub const SESSION_RUN_INTERRUPT: &'static str = "session.run.interrupt";
+    pub const SESSION_RUN_REPORT: &'static str = "session.run.report";
     pub const SESSION_RESIZE: &'static str = "session.resize";
     pub const SESSION_READ_SCREEN: &'static str = "session.read_screen";
     pub const SESSION_READ_SCROLLBACK: &'static str = "session.read_scrollback";
@@ -489,6 +492,66 @@ pub type SendTextResult = EmptyResult;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct SessionRunSendParams {
+    #[serde(rename = "sessionID")]
+    pub session_id: SessionId,
+    pub text: String,
+    pub submit: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_run_id: Option<u64>,
+    /// Caller-generated idempotency key. Retrying the same request id replays
+    /// its durable result instead of delivering the text again.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionRunSendResult {
+    pub queued: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run: Option<AgentRun>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionRunInterruptParams {
+    #[serde(rename = "sessionID")]
+    pub session_id: SessionId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_run_id: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionRunInterruptResult {
+    pub run: AgentRun,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionRunReportParams {
+    #[serde(rename = "reporterSessionID")]
+    pub reporter_session_id: SessionId,
+    pub text: String,
+    #[serde(default = "default_true")]
+    pub submit: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_run_id: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+}
+
+pub type SessionRunReportResult = SessionRunSendResult;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ResizeParams {
     #[serde(rename = "sessionID")]
     pub session_id: SessionId,
@@ -823,6 +886,10 @@ pub struct EventsWaitParams {
     pub session_id: SessionId,
     pub until: Vec<String>,
     pub timeout_ms: i64,
+    /// Pins the wait to one turn. A newer generation supersedes it instead of
+    /// letting an old completion satisfy the new run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<u64>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -830,6 +897,17 @@ pub struct EventsWaitParams {
 pub struct EventsWaitResult {
     pub session: SessionRecord,
     pub timed_out: bool,
+    #[serde(default)]
+    pub superseded: bool,
+    /// Whether the requested target was actually reached. Older daemons omit
+    /// this field; callers can continue to infer success from `timedOut` and
+    /// `superseded` when talking to them.
+    #[serde(default)]
+    pub reached: bool,
+    /// Exact run that resolved a pinned wait. This can differ from
+    /// `session.run` after a FIFO advances to the next generation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run: Option<AgentRun>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -964,5 +1042,29 @@ mod base64_bytes {
             b'/' => Some(63),
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod run_protocol_tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_idempotency_fields_are_additive_for_old_clients() {
+        let send: SessionRunSendParams = serde_json::from_value(serde_json::json!({
+            "sessionID": "agent",
+            "text": "hello",
+            "submit": true,
+            "expectedRunId": 4
+        }))
+        .unwrap();
+        assert!(send.request_id.is_none());
+
+        let result: SessionRunSendResult = serde_json::from_value(serde_json::json!({
+            "queued": true
+        }))
+        .unwrap();
+        assert!(result.request_id.is_none());
+        assert!(result.run.is_none());
     }
 }

--- a/diri/crates/diri-proto/src/model.rs
+++ b/diri/crates/diri-proto/src/model.rs
@@ -693,6 +693,55 @@ pub struct PortInfo {
     pub process_name: String,
 }
 
+/// The lifecycle of one agent turn. This is intentionally separate from the
+/// terminal's coarse [`SessionStatus`]: an idle terminal can mean "not yet
+/// started" or "finished", and a needs-input turn is paused rather than done.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AgentRunState {
+    Starting,
+    Running,
+    NeedsInput,
+    Completed,
+    Failed,
+    Aborted,
+}
+
+impl AgentRunState {
+    pub const fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Failed | Self::Aborted)
+    }
+}
+
+/// Monotonic identity and terminal outcome for a child-agent turn.
+///
+/// `id` increases whenever a completed/failed/aborted session accepts a new
+/// submitted prompt. Callers echo it on reports, waits, and interrupts so a
+/// delayed event from an older turn cannot mutate the current one.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentRun {
+    pub id: u64,
+    pub state: AgentRunState,
+    pub started_at: DateMillis,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finished_at: Option<DateMillis>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_outcome: Option<String>,
+}
+
+impl AgentRun {
+    pub fn starting(id: u64, now: DateMillis) -> Self {
+        Self {
+            id,
+            state: AgentRunState::Starting,
+            started_at: now,
+            finished_at: None,
+            terminal_outcome: None,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionRecord {
@@ -755,6 +804,10 @@ pub struct SessionRecord {
     pub listening_ports: Option<Vec<PortInfo>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub foreground_agent: Option<AgentKind>,
+    /// Explicit child-turn lifecycle. Absent on roots and records produced by
+    /// older Engines, which keeps the wire format backwards-compatible.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run: Option<AgentRun>,
 }
 
 impl SessionRecord {
@@ -845,4 +898,27 @@ where
         .get("_0")
         .ok_or_else(|| E::custom("associated-value payload is missing _0"))?;
     serde_json::from_value(value.clone()).map_err(E::custom)
+}
+
+#[cfg(test)]
+mod run_tests {
+    use super::*;
+
+    #[test]
+    fn run_state_wire_names_are_stable_and_terminal_is_explicit() {
+        let run = AgentRun {
+            id: 7,
+            state: AgentRunState::NeedsInput,
+            started_at: DateMillis(1.0),
+            finished_at: None,
+            terminal_outcome: None,
+        };
+        let value = serde_json::to_value(&run).unwrap();
+        assert_eq!(value["id"], 7);
+        assert_eq!(value["state"], "needsInput");
+        assert!(!run.state.is_terminal());
+        assert!(AgentRunState::Completed.is_terminal());
+        assert!(AgentRunState::Failed.is_terminal());
+        assert!(AgentRunState::Aborted.is_terminal());
+    }
 }

--- a/diri/crates/diri-proto/src/remote_pty.rs
+++ b/diri/crates/diri-proto/src/remote_pty.rs
@@ -18,8 +18,12 @@ use crate::grid::{GridCodecError, GridUpdate};
 use crate::terminal::MouseModes;
 
 pub const PROTOCOL_MAJOR: u16 = 1;
-pub const PROTOCOL_MINOR: u16 = 5;
+// Protocol 1.5 is independently assigned to negotiated application-cursor
+// input. Delivery receipts therefore occupy 1.6 when the two additive
+// branches are combined; capability negotiation remains the runtime gate.
+pub const PROTOCOL_MINOR: u16 = 6;
 pub const MOUSE_INPUT_PROTOCOL_MINOR: u16 = 4;
+pub const DELIVERY_RECEIPT_PROTOCOL_MINOR: u16 = 6;
 pub const MAX_CONTROL_FRAME_BYTES: usize = 64 * 1024;
 pub const MAX_ARGUMENTS: usize = 512;
 pub const MAX_ENVIRONMENT_VARIABLES: usize = 4096;
@@ -50,6 +54,7 @@ const KIND_SCROLLBACK_REQUEST: u8 = 43;
 const KIND_SCROLLBACK_RESPONSE: u8 = 44;
 const KIND_DELIVERY_INPUT: u8 = 45;
 const KIND_DELIVERY_ACCEPTED: u8 = 46;
+const KIND_DELIVERY_UNCERTAIN: u8 = 47;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -259,6 +264,8 @@ pub struct HelloAck {
     pub snapshot_sequence: u64,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub accepted_delivery_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub uncertain_delivery_ids: Vec<String>,
 }
 
 impl HelloAck {
@@ -633,6 +640,8 @@ pub struct SessionInspection {
     pub persistence: PersistenceCapability,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub accepted_delivery_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub uncertain_delivery_ids: Vec<String>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -764,6 +773,14 @@ pub struct DeliveryAccepted {
     pub delivery_id: String,
 }
 
+/// A prior Holder durably prepared this operation but did not durably record
+/// its PTY outcome. The controller must never retry its bytes automatically.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeliveryUncertain {
+    pub delivery_id: String,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RemoteMessage {
     Terminal(Frame),
@@ -781,6 +798,7 @@ pub enum RemoteMessage {
     ScrollbackResponse(ScrollbackResponse),
     DeliveryInput(DeliveryInput),
     DeliveryAccepted(DeliveryAccepted),
+    DeliveryUncertain(DeliveryUncertain),
     Error(RemoteError),
 }
 
@@ -973,6 +991,10 @@ impl RemoteCodec {
             RemoteMessage::DeliveryAccepted(value) => {
                 validate_identifier("delivery id", &value.delivery_id)?;
                 append_json(KIND_DELIVERY_ACCEPTED, value, output, start)
+            }
+            RemoteMessage::DeliveryUncertain(value) => {
+                validate_identifier("delivery id", &value.delivery_id)?;
+                append_json(KIND_DELIVERY_UNCERTAIN, value, output, start)
             }
             RemoteMessage::Error(value) => append_json(KIND_ERROR, value, output, start),
         })();
@@ -1183,6 +1205,11 @@ fn decode_message(kind: u8, payload: &[u8]) -> Result<RemoteMessage, RemoteCodec
             validate_identifier("delivery id", &value.delivery_id)?;
             Ok(RemoteMessage::DeliveryAccepted(value))
         }
+        KIND_DELIVERY_UNCERTAIN => {
+            let value: DeliveryUncertain = decode_json(kind, payload)?;
+            validate_identifier("delivery id", &value.delivery_id)?;
+            Ok(RemoteMessage::DeliveryUncertain(value))
+        }
         KIND_ERROR => Ok(RemoteMessage::Error(decode_json(kind, payload)?)),
         _ => Err(RemoteCodecError::UnknownMessageType(kind)),
     }
@@ -1190,7 +1217,7 @@ fn decode_message(kind: u8, payload: &[u8]) -> Result<RemoteMessage, RemoteCodec
 
 fn validate_kind(kind: u8) -> Result<(), RemoteCodecError> {
     if (1..=FrameType::Mouse as u8).contains(&kind)
-        || (KIND_HELLO..=KIND_DELIVERY_ACCEPTED).contains(&kind)
+        || (KIND_HELLO..=KIND_DELIVERY_UNCERTAIN).contains(&kind)
     {
         Ok(())
     } else {
@@ -1363,7 +1390,10 @@ mod tests {
         let accepted = RemoteMessage::DeliveryAccepted(DeliveryAccepted {
             delivery_id: "run-7-abcdef".into(),
         });
-        for message in [input, accepted] {
+        let uncertain = RemoteMessage::DeliveryUncertain(DeliveryUncertain {
+            delivery_id: "run-7-abcdef".into(),
+        });
+        for message in [input, accepted, uncertain] {
             let encoded = RemoteCodec::encode(&message).expect("encode");
             assert!(encoded[0] > KIND_SCROLLBACK_RESPONSE);
             assert_eq!(

--- a/diri/crates/diri-proto/src/remote_pty.rs
+++ b/diri/crates/diri-proto/src/remote_pty.rs
@@ -18,7 +18,7 @@ use crate::grid::{GridCodecError, GridUpdate};
 use crate::terminal::MouseModes;
 
 pub const PROTOCOL_MAJOR: u16 = 1;
-pub const PROTOCOL_MINOR: u16 = 4;
+pub const PROTOCOL_MINOR: u16 = 5;
 pub const MOUSE_INPUT_PROTOCOL_MINOR: u16 = 4;
 pub const MAX_CONTROL_FRAME_BYTES: usize = 64 * 1024;
 pub const MAX_ARGUMENTS: usize = 512;
@@ -48,6 +48,8 @@ const KIND_ERROR: u8 = 41;
 const KIND_GRID_DELTA: u8 = 42;
 const KIND_SCROLLBACK_REQUEST: u8 = 43;
 const KIND_SCROLLBACK_RESPONSE: u8 = 44;
+const KIND_DELIVERY_INPUT: u8 = 45;
+const KIND_DELIVERY_ACCEPTED: u8 = 46;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -97,6 +99,8 @@ pub enum RemoteCapability {
     PortForward,
     RebootRecovery,
     Migration,
+    /// Holder persists bounded idempotency receipts for lifecycle submits.
+    DeliveryReceipts,
     /// A capability introduced by a newer protocol minor. It is ignored
     /// unless the local side explicitly requires it.
     #[serde(other)]
@@ -125,6 +129,7 @@ impl RemoteCapability {
             Self::PortForward => "port-forward",
             Self::RebootRecovery => "reboot-recovery",
             Self::Migration => "migration",
+            Self::DeliveryReceipts => "delivery-receipts",
             Self::Unknown => "unknown",
         }
     }
@@ -252,6 +257,8 @@ pub struct HelloAck {
     pub process_state: RemoteProcessState,
     pub output_offset: u64,
     pub snapshot_sequence: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub accepted_delivery_ids: Vec<String>,
 }
 
 impl HelloAck {
@@ -624,6 +631,8 @@ pub struct SessionInspection {
     pub snapshot_sequence: u64,
     pub controller_epoch: u64,
     pub persistence: PersistenceCapability,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub accepted_delivery_ids: Vec<String>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -729,6 +738,32 @@ pub struct ScrollbackResponse {
     pub result: crate::ReadScrollbackCellsResult,
 }
 
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeliveryInput {
+    pub delivery_id: String,
+    pub data: Vec<u8>,
+}
+
+impl DeliveryInput {
+    pub fn validate(&self) -> Result<(), RemoteCodecError> {
+        validate_identifier("delivery id", &self.delivery_id)?;
+        if self.data.len() > 64 {
+            return Err(RemoteCodecError::InvalidControlPayload {
+                kind: KIND_DELIVERY_INPUT,
+                detail: "delivery input exceeds 64 bytes".into(),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeliveryAccepted {
+    pub delivery_id: String,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RemoteMessage {
     Terminal(Frame),
@@ -744,6 +779,8 @@ pub enum RemoteMessage {
     ReleaseControl(ReleaseControl),
     ScrollbackRequest(ScrollbackRequest),
     ScrollbackResponse(ScrollbackResponse),
+    DeliveryInput(DeliveryInput),
+    DeliveryAccepted(DeliveryAccepted),
     Error(RemoteError),
 }
 
@@ -928,6 +965,14 @@ impl RemoteCodec {
             }
             RemoteMessage::ScrollbackResponse(value) => {
                 append_json(KIND_SCROLLBACK_RESPONSE, value, output, start)
+            }
+            RemoteMessage::DeliveryInput(value) => {
+                value.validate()?;
+                append_json(KIND_DELIVERY_INPUT, value, output, start)
+            }
+            RemoteMessage::DeliveryAccepted(value) => {
+                validate_identifier("delivery id", &value.delivery_id)?;
+                append_json(KIND_DELIVERY_ACCEPTED, value, output, start)
             }
             RemoteMessage::Error(value) => append_json(KIND_ERROR, value, output, start),
         })();
@@ -1128,6 +1173,16 @@ fn decode_message(kind: u8, payload: &[u8]) -> Result<RemoteMessage, RemoteCodec
         KIND_SCROLLBACK_RESPONSE => Ok(RemoteMessage::ScrollbackResponse(decode_json(
             kind, payload,
         )?)),
+        KIND_DELIVERY_INPUT => {
+            let value: DeliveryInput = decode_json(kind, payload)?;
+            value.validate()?;
+            Ok(RemoteMessage::DeliveryInput(value))
+        }
+        KIND_DELIVERY_ACCEPTED => {
+            let value: DeliveryAccepted = decode_json(kind, payload)?;
+            validate_identifier("delivery id", &value.delivery_id)?;
+            Ok(RemoteMessage::DeliveryAccepted(value))
+        }
         KIND_ERROR => Ok(RemoteMessage::Error(decode_json(kind, payload)?)),
         _ => Err(RemoteCodecError::UnknownMessageType(kind)),
     }
@@ -1135,7 +1190,7 @@ fn decode_message(kind: u8, payload: &[u8]) -> Result<RemoteMessage, RemoteCodec
 
 fn validate_kind(kind: u8) -> Result<(), RemoteCodecError> {
     if (1..=FrameType::Mouse as u8).contains(&kind)
-        || (KIND_HELLO..=KIND_SCROLLBACK_RESPONSE).contains(&kind)
+        || (KIND_HELLO..=KIND_DELIVERY_ACCEPTED).contains(&kind)
     {
         Ok(())
     } else {
@@ -1296,6 +1351,25 @@ mod tests {
 
             let decoded = RemoteCodec::new().feed(&encoded).expect("decode");
             assert_eq!(decoded, vec![message]);
+        }
+    }
+
+    #[test]
+    fn delivery_receipt_messages_round_trip_additively() {
+        let input = RemoteMessage::DeliveryInput(DeliveryInput {
+            delivery_id: "run-7-abcdef".into(),
+            data: b"\r".to_vec(),
+        });
+        let accepted = RemoteMessage::DeliveryAccepted(DeliveryAccepted {
+            delivery_id: "run-7-abcdef".into(),
+        });
+        for message in [input, accepted] {
+            let encoded = RemoteCodec::encode(&message).expect("encode");
+            assert!(encoded[0] > KIND_SCROLLBACK_RESPONSE);
+            assert_eq!(
+                RemoteCodec::new().feed(&encoded).expect("decode"),
+                [message]
+            );
         }
     }
 

--- a/diri/crates/diri-remote/src/holder.rs
+++ b/diri/crates/diri-remote/src/holder.rs
@@ -11,8 +11,8 @@ use std::time::{Duration, Instant};
 
 use diri_proto::frames::{Frame, FrameType, MAX_FRAME_BYTES};
 use diri_proto::remote_pty::{
-    ControlGranted, ControlRevoked, FullSnapshot, GridDelta, Hello, HelloAck, LaunchRequest,
-    LaunchResult, PHASE_ONE_HOLDER_CAPABILITIES, ProcessExit, RemoteCodec, RemoteError,
+    ControlGranted, ControlRevoked, DeliveryAccepted, FullSnapshot, GridDelta, Hello, HelloAck,
+    LaunchRequest, LaunchResult, ProcessExit, RemoteCapability, RemoteCodec, RemoteError,
     RemoteMessage, RemoteProcessState, ScrollbackResponse, validate_terminal_dimensions,
 };
 use diri_pty::{Exit, ExitWatcher, Pty, PtySpec, PtyStream};
@@ -37,8 +37,17 @@ const MAX_PENDING_INPUT_BYTES: usize = 1 << 20;
 const REPLAY_BUDGET_BYTES: usize = 4 << 20;
 const PERSIST_OFFSET_INTERVAL: u64 = 1 << 20;
 
-pub const PHASE_ONE_CAPABILITIES: &[diri_proto::remote_pty::RemoteCapability] =
-    PHASE_ONE_HOLDER_CAPABILITIES;
+const DELIVERY_RECEIPT_LIMIT: usize = 64;
+
+pub const PHASE_ONE_CAPABILITIES: &[RemoteCapability] = &[
+    RemoteCapability::FullSnapshot,
+    RemoteCapability::IncrementalGrid,
+    RemoteCapability::ProcessExit,
+    RemoteCapability::Signal,
+    RemoteCapability::ControllerLease,
+    RemoteCapability::Scrollback,
+    RemoteCapability::DeliveryReceipts,
+];
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -850,6 +859,42 @@ impl Holder {
                     result,
                 }))
             }
+            RemoteMessage::DeliveryInput(delivery) => {
+                if self
+                    .state
+                    .accepted_delivery_ids
+                    .iter()
+                    .any(|accepted| accepted == &delivery.delivery_id)
+                {
+                    return connection.queue(RemoteMessage::DeliveryAccepted(DeliveryAccepted {
+                        delivery_id: delivery.delivery_id,
+                    }));
+                }
+                self.write_input(&delivery.data)?;
+                if !self.pending_input.is_empty() {
+                    // The nonblocking PTY has accepted this only into Holder
+                    // memory. Do not publish durable provenance until every
+                    // byte actually crossed into the PTY; a later output edge
+                    // may still reconcile the resulting uncertain delivery.
+                    return Err(io::Error::new(
+                        io::ErrorKind::WouldBlock,
+                        "delivery input is still pending before the PTY",
+                    ));
+                }
+                self.state
+                    .accepted_delivery_ids
+                    .push(delivery.delivery_id.clone());
+                if self.state.accepted_delivery_ids.len() > DELIVERY_RECEIPT_LIMIT {
+                    self.state.accepted_delivery_ids.remove(0);
+                }
+                // Receipt state must survive both an Engine restart and a
+                // Holder supervisor restart before the acknowledgement is
+                // put on the wire.
+                write_state(&self.paths.state, &self.state)?;
+                connection.queue(RemoteMessage::DeliveryAccepted(DeliveryAccepted {
+                    delivery_id: delivery.delivery_id,
+                }))
+            }
             RemoteMessage::ReleaseControl(release) => {
                 if release.controller_epoch != epoch {
                     return Err(io::Error::new(
@@ -915,6 +960,7 @@ impl Holder {
             process_state: self.state.process_state.clone(),
             output_offset: self.state.output_offset,
             snapshot_sequence: self.state.snapshot_sequence,
+            accepted_delivery_ids: self.state.accepted_delivery_ids.clone(),
         }))?;
         self.queue_replay(connection, hello.last_acknowledged_output_offset)?;
         self.state.snapshot_sequence = self.state.snapshot_sequence.saturating_add(1);

--- a/diri/crates/diri-remote/src/holder.rs
+++ b/diri/crates/diri-remote/src/holder.rs
@@ -11,9 +11,10 @@ use std::time::{Duration, Instant};
 
 use diri_proto::frames::{Frame, FrameType, MAX_FRAME_BYTES};
 use diri_proto::remote_pty::{
-    ControlGranted, ControlRevoked, DeliveryAccepted, FullSnapshot, GridDelta, Hello, HelloAck,
-    LaunchRequest, LaunchResult, ProcessExit, RemoteCapability, RemoteCodec, RemoteError,
-    RemoteMessage, RemoteProcessState, ScrollbackResponse, validate_terminal_dimensions,
+    ControlGranted, ControlRevoked, DeliveryAccepted, DeliveryUncertain, FullSnapshot, GridDelta,
+    Hello, HelloAck, LaunchRequest, LaunchResult, ProcessExit, RemoteCapability, RemoteCodec,
+    RemoteError, RemoteMessage, RemoteProcessState, ScrollbackResponse,
+    validate_terminal_dimensions,
 };
 use diri_pty::{Exit, ExitWatcher, Pty, PtySpec, PtyStream};
 use diri_terminal_state::HeadlessScreen;
@@ -207,7 +208,6 @@ fn validate_live_build_id(holder_build_id: &str) -> io::Result<()> {
 fn reset_dead_session(paths: &SessionPaths) -> io::Result<()> {
     for path in [
         &paths.socket,
-        &paths.state,
         &paths.auth,
         &paths.output,
         &paths.diagnostics,
@@ -232,6 +232,20 @@ fn reset_dead_session(paths: &SessionPaths) -> io::Result<()> {
             Err(error) if error.kind() == io::ErrorKind::NotFound => {}
             Err(error) => return Err(error),
         }
+    }
+    // Keep the bounded two-phase delivery ledger in the old state file. A
+    // replacement Holder adopts it before overwriting the rest of the stale
+    // process metadata, so an unresolved Enter can never become new input.
+    match fs::symlink_metadata(&paths.state) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "refusing to retain an unexpected session state path",
+            ));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
     }
     Ok(())
 }
@@ -416,6 +430,9 @@ struct Holder {
     connection: Option<Connection>,
     pending_connection: Option<Connection>,
     pending_input: PendingBytes,
+    /// Submission ids are committed only after all earlier queued input and
+    /// their Enter bytes have crossed into the PTY, preserving stream order.
+    pending_delivery_receipts: Vec<String>,
     dirty_since: Option<Instant>,
     interactive_grid_budget: u8,
     last_persisted_offset: u64,
@@ -470,7 +487,15 @@ impl Holder {
             usize::from(start.request.rows),
         );
         let log = OutputLog::open(&paths.output)?;
+        let previous_delivery_ledger = read_state(&paths.state).ok().and_then(|state| {
+            (state.session_id == start.request.session_id)
+                .then_some((state.accepted_delivery_ids, state.pending_delivery_ids))
+        });
         let mut state = SessionState::new(&start.request, start.incarnation, process_pid);
+        if let Some((accepted, pending)) = previous_delivery_ledger {
+            state.accepted_delivery_ids = accepted;
+            state.pending_delivery_ids = pending;
+        }
         state.output_offset = log.tail_offset();
         write_state(&paths.state, &state)?;
 
@@ -489,6 +514,7 @@ impl Holder {
             connection: None,
             pending_connection: None,
             pending_input: PendingBytes::default(),
+            pending_delivery_receipts: Vec::new(),
             dirty_since: None,
             interactive_grid_budget: 0,
             last_persisted_offset: 0,
@@ -792,7 +818,10 @@ impl Holder {
         }
         match message {
             RemoteMessage::Terminal(frame) => match frame.frame_type {
-                FrameType::Input | FrameType::Mouse => self.write_input(&frame.payload),
+                FrameType::Input | FrameType::Mouse => {
+                    self.write_input(&frame.payload)?;
+                    self.commit_delivery_receipts(connection)
+                }
                 FrameType::Resize => {
                     let Some((cols, rows)) = frame.resize_payload() else {
                         return Err(io::Error::new(
@@ -829,7 +858,8 @@ impl Holder {
                         usize::from(col),
                         usize::from(row),
                     );
-                    self.write_input(&bytes)
+                    self.write_input(&bytes)?;
+                    self.commit_delivery_receipts(connection)
                 }
                 _ => Err(io::Error::new(
                     io::ErrorKind::InvalidData,
@@ -870,30 +900,50 @@ impl Holder {
                         delivery_id: delivery.delivery_id,
                     }));
                 }
-                self.write_input(&delivery.data)?;
-                if !self.pending_input.is_empty() {
-                    // The nonblocking PTY has accepted this only into Holder
-                    // memory. Do not publish durable provenance until every
-                    // byte actually crossed into the PTY; a later output edge
-                    // may still reconcile the resulting uncertain delivery.
+                if self
+                    .state
+                    .pending_delivery_ids
+                    .iter()
+                    .any(|pending| pending == &delivery.delivery_id)
+                    && !self
+                        .pending_delivery_receipts
+                        .iter()
+                        .any(|pending| pending == &delivery.delivery_id)
+                {
+                    return connection.queue(RemoteMessage::DeliveryUncertain(DeliveryUncertain {
+                        delivery_id: delivery.delivery_id,
+                    }));
+                }
+                if self
+                    .pending_delivery_receipts
+                    .iter()
+                    .any(|pending| pending == &delivery.delivery_id)
+                {
+                    // The original bytes are still ahead of this receipt in
+                    // the PTY queue. A retry must wait for that same landing,
+                    // never append a second copy.
+                    return self.commit_delivery_receipts(connection);
+                }
+                if self.pending_input.len().saturating_add(delivery.data.len())
+                    > MAX_PENDING_INPUT_BYTES
+                {
                     return Err(io::Error::new(
                         io::ErrorKind::WouldBlock,
-                        "delivery input is still pending before the PTY",
+                        "pending input queue is full",
                     ));
                 }
-                self.state
-                    .accepted_delivery_ids
-                    .push(delivery.delivery_id.clone());
-                if self.state.accepted_delivery_ids.len() > DELIVERY_RECEIPT_LIMIT {
-                    self.state.accepted_delivery_ids.remove(0);
-                }
-                // Receipt state must survive both an Engine restart and a
-                // Holder supervisor restart before the acknowledgement is
-                // put on the wire.
-                write_state(&self.paths.state, &self.state)?;
-                connection.queue(RemoteMessage::DeliveryAccepted(DeliveryAccepted {
-                    delivery_id: delivery.delivery_id,
-                }))
+                prepare_delivery_receipt(
+                    &self.paths.state,
+                    &mut self.state,
+                    &delivery.delivery_id,
+                )?;
+                // Register the id before the nonblocking write. If the PTY
+                // accepts only a prefix and then errors, the remaining bytes
+                // and this id stay paired for a later flush/retry instead of
+                // allowing the controller to append a duplicate operation.
+                self.pending_delivery_receipts.push(delivery.delivery_id);
+                self.write_input(&delivery.data)?;
+                self.commit_delivery_receipts(connection)
             }
             RemoteMessage::ReleaseControl(release) => {
                 if release.controller_epoch != epoch {
@@ -961,6 +1011,7 @@ impl Holder {
             output_offset: self.state.output_offset,
             snapshot_sequence: self.state.snapshot_sequence,
             accepted_delivery_ids: self.state.accepted_delivery_ids.clone(),
+            uncertain_delivery_ids: self.state.pending_delivery_ids.clone(),
         }))?;
         self.queue_replay(connection, hello.last_acknowledged_output_offset)?;
         self.state.snapshot_sequence = self.state.snapshot_sequence.saturating_add(1);
@@ -1028,7 +1079,42 @@ impl Holder {
                 Err(error) => return Err(error),
             }
         }
+        if self.pending_delivery_receipts.is_empty() {
+            return Ok(());
+        }
+        let Some(mut connection) = self.connection.take() else {
+            // `read_connection` temporarily lends the live connection to the
+            // message handler. Leave receipts pending so that handler can
+            // persist them and queue acknowledgements on the same connection.
+            return Ok(());
+        };
+        let result = self.commit_delivery_receipts(&mut connection);
+        self.connection = Some(connection);
+        result
+    }
+
+    fn commit_delivery_receipts(&mut self, connection: &mut Connection) -> io::Result<()> {
+        if !self.pending_input.is_empty() || self.pending_delivery_receipts.is_empty() {
+            return Ok(());
+        }
+        let receipts = self.persist_pending_delivery_receipts()?;
+        for delivery_id in receipts {
+            connection.queue(RemoteMessage::DeliveryAccepted(DeliveryAccepted {
+                delivery_id,
+            }))?;
+        }
         Ok(())
+    }
+
+    fn persist_pending_delivery_receipts(&mut self) -> io::Result<Vec<String>> {
+        if !self.pending_input.is_empty() || self.pending_delivery_receipts.is_empty() {
+            return Ok(Vec::new());
+        }
+        persist_delivery_receipts(
+            &self.paths.state,
+            &mut self.state,
+            &mut self.pending_delivery_receipts,
+        )
     }
 
     fn flush_connection(&mut self) -> io::Result<()> {
@@ -1155,6 +1241,79 @@ impl Holder {
         write_state(&self.paths.state, &self.state)?;
         self.queue(RemoteMessage::ProcessExit(message))
     }
+}
+
+fn persist_delivery_receipts(
+    path: &std::path::Path,
+    state: &mut SessionState,
+    pending: &mut Vec<String>,
+) -> io::Result<Vec<String>> {
+    let receipts = pending.clone();
+    let mut next_state = state.clone();
+    for delivery_id in &receipts {
+        if !next_state
+            .accepted_delivery_ids
+            .iter()
+            .any(|accepted| accepted == delivery_id)
+        {
+            next_state.accepted_delivery_ids.push(delivery_id.clone());
+        }
+        next_state
+            .pending_delivery_ids
+            .retain(|pending| pending != delivery_id);
+    }
+    while next_state.accepted_delivery_ids.len() > DELIVERY_RECEIPT_LIMIT {
+        next_state.accepted_delivery_ids.remove(0);
+    }
+    // State reaches durable storage before any acknowledgement can leave
+    // this Holder. Preserve the pending ids and old in-memory state if
+    // persistence fails so a later flush retries the exact transaction.
+    write_state(path, &next_state)?;
+    *state = next_state;
+    pending.clear();
+    Ok(receipts)
+}
+
+fn prepare_delivery_receipt(
+    path: &std::path::Path,
+    state: &mut SessionState,
+    delivery_id: &str,
+) -> io::Result<()> {
+    if state
+        .pending_delivery_ids
+        .iter()
+        .any(|pending| pending == delivery_id)
+    {
+        return Ok(());
+    }
+    if state.pending_delivery_ids.len() >= DELIVERY_RECEIPT_LIMIT {
+        return Err(io::Error::new(
+            io::ErrorKind::WouldBlock,
+            "unresolved delivery journal is full",
+        ));
+    }
+    let mut next_state = state.clone();
+    while next_state
+        .accepted_delivery_ids
+        .len()
+        .saturating_add(next_state.pending_delivery_ids.len())
+        >= DELIVERY_RECEIPT_LIMIT
+    {
+        if next_state.accepted_delivery_ids.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "delivery outcome journal is full",
+            ));
+        }
+        next_state.accepted_delivery_ids.remove(0);
+    }
+    next_state.pending_delivery_ids.push(delivery_id.to_owned());
+    // This is the write-ahead half of the Holder receipt protocol. It lands
+    // before any byte can reach the PTY; a crash after this point is exposed
+    // as outcome-uncertain instead of silently replayed.
+    write_state(path, &next_state)?;
+    *state = next_state;
+    Ok(())
 }
 
 fn resolve_remote_executable(
@@ -1347,7 +1506,29 @@ fn terminate_process_group(pid: u32) {
 
 #[cfg(test)]
 mod tests {
+    use diri_proto::remote_pty::PersistenceCapability;
+
     use super::*;
+
+    fn receipt_state() -> SessionState {
+        SessionState {
+            schema: 1,
+            session_id: "session".into(),
+            session_incarnation: "incarnation".into(),
+            holder_build_id: "holder".into(),
+            holder_pid: 1,
+            process_state: RemoteProcessState::Running { pid: 2 },
+            cols: 80,
+            rows: 24,
+            output_offset: 0,
+            snapshot_sequence: 0,
+            controller_epoch: 1,
+            persistence: PersistenceCapability::NonPersistent,
+            created_at_unix_ms: 1,
+            accepted_delivery_ids: vec!["older".into()],
+            pending_delivery_ids: Vec::new(),
+        }
+    }
 
     #[test]
     fn pending_bytes_compact_after_a_complete_write() {
@@ -1359,6 +1540,59 @@ mod tests {
         assert!(pending.is_empty());
         pending.push(b"two");
         assert_eq!(pending.remaining(), b"two");
+    }
+
+    #[test]
+    fn failed_receipt_persistence_keeps_fifo_ids_and_state_for_retry() {
+        let root = tempfile::tempdir().expect("temp");
+        let blocked_parent = root.path().join("not-a-directory");
+        fs::write(&blocked_parent, b"file").expect("blocking file");
+        let mut state = receipt_state();
+        let before = state.clone();
+        let mut pending = vec!["first".into(), "second".into()];
+
+        assert!(
+            persist_delivery_receipts(&blocked_parent.join("state.json"), &mut state, &mut pending)
+                .is_err()
+        );
+        assert_eq!(state, before);
+        assert_eq!(pending, ["first", "second"]);
+
+        let landed =
+            persist_delivery_receipts(&root.path().join("state.json"), &mut state, &mut pending)
+                .expect("retry");
+        assert_eq!(landed, ["first", "second"]);
+        assert!(pending.is_empty());
+        assert_eq!(state.accepted_delivery_ids, ["older", "first", "second"]);
+    }
+
+    #[test]
+    fn receipt_intent_is_durable_before_delivery_and_survives_a_failed_commit() {
+        let root = tempfile::tempdir().expect("temp");
+        let state_path = root.path().join("state.json");
+        let mut state = receipt_state();
+        prepare_delivery_receipt(&state_path, &mut state, "delivery-1").expect("prepare");
+        assert_eq!(
+            read_state(&state_path)
+                .expect("durable intent")
+                .pending_delivery_ids,
+            ["delivery-1"]
+        );
+
+        let blocked_parent = root.path().join("not-a-directory");
+        fs::write(&blocked_parent, b"file").expect("blocking file");
+        let mut pending = vec!["delivery-1".into()];
+        assert!(
+            persist_delivery_receipts(&blocked_parent.join("state.json"), &mut state, &mut pending)
+                .is_err()
+        );
+        assert_eq!(state.pending_delivery_ids, ["delivery-1"]);
+        assert_eq!(pending, ["delivery-1"]);
+
+        persist_delivery_receipts(&state_path, &mut state, &mut pending).expect("commit retry");
+        let durable = read_state(&state_path).expect("durable commit");
+        assert!(durable.pending_delivery_ids.is_empty());
+        assert_eq!(durable.accepted_delivery_ids, ["older", "delivery-1"]);
     }
 
     #[test]

--- a/diri/crates/diri-remote/src/state.rs
+++ b/diri/crates/diri-remote/src/state.rs
@@ -34,6 +34,11 @@ pub struct SessionState {
     pub created_at_unix_ms: u64,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub accepted_delivery_ids: Vec<String>,
+    /// Operations durably prepared before a PTY side effect whose final
+    /// outcome was not durably committed. These tombstones survive Holder
+    /// replacement and may never be replayed automatically.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pending_delivery_ids: Vec<String>,
 }
 
 impl SessionState {
@@ -53,6 +58,7 @@ impl SessionState {
             persistence: request.persistence,
             created_at_unix_ms: unix_millis(),
             accepted_delivery_ids: Vec::new(),
+            pending_delivery_ids: Vec::new(),
         }
     }
 
@@ -71,6 +77,7 @@ impl SessionState {
             controller_epoch: self.controller_epoch,
             persistence: self.persistence,
             accepted_delivery_ids: self.accepted_delivery_ids.clone(),
+            uncertain_delivery_ids: self.pending_delivery_ids.clone(),
         }
     }
 }

--- a/diri/crates/diri-remote/src/state.rs
+++ b/diri/crates/diri-remote/src/state.rs
@@ -32,6 +32,8 @@ pub struct SessionState {
     pub controller_epoch: u64,
     pub persistence: PersistenceCapability,
     pub created_at_unix_ms: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub accepted_delivery_ids: Vec<String>,
 }
 
 impl SessionState {
@@ -50,6 +52,7 @@ impl SessionState {
             controller_epoch: 0,
             persistence: request.persistence,
             created_at_unix_ms: unix_millis(),
+            accepted_delivery_ids: Vec::new(),
         }
     }
 
@@ -67,6 +70,7 @@ impl SessionState {
             snapshot_sequence: self.snapshot_sequence,
             controller_epoch: self.controller_epoch,
             persistence: self.persistence,
+            accepted_delivery_ids: self.accepted_delivery_ids.clone(),
         }
     }
 }

--- a/diri/crates/diri-remote/tests/holder_e2e.rs
+++ b/diri/crates/diri-remote/tests/holder_e2e.rs
@@ -206,6 +206,8 @@ fn message_kinds(messages: &[RemoteMessage]) -> String {
             RemoteMessage::ReleaseControl(_) => "ReleaseControl",
             RemoteMessage::ScrollbackRequest(_) => "ScrollbackRequest",
             RemoteMessage::ScrollbackResponse(_) => "ScrollbackResponse",
+            RemoteMessage::DeliveryInput(_) => "DeliveryInput",
+            RemoteMessage::DeliveryAccepted(_) => "DeliveryAccepted",
             RemoteMessage::Error(_) => "Error",
         })
         .collect::<Vec<_>>()
@@ -376,6 +378,84 @@ fn detach_reconnect_preserves_pid_snapshot_and_input() {
         killed.process_state,
         RemoteProcessState::Exited { .. }
     ));
+}
+
+#[test]
+fn delivery_receipt_survives_controller_response_loss_and_reconnect() {
+    use diri_proto::remote_pty::DeliveryInput;
+
+    let temporary = tempfile::tempdir().expect("temp");
+    let state_dir = temporary.path().join("state");
+    let request = LaunchRequest {
+        session_id: "delivery-receipt-e2e".into(),
+        session_token: token(),
+        argv: vec!["/bin/cat".into()],
+        cwd: "/".into(),
+        environment: vec![diri_proto::remote_pty::EnvironmentVariable {
+            name: "TERM".into(),
+            value: "xterm-256color".into(),
+        }],
+        cols: 80,
+        rows: 24,
+        persistence: PersistenceCapability::NonPersistent,
+    };
+    let launch: LaunchResult = run_json("launch", &state_dir, Some(&request));
+    let mut first = Attach::open(&state_dir, hello(&launch, Some(0), "receipt-one"));
+    first.receive_until(Duration::from_secs(2), |message| {
+        matches!(message, RemoteMessage::ControlGranted(_))
+    });
+    first.send(RemoteMessage::DeliveryInput(DeliveryInput {
+        delivery_id: "delivery-1".into(),
+        data: b"only once\n".to_vec(),
+    }));
+    first.receive_until(Duration::from_secs(2), |message| {
+        matches!(
+            message,
+            RemoteMessage::DeliveryAccepted(accepted) if accepted.delivery_id == "delivery-1"
+        )
+    });
+    drop(first);
+
+    let inspection: SessionInspection = run_json(
+        "inspect",
+        &state_dir,
+        Some(&SessionSelector {
+            session_id: launch.session_id.clone(),
+            session_token: token(),
+            expected_incarnation: Some(launch.session_incarnation.clone()),
+        }),
+    );
+    assert_eq!(inspection.accepted_delivery_ids, ["delivery-1"]);
+
+    let mut second = Attach::open(&state_dir, hello(&launch, Some(0), "receipt-two"));
+    let hello_messages = second.receive_until(Duration::from_secs(2), |message| {
+        matches!(message, RemoteMessage::ControlGranted(_))
+    });
+    let ack = hello_messages
+        .iter()
+        .find_map(|message| match message {
+            RemoteMessage::HelloAck(ack) => Some(ack),
+            _ => None,
+        })
+        .expect("HelloAck");
+    assert_eq!(ack.accepted_delivery_ids, ["delivery-1"]);
+    second.send(RemoteMessage::DeliveryInput(DeliveryInput {
+        delivery_id: "delivery-1".into(),
+        data: b"only once\n".to_vec(),
+    }));
+    second.receive_until(Duration::from_secs(2), |message| {
+        matches!(
+            message,
+            RemoteMessage::DeliveryAccepted(accepted) if accepted.delivery_id == "delivery-1"
+        )
+    });
+
+    let selector = SessionSelector {
+        session_id: launch.session_id,
+        session_token: token(),
+        expected_incarnation: Some(launch.session_incarnation),
+    };
+    let _: SessionInspection = run_json("kill", &state_dir, Some(&selector));
 }
 
 #[test]

--- a/diri/crates/diri-remote/tests/holder_e2e.rs
+++ b/diri/crates/diri-remote/tests/holder_e2e.rs
@@ -208,6 +208,7 @@ fn message_kinds(messages: &[RemoteMessage]) -> String {
             RemoteMessage::ScrollbackResponse(_) => "ScrollbackResponse",
             RemoteMessage::DeliveryInput(_) => "DeliveryInput",
             RemoteMessage::DeliveryAccepted(_) => "DeliveryAccepted",
+            RemoteMessage::DeliveryUncertain(_) => "DeliveryUncertain",
             RemoteMessage::Error(_) => "Error",
         })
         .collect::<Vec<_>>()
@@ -456,6 +457,97 @@ fn delivery_receipt_survives_controller_response_loss_and_reconnect() {
         expected_incarnation: Some(launch.session_incarnation),
     };
     let _: SessionInspection = run_json("kill", &state_dir, Some(&selector));
+}
+
+#[test]
+fn replacement_holder_rejects_a_durable_pre_side_effect_tombstone() {
+    use diri_proto::remote_pty::DeliveryInput;
+
+    let temporary = tempfile::tempdir().expect("temp");
+    let state_dir = temporary.path().join("state");
+    let request = LaunchRequest {
+        session_id: "delivery-uncertain-e2e".into(),
+        session_token: token(),
+        argv: vec!["/bin/cat".into()],
+        cwd: "/".into(),
+        environment: vec![diri_proto::remote_pty::EnvironmentVariable {
+            name: "TERM".into(),
+            value: "xterm-256color".into(),
+        }],
+        cols: 80,
+        rows: 24,
+        persistence: PersistenceCapability::NonPersistent,
+    };
+    let first: LaunchResult = run_json("launch", &state_dir, Some(&request));
+    let _: SessionInspection = run_json(
+        "kill",
+        &state_dir,
+        Some(&SessionSelector {
+            session_id: first.session_id.clone(),
+            session_token: token(),
+            expected_incarnation: Some(first.session_incarnation),
+        }),
+    );
+
+    // Model a crash after the write-ahead state commit but before the Holder
+    // could durably commit its PTY outcome.
+    let state_path = state_dir.join("sessions/delivery-uncertain-e2e/session.json");
+    let mut state: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&state_path).expect("old state")).expect("JSON");
+    state["pendingDeliveryIds"] = serde_json::json!(["delivery-uncertain"]);
+    std::fs::write(&state_path, serde_json::to_vec(&state).expect("encode")).expect("inject");
+
+    let second: LaunchResult = run_json("launch", &state_dir, Some(&request));
+    let mut attach = Attach::open(&state_dir, hello(&second, None, "uncertain-client"));
+    let handshake = attach.receive_until(Duration::from_secs(2), |message| {
+        matches!(message, RemoteMessage::ControlGranted(_))
+    });
+    let acknowledgement = handshake
+        .iter()
+        .find_map(|message| match message {
+            RemoteMessage::HelloAck(acknowledgement) => Some(acknowledgement),
+            _ => None,
+        })
+        .expect("HelloAck");
+    assert_eq!(
+        acknowledgement.uncertain_delivery_ids,
+        ["delivery-uncertain"]
+    );
+
+    attach.send(RemoteMessage::DeliveryInput(DeliveryInput {
+        delivery_id: "delivery-uncertain".into(),
+        data: b"must not land\n".to_vec(),
+    }));
+    attach.receive_until(Duration::from_secs(2), |message| {
+        matches!(
+            message,
+            RemoteMessage::DeliveryUncertain(uncertain)
+                if uncertain.delivery_id == "delivery-uncertain"
+        )
+    });
+
+    attach.send(RemoteMessage::DeliveryInput(DeliveryInput {
+        delivery_id: "delivery-probe".into(),
+        data: b"probe\n".to_vec(),
+    }));
+    let output = attach.receive_until(Duration::from_secs(2), |message| {
+        message_contains(message, "probe")
+    });
+    assert!(
+        !output
+            .iter()
+            .any(|message| message_contains(message, "must not land"))
+    );
+
+    let _: SessionInspection = run_json(
+        "kill",
+        &state_dir,
+        Some(&SessionSelector {
+            session_id: second.session_id,
+            session_token: token(),
+            expected_incarnation: Some(second.session_incarnation),
+        }),
+    );
 }
 
 #[test]

--- a/diri/crates/dirijor-mcp/src/bin/dirijor.rs
+++ b/diri/crates/dirijor-mcp/src/bin/dirijor.rs
@@ -1212,6 +1212,7 @@ mod tests {
             pull_requests: None,
             listening_ports: None,
             foreground_agent: None,
+            run: None,
         }
     }
 

--- a/diri/crates/dirijor-mcp/src/bridge.rs
+++ b/diri/crates/dirijor-mcp/src/bridge.rs
@@ -70,6 +70,7 @@ impl Bridge {
             "list_agents" => self.list_agents(),
             "get_status" => self.get_status(arguments),
             "send_prompt" => self.send_prompt(arguments),
+            "interrupt_agent" => self.interrupt_agent(arguments),
             "wait_for_agent" => self.wait_for_agent(arguments),
             "read_output" => self.read_output(arguments),
             "get_artifacts" => self.get_artifacts(arguments),
@@ -159,16 +160,36 @@ impl Bridge {
             ));
         }
         let delivered = lineage.frame(&text, relation);
-        self.request(
-            Method::SESSION_SEND_TEXT,
-            json!({"sessionID": id, "text": delivered, "submit": submit}),
+        let delivery = self.request(
+            Method::SESSION_RUN_SEND,
+            json!({
+                "sessionID": id,
+                "text": delivered,
+                "submit": submit,
+                "expectedRunId": optional_number(arguments, "run_id").map(|id| id as u64),
+                "requestId": optional_string(arguments, "request_id"),
+            }),
             DEFAULT_TIMEOUT,
         )?;
         Ok(json!({
             "ok": true,
             "relation": relation.as_str(),
             "attributed": delivered != text,
+            "delivery": delivery,
         }))
+    }
+
+    fn interrupt_agent(&self, arguments: &Value) -> Result<Value, String> {
+        let id = required_string(arguments, "session_id")?;
+        self.request(
+            Method::SESSION_RUN_INTERRUPT,
+            json!({
+                "sessionID": id,
+                "expectedRunId": optional_number(arguments, "run_id").map(|id| id as u64),
+                "requestId": optional_string(arguments, "request_id"),
+            }),
+            DEFAULT_TIMEOUT,
+        )
     }
 
     fn wait_for_agent(&self, arguments: &Value) -> Result<Value, String> {
@@ -183,6 +204,7 @@ impl Bridge {
                 "sessionID": id,
                 "until": [until],
                 "timeoutMs": (timeout_seconds * 1000.0) as i64,
+                "runId": optional_number(arguments, "run_id").map(|id| id as u64),
             }),
             Duration::from_secs_f64(timeout_seconds + 5.0),
         )
@@ -420,8 +442,8 @@ impl Bridge {
                 .into_iter()
                 .filter(|record| wanted.contains(&record.id.0))
                 .collect();
-            let settled = latest.len() != wanted.len()
-                || latest.iter().all(|record| reached(&mode, &record.status));
+            let settled =
+                latest.len() != wanted.len() || latest.iter().all(|record| reached(&mode, record));
             Ok((latest, settled))
         };
         let (mut latest, mut settled) = reassess()?;
@@ -432,12 +454,21 @@ impl Bridge {
                 "sessions": wanted.iter().cloned().collect::<Vec<_>>(),
                 "kinds": ["session.updated", "session.removed"],
             });
-            let result = client.subscribe(subscription, deadline, |_, _, _| {
+            let refresh = || {
                 (latest, settled) = reassess().map_err(|message| {
                     ControlFailure::Protocol(format!("could not refresh children: {message}"))
                 })?;
                 Ok(!settled)
-            });
+            };
+            // Both callbacks are sequential, but they need access to the same
+            // mutable reassessment closure.
+            let refresh = std::cell::RefCell::new(refresh);
+            let result = client.subscribe_after(
+                subscription,
+                deadline,
+                || refresh.borrow_mut()(),
+                |_, _, _| refresh.borrow_mut()(),
+            );
             if !matches!(result, Ok(()) | Err(ControlFailure::Timeout)) {
                 result.map_err(render_failure)?;
             }
@@ -445,6 +476,8 @@ impl Bridge {
         Ok(json!({
             "settled": settled,
             "timed_out": !settled,
+            "all_done": latest.iter().all(run_is_done),
+            "needs_input": latest.iter().any(|record| record.run.as_ref().is_some_and(|run| matches!(run.state, diri_proto::AgentRunState::NeedsInput))),
             "children": latest.iter().map(|record| detailed(record, Relation::Child)).collect::<Vec<_>>(),
             "waited_for": mode,
         }))
@@ -551,12 +584,14 @@ impl Bridge {
             }
         }
         let delivered = lines.join("\n");
-        self.request(
-            Method::SESSION_SEND_TEXT,
+        let delivery = self.request(
+            Method::SESSION_RUN_REPORT,
             json!({
-                "sessionID": parent,
+                "reporterSessionID": caller,
                 "text": delivered,
                 "submit": optional_bool(arguments, "submit").unwrap_or(true),
+                "expectedRunId": optional_number(arguments, "run_id").map(|id| id as u64),
+                "requestId": optional_string(arguments, "request_id"),
             }),
             DEFAULT_TIMEOUT,
         )?;
@@ -565,6 +600,7 @@ impl Bridge {
             "parent": parent,
             "status": status,
             "delivered": delivered,
+            "delivery": delivery,
         }))
     }
 
@@ -680,6 +716,9 @@ fn compact(record: &SessionRecord) -> Value {
     }
     if let Some(host) = &record.host {
         object.insert("host".into(), json!(host));
+    }
+    if let Some(run) = &record.run {
+        object.insert("run".into(), json!(run));
     }
     Value::Object(object)
 }
@@ -886,15 +925,40 @@ fn child_subset<'a>(
         .collect()
 }
 
-fn reached(mode: &str, status: &SessionStatus) -> bool {
+fn reached(mode: &str, record: &SessionRecord) -> bool {
+    if let Some(run) = &record.run {
+        return match mode {
+            "exited" => matches!(record.status, SessionStatus::Exited(_)),
+            "done" => run.state.is_terminal(),
+            _ => {
+                run.state.is_terminal()
+                    || matches!(run.state, diri_proto::AgentRunState::NeedsInput)
+            }
+        };
+    }
     match mode {
-        "exited" => matches!(status, SessionStatus::Exited(_)),
-        "done" => matches!(status, SessionStatus::Idle | SessionStatus::Exited(_)),
+        "exited" => matches!(record.status, SessionStatus::Exited(_)),
+        "done" => matches!(
+            record.status,
+            SessionStatus::Idle | SessionStatus::Exited(_)
+        ),
         _ => matches!(
-            status,
+            record.status,
             SessionStatus::Idle | SessionStatus::NeedsInput(_) | SessionStatus::Exited(_)
         ),
     }
+}
+
+fn run_is_done(record: &SessionRecord) -> bool {
+    record.run.as_ref().map_or_else(
+        || {
+            matches!(
+                record.status,
+                SessionStatus::Idle | SessionStatus::Exited(_)
+            )
+        },
+        |run| run.state.is_terminal(),
+    )
 }
 
 #[cfg(test)]
@@ -934,6 +998,7 @@ mod tests {
             pull_requests: None,
             listening_ports: None,
             foreground_agent: None,
+            run: None,
         }
     }
 
@@ -959,15 +1024,20 @@ mod tests {
 
     #[test]
     fn settled_counts_input_and_exit_but_done_does_not_count_input() {
-        assert!(reached(
-            "settled",
-            &SessionStatus::NeedsInput(diri_proto::NeedsInputKind::Question)
-        ));
-        assert!(!reached(
-            "done",
-            &SessionStatus::NeedsInput(diri_proto::NeedsInputKind::Question)
-        ));
-        assert!(reached("done", &SessionStatus::Idle));
+        let mut paused = record("child", Some("caller"));
+        paused.status = SessionStatus::NeedsInput(diri_proto::NeedsInputKind::Question);
+        paused.run = Some(diri_proto::AgentRun {
+            id: 1,
+            state: diri_proto::AgentRunState::NeedsInput,
+            started_at: paused.created_at,
+            finished_at: None,
+            terminal_outcome: None,
+        });
+        assert!(reached("settled", &paused));
+        assert!(!reached("done", &paused));
+        paused.status = SessionStatus::Idle;
+        paused.run.as_mut().unwrap().state = diri_proto::AgentRunState::Completed;
+        assert!(reached("done", &paused));
     }
 
     #[test]

--- a/diri/crates/dirijor-mcp/src/control.rs
+++ b/diri/crates/dirijor-mcp/src/control.rs
@@ -116,6 +116,24 @@ impl ControlClient {
         deadline: Instant,
         mut on_event: impl FnMut(&str, u64, &Value) -> Result<bool, ControlFailure>,
     ) -> Result<(), ControlFailure> {
+        self.subscribe_after(
+            params,
+            deadline,
+            || Ok(true),
+            |name, seq, params| on_event(name, seq, params),
+        )
+    }
+
+    /// Subscribes, then runs one gap-closing assessment after the daemon has
+    /// installed the subscription but before waiting for the first event.
+    /// This is the event-driven equivalent of subscribe-before-read.
+    pub fn subscribe_after(
+        &mut self,
+        params: Value,
+        deadline: Instant,
+        mut after_subscribe: impl FnMut() -> Result<bool, ControlFailure>,
+        mut on_event: impl FnMut(&str, u64, &Value) -> Result<bool, ControlFailure>,
+    ) -> Result<(), ControlFailure> {
         let now = Instant::now();
         if now >= deadline {
             return Err(ControlFailure::Timeout);
@@ -126,6 +144,9 @@ impl ControlClient {
             return Err(ControlFailure::Protocol(
                 "daemon did not acknowledge the event subscription".into(),
             ));
+        }
+        if !after_subscribe()? {
+            return Ok(());
         }
 
         loop {
@@ -191,6 +212,50 @@ impl ControlClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn subscribe_after_closes_the_ack_to_first_event_gap() {
+        let (client_stream, mut server_stream) = UnixStream::pair().expect("pair");
+        let server = std::thread::spawn(move || {
+            let mut request = String::new();
+            BufReader::new(server_stream.try_clone().unwrap())
+                .read_line(&mut request)
+                .unwrap();
+            let request: ControlMessage = serde_json::from_str(&request).unwrap();
+            let ControlMessage::Request { id, .. } = request else {
+                panic!("request")
+            };
+            serde_json::to_writer(
+                &mut server_stream,
+                &ControlMessage::Response {
+                    id,
+                    result: Ok(serde_json::json!({"subscribed": true})),
+                },
+            )
+            .unwrap();
+            server_stream.write_all(b"\n").unwrap();
+        });
+        let reader = BufReader::new(client_stream.try_clone().unwrap());
+        let mut client = ControlClient {
+            stream: client_stream,
+            reader,
+        };
+        let mut assessed = false;
+        client
+            .subscribe_after(
+                serde_json::json!({}),
+                Instant::now() + Duration::from_secs(1),
+                || {
+                    assessed = true;
+                    Ok(false)
+                },
+                |_, _, _| panic!("no event should be needed"),
+            )
+            .unwrap();
+        assert!(assessed);
+        server.join().unwrap();
+    }
 
     #[test]
     fn explicit_socket_override_wins() {

--- a/diri/crates/dirijor-mcp/src/tools.rs
+++ b/diri/crates/dirijor-mcp/src/tools.rs
@@ -65,7 +65,9 @@ pub fn tool_definitions_for(kinds: &[String]) -> Vec<ToolDefinition> {
                 "properties": {
                     "session_id": {"type": "string"},
                     "text": {"type": "string"},
-                    "submit": {"type": "boolean", "description": "Press Enter after typing; defaults to true."}
+                    "submit": {"type": "boolean", "description": "Press Enter after typing; defaults to true."},
+                    "run_id": {"type": "integer", "minimum": 1, "description": "Reject the write if this run is no longer current."},
+                    "request_id": {"type": "string", "minLength": 1, "maxLength": 256, "description": "Stable idempotency key. Reuse it when retrying after a lost response."}
                 },
                 "required": ["session_id", "text"]
             }),
@@ -77,8 +79,9 @@ pub fn tool_definitions_for(kinds: &[String]) -> Vec<ToolDefinition> {
                 "type": "object",
                 "properties": {
                     "session_id": {"type": "string"},
-                    "until": {"type": "string", "enum": ["done", "needs_me", "idle", "exited"]},
-                    "timeout_s": {"type": "number", "default": 600}
+                    "until": {"type": "string", "enum": ["done", "completed", "failed", "aborted", "needs_me", "idle", "exited"], "description": "done returns on any terminal run; completed requires success."},
+                    "timeout_s": {"type": "number", "default": 600},
+                    "run_id": {"type": "integer", "minimum": 1, "description": "Pin the wait to this run; returns superseded if a newer run exists."}
                 },
                 "required": ["session_id"]
             }),
@@ -130,6 +133,19 @@ pub fn tool_definitions_for(kinds: &[String]) -> Vec<ToolDefinition> {
                     "force": {"type": "boolean"}
                 },
                 "required": ["repo", "path"]
+            }),
+        ),
+        ToolDefinition::new(
+            "interrupt_agent",
+            "Abort the current run with Ctrl-C while keeping the session reusable for a later prompt.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "session_id": {"type": "string"},
+                    "run_id": {"type": "integer", "minimum": 1},
+                    "request_id": {"type": "string", "minLength": 1, "maxLength": 256, "description": "Stable idempotency key. Reuse it when retrying after a lost response."}
+                },
+                "required": ["session_id"]
             }),
         ),
         ToolDefinition::new(
@@ -213,7 +229,9 @@ pub fn tool_definitions_for(kinds: &[String]) -> Vec<ToolDefinition> {
                     "changed_paths": string_array(),
                     "artifacts": string_array(),
                     "proof": string_array(),
-                    "submit": {"type": "boolean"}
+                    "submit": {"type": "boolean"},
+                    "run_id": {"type": "integer", "minimum": 1, "description": "Reject a delayed report from an older run."},
+                    "request_id": {"type": "string", "minLength": 1, "maxLength": 256, "description": "Stable idempotency key. Reuse it when retrying after a lost response."}
                 },
                 "required": ["summary"]
             }),


### PR DESCRIPTION
## Summary

- add durable run identities, expected-run admission, replay-safe send, report, wait, and interrupt semantics
- introduce local Holder and remote protocol 1.6 delivery receipts with pre-PTY tombstones and bounded uncertainty journals
- pin active replay provenance until terminal resolution and fail closed for legacy remotes without authoritative receipts
- serialize attached Enter with lifecycle admission and generation-bound remote submission
- persist receipt-first observations through a retryable per-session durability watermark before stale replies

## Verification

- full affected proto, client, engine, remote, and MCP suites
- Registry: 28 passed, 1 ignored; Orchestration: 25 passed; remote client: 4 passed
- strict engine all-target Clippy
- Holder replacement, lost acknowledgement, daemon restart, raw-Enter, storage failure, legacy protocol, and replay regressions
- repeated fresh adversarial reviews; no remaining P0 or P1 finding
- formatting and lockfile checks clean