### PR TITLE
feat(node): portable local-to-VPS handoff config

### DIFF
--- a/diri/Cargo.lock
+++ b/diri/Cargo.lock
@@ -1615,6 +1615,7 @@ dependencies = [
  "sha2 0.11.0",
  "tempfile",
  "tokio",
+ "toml 0.8.23",
 ]
 
 [[package]]

--- a/diri/Cargo.toml
+++ b/diri/Cargo.toml
@@ -50,6 +50,7 @@ rusqlite = { version = "0.40.1", features = ["bundled"] }
 sha2 = "0.11"
 tempfile = "3"
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
+toml = "0.8.23"
 unicode-segmentation = "1"
 url = "2"
 zeroize = { version = "1", features = ["derive"] }

--- a/diri/HANDOFF.md
+++ b/diri/HANDOFF.md
@@ -38,6 +38,14 @@ conflict without being overwritten. Claude's mixed `.claude.json` receives a
 server-by-server merge, preserving its local OAuth and app state. The apply
 report is returned with the handoff and printed by the CLI.
 
+Paths are deliberately node-relative. Portable-config bundles contain only
+provider-home-relative allowlisted names; the source and target nodes resolve
+those names against their own profile homes. Likewise, the source workspace's
+absolute path is informational metadata only. The target stages files below its
+own node restore root and passes that target-local path to provider resume/fork.
+This allows paths such as `/Users/alice/code/project` and
+`/home/alice/.local/share/dirijor/node/restores/...` to differ safely.
+
 Portable-config installation is a separate, additive step and is not rolled
 back if a later workspace or conversation handoff step fails.
 

