### PR TITLE
test: stabilize terminal lifecycle and repaint coverage

### DIFF
--- a/diri/crates/diri-engine/src/control.rs
+++ b/diri/crates/diri-engine/src/control.rs
@@ -3755,11 +3755,32 @@ mod tests {
         assert_eq!(result["resumability"], "live");
 
         let id = result["id"].as_str().expect("session id").to_owned();
+        // End the fixture through its own PTY contract. `kill(-pgid, …)` is a
+        // production path covered by process-tree tests; invoking it here made
+        // this identity-only regression depend on the CI runner granting
+        // process-group signalling (macOS runners intermittently return
+        // EPERM). The resumed command is `sh -c 'read line'`, so one submitted
+        // line exits it naturally and exercises the same status fold.
         registry
             .lock()
             .expect("registry")
-            .terminate(&id, Duration::from_millis(100))
-            .expect("terminate resumed probe");
+            .get(&id)
+            .expect("resumed probe")
+            .send_text("done", true)
+            .expect("finish resumed probe");
+        for _ in 0..100 {
+            let exited = registry
+                .lock()
+                .expect("registry")
+                .record(&id)
+                .is_some_and(|record| {
+                    matches!(record.status, diri_proto::SessionStatus::Exited(_))
+                });
+            if exited {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
         assert_eq!(
             registry
                 .lock()

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -125,6 +125,15 @@ const OUTPUT_BATCH_CEILING: Duration = Duration::from_millis(8);
 /// that continuously adds content still publishes at up to 120 Hz.
 const OUTPUT_REPAINT_CEILING: Duration = Duration::from_millis(16);
 
+/// An entirely blank intermediate frame gets a little more grace than a
+/// partial repaint. A loaded machine can deschedule a TUI between its clear
+/// and redraw writes for longer than one display frame; publishing that state
+/// is the most visible possible flash. Keep enough headroom beyond a typical
+/// 30 ms scheduler pause for the resumed process to issue its redraw; a
+/// program that intentionally clears and stops still appears within the
+/// sub-100 ms perceptual-continuity bound.
+const OUTPUT_BLANK_REPAINT_CEILING: Duration = Duration::from_millis(80);
+
 /// Byte ceiling on one batch, matching `alacritty_terminal`'s
 /// `MAX_LOCKED_READ`. A child that writes faster than it can be parsed must
 /// not starve the grid indefinitely.
@@ -2405,15 +2414,18 @@ fn feed_output_batch(
             // still running and its status still matters.
             let _ = log.append(&buffer[..count]);
         }
-        let mid_repaint = {
+        let (mid_repaint, blank_repaint) = {
             let mut screen = shared.screen.lock().expect("screen");
             let before = *filled_before.get_or_insert_with(|| screen.filled_cells());
             screen.feed(&buffer[..count]);
-            screen.filled_cells() < before
+            let after = screen.filled_cells();
+            (after < before, after == 0 && before != 0)
         };
         total += count;
 
-        let deadline = if mid_repaint {
+        let deadline = if blank_repaint {
+            started_at + OUTPUT_BLANK_REPAINT_CEILING
+        } else if mid_repaint {
             repaint_deadline
         } else {
             batch_deadline
@@ -2427,7 +2439,12 @@ fn feed_output_batch(
         // have not arrived is reserved for a screen that currently holds less
         // than it did when the batch opened, which is a repaint caught between
         // its erase and its redraw. An echo, which only adds, never waits.
-        let settle = if mid_repaint {
+        let settle = if blank_repaint {
+            // A full erase is the most destructive intermediate frame. Give
+            // its redraw the entire bounded grace period instead of falling
+            // through the ordinary 16 ms partial-repaint settle window.
+            remaining
+        } else if mid_repaint {
             OUTPUT_SETTLE
         } else {
             Duration::ZERO

--- a/diri/crates/diri-engine/tests/repaint.rs
+++ b/diri/crates/diri-engine/tests/repaint.rs
@@ -113,9 +113,9 @@ fn an_erase_and_redraw_never_reach_a_client_as_a_blank_screen() {
     }
 
     // A minimal TUI: every line of input repaints the screen the way a real
-    // one does — erase, then draw — as two separate writes. The small gap
-    // deterministically models a writer descheduled between those calls; a
-    // busy macOS runner exposed the same gap naturally.
+    // one does — erase, then draw — as two separate writes. Thirty
+    // milliseconds is deliberately beyond the ordinary 16 ms partial-repaint
+    // settle: only the bounded blank-frame grace can keep this atomic.
     let control = UnixStream::connect(server.socket_path()).expect("connect control");
     let send = |message: &ControlMessage| {
         let mut bytes = serde_json::to_vec(message).expect("encode");
@@ -133,8 +133,12 @@ fn an_erase_and_redraw_never_reach_a_client_as_a_blank_screen() {
                 "-c",
                 "stty -echo; printf 'frame-0\\r\\n'; \
                  while read -r turn; do \
-                   printf '\\033[2J\\033[H'; sleep 0.001; \
-                   printf 'frame-%s\\r\\n' \"$turn\"; \
+                   case \"$turn\" in \
+                     blank) printf '\\033[2J\\033[H' ;; \
+                     additive) printf 'additive-frame\\r\\n' ;; \
+                     *) printf '\\033[2J\\033[H'; sleep 0.030; \
+                        printf 'frame-%s\\r\\n' \"$turn\" ;; \
+                   esac; \
                  done",
             ],
         })),
@@ -197,6 +201,48 @@ fn an_erase_and_redraw_never_reach_a_client_as_a_blank_screen() {
             }
         }
     }
+
+    // An intentional erase must not be hidden forever. With no redraw, the
+    // blank frame is published once the bounded grace expires.
+    let blank_started = Instant::now();
+    data.write_all(&FrameCodec::encode(&Frame::input(b"blank\n".to_vec())).expect("encode"))
+        .expect("send blank");
+    loop {
+        let frame = frames.next_frame("the intentional blank", deadline);
+        if frame.frame_type != FrameType::Grid {
+            continue;
+        }
+        let update = frame.grid_payload().expect("decode").expect("grid");
+        mirror.apply(&update);
+        if mirror.is_blank() {
+            break;
+        }
+    }
+    assert!(
+        blank_started.elapsed() < Duration::from_millis(500),
+        "an intentional clear must publish by a bounded deadline"
+    );
+
+    // Additive output never uses the blank repaint grace. It should remain an
+    // immediate streaming path even after an intentional clear.
+    let additive_started = Instant::now();
+    data.write_all(&FrameCodec::encode(&Frame::input(b"additive\n".to_vec())).expect("encode"))
+        .expect("send additive output");
+    loop {
+        let frame = frames.next_frame("the additive frame", deadline);
+        if frame.frame_type != FrameType::Grid {
+            continue;
+        }
+        let update = frame.grid_payload().expect("decode").expect("grid");
+        mirror.apply(&update);
+        if mirror.text().contains("additive-frame") {
+            break;
+        }
+    }
+    assert!(
+        additive_started.elapsed() < Duration::from_millis(100),
+        "additive output regressed onto the repaint grace path"
+    );
 
     send(&ControlMessage::Request {
         id: 2,


### PR DESCRIPTION
## Summary

- distinguish destructive blank-frame grace from partial repaint and additive streaming deadlines
- fold delayed erase-redraw sequences without publishing a visible blank frame
- keep intentional clears bounded and preserve the low-latency additive path
- harden history-resume lifecycle coverage around natural PTY exit and cleanup

## Verification

- repeated real-PTY repaint stress
- focused history-resume stress
- full engine suite
- strict all-target Clippy
- formatting, lockfile, and diff checks clean