--- a/diri/HANDOFF.md
+++ b/diri/HANDOFF.md
@@ -1,0 +1,108 @@
+# Local ↔ VPS handoff design
+
+Dirijor handoff moves a running coding session without pretending that every
+piece of machine state belongs in one synchronizer. The design has four lanes:
+
+| State | Mechanism | Conflict / security rule |
+| --- | --- | --- |
+| Conversation | Provider-native resume/fork plus the one session transcript | Never includes provider credentials |
+| Working tree | Existing content-addressed checkpoint into a target quarantine | `.git`, `.jj`, `.env*`, credential files, dependencies, and build output stay out |
+| Settings + MCP topology | `portable-config.v1` profile bundle | Fixed allowlist, 1 MiB maximum, target wins every conflict |
+| Authentication + MCP OAuth | A matching profile is signed in independently on each node | Identity mismatch blocks handoff; tokens never cross the node protocol |
+
+This keeps the interface small: callers request one handoff. The node hides
+configuration filtering, target conflict handling, checkpoint transfer, resume,
+and lease commit behind that interface.
+
+## What the proof of concept does
+
+Before a handoff, the client checks that the source and target profiles use the
+requested provider, are ready, and resolve to the same account identity when
+both providers expose one. It then synchronizes this bounded configuration:
+
+- Codex: `config.toml` and `AGENTS.md`. The TOML carries Codex settings and MCP
+  definitions. A config containing inline MCP `env` or `http_headers` values is
+  omitted; environment-variable references such as `bearer_token_env_var` and
+  `env_http_headers` remain portable.
+- Claude: `settings.json`, `CLAUDE.md`, `keybindings.json`, and only the
+  top-level `mcpServers` map extracted from `.claude.json`. OAuth, machine IDs,
+  project caches, approvals, and other app state in `.claude.json` are never
+  exported. An MCP definition with a known inline credential field is omitted.
+- Claude project MCP configuration already travels as the workspace's checked-in
+  `.mcp.json`. Environment references are the recommended way to keep its
+  secrets machine-local.
+
+On the target, a missing file is installed with owner-only permissions, an
+identical file is reported unchanged, and a differing file is reported as a
+conflict without being overwritten. Claude's mixed `.claude.json` receives a
+server-by-server merge, preserving its local OAuth and app state. The apply
+report is returned with the handoff and printed by the CLI.
+
+Portable-config installation is a separate, additive step and is not rolled
+back if a later workspace or conversation handoff step fails.
+
+Configuration sync is also independently useful:
+
+```sh
+diri-node account sync-config --id work \
+  --target-endpoint tcp://100.64.0.2:7337 \
+  --target-token-file ~/.config/dirijor/forge.token \
+  --target-node-id node-a1b2c3d4
+```
+
+To sync back, make the VPS the source with `--endpoint`, `--token-file`, and
+`--node-id`, then point the `--target-*` flags at the local node. The operation
+is additive in both directions; it is intentionally not last-writer-wins.
+
+## Why authentication is re-created, not synchronized
+
+Codex can cache credentials in `auth.json` or an OS credential store, and the
+official headless flow supports device login as well as an explicit
+`auth.json` copy fallback. Claude's `.claude.json` combines OAuth with MCP,
+project, UI, and cache state, while macOS may use Keychain. Those storage
+models do not form a stable, provider-neutral transfer format.
+
+Dirijor therefore synchronizes *identity intent* (the profile and observed
+account identity), not bearer credentials. Run `diri-node account login --id
+work` against each node. The browser/device challenge is printed locally even
+when the node is on a VPS. This avoids turning an enrollment token into a remote
+credential-export capability and avoids persisting account tokens in checkpoint
+blobs.
+
+References:
+
+- [Codex authentication and headless login](https://learn.chatgpt.com/docs/auth)
+- [Claude settings scopes and global state](https://code.claude.com/docs/en/settings)
+- [Claude MCP scopes and environment references](https://code.claude.com/docs/en/mcp)
+
+## Where Jujutsu fits
+
+Jujutsu is a strong optional adapter for the **code lane**, not a transport for
+settings or credentials. A colocated Jujutsu workspace interoperates with Git
+remotes, but `.jj` contains local operation/workspace state and should not be
+copied between machines. Jujutsu workspaces attached to one repository are also
+local working copies, not a cross-host replication primitive.
+
+The proof of concept keeps the existing Git-compatible checkpoint path and has
+no runtime dependency on `jj`. A later adapter can detect a colocated workspace,
+publish its working-copy commit/bookmark to the existing Git remote, and create
+a fresh target workspace. That adapter should still leave portable config and
+authentication in their current lanes.
+
+References:
+
+- [Jujutsu Git compatibility and colocation](https://docs.jj-vcs.dev/latest/git-compatibility/)
+- [Jujutsu working copies and workspaces](https://docs.jj-vcs.dev/latest/working-copy/)
+
+## POC limits and next steps
+
+- Only small top-level provider settings are portable. Skills, plugins, hooks
+  with executable payloads, memories, arbitrary dotfiles, and shell profiles
+  need their own threat model before joining the allowlist.
+- A config conflict is reported, not merged. A future UI can preview a
+  provider-aware three-way merge using the last successfully applied digest.
+- The workspace checkpoint remains the data path for uncommitted files. A
+  future Git/Jujutsu adapter can seed the target quarantine from a remote commit
+  first, reducing transfer size without changing the handoff interface.
+- Existing nodes that do not advertise `portable-config.v1` still hand off the
+  session and workspace; configuration sync is skipped and reported.

--- a/diri/NODE.md
+++ b/diri/NODE.md
@@ -2,6 +2,11 @@
 
 `diri-node` makes a VPS (or another workstation) a first-party Dirijor execution host. It is a per-user service: provider credentials remain on the machine where Claude Code or Codex runs, while Dirijor gets one versioned management interface for accounts, usage, provider sessions, and handoff.
 
+The [handoff design](HANDOFF.md) explains exactly which settings, MCP state,
+authentication, conversation data, and working-tree data move between nodes,
+including why Jujutsu is an optional code adapter rather than a credential
+synchronizer.
+
 SSH is still configured. It is the install/recovery path and the compatibility terminal path; it is no longer the source of truth for identity, usage, or movement.
 
 ## Install on the VPS
@@ -86,6 +91,21 @@ diri-node account login --id personal \
 Codex uses the official app-server device-code/browser flow. The URL and one-time code are printed where the command runs, so a VPS login completes in the local browser without copying `auth.json`. Claude's supported interactive auth command is streamed through the node; open the emitted URL locally. On Linux, each Claude installation uses its own `CLAUDE_CONFIG_DIR`. Claude Code's macOS Keychain credential is host-wide, so multiple simultaneous Claude subscription identities on one Mac are intentionally not claimed as isolated.
 
 Codex installations use a separate `CODEX_HOME`. Sessions bind to an explicit profile; changing a node default affects new sessions, not a running session. This is identity selection for legitimate personal/work contexts—not automatic rate-limit failover.
+
+Provider settings can follow the profile without its credentials:
+
+```sh
+diri-node account sync-config --id work \
+  --target-endpoint tcp://100.64.0.2:7337 \
+  --target-token-file ~/.config/dirijor/forge.token \
+  --target-node-id node-a1b2c3d4
+```
+
+The handoff command runs the same sync automatically when both nodes advertise
+`portable-config.v1`. Target conflicts are kept and reported; known inline MCP
+credential fields are omitted, and provider login state never crosses the node
+boundary. See [Local ↔ VPS handoff design](HANDOFF.md) for the allowlist and
+security model.
 
 ## Instant move and fork
 

--- a/diri/crates/diri-client/src/node_client.rs
+++ b/diri/crates/diri-client/src/node_client.rs
@@ -12,8 +12,9 @@ use diri_proto::{
     CheckpointManifestParams, CheckpointPrepareParams, CheckpointStageResult, HostEntry,
     InstallationStatus, LoginChallenge, LoginInputParams, LoginSessionParams, MoveAbortParams,
     MoveCommitParams, MoveRecord, NodeHelloParams, NodeHelloResult, NodeMethod, NodeStatusResult,
-    ProviderCallParams, ProviderCallResult, ProviderKind, SessionHandoffResult, TransferMode,
-    UsageEvent, UsageQueryParams, UsageQueryResult, UsageRecordParams,
+    PortableConfigApplyParams, PortableConfigApplyResult, PortableConfigBundle, ProviderCallParams,
+    ProviderCallResult, ProviderKind, SessionHandoffResult, TransferMode, UsageEvent,
+    UsageQueryParams, UsageQueryResult, UsageRecordParams,
 };
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -166,6 +167,47 @@ impl NodeClient {
         Ok(())
     }
 
+    pub async fn export_portable_config(
+        &self,
+        profile_id: impl Into<String>,
+    ) -> Result<PortableConfigBundle, ClientError> {
+        self.typed(
+            NodeMethod::ACCOUNT_PORTABLE_CONFIG_EXPORT,
+            &AccountProfileParams {
+                profile_id: profile_id.into(),
+            },
+        )
+        .await
+    }
+
+    pub async fn apply_portable_config(
+        &self,
+        bundle: PortableConfigBundle,
+    ) -> Result<PortableConfigApplyResult, ClientError> {
+        self.typed(
+            NodeMethod::ACCOUNT_PORTABLE_CONFIG_APPLY,
+            &PortableConfigApplyParams { bundle },
+        )
+        .await
+    }
+
+    /// Sync only portable provider settings. The source and target account
+    /// profiles must already exist; login remains a per-node action.
+    pub async fn sync_portable_config(
+        &self,
+        target: &NodeClient,
+        profile_id: &str,
+    ) -> Result<PortableConfigApplyResult, ClientError> {
+        let (source, destination) = tokio::try_join!(self.hello(), target.hello())?;
+        if !supports_portable_config(&source) || !supports_portable_config(&destination) {
+            return Err(ClientError::protocol(
+                "both nodes must support portable-config.v1",
+            ));
+        }
+        let bundle = self.export_portable_config(profile_id).await?;
+        target.apply_portable_config(bundle).await
+    }
+
     pub async fn provider_call(
         &self,
         params: ProviderCallParams,
@@ -209,14 +251,31 @@ impl NodeClient {
     ) -> Result<SessionHandoffResult, ClientError> {
         let provider = params.provider;
         let profile_id = params.profile_id.clone();
-        let target_hello = target.hello().await?;
-        let installation = target.account_status(&profile_id).await?;
-        if installation.status != InstallationStatus::Ready {
+        let (source_hello, target_hello) = tokio::try_join!(self.hello(), target.hello())?;
+        let (source_installation, target_installation) = tokio::try_join!(
+            self.account_status(&profile_id),
+            target.account_status(&profile_id)
+        )?;
+        validate_account_continuity(
+            provider,
+            &source_installation,
+            &target_installation,
+            &source_hello.display_name,
+            &target_hello.display_name,
+        )?;
+        if target_installation.status != InstallationStatus::Ready {
             return Err(ClientError::protocol(format!(
                 "account profile `{profile_id}` is not signed in on {}",
                 target_hello.display_name
             )));
         }
+        let portable_config =
+            if supports_portable_config(&source_hello) && supports_portable_config(&target_hello) {
+                let bundle = self.export_portable_config(&profile_id).await?;
+                Some(target.apply_portable_config(bundle).await?)
+            } else {
+                None
+            };
         let checkpoint = self.prepare_checkpoint(params).await?;
         if checkpoint.provider_session_id.is_none() {
             return Err(ClientError::protocol(
@@ -275,6 +334,7 @@ impl NodeClient {
             Ok::<SessionHandoffResult, ClientError>(SessionHandoffResult {
                 checkpoint: checkpoint.clone(),
                 staged,
+                portable_config,
                 provider_result,
                 target_commit,
                 source_commit,
@@ -479,6 +539,46 @@ impl NodeClient {
     }
 }
 
+fn supports_portable_config(hello: &NodeHelloResult) -> bool {
+    hello
+        .capabilities
+        .iter()
+        .any(|capability| capability == diri_proto::NodeCapability::PORTABLE_CONFIG)
+}
+
+fn validate_account_continuity(
+    provider: ProviderKind,
+    source: &AccountInstallation,
+    target: &AccountInstallation,
+    source_name: &str,
+    target_name: &str,
+) -> Result<(), ClientError> {
+    if source.provider != provider || target.provider != provider {
+        return Err(ClientError::protocol(
+            "source and target profiles must use the handoff provider",
+        ));
+    }
+    if source.status != InstallationStatus::Ready {
+        return Err(ClientError::protocol(format!(
+            "account profile `{}` is not signed in on {source_name}",
+            source.profile_id
+        )));
+    }
+    if let (Some(source_identity), Some(target_identity)) =
+        (source.identity.as_deref(), target.identity.as_deref())
+        && target.status == InstallationStatus::Ready
+        && !source_identity.trim().is_empty()
+        && !target_identity.trim().is_empty()
+        && !source_identity.eq_ignore_ascii_case(target_identity)
+    {
+        return Err(ClientError::protocol(format!(
+            "account profile `{}` resolves to different identities on {source_name} and {target_name}",
+            source.profile_id
+        )));
+    }
+    Ok(())
+}
+
 async fn read_response<R: AsyncBufReadExt + Unpin>(
     reader: &mut R,
     expected_id: u64,
@@ -578,6 +678,20 @@ fn random_lease_id() -> Result<String, ClientError> {
 mod tests {
     use super::*;
 
+    fn installation(identity: &str) -> AccountInstallation {
+        AccountInstallation {
+            profile_id: "work".into(),
+            provider: ProviderKind::Codex,
+            node_id: "node".into(),
+            status: InstallationStatus::Ready,
+            config_home: "/tmp/codex-work".into(),
+            identity: Some(identity.into()),
+            plan: None,
+            last_error: None,
+            checked_at: None,
+        }
+    }
+
     #[test]
     fn token_files_accept_plain_or_explicit_json_but_not_short_values() {
         let token = "a".repeat(64);
@@ -634,5 +748,27 @@ mod tests {
             "100.64.0.2:7337"
         );
         assert!(endpoint_address("https://example.com").is_err());
+    }
+
+    #[test]
+    fn handoff_rejects_a_profile_that_resolves_to_another_identity() {
+        let source = installation("person@example.com");
+        let target = installation("someone-else@example.com");
+        let error =
+            validate_account_continuity(ProviderKind::Codex, &source, &target, "Local", "Forge")
+                .expect_err("identity mismatch");
+        assert!(error.to_string().contains("different identities"));
+    }
+
+    #[test]
+    fn handoff_identity_comparison_is_case_insensitive() {
+        validate_account_continuity(
+            ProviderKind::Codex,
+            &installation("Person@Example.com"),
+            &installation("person@example.com"),
+            "Local",
+            "Forge",
+        )
+        .expect("same identity");
     }
 }

--- a/diri/crates/diri-client/src/node_client.rs
+++ b/diri/crates/diri-client/src/node_client.rs
@@ -298,16 +298,7 @@ impl NodeClient {
                 self.transfer_blob(target, &digest).await?;
             }
             let staged = target.stage_checkpoint(&checkpoint.checkpoint_id).await?;
-            let provider_session_id = checkpoint
-                .provider_session_id
-                .as_deref()
-                .expect("checked above");
-            let (method, call_params) = provider_resume_call(
-                provider,
-                checkpoint.mode,
-                provider_session_id,
-                &staged.quarantine_path,
-            );
+            let (method, call_params) = provider_resume_call_for_handoff(&checkpoint, &staged)?;
             let provider_result = target
                 .provider_call(ProviderCallParams {
                     profile_id: profile_id.clone(),
@@ -662,6 +653,22 @@ fn provider_resume_call(
     (method, params)
 }
 
+fn provider_resume_call_for_handoff(
+    checkpoint: &CheckpointManifest,
+    staged: &CheckpointStageResult,
+) -> Result<(&'static str, Value), ClientError> {
+    let provider_session_id = checkpoint
+        .provider_session_id
+        .as_deref()
+        .ok_or_else(|| ClientError::protocol("checkpoint omitted provider session state"))?;
+    Ok(provider_resume_call(
+        checkpoint.provider,
+        checkpoint.mode,
+        provider_session_id,
+        &staged.quarantine_path,
+    ))
+}
+
 fn random_lease_id() -> Result<String, ClientError> {
     let mut bytes = [0_u8; 16];
     getrandom::fill(&mut bytes).map_err(ClientError::io)?;
@@ -722,23 +729,48 @@ mod tests {
     }
 
     #[test]
-    fn provider_handoff_uses_first_party_resume_shapes() {
-        let (codex, params) = provider_resume_call(
-            ProviderKind::Codex,
-            TransferMode::Move,
-            "thread-1",
-            "/tmp/staged",
-        );
+    fn provider_handoff_rebases_resume_cwd_onto_the_target_stage() {
+        let source_workspace = "/Users/alice/code/project";
+        let target_workspace = "/home/alice/.local/share/dirijor/node/restores/cp-1";
+        let checkpoint = CheckpointManifest {
+            version: 1,
+            checkpoint_id: "cp-1".into(),
+            source_node_id: "mac".into(),
+            session_id: "session-1".into(),
+            provider: ProviderKind::Codex,
+            profile_id: "work".into(),
+            workspace_root: source_workspace.into(),
+            provider_session_id: Some("thread-1".into()),
+            mode: TransferMode::Move,
+            created_at: 1,
+            files: Vec::new(),
+            provider_state: None,
+            excluded: Vec::new(),
+        };
+        let staged = CheckpointStageResult {
+            checkpoint_id: "cp-1".into(),
+            quarantine_path: target_workspace.into(),
+            ready: true,
+        };
+        let (codex, params) =
+            provider_resume_call_for_handoff(&checkpoint, &staged).expect("resume call");
         assert_eq!(codex, "thread/resume");
         assert_eq!(params["threadId"], "thread-1");
-        let (claude, params) = provider_resume_call(
-            ProviderKind::Claude,
-            TransferMode::Fork,
-            "session-1",
-            "/tmp/staged",
-        );
+        assert_eq!(params["cwd"], target_workspace);
+        assert_ne!(params["cwd"], source_workspace);
+
+        let checkpoint = CheckpointManifest {
+            provider: ProviderKind::Claude,
+            provider_session_id: Some("session-1".into()),
+            mode: TransferMode::Fork,
+            ..checkpoint
+        };
+        let (claude, params) =
+            provider_resume_call_for_handoff(&checkpoint, &staged).expect("fork call");
         assert_eq!(claude, "session/fork");
         assert_eq!(params["sessionId"], "session-1");
+        assert_eq!(params["cwd"], target_workspace);
+        assert_ne!(params["cwd"], source_workspace);
     }
 
     #[test]

--- a/diri/crates/diri-node/Cargo.toml
+++ b/diri/crates/diri-node/Cargo.toml
@@ -19,6 +19,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 tokio.workspace = true
+toml.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/diri/crates/diri-node/src/checkpoint.rs
+++ b/diri/crates/diri-node/src/checkpoint.rs
@@ -717,6 +717,8 @@ mod tests {
         let staged = store
             .stage(&manifest.checkpoint_id, &provider_home)
             .expect("stage");
+        assert_ne!(Path::new(&staged.quarantine_path), workspace);
+        assert!(Path::new(&staged.quarantine_path).starts_with(&paths.restores));
         assert!(
             Path::new(&staged.quarantine_path)
                 .join("README.md")

--- a/diri/crates/diri-node/src/lib.rs
+++ b/diri/crates/diri-node/src/lib.rs
@@ -8,6 +8,7 @@ pub mod accounts;
 pub mod checkpoint;
 pub mod config;
 pub mod error;
+pub mod portable;
 pub mod provider;
 pub mod server;
 pub mod service;

--- a/diri/crates/diri-node/src/main.rs
+++ b/diri/crates/diri-node/src/main.rs
@@ -7,7 +7,7 @@ use diri_client::{NodeClient, NodeClientConfig};
 use diri_node::{NodeConfig, NodePaths, NodeServer, NodeService};
 use diri_proto::{
     AccountLoginStartParams, AccountSetDefaultParams, AccountUpsertParams, CheckpointPrepareParams,
-    LoginMode, ProviderKind, TransferMode,
+    LoginMode, PortableConfigApplyResult, ProviderKind, TransferMode,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -96,9 +96,21 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             serve(paths, config, listen).await?;
         }
         "account" => {
-            reject_target_options(&target)?;
-            let client = management_client(&paths, listen, &remote, &home)?;
-            account_command(&arguments[1..], &client).await?;
+            let source = management_client(&paths, listen, &remote, &home)?;
+            if arguments
+                .get(1)
+                .is_some_and(|command| command == "sync-config")
+            {
+                let profile_id = required_flag(&arguments[2..], "--id")?;
+                let destination = target.client(&home)?;
+                let result = source
+                    .sync_portable_config(&destination, profile_id)
+                    .await?;
+                print_portable_config(&result);
+            } else {
+                reject_target_options(&target)?;
+                account_command(&arguments[1..], &source).await?;
+            }
         }
         "handoff" => {
             let source = management_client(&paths, listen, &remote, &home)?;
@@ -343,11 +355,50 @@ async fn handoff_command(
     );
     println!("Checkpoint: {}", result.checkpoint.checkpoint_id);
     println!("Workspace: {}", result.staged.quarantine_path);
+    if let Some(portable) = &result.portable_config {
+        print_portable_config(portable);
+    } else {
+        println!("Portable config: skipped (one node predates portable-config.v1)");
+    }
     println!(
         "Provider: {}",
         serde_json::to_string(&result.provider_result)?
     );
     Ok(())
+}
+
+fn print_portable_config(result: &PortableConfigApplyResult) {
+    println!(
+        "Portable config: {} installed, {} unchanged, {} conflicts, {} omitted",
+        result.installed.len(),
+        result.unchanged.len(),
+        result.conflicts.len(),
+        result.omitted.len()
+    );
+    for path in &result.installed {
+        println!("  installed: {}", terminal_text(path));
+    }
+    for path in &result.conflicts {
+        println!("  kept target conflict: {}", terminal_text(path));
+    }
+    for omission in &result.omitted {
+        println!(
+            "  omitted: {} ({})",
+            terminal_text(&omission.path),
+            terminal_text(&omission.reason)
+        );
+    }
+}
+
+fn terminal_text(value: &str) -> String {
+    value.chars().fold(String::new(), |mut output, character| {
+        if character.is_control() {
+            output.extend(character.escape_default());
+        } else {
+            output.push(character);
+        }
+        output
+    })
 }
 
 fn management_client(
@@ -431,6 +482,8 @@ Usage:
   diri-node account default --provider claude|codex --id ID
   diri-node account status --id ID
   diri-node account login --id ID [--mode device|browser|interactive]
+  diri-node account sync-config --id ID \
+    --target-endpoint tcp://HOST:PORT --target-token-file PATH [--target-node-id ID]
   diri-node handoff --provider claude|codex --profile ID --session ID \
     --provider-session ID --workspace PATH [--mode move|fork] \
     --target-endpoint tcp://HOST:PORT --target-token-file PATH [--target-node-id ID]

--- a/diri/crates/diri-node/src/portable.rs
+++ b/diri/crates/diri-node/src/portable.rs
@@ -1,0 +1,756 @@
+//! Provider-auth-free configuration that can follow a session between nodes.
+//!
+//! This module is intentionally narrower than a dotfiles synchronizer. It
+//! exports a fixed list of provider settings, extracts only MCP topology from
+//! Claude's mixed global-state file, rejects known inline credential fields,
+//! and never overwrites a target conflict.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use diri_proto::{
+    AccountProfile, PortableConfigApplyResult, PortableConfigBundle, PortableConfigFile,
+    PortableConfigOmission, ProviderKind,
+};
+use serde_json::{Map, Value, json};
+use sha2::{Digest, Sha256};
+
+use crate::config::{hex_encode, random_hex, set_owner_directory, set_owner_file};
+use crate::error::{NodeError, NodeResult};
+
+pub const PORTABLE_CONFIG_VERSION: u32 = 1;
+
+const MAX_SOURCE_FILE_BYTES: u64 = 4 * 1024 * 1024;
+const MAX_BUNDLE_BYTES: usize = 1024 * 1024;
+const CODEX_PATHS: &[&str] = &["config.toml", "AGENTS.md"];
+const CLAUDE_PATHS: &[&str] = &[
+    "settings.json",
+    "CLAUDE.md",
+    "keybindings.json",
+    ".claude.json",
+];
+
+/// Capture the small declarative part of one provider installation. The
+/// resulting bundle contains no provider login or MCP OAuth state, caches,
+/// transcripts, or arbitrary dotfiles. Known inline MCP credential fields fail
+/// closed and are reported as omissions.
+pub fn capture(profile: &AccountProfile, config_home: &Path) -> NodeResult<PortableConfigBundle> {
+    let mut files = Vec::new();
+    let mut omitted = Vec::new();
+    let paths = allowed_paths(profile.provider);
+    for &relative in paths {
+        let source = config_home.join(relative);
+        if !source.exists() {
+            continue;
+        }
+        let metadata = fs::symlink_metadata(&source)?;
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            omitted.push(omission(relative, "not a regular file"));
+            continue;
+        }
+        if metadata.len() > MAX_SOURCE_FILE_BYTES {
+            omitted.push(omission(relative, "exceeds the portable-config size limit"));
+            continue;
+        }
+        let raw = match fs::read_to_string(&source) {
+            Ok(raw) => raw,
+            Err(error) if error.kind() == std::io::ErrorKind::InvalidData => {
+                omitted.push(omission(relative, "is not UTF-8 text"));
+                continue;
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let content = match (profile.provider, relative) {
+            (ProviderKind::Codex, "config.toml") => {
+                portable_codex_config(&raw).map_err(|reason| omission(relative, reason))
+            }
+            (ProviderKind::Claude, "settings.json") => {
+                portable_claude_settings(&raw).map_err(|reason| omission(relative, reason))
+            }
+            (ProviderKind::Claude, ".claude.json") => {
+                portable_claude_mcp(&raw, &mut omitted).map_err(|reason| omission(relative, reason))
+            }
+            _ => reject_private_key_material(&raw)
+                .map(|()| Some(raw))
+                .map_err(|reason| omission(relative, reason)),
+        };
+        match content {
+            Ok(Some(content)) => files.push(portable_file(relative, content)),
+            Ok(None) => {}
+            Err(item) => omitted.push(item),
+        }
+    }
+
+    record_auth_omission(profile.provider, config_home, &mut omitted);
+    let bundle = PortableConfigBundle {
+        version: PORTABLE_CONFIG_VERSION,
+        provider: profile.provider,
+        profile_id: profile.id.clone(),
+        files,
+        omitted,
+    };
+    ensure_bundle_size(&bundle)?;
+    Ok(bundle)
+}
+
+/// Add a portable bundle to a target profile without replacing local choices.
+/// Claude's `.claude.json` receives a field-level MCP merge so its OAuth and
+/// machine state remain untouched; every other file uses add/same/conflict.
+pub fn apply(
+    profile: &AccountProfile,
+    config_home: &Path,
+    bundle: PortableConfigBundle,
+) -> NodeResult<PortableConfigApplyResult> {
+    validate_bundle(profile, &bundle)?;
+    fs::create_dir_all(config_home)?;
+    set_owner_directory(config_home)?;
+    let mut result = PortableConfigApplyResult {
+        provider: profile.provider,
+        profile_id: profile.id.clone(),
+        installed: Vec::new(),
+        unchanged: Vec::new(),
+        conflicts: Vec::new(),
+        omitted: bundle.omitted,
+    };
+    for file in bundle.files {
+        if profile.provider == ProviderKind::Claude && file.path == ".claude.json" {
+            merge_claude_mcp(config_home, &file, &mut result)?;
+        } else {
+            apply_file(config_home, &file, &mut result)?;
+        }
+    }
+    Ok(result)
+}
+
+fn allowed_paths(provider: ProviderKind) -> &'static [&'static str] {
+    match provider {
+        ProviderKind::Claude => CLAUDE_PATHS,
+        ProviderKind::Codex => CODEX_PATHS,
+    }
+}
+
+fn portable_file(path: &str, content: String) -> PortableConfigFile {
+    PortableConfigFile {
+        path: path.into(),
+        sha256: sha256(content.as_bytes()),
+        content,
+    }
+}
+
+fn portable_codex_config(raw: &str) -> Result<Option<String>, &'static str> {
+    reject_private_key_material(raw)?;
+    let value: toml::Value =
+        toml::from_str(raw).map_err(|_| "is not valid TOML and was left on the source")?;
+    if let Some(servers) = value.get("mcp_servers").and_then(toml::Value::as_table) {
+        for server in servers.values().filter_map(toml::Value::as_table) {
+            if table_is_nonempty(server.get("env")) || table_is_nonempty(server.get("http_headers"))
+            {
+                return Err(
+                    "contains inline MCP environment or header values; use environment-variable references before syncing",
+                );
+            }
+            if server
+                .get("args")
+                .and_then(toml::Value::as_array)
+                .is_some_and(|arguments| {
+                    string_arguments_have_inline_secret(
+                        arguments.iter().filter_map(toml::Value::as_str),
+                    )
+                })
+                || server
+                    .get("url")
+                    .and_then(toml::Value::as_str)
+                    .is_some_and(url_has_inline_secret)
+            {
+                return Err(
+                    "contains a credential-shaped MCP argument or URL; use environment-variable references before syncing",
+                );
+            }
+        }
+    }
+    Ok(Some(raw.to_owned()))
+}
+
+fn table_is_nonempty(value: Option<&toml::Value>) -> bool {
+    value
+        .and_then(toml::Value::as_table)
+        .is_some_and(|table| !table.is_empty())
+}
+
+fn portable_claude_settings(raw: &str) -> Result<Option<String>, &'static str> {
+    reject_private_key_material(raw)?;
+    let value: Value =
+        serde_json::from_str(raw).map_err(|_| "is not valid JSON and was left on the source")?;
+    if value
+        .get("env")
+        .and_then(Value::as_object)
+        .is_some_and(|env| env.keys().any(|name| sensitive_name(name)))
+    {
+        return Err(
+            "contains credential-shaped environment values; move them to the target environment before syncing",
+        );
+    }
+    Ok(Some(raw.to_owned()))
+}
+
+fn portable_claude_mcp(
+    raw: &str,
+    omitted: &mut Vec<PortableConfigOmission>,
+) -> Result<Option<String>, &'static str> {
+    reject_private_key_material(raw)?;
+    let value: Value =
+        serde_json::from_str(raw).map_err(|_| "is not valid JSON and was left on the source")?;
+    let Some(servers) = value.get("mcpServers").and_then(Value::as_object) else {
+        return Ok(None);
+    };
+    let mut portable = Map::new();
+    for (name, server) in servers {
+        if mcp_server_has_inline_secret(server) {
+            omitted.push(omission(
+                format!(".claude.json#mcpServers.{name}"),
+                "contains inline credentials; use environment references or sign in on the target",
+            ));
+        } else {
+            portable.insert(name.clone(), server.clone());
+        }
+    }
+    if portable.is_empty() {
+        return Ok(None);
+    }
+    let mut content = serde_json::to_string_pretty(&json!({ "mcpServers": portable }))
+        .map_err(|_| "could not serialize portable MCP configuration")?;
+    content.push('\n');
+    Ok(Some(content))
+}
+
+fn mcp_server_has_inline_secret(value: &Value) -> bool {
+    let Some(object) = value.as_object() else {
+        return true;
+    };
+    for (key, value) in object {
+        let normalized = normalize_name(key);
+        if matches!(
+            normalized.as_str(),
+            "token" | "accesstoken" | "refreshtoken" | "clientsecret" | "apikey" | "password"
+        ) && !is_environment_reference(value)
+        {
+            return true;
+        }
+        if matches!(normalized.as_str(), "env" | "headers")
+            && value.as_object().is_some_and(|entries| {
+                entries
+                    .iter()
+                    .any(|(name, value)| sensitive_name(name) && !is_environment_reference(value))
+            })
+        {
+            return true;
+        }
+        if normalized == "args" && arguments_have_inline_secret(value) {
+            return true;
+        }
+        if normalized == "url" && value.as_str().is_some_and(url_has_inline_secret) {
+            return true;
+        }
+        if value.is_object() && mcp_server_has_inline_secret(value) {
+            return true;
+        }
+    }
+    false
+}
+
+fn arguments_have_inline_secret(value: &Value) -> bool {
+    let Some(arguments) = value.as_array() else {
+        return false;
+    };
+    string_arguments_have_inline_secret(arguments.iter().filter_map(Value::as_str))
+}
+
+fn string_arguments_have_inline_secret<'a>(arguments: impl Iterator<Item = &'a str>) -> bool {
+    let arguments = arguments.collect::<Vec<_>>();
+    for (index, argument) in arguments.iter().enumerate() {
+        if let Some((name, value)) = argument.split_once('=')
+            && sensitive_name(name)
+            && !contains_environment_reference(value)
+        {
+            return true;
+        }
+        if sensitive_name(argument)
+            && arguments
+                .get(index + 1)
+                .is_some_and(|value| !contains_environment_reference(value))
+        {
+            return true;
+        }
+        let normalized = argument.to_ascii_lowercase();
+        if (normalized.contains("authorization:") || normalized.contains("api-key:"))
+            && !contains_environment_reference(argument)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+fn url_has_inline_secret(value: &str) -> bool {
+    let after_scheme = value.split_once("://").map_or(value, |(_, rest)| rest);
+    let authority = after_scheme
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or_default();
+    if authority.contains('@') {
+        return true;
+    }
+    value
+        .split_once('?')
+        .map(|(_, query)| query.split('#').next().unwrap_or(query))
+        .into_iter()
+        .flat_map(|query| query.split('&'))
+        .filter_map(|pair| pair.split_once('='))
+        .any(|(name, value)| sensitive_name(name) && !contains_environment_reference(value))
+}
+
+fn is_environment_reference(value: &Value) -> bool {
+    value.as_str().is_some_and(|value| {
+        let trimmed = value.trim();
+        trimmed.starts_with("${") && trimmed.ends_with('}')
+    })
+}
+
+fn contains_environment_reference(value: &str) -> bool {
+    value.contains("${") && value.contains('}')
+}
+
+fn sensitive_name(name: &str) -> bool {
+    let normalized = normalize_name(name);
+    normalized.contains("password")
+        || normalized.contains("secret")
+        || normalized.contains("token")
+        || normalized.contains("credential")
+        || normalized.contains("privatekey")
+        || normalized.contains("apikey")
+        || normalized.contains("accesskey")
+        || normalized == "authorization"
+}
+
+fn normalize_name(name: &str) -> String {
+    name.chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn reject_private_key_material(raw: &str) -> Result<(), &'static str> {
+    if raw.contains("-----BEGIN PRIVATE KEY-----")
+        || raw.contains("-----BEGIN RSA PRIVATE KEY-----")
+        || raw.contains("-----BEGIN OPENSSH PRIVATE KEY-----")
+    {
+        Err("contains private-key material")
+    } else {
+        Ok(())
+    }
+}
+
+fn record_auth_omission(
+    provider: ProviderKind,
+    config_home: &Path,
+    omitted: &mut Vec<PortableConfigOmission>,
+) {
+    let (path, exists) = match provider {
+        ProviderKind::Codex => ("auth.json", config_home.join("auth.json").exists()),
+        ProviderKind::Claude => (
+            ".claude.json#app-state-and-auth",
+            config_home.join(".claude.json").exists(),
+        ),
+    };
+    if exists {
+        omitted.push(omission(
+            path,
+            "authentication remains node-local; sign in the matching profile on the target",
+        ));
+    }
+}
+
+fn validate_bundle(profile: &AccountProfile, bundle: &PortableConfigBundle) -> NodeResult<()> {
+    if bundle.version != PORTABLE_CONFIG_VERSION {
+        return Err(NodeError::Protocol(format!(
+            "unsupported portable-config version {}",
+            bundle.version
+        )));
+    }
+    if bundle.provider != profile.provider || bundle.profile_id != profile.id {
+        return Err(NodeError::Conflict(
+            "portable config does not match the target account profile".into(),
+        ));
+    }
+    let allowed = allowed_paths(profile.provider);
+    let mut seen = BTreeSet::new();
+    for file in &bundle.files {
+        if !allowed.contains(&file.path.as_str()) {
+            return Err(NodeError::BadRequest(format!(
+                "portable config path `{}` is not allowed",
+                file.path
+            )));
+        }
+        if !seen.insert(&file.path) {
+            return Err(NodeError::BadRequest(format!(
+                "portable config path `{}` appears more than once",
+                file.path
+            )));
+        }
+        if sha256(file.content.as_bytes()) != file.sha256 {
+            return Err(NodeError::BadRequest(format!(
+                "portable config digest mismatch for `{}`",
+                file.path
+            )));
+        }
+    }
+    ensure_bundle_size(bundle)
+}
+
+fn ensure_bundle_size(bundle: &PortableConfigBundle) -> NodeResult<()> {
+    if serde_json::to_vec(bundle)?.len() > MAX_BUNDLE_BYTES {
+        return Err(NodeError::BadRequest(
+            "portable provider configuration exceeds 1 MiB".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn apply_file(
+    config_home: &Path,
+    file: &PortableConfigFile,
+    result: &mut PortableConfigApplyResult,
+) -> NodeResult<()> {
+    let destination = config_home.join(&file.path);
+    match fs::symlink_metadata(&destination) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            result.conflicts.push(file.path.clone());
+        }
+        Ok(_) => {
+            if sha256(&fs::read(&destination)?) == file.sha256 {
+                result.unchanged.push(file.path.clone());
+            } else {
+                result.conflicts.push(file.path.clone());
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            atomic_text(&destination, &file.content)?;
+            result.installed.push(file.path.clone());
+        }
+        Err(error) => return Err(error.into()),
+    }
+    Ok(())
+}
+
+fn merge_claude_mcp(
+    config_home: &Path,
+    file: &PortableConfigFile,
+    result: &mut PortableConfigApplyResult,
+) -> NodeResult<()> {
+    let incoming: Value = serde_json::from_str(&file.content)?;
+    let Some(incoming_servers) = incoming.get("mcpServers").and_then(Value::as_object) else {
+        return Err(NodeError::BadRequest(
+            "portable Claude MCP config omitted mcpServers".into(),
+        ));
+    };
+    let destination = config_home.join(".claude.json");
+    if fs::symlink_metadata(&destination)
+        .is_ok_and(|metadata| metadata.file_type().is_symlink() || !metadata.is_file())
+    {
+        result.conflicts.push(".claude.json".into());
+        return Ok(());
+    }
+    let mut target = if destination.exists() {
+        match fs::read_to_string(&destination)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+        {
+            Some(Value::Object(object)) => Value::Object(object),
+            _ => {
+                result.conflicts.push(".claude.json".into());
+                return Ok(());
+            }
+        }
+    } else {
+        Value::Object(Map::new())
+    };
+    let target_object = target.as_object_mut().expect("constructed as an object");
+    let target_servers = target_object
+        .entry("mcpServers")
+        .or_insert_with(|| Value::Object(Map::new()));
+    let Some(target_servers) = target_servers.as_object_mut() else {
+        result.conflicts.push(".claude.json#mcpServers".into());
+        return Ok(());
+    };
+    let mut changed = false;
+    for (name, server) in incoming_servers {
+        let path = format!(".claude.json#mcpServers.{name}");
+        match target_servers.get(name) {
+            Some(current) if current == server => result.unchanged.push(path),
+            Some(_) => result.conflicts.push(path),
+            None => {
+                target_servers.insert(name.clone(), server.clone());
+                result.installed.push(path);
+                changed = true;
+            }
+        }
+    }
+    if changed {
+        let mut content = serde_json::to_string_pretty(&target)?;
+        content.push('\n');
+        atomic_text(&destination, &content)?;
+    }
+    Ok(())
+}
+
+fn atomic_text(path: &Path, content: &str) -> NodeResult<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| NodeError::BadRequest("portable path has no parent".into()))?;
+    fs::create_dir_all(parent)?;
+    set_owner_directory(parent)?;
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("config");
+    let temporary: PathBuf = parent.join(format!(".{name}.portable-{}", random_hex(8)?));
+    let result = (|| {
+        fs::write(&temporary, content)?;
+        set_owner_file(&temporary)?;
+        fs::rename(&temporary, path)?;
+        Ok::<_, std::io::Error>(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result.map_err(Into::into)
+}
+
+fn omission(path: impl Into<String>, reason: impl Into<String>) -> PortableConfigOmission {
+    PortableConfigOmission {
+        path: path.into(),
+        reason: reason.into(),
+    }
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    hex_encode(&Sha256::digest(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use diri_proto::AccountProfile;
+
+    fn profile(provider: ProviderKind) -> AccountProfile {
+        AccountProfile {
+            id: "work".into(),
+            provider,
+            label: "Work".into(),
+            email: None,
+            organization: None,
+            tags: Vec::new(),
+            created_at: 1,
+            updated_at: 1,
+        }
+    }
+
+    #[test]
+    fn codex_bundle_carries_env_references_but_never_auth() {
+        let directory = tempfile::tempdir().expect("config home");
+        fs::write(
+            directory.path().join("config.toml"),
+            r#"model = "gpt-5"
+[mcp_servers.github]
+url = "https://example.test/mcp"
+bearer_token_env_var = "GITHUB_TOKEN"
+"#,
+        )
+        .expect("config");
+        fs::write(
+            directory.path().join("auth.json"),
+            r#"{"access_token":"secret"}"#,
+        )
+        .expect("auth");
+
+        let bundle = capture(&profile(ProviderKind::Codex), directory.path()).expect("bundle");
+        assert_eq!(bundle.files.len(), 1);
+        assert!(bundle.files[0].content.contains("GITHUB_TOKEN"));
+        let encoded = serde_json::to_string(&bundle).expect("json");
+        assert!(!encoded.contains("access_token"));
+        assert!(!encoded.contains("secret"));
+        assert!(bundle.omitted.iter().any(|item| item.path == "auth.json"));
+    }
+
+    #[test]
+    fn codex_config_with_inline_mcp_values_is_omitted() {
+        let directory = tempfile::tempdir().expect("config home");
+        fs::write(
+            directory.path().join("config.toml"),
+            r#"[mcp_servers.github]
+command = "server"
+[mcp_servers.github.env]
+GITHUB_TOKEN = "do-not-send"
+"#,
+        )
+        .expect("config");
+
+        let bundle = capture(&profile(ProviderKind::Codex), directory.path()).expect("bundle");
+        assert!(bundle.files.is_empty());
+        assert_eq!(bundle.omitted[0].path, "config.toml");
+        assert!(
+            !serde_json::to_string(&bundle)
+                .unwrap()
+                .contains("do-not-send")
+        );
+    }
+
+    #[test]
+    fn codex_config_with_credentials_in_mcp_arguments_is_omitted() {
+        let directory = tempfile::tempdir().expect("config home");
+        fs::write(
+            directory.path().join("config.toml"),
+            r#"[mcp_servers.github]
+command = "server"
+args = ["--api-key=do-not-send"]
+"#,
+        )
+        .expect("config");
+
+        let bundle = capture(&profile(ProviderKind::Codex), directory.path()).expect("bundle");
+        assert!(bundle.files.is_empty());
+        assert!(
+            !serde_json::to_string(&bundle)
+                .unwrap()
+                .contains("do-not-send")
+        );
+    }
+
+    #[test]
+    fn claude_global_state_exports_only_safe_mcp_topology() {
+        let directory = tempfile::tempdir().expect("config home");
+        fs::write(
+            directory.path().join(".claude.json"),
+            r#"{
+  "oauthAccount": {"accessToken": "never-send"},
+  "machineID": "local-only",
+  "mcpServers": {
+    "safe": {"type": "http", "url": "https://example.test/mcp", "headers": {"Authorization": "${MCP_TOKEN}"}},
+    "unsafe": {"type": "http", "url": "https://example.test/mcp", "headers": {"Authorization": "Bearer literal"}}
+  }
+}"#,
+        )
+        .expect("state");
+
+        let bundle = capture(&profile(ProviderKind::Claude), directory.path()).expect("bundle");
+        assert_eq!(bundle.files.len(), 1);
+        assert!(bundle.files[0].content.contains("safe"));
+        assert!(!bundle.files[0].content.contains("unsafe"));
+        let encoded = serde_json::to_string(&bundle).expect("json");
+        assert!(!encoded.contains("never-send"));
+        assert!(!encoded.contains("local-only"));
+        assert!(
+            bundle
+                .omitted
+                .iter()
+                .any(|item| item.path.ends_with("mcpServers.unsafe"))
+        );
+    }
+
+    #[test]
+    fn claude_mcp_omits_credentials_in_arguments_and_urls() {
+        let directory = tempfile::tempdir().expect("config home");
+        fs::write(
+            directory.path().join(".claude.json"),
+            r#"{"mcpServers":{
+  "argument":{"command":"server","args":["--api-key=do-not-send"]},
+  "url":{"type":"http","url":"https://example.test/mcp?token=do-not-send"},
+  "reference":{"command":"server","args":["--api-key=${MCP_TOKEN}"]}
+}}"#,
+        )
+        .expect("state");
+
+        let bundle = capture(&profile(ProviderKind::Claude), directory.path()).expect("bundle");
+        let encoded = serde_json::to_string(&bundle).expect("json");
+        assert!(!encoded.contains("do-not-send"));
+        assert!(encoded.contains("reference"));
+        assert!(
+            bundle
+                .omitted
+                .iter()
+                .any(|item| item.path.ends_with(".argument"))
+        );
+        assert!(
+            bundle
+                .omitted
+                .iter()
+                .any(|item| item.path.ends_with(".url"))
+        );
+    }
+
+    #[test]
+    fn claude_mcp_merge_preserves_target_auth_and_reports_conflicts() {
+        let source = tempfile::tempdir().expect("source");
+        fs::write(
+            source.path().join(".claude.json"),
+            r#"{"mcpServers":{"same":{"command":"same"},"new":{"command":"new"},"different":{"command":"source"}}}"#,
+        )
+        .expect("source state");
+        let provider = profile(ProviderKind::Claude);
+        let bundle = capture(&provider, source.path()).expect("bundle");
+
+        let target = tempfile::tempdir().expect("target");
+        fs::write(
+            target.path().join(".claude.json"),
+            r#"{"oauthAccount":{"accessToken":"keep-me"},"mcpServers":{"same":{"command":"same"},"different":{"command":"target"}}}"#,
+        )
+        .expect("target state");
+        let result = apply(&provider, target.path(), bundle).expect("apply");
+        assert!(result.installed.iter().any(|path| path.ends_with(".new")));
+        assert!(result.unchanged.iter().any(|path| path.ends_with(".same")));
+        assert!(
+            result
+                .conflicts
+                .iter()
+                .any(|path| path.ends_with(".different"))
+        );
+        let state = fs::read_to_string(target.path().join(".claude.json")).expect("state");
+        assert!(state.contains("keep-me"));
+        assert!(state.contains(r#""command": "target""#));
+        assert!(state.contains(r#""command": "new""#));
+    }
+
+    #[test]
+    fn direct_file_conflicts_are_never_overwritten() {
+        let source = tempfile::tempdir().expect("source");
+        fs::write(source.path().join("AGENTS.md"), "source\n").expect("source config");
+        let provider = profile(ProviderKind::Codex);
+        let bundle = capture(&provider, source.path()).expect("bundle");
+        let target = tempfile::tempdir().expect("target");
+        fs::write(target.path().join("AGENTS.md"), "target\n").expect("target config");
+
+        let result = apply(&provider, target.path(), bundle).expect("apply");
+        assert_eq!(result.conflicts, vec!["AGENTS.md"]);
+        assert_eq!(
+            fs::read_to_string(target.path().join("AGENTS.md")).expect("target config"),
+            "target\n"
+        );
+    }
+
+    #[test]
+    fn omission_metadata_cannot_bypass_the_bundle_limit() {
+        let provider = profile(ProviderKind::Codex);
+        let bundle = PortableConfigBundle {
+            version: PORTABLE_CONFIG_VERSION,
+            provider: ProviderKind::Codex,
+            profile_id: provider.id.clone(),
+            files: Vec::new(),
+            omitted: vec![omission("config.toml", "x".repeat(MAX_BUNDLE_BYTES))],
+        };
+        let target = tempfile::tempdir().expect("target");
+
+        let error = apply(&provider, target.path(), bundle).expect_err("oversized bundle");
+        assert!(error.to_string().contains("exceeds 1 MiB"));
+    }
+}

--- a/diri/crates/diri-node/src/provider/mod.rs
+++ b/diri/crates/diri-node/src/provider/mod.rs
@@ -62,6 +62,13 @@ impl ProviderManager {
         self.logins.len()
     }
 
+    /// Drop a cached provider process after its declarative configuration
+    /// changes. Credentials remain in the profile home/keyring; the next call
+    /// starts a fresh adapter that reads the newly applied settings.
+    pub fn reset_profile(&mut self, profile_id: &str) {
+        self.codex.remove(profile_id);
+    }
+
     pub async fn status(
         &mut self,
         store: &AccountStore,

--- a/diri/crates/diri-node/src/service.rs
+++ b/diri/crates/diri-node/src/service.rs
@@ -6,7 +6,7 @@ use diri_proto::{
     BlobPutParams, BlobReadParams, CheckpointIdParams, CheckpointManifestParams,
     CheckpointPrepareParams, EmptyParams, LoginInputParams, LoginSessionParams, MoveAbortParams,
     MoveCommitParams, NodeCapability, NodeHelloResult, NodeMethod, NodeStatusResult,
-    ProviderCallParams, UsageQueryParams, UsageRecordParams,
+    PortableConfigApplyParams, ProviderCallParams, UsageQueryParams, UsageRecordParams,
 };
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -66,6 +66,7 @@ impl NodeService {
                 NodeCapability::FLEET_USAGE.into(),
                 NodeCapability::CHECKPOINTS.into(),
                 NodeCapability::MOVE_LEASES.into(),
+                NodeCapability::PORTABLE_CONFIG.into(),
             ],
         }
     }
@@ -139,6 +140,28 @@ impl NodeService {
                 let params: LoginSessionParams = decode(params)?;
                 self.providers.lock().await.cancel_login(params).await?;
                 encode(json!({"ok": true}))
+            }
+            NodeMethod::ACCOUNT_PORTABLE_CONFIG_EXPORT => {
+                let params: AccountProfileParams = decode(params)?;
+                let accounts = self.accounts.lock().await;
+                let profile = accounts.profile(&params.profile_id)?;
+                encode(crate::portable::capture(
+                    profile,
+                    &accounts.config_home(profile),
+                )?)
+            }
+            NodeMethod::ACCOUNT_PORTABLE_CONFIG_APPLY => {
+                let params: PortableConfigApplyParams = decode(params)?;
+                let profile_id = params.bundle.profile_id.clone();
+                let result = {
+                    let accounts = self.accounts.lock().await;
+                    let profile = accounts.profile(&profile_id)?;
+                    crate::portable::apply(profile, &accounts.config_home(profile), params.bundle)?
+                };
+                if !result.installed.is_empty() {
+                    self.providers.lock().await.reset_profile(&profile_id);
+                }
+                encode(result)
             }
             NodeMethod::PROVIDER_CALL => {
                 let params: ProviderCallParams = decode(params)?;

--- a/diri/crates/diri-node/src/service.rs
+++ b/diri/crates/diri-node/src/service.rs
@@ -284,15 +284,16 @@ fn encode<T: Serialize>(value: T) -> NodeResult<JsonValue> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use diri_proto::{ProviderKind, UsageEvent, UsageSource, UsageValueKind};
+    use std::fs;
+    use std::path::Path;
 
-    #[tokio::test]
-    async fn service_exposes_accounts_and_fleet_usage_without_secrets() {
-        let directory = tempfile::tempdir().expect("temporary directory");
-        let paths = NodePaths::for_root(directory.path().join("node"));
-        let config = NodeConfig::load_or_initialize(&paths).expect("config");
-        let service = NodeService::open(paths, config).expect("service");
+    use super::*;
+    use diri_proto::{
+        PortableConfigApplyParams, PortableConfigBundle, ProviderKind, UsageEvent, UsageSource,
+        UsageValueKind,
+    };
+
+    async fn add_codex_profile(service: &NodeService) {
         service
             .dispatch(
                 NodeMethod::ACCOUNT_UPSERT,
@@ -304,6 +305,15 @@ mod tests {
             )
             .await
             .expect("account");
+    }
+
+    #[tokio::test]
+    async fn service_exposes_accounts_and_fleet_usage_without_secrets() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let paths = NodePaths::for_root(directory.path().join("node"));
+        let config = NodeConfig::load_or_initialize(&paths).expect("config");
+        let service = NodeService::open(paths, config).expect("service");
+        add_codex_profile(&service).await;
         service
             .dispatch(
                 NodeMethod::USAGE_RECORD,
@@ -342,5 +352,74 @@ mod tests {
             .await
             .expect("usage query");
         assert_eq!(usage["totals"]["inputTokens"], 5);
+    }
+
+    #[tokio::test]
+    async fn portable_config_rebases_from_a_mac_home_to_the_remote_node_home() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let source_paths = NodePaths::for_root(
+            directory
+                .path()
+                .join("Users/alice/Library/Application Support/Dirijor/node"),
+        );
+        let target_paths = NodePaths::for_root(
+            directory
+                .path()
+                .join("home/alice/.local/share/dirijor/node"),
+        );
+        let source = NodeService::open(
+            source_paths.clone(),
+            NodeConfig::load_or_initialize(&source_paths).expect("source config"),
+        )
+        .expect("source service");
+        let target = NodeService::open(
+            target_paths.clone(),
+            NodeConfig::load_or_initialize(&target_paths).expect("target config"),
+        )
+        .expect("target service");
+        add_codex_profile(&source).await;
+        add_codex_profile(&target).await;
+
+        let source_home = source_paths.accounts_root.join("codex/work");
+        let target_home = target_paths.accounts_root.join("codex/work");
+        assert_ne!(source_home, target_home);
+        fs::write(source_home.join("AGENTS.md"), "portable instructions\n")
+            .expect("source settings");
+
+        let exported = source
+            .dispatch(
+                NodeMethod::ACCOUNT_PORTABLE_CONFIG_EXPORT,
+                Some(json!({"profileId": "work"})),
+            )
+            .await
+            .expect("export");
+        let bundle: PortableConfigBundle =
+            serde_json::from_value(exported).expect("portable bundle");
+        assert!(
+            bundle
+                .files
+                .iter()
+                .all(|file| Path::new(&file.path).is_relative())
+        );
+        assert!(
+            !serde_json::to_string(&bundle)
+                .expect("bundle json")
+                .contains(&source_home.to_string_lossy().to_string())
+        );
+
+        target
+            .dispatch(
+                NodeMethod::ACCOUNT_PORTABLE_CONFIG_APPLY,
+                Some(
+                    serde_json::to_value(PortableConfigApplyParams { bundle })
+                        .expect("apply params"),
+                ),
+            )
+            .await
+            .expect("apply");
+        assert_eq!(
+            fs::read_to_string(target_home.join("AGENTS.md")).expect("target settings"),
+            "portable instructions\n"
+        );
     }
 }

--- a/diri/crates/diri-proto/src/node.rs
+++ b/diri/crates/diri-proto/src/node.rs
@@ -25,6 +25,8 @@ impl NodeMethod {
     pub const ACCOUNT_LOGIN_POLL: &'static str = "account.login.poll";
     pub const ACCOUNT_LOGIN_INPUT: &'static str = "account.login.input";
     pub const ACCOUNT_LOGIN_CANCEL: &'static str = "account.login.cancel";
+    pub const ACCOUNT_PORTABLE_CONFIG_EXPORT: &'static str = "account.portable-config.export";
+    pub const ACCOUNT_PORTABLE_CONFIG_APPLY: &'static str = "account.portable-config.apply";
     pub const PROVIDER_CALL: &'static str = "provider.call";
     pub const USAGE_RECORD: &'static str = "usage.record";
     pub const USAGE_QUERY: &'static str = "usage.query";
@@ -48,6 +50,7 @@ impl NodeCapability {
     pub const FLEET_USAGE: &'static str = "usage-ledger.v1";
     pub const CHECKPOINTS: &'static str = "checkpoints.v1";
     pub const MOVE_LEASES: &'static str = "move-leases.v1";
+    pub const PORTABLE_CONFIG: &'static str = "portable-config.v1";
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -187,6 +190,59 @@ pub struct AccountUpsertParams {
 #[serde(rename_all = "camelCase")]
 pub struct AccountProfileParams {
     pub profile_id: String,
+}
+
+/// A bounded snapshot of the settings that make one provider profile behave
+/// consistently across nodes. Provider authentication and MCP OAuth state are
+/// never part of this structure; known inline credential fields are reported
+/// as omissions.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PortableConfigBundle {
+    pub version: u32,
+    pub provider: ProviderKind,
+    pub profile_id: String,
+    pub files: Vec<PortableConfigFile>,
+    #[serde(default)]
+    pub omitted: Vec<PortableConfigOmission>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PortableConfigFile {
+    /// Provider-home-relative path from a fixed allowlist.
+    pub path: String,
+    pub sha256: String,
+    /// Portable config is deliberately text-only and bounded below the control
+    /// protocol's message limit.
+    pub content: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct PortableConfigOmission {
+    pub path: String,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct PortableConfigApplyParams {
+    pub bundle: PortableConfigBundle,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PortableConfigApplyResult {
+    pub provider: ProviderKind,
+    pub profile_id: String,
+    /// New files or MCP server definitions installed on the target.
+    pub installed: Vec<String>,
+    /// Files or definitions already byte-identical on the target.
+    pub unchanged: Vec<String>,
+    /// Target values kept because source and target differ. Sync never
+    /// overwrites a conflict.
+    pub conflicts: Vec<String>,
+    #[serde(default)]
+    pub omitted: Vec<PortableConfigOmission>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -505,6 +561,9 @@ pub struct MoveRecord {
 pub struct SessionHandoffResult {
     pub checkpoint: CheckpointManifest,
     pub staged: CheckpointStageResult,
+    /// Absent when either side predates `portable-config.v1`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub portable_config: Option<PortableConfigApplyResult>,
     pub provider_result: JsonValue,
     pub target_commit: MoveRecord,
     pub source_commit: MoveRecord,

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,10 @@
 - [Security model](SECURITY-MODEL.md) — trust boundaries and safe-use guidance.
 - [Agent manifests](AGENT-MANIFESTS.md) — add an agent, author screen rules,
   capture safe fixtures, and validate both engines.
-- [Remote nodes](../diri/NODE.md) — run sessions over SSH and tmux.
+- [Remote nodes](../diri/NODE.md) — run sessions through bootstrapped Remote PTY
+  Holders or an enhanced first-party VPS node.
+- [Local ↔ VPS handoff](../diri/HANDOFF.md) — settings, MCP, authentication,
+  code, and Jujutsu design decisions.
 - [Packaging](../diri/PACKAGING.md) — build, signing, and notarization.
 - [Updates and releases](../diri/UPDATING.md) — updater design and release flow.
 - [Engine port history](../diri/PORT.md) — record of the completed Rust migration.


### PR DESCRIPTION
## Summary

- add a `portable-config.v1` node capability with explicit export/apply methods and `diri-node account sync-config`
- run that sync automatically during local/VPS handoff when both nodes support it, while preserving mixed-fleet compatibility
- carry allowlisted Codex and Claude settings plus MCP topology without carrying provider auth or MCP OAuth state
- preflight source/target provider readiness and reject known account-identity mismatches before mutating the handoff
- document the four state lanes (conversation, working tree, portable config, per-node auth) and why Jujutsu belongs only in a future code-lane adapter

## Security and conflict behavior

- fixed provider-specific path allowlists and a 1 MiB bound over the full serialized bundle
- Codex `auth.json` is never read; Claude `.claude.json` is reduced to `mcpServers`, excluding OAuth, machine, cache, approval, and UI state
- known inline credential fields, headers, environment values, arguments, URLs, and private-key material fail closed and are reported as omissions
- environment-variable references remain portable
- existing target files and differing MCP definitions win conflicts; writes are atomic and owner-only
- control characters in CLI apply reports are escaped

## Verification

- `./scripts/check.sh` (all contributor checks passed)
- `cargo test -p diri-node -p diri-client -p diri-proto`
- `cargo clippy -p diri-node -p diri-client -p diri-proto --all-targets -- -D warnings`

## POC boundary

This deliberately does not copy credentials, keychain state, `.git`, or `.jj`. Each node signs into the intended profile independently; the current content-addressed checkpoint remains the path for dirty working-tree state. The design doc records a future colocated-Jujutsu/Git-remote adapter that can optimize the code lane without widening the credential boundary.
