### PR TITLE
Polish account, settings, and Command-K surfaces

### DIFF
--- a/diri/crates/diri-app/src/commands.rs
+++ b/diri/crates/diri-app/src/commands.rs
@@ -251,7 +251,7 @@ pub const COMMANDS: &[CommandSpec] = &[
         Some("cmd-p"),
         Some("⌘P"),
         Some(APP_CONTEXT),
-        "Quick Open…",
+        "Open Folder…",
         "magnifyingglass",
         "folder project directory jump goto find"
     ),

--- a/diri/crates/diri-app/src/navigation.rs
+++ b/diri/crates/diri-app/src/navigation.rs
@@ -27,18 +27,21 @@ use gpui::{
 /// The search field above the results, and the gap the surface keeps from the
 /// window edges. Everything else is measured against the live viewport so the
 /// list grows into a tall window and never overflows a short one.
-const SEARCH_HEIGHT: f32 = 46.0;
+const SEARCH_HEIGHT: f32 = 40.0;
 const ROW_HEIGHT: f32 = 32.0;
 const QUICK_ROW_HEIGHT: f32 = 34.0;
 /// Quick Open rows that show a parent path stack two lines.
 const QUICK_ROW_HEIGHT_WITH_PATH: f32 = 44.0;
-const SECTION_HEADER_HEIGHT: f32 = 24.0;
-const LIST_PADDING_X: f32 = 8.0;
-const LIST_PADDING_Y: f32 = 6.0;
-const ROW_PADDING_X: f32 = 14.0;
-const SURFACE_WIDTH: f32 = 580.0;
+const SECTION_HEADER_HEIGHT: f32 = 26.0;
+const LIST_PADDING_X: f32 = 4.0;
+const LIST_PADDING_Y: f32 = 2.0;
+const ROW_PADDING_X: f32 = 10.0;
+const COMMAND_SURFACE_WIDTH: f32 = 520.0;
+const QUICK_OPEN_SURFACE_WIDTH: f32 = 580.0;
 const MIN_LIST_HEIGHT: f32 = 96.0;
-const MAX_LIST_HEIGHT: f32 = 640.0;
+const COMMAND_MAX_LIST_HEIGHT: f32 = 440.0;
+const QUICK_OPEN_MAX_LIST_HEIGHT: f32 = 640.0;
+const CHAT_PREVIEW_LIMIT: usize = 7;
 const MIN_TOP_INSET: f32 = 12.0;
 const MAX_TOP_INSET: f32 = 96.0;
 const BOTTOM_INSET: f32 = 24.0;
@@ -52,7 +55,21 @@ struct OverlayLayout {
 }
 
 impl OverlayLayout {
-    fn for_viewport(viewport: gpui::Size<Pixels>) -> Self {
+    fn command_palette(viewport: gpui::Size<Pixels>) -> Self {
+        let height = viewport.height.as_f32();
+        let list = (height - 2.0 * MIN_TOP_INSET - SEARCH_HEIGHT - 1.0)
+            .clamp(MIN_LIST_HEIGHT, COMMAND_MAX_LIST_HEIGHT);
+        let surface_height = SEARCH_HEIGHT + 1.0 + list;
+        Self {
+            top_inset: px(((height - surface_height) / 2.0).max(MIN_TOP_INSET)),
+            width: px(
+                (viewport.width.as_f32() - 2.0 * BOTTOM_INSET).clamp(280.0, COMMAND_SURFACE_WIDTH)
+            ),
+            list_height: px(list),
+        }
+    }
+
+    fn quick_open(viewport: gpui::Size<Pixels>) -> Self {
         let height = viewport.height.as_f32();
         let chrome = SEARCH_HEIGHT + 1.0 + BOTTOM_INSET;
         // Float the surface a twelfth of the way down, but give the inset back
@@ -60,10 +77,11 @@ impl OverlayLayout {
         let top = (height / 12.0)
             .clamp(MIN_TOP_INSET, MAX_TOP_INSET)
             .min((height - chrome - MIN_LIST_HEIGHT).max(MIN_TOP_INSET));
-        let list = (height - top - chrome).clamp(MIN_LIST_HEIGHT, MAX_LIST_HEIGHT);
+        let list = (height - top - chrome).clamp(MIN_LIST_HEIGHT, QUICK_OPEN_MAX_LIST_HEIGHT);
         Self {
             top_inset: px(top),
-            width: px((viewport.width.as_f32() - 2.0 * BOTTOM_INSET).clamp(280.0, SURFACE_WIDTH)),
+            width: px((viewport.width.as_f32() - 2.0 * BOTTOM_INSET)
+                .clamp(280.0, QUICK_OPEN_SURFACE_WIDTH)),
             list_height: px(list),
         }
     }
@@ -212,13 +230,13 @@ impl NavigationOverlay {
     /// The row the user is on, so a rebuild can put the highlight back on it
     /// rather than on whatever inherits its index.
     fn highlighted_command(&self) -> Option<CommandSelection> {
-        self.ranked_actions.get(self.highlight).map_or_else(
+        self.ranked_sessions.get(self.highlight).map_or_else(
             || {
-                self.ranked_sessions
-                    .get(self.highlight.saturating_sub(self.ranked_actions.len()))
-                    .map(|ranked| CommandSelection::Session(ranked.item.id.clone()))
+                self.ranked_actions
+                    .get(self.highlight.saturating_sub(self.ranked_sessions.len()))
+                    .map(|ranked| CommandSelection::Action(ranked.item.command.clone()))
             },
-            |action| Some(CommandSelection::Action(action.item.command.clone())),
+            |session| Some(CommandSelection::Session(session.item.id.clone())),
         )
     }
 
@@ -227,12 +245,12 @@ impl NavigationOverlay {
             Some(CommandSelection::Action(command)) => self
                 .ranked_actions
                 .iter()
-                .position(|ranked| ranked.item.command == *command),
+                .position(|ranked| ranked.item.command == *command)
+                .map(|index| index + self.ranked_sessions.len()),
             Some(CommandSelection::Session(id)) => self
                 .ranked_sessions
                 .iter()
-                .position(|ranked| ranked.item.id == *id)
-                .map(|index| index + self.ranked_actions.len()),
+                .position(|ranked| ranked.item.id == *id),
             None => None,
         };
         let count = self.ranked_actions.len() + self.ranked_sessions.len();
@@ -516,15 +534,20 @@ impl NavigationOverlay {
     /// Index of the highlighted row among the scroll container's children,
     /// which include the section headers.
     fn highlight_child(&self) -> usize {
-        let first_section = match self.overlay {
-            Some(Overlay::CommandPalette) => Some(self.ranked_actions.len()),
+        match self.overlay {
+            Some(Overlay::CommandPalette) => command_row_child_index(
+                self.highlight,
+                self.ranked_sessions.len(),
+                self.quick_action_count(),
+                self.ranked_actions.len(),
+                self.query.text().trim().is_empty(),
+            ),
             Some(Overlay::QuickOpen) if self.query.text().trim().is_empty() => {
-                Some(self.quick_snapshot.recent.len())
+                row_child_index(self.highlight, Some(self.quick_snapshot.recent.len()))
             }
             // A searched Quick Open list is one flat section, no headers.
-            _ => None,
-        };
-        row_child_index(self.highlight, first_section)
+            _ => row_child_index(self.highlight, None),
+        }
     }
 
     fn visible_count(&self) -> usize {
@@ -538,18 +561,31 @@ impl NavigationOverlay {
         }
     }
 
+    fn quick_action_count(&self) -> usize {
+        if self.query.text().trim().is_empty() {
+            self.ranked_actions
+                .iter()
+                .take_while(|ranked| is_quick_action(&ranked.item))
+                .count()
+        } else {
+            0
+        }
+    }
+
     fn run_highlighted(&mut self, secondary: bool, window: &mut Window, cx: &mut Context<Self>) {
         match self.overlay {
             Some(Overlay::CommandPalette) => {
-                let selection = if let Some(action) = self.ranked_actions.get(self.highlight) {
-                    action
-                        .item
-                        .enabled
-                        .then(|| CommandSelection::Action(action.item.command.clone()))
+                let selection = if let Some(session) = self.ranked_sessions.get(self.highlight) {
+                    Some(CommandSelection::Session(session.item.id.clone()))
                 } else {
-                    self.ranked_sessions
-                        .get(self.highlight.saturating_sub(self.ranked_actions.len()))
-                        .map(|ranked| CommandSelection::Session(ranked.item.id.clone()))
+                    self.ranked_actions
+                        .get(self.highlight.saturating_sub(self.ranked_sessions.len()))
+                        .and_then(|action| {
+                            action
+                                .item
+                                .enabled
+                                .then(|| CommandSelection::Action(action.item.command.clone()))
+                        })
                 };
                 if let Some(selection) = selection {
                     self.run_command_selection(selection, window, cx);
@@ -687,8 +723,23 @@ impl NavigationOverlay {
         };
         self.agent_actions_fingerprint = fingerprint;
         let query = FuzzyQuery::new(self.query.text());
-        self.ranked_actions = palette::rank_actions(actions, &query, &mut self.matcher);
+        let searching = !self.query.text().trim().is_empty();
+        let mut ranked_actions = palette::rank_actions(actions, &query, &mut self.matcher);
+        if !searching {
+            // Empty-query browsing is intentionally curated: two frequent
+            // actions stay visible directly below chats, while fuzzy
+            // search remains score-ordered across every command.
+            let (mut quick, commands): (Vec<_>, Vec<_>) = ranked_actions
+                .into_iter()
+                .partition(|ranked| is_quick_action(&ranked.item));
+            quick.extend(commands);
+            ranked_actions = quick;
+        }
+        self.ranked_actions = ranked_actions;
         self.ranked_sessions = palette::rank_sessions(sessions, &query, &mut self.matcher);
+        if !searching {
+            self.ranked_sessions.truncate(CHAT_PREVIEW_LIMIT);
+        }
     }
 
     fn current_quick_item(&self) -> Option<QuickOpenItem> {
@@ -715,6 +766,16 @@ impl NavigationOverlay {
             Some(Overlay::CommandPalette) => self.render_command_palette(layout, colors, cx),
             Some(Overlay::QuickOpen) => self.render_quick_open(layout, colors, cx),
             None => return div().into_any_element(),
+        };
+        let surface = if self.overlay == Some(Overlay::CommandPalette) {
+            // Command palettes are keyboard-triggered, so their frame is
+            // immediate; a settled surface is faster to parse than a
+            // decorative entrance animation.
+            FloatingSurface::new(colors, content)
+                .radius(20.0)
+                .animate_entry(false)
+        } else {
+            FloatingSurface::new(colors, content)
         };
         div()
             .absolute()
@@ -745,7 +806,7 @@ impl NavigationOverlay {
                     .on_mouse_down_out(cx.listener(|this, _, _, cx| {
                         this.close_overlay(cx);
                     }))
-                    .child(FloatingSurface::new(colors, content)),
+                    .child(surface),
             )
             .into_any_element()
     }
@@ -783,6 +844,7 @@ impl NavigationOverlay {
         let sessions = self.ranked_sessions.clone();
         let action_count = actions.len();
         let session_count = sessions.len();
+        let quick_count = self.quick_action_count();
         let mut results = div()
             .id("command-palette-results")
             .track_scroll(&self.scroll_handle)
@@ -793,18 +855,29 @@ impl NavigationOverlay {
             .px(px(LIST_PADDING_X))
             .py(px(LIST_PADDING_Y));
 
-        if !actions.is_empty() {
-            results = results.child(section_header("Actions", colors));
-            for (index, action) in actions.into_iter().enumerate() {
-                results = results.child(self.render_action_row(action, index, colors, cx));
+        if !sessions.is_empty() {
+            results = results.child(section_header("Chats", colors));
+            for (index, session) in sessions.into_iter().enumerate() {
+                results = results.child(self.render_session_row(session, index, colors, cx));
             }
         }
-        if !sessions.is_empty() {
-            results = results.child(section_header("Sessions", colors));
-            for (offset, session) in sessions.into_iter().enumerate() {
-                results = results.child(self.render_session_row(
-                    session,
-                    action_count + offset,
+        if quick_count > 0 {
+            results = results.child(section_header("Quick actions", colors));
+            for (offset, action) in actions.iter().take(quick_count).cloned().enumerate() {
+                results = results.child(self.render_action_row(
+                    action,
+                    session_count + offset,
+                    colors,
+                    cx,
+                ));
+            }
+        }
+        if action_count > quick_count {
+            results = results.child(section_header("Commands", colors));
+            for (offset, action) in actions.iter().skip(quick_count).cloned().enumerate() {
+                results = results.child(self.render_action_row(
+                    action,
+                    session_count + quick_count + offset,
                     colors,
                     cx,
                 ));
@@ -815,10 +888,15 @@ impl NavigationOverlay {
         }
 
         div()
+            .id("command-palette")
+            .debug_selector(|| "command-palette".into())
             .w(layout.width)
+            .p(px(4.0))
+            .flex()
+            .flex_col()
+            .gap(px(4.0))
             .text_color(colors.primary)
-            .child(self.render_search("Type a command or session…", colors))
-            .child(HairlineDivider::horizontal(colors))
+            .child(self.render_search("Search chats or run a command…", colors))
             .child(results)
             .into_any_element()
     }
@@ -837,7 +915,9 @@ impl NavigationOverlay {
             .detail
             .clone()
             .map(SharedString::from)
-            .or_else(|| action.shortcut.map(SharedString::from));
+            .or_else(|| action.shortcut.map(SharedString::from))
+            .into_iter()
+            .collect();
         palette_row(
             highlighted_label(action.title, &ranked.title_matches),
             sf_symbol(action.system_image, 12.5, colors.secondary),
@@ -871,7 +951,10 @@ impl NavigationOverlay {
         let session = ranked.item;
         let id = session.id.clone();
         let dot_color = attention_color(session.attention(), colors);
-        let chip = kind_label(session.effective_kind());
+        let mut trailing = vec![SharedString::from(kind_label(session.effective_kind()))];
+        if let Some(shortcut) = session_shortcut(index) {
+            trailing.push(shortcut.into());
+        }
         palette_row(
             highlighted_label(session.title, &ranked.title_matches),
             div()
@@ -880,7 +963,7 @@ impl NavigationOverlay {
                 .rounded_full()
                 .bg(dot_color)
                 .into_any_element(),
-            Some(SharedString::from(chip)),
+            trailing,
             index == self.highlight,
             index,
             true,
@@ -1102,7 +1185,11 @@ impl Focusable for NavigationOverlay {
 
 impl Render for NavigationOverlay {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let layout = OverlayLayout::for_viewport(window.viewport_size());
+        let layout = if self.overlay == Some(Overlay::CommandPalette) {
+            OverlayLayout::command_palette(window.viewport_size())
+        } else {
+            OverlayLayout::quick_open(window.viewport_size())
+        };
         let overlay = self.overlay.map(|_| self.render_overlay(layout, cx));
         let root = div()
             .id("navigation-overlay")
@@ -1149,6 +1236,59 @@ fn empty_label(text: &'static str, colors: SemanticColors) -> AnyElement {
         .text_color(colors.tertiary)
         .child(text)
         .into_any_element()
+}
+
+fn is_quick_action(action: &PaletteAction) -> bool {
+    let default_shortcut =
+        crate::commands::command(crate::commands::CommandId::NewDefaultSession).shortcut_label();
+    matches!(
+        action.command,
+        PaletteCommand::Action(crate::commands::CommandId::ToggleQuickOpen)
+    ) || action.shortcut.as_deref() == default_shortcut.as_deref()
+}
+
+fn session_shortcut(index: usize) -> Option<String> {
+    use crate::commands::CommandId;
+
+    let command = match index {
+        0 => CommandId::SelectSession1,
+        1 => CommandId::SelectSession2,
+        2 => CommandId::SelectSession3,
+        3 => CommandId::SelectSession4,
+        4 => CommandId::SelectSession5,
+        5 => CommandId::SelectSession6,
+        6 => CommandId::SelectSession7,
+        7 => CommandId::SelectSession8,
+        _ => return None,
+    };
+    crate::commands::command(command).shortcut_label()
+}
+
+/// The command palette has up to three visible sections: recent chats, two
+/// curated quick actions, then the remaining commands. Convert a row index in
+/// that keyboard order into the scroll container's child index.
+const fn command_row_child_index(
+    row: usize,
+    session_count: usize,
+    quick_count: usize,
+    action_count: usize,
+    show_quick_section: bool,
+) -> usize {
+    let mut child = row;
+    if session_count > 0 {
+        child += 1;
+    }
+    if row >= session_count {
+        if show_quick_section && quick_count > 0 {
+            child += 1;
+        } else if !show_quick_section && action_count > 0 {
+            child += 1;
+        }
+        if show_quick_section && row >= session_count + quick_count && action_count > quick_count {
+            child += 1;
+        }
+    }
+    child
 }
 
 /// Rows and section headers are siblings in the scroll container, so scrolling
@@ -1213,8 +1353,8 @@ fn highlighted_label_styled(
 fn palette_row(
     title: AnyElement,
     leading: AnyElement,
-    // Owned: agent chips are manifest ids now, not compile-time literals.
-    trailing: Option<SharedString>,
+    // Owned: agent chips and shortcut hints are not compile-time literals.
+    trailing: Vec<SharedString>,
     highlighted: bool,
     index: usize,
     enabled: bool,
@@ -1262,7 +1402,16 @@ fn palette_row(
                         .child(title),
                 ),
         )
-        .when_some(trailing, |row, trailing| row.child(chip(trailing, colors)))
+        .when(!trailing.is_empty(), |row| {
+            row.child(
+                div()
+                    .flex_none()
+                    .flex()
+                    .items_center()
+                    .gap(px(4.0))
+                    .children(trailing.into_iter().map(|trailing| chip(trailing, colors))),
+            )
+        })
 }
 
 fn chip(text: impl Into<gpui::SharedString>, colors: SemanticColors) -> AnyElement {
@@ -1341,13 +1490,31 @@ fn relative_parent(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(target_os = "macos")]
+    use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
     use crate::commands::CommandId;
+    use crate::sidebar::{PreviewScenario, SidebarPreviewFixture};
     use diri_proto::{
         AgentDescriptor, AgentPathSource, AgentReadinessItem, AgentReadinessResult, HostEntry,
     };
+    #[cfg(target_os = "macos")]
+    use gpui::HeadlessAppContext;
     use gpui::{Entity, ScrollDelta, ScrollWheelEvent, TestAppContext, point};
+
+    struct CommandPalettePreviewHarness {
+        overlay: Entity<NavigationOverlay>,
+    }
+
+    impl Render for CommandPalettePreviewHarness {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .size_full()
+                .bg(gpui::rgb(0x191b20))
+                .child(crate::root::cached_window_overlay(self.overlay.clone()))
+        }
+    }
 
     #[test]
     fn relative_parent_abbreviates_home_like_swift() {
@@ -1364,19 +1531,24 @@ mod tests {
 
     #[test]
     fn scrolling_to_a_row_counts_the_section_headers_above_it() {
-        // Five actions, then sessions: "Actions" header, five rows, "Sessions"
-        // header, then the session rows.
-        assert_eq!(row_child_index(0, Some(5)), 1);
-        assert_eq!(row_child_index(4, Some(5)), 5);
-        assert_eq!(row_child_index(5, Some(5)), 7);
-        // No actions matched: only the "Sessions" header sits above row 0.
-        assert_eq!(row_child_index(0, Some(0)), 1);
+        // Three chats, two quick actions, then three commands.
+        assert_eq!(command_row_child_index(0, 3, 2, 5, true), 1);
+        assert_eq!(command_row_child_index(2, 3, 2, 5, true), 3);
+        assert_eq!(command_row_child_index(3, 3, 2, 5, true), 5);
+        assert_eq!(command_row_child_index(4, 3, 2, 5, true), 6);
+        assert_eq!(command_row_child_index(5, 3, 2, 5, true), 8);
+        // Search collapses actions into one Commands section.
+        assert_eq!(command_row_child_index(3, 3, 0, 5, false), 5);
         // A searched Quick Open list has no headers at all.
         assert_eq!(row_child_index(3, None), 3);
     }
 
-    fn layout(width: f32, height: f32) -> OverlayLayout {
-        OverlayLayout::for_viewport(gpui::size(px(width), px(height)))
+    fn command_layout(width: f32, height: f32) -> OverlayLayout {
+        OverlayLayout::command_palette(gpui::size(px(width), px(height)))
+    }
+
+    fn quick_open_layout(width: f32, height: f32) -> OverlayLayout {
+        OverlayLayout::quick_open(gpui::size(px(width), px(height)))
     }
 
     #[test]
@@ -1387,31 +1559,125 @@ mod tests {
             (900.0, 495.0),
             (600.0, 360.0),
         ] {
-            let layout = layout(width, height);
-            let total = layout.top_inset + px(SEARCH_HEIGHT + 1.0) + layout.list_height;
-            assert!(
-                total <= px(height),
-                "{width}x{height} overflows by {:?}",
-                total - px(height)
-            );
-            assert!(layout.width <= px(width));
+            for layout in [
+                command_layout(width, height),
+                quick_open_layout(width, height),
+            ] {
+                let total = layout.top_inset + px(SEARCH_HEIGHT + 1.0) + layout.list_height;
+                assert!(
+                    total <= px(height),
+                    "{width}x{height} overflows by {:?}",
+                    total - px(height)
+                );
+                assert!(layout.width <= px(width));
+            }
         }
     }
 
     #[test]
     fn the_list_uses_the_height_the_window_actually_has() {
-        // The old fixed 400pt list wasted a tall window and overflowed a short
-        // one; both directions now track the viewport.
-        assert!(layout(1400.0, 1100.0).list_height > px(400.0));
-        assert!(layout(900.0, 495.0).list_height < px(400.0));
-        // Beyond the cap the surface stops growing rather than becoming a wall.
-        assert_eq!(layout(1600.0, 3000.0).list_height, px(MAX_LIST_HEIGHT));
-        // A window too short for the minimum list gives up its top inset first,
-        // down to the floor.
-        let cramped = layout(800.0, 180.0);
-        assert!(cramped.top_inset < px(180.0 / 12.0));
+        let tall = command_layout(1400.0, 1100.0);
+        assert_eq!(tall.list_height, px(COMMAND_MAX_LIST_HEIGHT));
+        assert_eq!(
+            tall.top_inset,
+            px((1100.0 - SEARCH_HEIGHT - 1.0 - COMMAND_MAX_LIST_HEIGHT) / 2.0)
+        );
+        assert!(command_layout(900.0, 360.0).list_height < px(400.0));
+        assert_eq!(
+            quick_open_layout(1600.0, 3000.0).list_height,
+            px(QUICK_OPEN_MAX_LIST_HEIGHT)
+        );
+        let cramped = command_layout(800.0, 150.0);
         assert_eq!(cramped.list_height, px(MIN_LIST_HEIGHT));
-        assert_eq!(layout(800.0, 150.0).top_inset, px(MIN_TOP_INSET));
+        assert_eq!(cramped.top_inset, px(MIN_TOP_INSET));
+    }
+
+    #[gpui::test]
+    fn empty_command_palette_begins_with_chats_then_quick_actions(cx: &mut TestAppContext) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        let fixture = SidebarPreviewFixture::make(PreviewScenario::Typical);
+        {
+            let mut store = runtime.store.write().expect("session store lock poisoned");
+            store.hydrate(fixture.list);
+            if let Some(selected) = fixture.selected_session_id {
+                store.select(selected);
+            }
+        }
+        let runtime_for_view = Arc::clone(&runtime);
+        let (overlay, cx) = cx.add_window_view(move |_, cx| {
+            let mut overlay = NavigationOverlay::opened_for_test(runtime_for_view, cx);
+            overlay.refresh_command_items();
+            overlay
+        });
+
+        overlay.read_with(cx, |overlay, _| {
+            assert!(!overlay.ranked_sessions.is_empty());
+            assert!(overlay.ranked_sessions.len() <= CHAT_PREVIEW_LIMIT);
+            assert_eq!(overlay.quick_action_count(), 2);
+            assert!(
+                overlay.ranked_actions[..2]
+                    .iter()
+                    .all(|ranked| is_quick_action(&ranked.item))
+            );
+            assert!(
+                overlay.ranked_actions[2..]
+                    .iter()
+                    .all(|ranked| !is_quick_action(&ranked.item))
+            );
+            assert!(matches!(
+                overlay.highlighted_command(),
+                Some(CommandSelection::Session(_))
+            ));
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "writes the deterministic command-palette screenshot artifact"]
+    fn render_command_palette_preview_screenshot() {
+        let output = std::env::var_os("DIRI_VISUAL_OUTPUT")
+            .map(PathBuf::from)
+            .expect("set DIRI_VISUAL_OUTPUT to the target PNG path");
+        let platform = gpui_platform::current_platform(true);
+        let mut cx = HeadlessAppContext::with_platform(
+            platform.text_system(),
+            Arc::new(diri_ui::IconAssets),
+            gpui_platform::current_headless_renderer,
+        );
+        cx.update(|cx| crate::fonts::init(cx));
+
+        let runtime = Arc::new(StoreRuntime::inert());
+        let fixture = SidebarPreviewFixture::make(PreviewScenario::Typical);
+        {
+            let mut store = runtime.store.write().expect("session store lock poisoned");
+            store.hydrate(fixture.list);
+            if let Some(selected) = fixture.selected_session_id {
+                store.select(selected);
+            }
+        }
+        let window = cx
+            .open_window(gpui::size(px(1100.0), px(700.0)), move |_, cx| {
+                let overlay = cx.new(|cx| {
+                    let mut overlay = NavigationOverlay::opened_for_test(runtime, cx);
+                    overlay.refresh_command_items();
+                    overlay
+                });
+                cx.new(|_| CommandPalettePreviewHarness { overlay })
+            })
+            .expect("open headless command-palette window");
+        cx.run_until_parked();
+        cx.update_window(window.into(), |_, window, _| window.refresh())
+            .expect("refresh command-palette window");
+        cx.run_until_parked();
+        let screenshot = cx
+            .capture_screenshot(window.into())
+            .expect("capture command-palette screenshot");
+        if let Some(parent) = output.parent() {
+            std::fs::create_dir_all(parent).expect("create screenshot directory");
+        }
+        screenshot
+            .save(output)
+            .expect("save command-palette screenshot");
     }
 
     #[gpui::test]

--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -1054,7 +1054,7 @@ impl RootView {
             }
             CommandId::OpenSettings => {
                 if let Some(surfaces) = &self.utility_surfaces {
-                    surfaces.update(cx, |surfaces, cx| surfaces.open_settings(cx));
+                    surfaces.update(cx, |surfaces, cx| surfaces.toggle_settings(cx));
                 }
             }
             CommandId::ToggleSidebar => {

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -247,13 +247,17 @@ impl Sidebar {
         };
         sidebar.ui.preview_account = preview;
         // Preview-only hook so headless screenshots can verify popover layout.
-        if preview
-            && std::env::var("DIRIJOR_SIDEBAR_POPOVER").is_ok_and(|value| value == "new-agent")
-        {
-            sidebar.ui.popover = Some(Popover::NewAgent {
-                directory: None,
-                host: None,
-            });
+        if preview {
+            match std::env::var("DIRIJOR_SIDEBAR_POPOVER").as_deref() {
+                Ok("new-agent") => {
+                    sidebar.ui.popover = Some(Popover::NewAgent {
+                        directory: None,
+                        host: None,
+                    });
+                }
+                Ok("account") => sidebar.ui.popover = Some(Popover::Account),
+                _ => {}
+            }
         }
         sidebar
     }
@@ -2240,6 +2244,7 @@ impl Sidebar {
 
     fn account_footer(&self, colors: SemanticColors, cx: &mut Context<Self>) -> AnyElement {
         let hovered = self.ui.hovered_control == Some("account");
+        let account_label = local_account_label(self.preview);
         let cost = if self.preview {
             Some(PREVIEW_USAGE)
         } else {
@@ -2258,12 +2263,12 @@ impl Sidebar {
             .child(
                 div()
                     .id("account")
-                    .px(px(Space::ROW_H))
-                    .h(px(Metrics::ROW_HEIGHT))
+                    .px(px(8.0))
+                    .h(px(36.0))
                     .flex()
                     .items_center()
-                    .gap(px(8.0))
-                    .rounded(px(Radius::ROW))
+                    .gap(px(9.0))
+                    .rounded(px(10.0))
                     .bg(Fill::hover(colors, hovered))
                     .cursor_pointer()
                     .on_hover(cx.listener(|this, is_hovered: &bool, _, cx| {
@@ -2271,17 +2276,14 @@ impl Sidebar {
                         cx.notify();
                     }))
                     .on_click(cx.listener(|this, _, _, cx| {
-                        this.ui.popover = Some(Popover::Account);
+                        this.ui.popover = if this.ui.popover == Some(Popover::Account) {
+                            None
+                        } else {
+                            Some(Popover::Account)
+                        };
                         cx.notify();
                     }))
-                    .child(
-                        div()
-                            .w(px(16.0))
-                            .text_center()
-                            .text_size(px(13.0))
-                            .text_color(colors.secondary)
-                            .child(sf_symbol("person.crop.circle", 12.5, colors.secondary)),
-                    )
+                    .child(account_avatar(&account_label, 22.0, colors))
                     .child(
                         div()
                             .min_w(px(0.0))
@@ -2291,11 +2293,7 @@ impl Sidebar {
                             .text_ellipsis()
                             .text_size(px(Typo::ROW.size))
                             .text_color(colors.text(diri_ui::TextTone::Label))
-                            .child(if self.preview {
-                                "preview@dirijor.local"
-                            } else {
-                                "Local agents"
-                            }),
+                            .child(account_label),
                     )
                     .when_some(cost, |row, cost| {
                         row.child(
@@ -3168,7 +3166,7 @@ impl Sidebar {
             .id("account-version")
             .mx(px(6.0))
             .px(px(8.0))
-            .h(px(28.0))
+            .h(px(30.0))
             .flex()
             .items_center()
             .justify_between()
@@ -3180,6 +3178,19 @@ impl Sidebar {
             } else {
                 colors.primary
             })
+            .child(
+                div()
+                    .w(px(16.0))
+                    .flex_none()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .child(sf_symbol(
+                        "arrow.triangle.2.circlepath",
+                        11.0,
+                        colors.secondary,
+                    )),
+            )
             .child(
                 div()
                     .min_w(px(0.0))
@@ -3220,18 +3231,48 @@ impl Sidebar {
         window: &Window,
         cx: &mut Context<Self>,
     ) -> AnyElement {
-        let mut usage = div()
-            .flex()
-            .flex_col()
-            .child(section_label("Usage", colors));
+        /* ─────────────────────────────────────────────────────────
+         * ACCOUNT MENU STORYBOARD
+         *
+         *    0ms   footer remains in place; menu mounts above it
+         *  160ms   shared floating surface settles to full opacity
+         *
+         * The shared FloatingSurface owns the entry timing. Rows never
+         * animate independently: this is a frequent, keyboard-adjacent menu.
+         * ───────────────────────────────────────────────────────── */
+        let account_label = local_account_label(self.preview);
+        let mut usage = div().flex().flex_col().py(px(3.0));
         if self.preview {
             usage = usage
-                .child(usage_row("Session", "resets in 2h 14m", "$2.31", colors))
-                .child(usage_row("Today", "1.8M tokens", "$4.82", colors))
-                .child(usage_row("This month", "", "$86.40", colors));
+                .child(usage_menu_row(
+                    "account-usage-session",
+                    "clock",
+                    "Session",
+                    "resets in 2h 14m",
+                    "$2.31",
+                    colors,
+                ))
+                .child(usage_menu_row(
+                    "account-usage-today",
+                    "chart.bar.xaxis",
+                    "Today",
+                    "1.8M tokens",
+                    "$4.82",
+                    colors,
+                ))
+                .child(usage_menu_row(
+                    "account-usage-month",
+                    "calendar",
+                    "This month",
+                    "",
+                    "$86.40",
+                    colors,
+                ));
         } else if let Some(snapshot) = self.usage {
             usage = usage
-                .child(usage_row(
+                .child(usage_menu_row(
+                    "account-usage-session",
+                    "clock",
                     "Session",
                     snapshot
                         .session_remaining_seconds
@@ -3244,7 +3285,9 @@ impl Sidebar {
                         .unwrap_or_else(|| "—".into()),
                     colors,
                 ))
-                .child(usage_row(
+                .child(usage_menu_row(
+                    "account-usage-today",
+                    "chart.bar.xaxis",
                     "Today",
                     &format!(
                         "{} tokens",
@@ -3253,7 +3296,9 @@ impl Sidebar {
                     &UsageFormat::money(snapshot.today().cost),
                     colors,
                 ))
-                .child(usage_row(
+                .child(usage_menu_row(
+                    "account-usage-month",
+                    "calendar",
                     "This month",
                     "",
                     &UsageFormat::money(snapshot.month().cost),
@@ -3262,22 +3307,69 @@ impl Sidebar {
         } else {
             usage = usage.child(
                 div()
-                    .px(px(14.0))
-                    .py(px(6.0))
+                    .id("account-usage-measuring")
+                    .mx(px(6.0))
+                    .px(px(8.0))
+                    .h(px(30.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(8.0))
                     .text_size(px(Typo::ROW.size))
                     .text_color(colors.tertiary)
+                    .child(sf_symbol("chart.bar.xaxis", 11.0, colors.tertiary))
                     .child("Measuring…"),
             );
         }
         let content = div()
+            .id("account-menu")
+            .debug_selector(|| "account-menu".into())
             .flex()
             .flex_col()
+            .child(
+                div()
+                    .mx(px(6.0))
+                    .px(px(8.0))
+                    .h(px(40.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(9.0))
+                    .child(account_avatar(&account_label, 24.0, colors))
+                    .child(
+                        div()
+                            .min_w(px(0.0))
+                            .flex_1()
+                            .flex()
+                            .flex_col()
+                            .child(
+                                div()
+                                    .whitespace_nowrap()
+                                    .overflow_hidden()
+                                    .text_ellipsis()
+                                    .text_size(px(Typo::ROW.size))
+                                    .text_color(colors.primary)
+                                    .child(account_label),
+                            )
+                            .child(
+                                div()
+                                    .text_size(px(Typo::META.size))
+                                    .text_color(colors.tertiary)
+                                    .child("Local agents"),
+                            ),
+                    )
+                    .child(
+                        div()
+                            .px(px(5.0))
+                            .py(px(2.0))
+                            .rounded(px(Radius::CHIP))
+                            .bg(colors.primary.alpha(0.06))
+                            .text_size(px(Typo::META.size))
+                            .text_color(colors.secondary)
+                            .child("This Mac"),
+                    ),
+            )
+            .child(menu_divider(colors))
             .child(usage)
-            .child(div().mt(px(8.0)).h(px(1.0)).bg(colors.primary.alpha(0.06)))
-            .child(section_label("Version", colors))
-            .child(self.update_menu_row(colors, cx))
-            .child(div().mt(px(8.0)).h(px(1.0)).bg(colors.primary.alpha(0.06)))
-            .child(section_label("Remote", colors))
+            .child(menu_divider(colors))
             .child(
                 div()
                     .id("quick-add-remote-host")
@@ -3307,52 +3399,49 @@ impl Sidebar {
                         cx.notify();
                     })),
             )
-            .child(div().mt(px(8.0)).h(px(1.0)).bg(colors.primary.alpha(0.06)))
-            .child(section_label("Account", colors))
             .child(
                 div()
-                    .id("account-active")
+                    .id("account-settings")
+                    .debug_selector(|| "account-settings".into())
                     .mx(px(6.0))
                     .px(px(8.0))
-                    .h(px(28.0))
+                    .h(px(30.0))
                     .flex()
                     .items_center()
                     .gap(px(8.0))
                     .rounded(px(Radius::ROW))
-                    .text_size(px(Typo::ROW.size))
-                    .text_color(colors.primary)
-                    .child(sf_symbol_weighted(
-                        "checkmark",
-                        10.0,
-                        SymbolWeight::Semibold,
-                        colors.secondary,
-                    ))
-                    .child(if self.preview {
-                        "preview@dirijor.local"
-                    } else {
-                        "Local agents"
-                    }),
-            )
-            .child(
-                div()
-                    .id("dismiss-account")
-                    .mx(px(6.0))
-                    .my(px(6.0))
-                    .px(px(8.0))
-                    .h(px(28.0))
-                    .flex()
-                    .items_center()
-                    .rounded(px(Radius::ROW))
                     .cursor_pointer()
                     .hover(move |element| element.bg(colors.primary.alpha(0.06)))
                     .text_size(px(Typo::ROW.size))
-                    .text_color(colors.secondary)
-                    .child("Done")
-                    .on_click(cx.listener(|this, _, _, cx| {
+                    .text_color(colors.primary)
+                    .child(
+                        div()
+                            .w(px(16.0))
+                            .flex_none()
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .child(sf_symbol("gearshape", 11.0, colors.secondary)),
+                    )
+                    .child(div().flex_1().child("Settings"))
+                    .child(
+                        div()
+                            .text_size(px(Typo::META.size))
+                            .text_color(colors.tertiary)
+                            .child(
+                                crate::commands::command(CommandId::OpenSettings)
+                                    .shortcut_label()
+                                    .unwrap_or_default(),
+                            ),
+                    )
+                    .on_click(cx.listener(|this, _, window, cx| {
                         this.ui.popover = None;
+                        window.dispatch_action(Box::new(OpenSettings), cx);
                         cx.notify();
                     })),
-            );
+            )
+            .child(self.update_menu_row(colors, cx))
+            .child(div().h(px(3.0)));
         self.popover_shell_above_footer(content, colors, window, cx)
     }
 
@@ -4811,39 +4900,98 @@ fn count_label(verb: &str, count: usize) -> String {
     }
 }
 
-fn section_label(label: &'static str, colors: SemanticColors) -> AnyElement {
+fn local_account_label(preview: bool) -> String {
+    if preview {
+        return "cretu".to_owned();
+    }
+
+    std::env::var("USER")
+        .or_else(|_| std::env::var("LOGNAME"))
+        .ok()
+        .map(|label| label.trim().to_owned())
+        .filter(|label| !label.is_empty())
+        .unwrap_or_else(|| "Local agents".to_owned())
+}
+
+fn account_avatar(label: &str, size: f32, colors: SemanticColors) -> AnyElement {
+    let initial = label
+        .chars()
+        .find(|character| character.is_alphanumeric())
+        .map(|character| character.to_uppercase().collect::<String>())
+        .unwrap_or_else(|| "D".to_owned());
+
     div()
-        .px(px(14.0))
-        .pt(px(10.0))
-        .pb(px(3.0))
-        .text_size(px(Typo::SECTION_HEADER.size))
-        .font_weight(Typo::SECTION_HEADER.weight)
-        .text_color(colors.tertiary)
-        .child(label)
+        .flex_none()
+        .size(px(size))
+        .flex()
+        .items_center()
+        .justify_center()
+        .rounded_full()
+        .bg(Palette::CLAY.alpha(0.88))
+        .text_size(px(Typo::META.size))
+        .font_weight(FontWeight::SEMIBOLD)
+        .text_color(colors.background.alpha(0.92))
+        .child(initial)
         .into_any_element()
 }
 
-fn usage_row(label: &str, detail: &str, value: &str, colors: SemanticColors) -> AnyElement {
+fn usage_menu_row(
+    id: &'static str,
+    icon: &'static str,
+    label: &str,
+    detail: &str,
+    value: &str,
+    colors: SemanticColors,
+) -> AnyElement {
     div()
-        .px(px(14.0))
-        .h(px(24.0))
+        .id(id)
+        .debug_selector(move || id.into())
+        .mx(px(6.0))
+        .px(px(8.0))
+        .h(px(30.0))
         .flex()
         .items_center()
         .gap(px(8.0))
-        .text_size(px(Typo::ROW.size))
-        .text_color(colors.text(diri_ui::TextTone::Label))
-        .child(label.to_owned())
-        .child(div().flex_1())
-        .when(!detail.is_empty(), |row| {
-            row.child(
-                div()
-                    .text_size(px(Typo::META.size))
-                    .text_color(colors.tertiary)
-                    .child(detail.to_owned()),
-            )
-        })
+        .rounded(px(Radius::ROW))
         .child(
             div()
+                .w(px(16.0))
+                .flex_none()
+                .flex()
+                .items_center()
+                .justify_center()
+                .child(sf_symbol(icon, 11.0, colors.secondary)),
+        )
+        .child(
+            div()
+                .min_w(px(0.0))
+                .flex_1()
+                .flex()
+                .items_baseline()
+                .gap(px(6.0))
+                .child(
+                    div()
+                        .flex_none()
+                        .text_size(px(Typo::ROW.size))
+                        .text_color(colors.text(diri_ui::TextTone::Label))
+                        .child(label.to_owned()),
+                )
+                .when(!detail.is_empty(), |row| {
+                    row.child(
+                        div()
+                            .min_w(px(0.0))
+                            .whitespace_nowrap()
+                            .overflow_hidden()
+                            .text_ellipsis()
+                            .text_size(px(Typo::META.size))
+                            .text_color(colors.tertiary)
+                            .child(detail.to_owned()),
+                    )
+                }),
+        )
+        .child(
+            div()
+                .flex_none()
                 .font_family(crate::fonts::mono_family())
                 .text_size(px(Typo::META_MONO.size))
                 .text_color(colors.secondary)
@@ -5101,6 +5249,11 @@ fn compact_duration(seconds: i64) -> String {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_os = "macos")]
+    use std::path::PathBuf;
+
+    #[cfg(target_os = "macos")]
+    use gpui::{HeadlessAppContext, size};
     use gpui::{Modifiers, TestAppContext, VisualTestContext};
 
     use super::*;
@@ -5479,7 +5632,7 @@ mod tests {
     }
 
     #[gpui::test]
-    fn account_popover_exposes_the_remote_host_shortcut(cx: &mut TestAppContext) {
+    fn account_popover_exposes_usage_and_account_shortcuts(cx: &mut TestAppContext) {
         let (_view, cx) = cx.add_window_view(|_, cx| {
             let sidebar = cx.new(|cx| {
                 let mut sidebar = Sidebar::new(None, true, PreviewScenario::Typical, cx);
@@ -5489,7 +5642,54 @@ mod tests {
             SidebarPopoverHarness { sidebar }
         });
 
+        assert!(cx.debug_bounds("account-menu").is_some());
+        assert!(cx.debug_bounds("account-usage-session").is_some());
+        assert!(cx.debug_bounds("account-usage-today").is_some());
+        assert!(cx.debug_bounds("account-usage-month").is_some());
         assert!(cx.debug_bounds("quick-add-remote-host").is_some());
+        assert!(cx.debug_bounds("account-settings").is_some());
+    }
+
+    /// Produces a deterministic image for design review without reading live
+    /// account data or requiring Screen Recording permission.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "writes the deterministic account-menu screenshot artifact"]
+    fn render_account_menu_preview_screenshot() {
+        let output = std::env::var_os("DIRI_VISUAL_OUTPUT")
+            .map(PathBuf::from)
+            .expect("set DIRI_VISUAL_OUTPUT to the target PNG path");
+        let platform = gpui_platform::current_platform(true);
+        let mut cx = HeadlessAppContext::with_platform(
+            platform.text_system(),
+            Arc::new(diri_ui::IconAssets),
+            gpui_platform::current_headless_renderer,
+        );
+        cx.update(|cx| crate::fonts::init(cx));
+
+        let window = cx
+            .open_window(size(px(300.0), px(720.0)), |_, cx| {
+                let sidebar = cx.new(|cx| {
+                    let mut sidebar = Sidebar::new(None, true, PreviewScenario::Typical, cx);
+                    sidebar.ui.popover = Some(Popover::Account);
+                    sidebar
+                });
+                cx.new(|_| SidebarPopoverHarness { sidebar })
+            })
+            .expect("open headless account-menu window");
+        cx.run_until_parked();
+        cx.update_window(window.into(), |_, window, _| window.refresh())
+            .expect("refresh account-menu window");
+        cx.run_until_parked();
+        let screenshot = cx
+            .capture_screenshot(window.into())
+            .expect("capture account-menu screenshot");
+        if let Some(parent) = output.parent() {
+            std::fs::create_dir_all(parent).expect("create screenshot directory");
+        }
+        screenshot
+            .save(output)
+            .expect("save account-menu screenshot");
     }
 
     #[gpui::test]

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -18,12 +18,13 @@ use diri_proto::{AgentKind as ProtoAgentKind, HistoryEntry, HostEntry, HostsConf
 use diri_term::theme::{TermTheme, ThemeAppearance};
 use diri_ui::{
     AgentLogo, Fill, FloatingSurface, HairlineDivider, Ink, LoadingIndicator, Metrics, Palette,
-    Radius, SemanticColors, Space, Typo,
+    Radius, SemanticColors, Typo,
 };
 use gpui::{
-    AnyElement, App, Bounds, ClickEvent, Context, CursorStyle, FocusHandle, Focusable, FontWeight,
-    IntoElement, KeyDownEvent, MouseButton, PathPromptOptions, Pixels, Render, Rgba, SharedString,
-    Task, TextRun, Window, canvas, deferred, div, font, prelude::*, px, rgba,
+    Animation, AnimationExt, AnyElement, App, Bounds, ClickEvent, Context, CursorStyle,
+    FocusHandle, Focusable, FontWeight, IntoElement, KeyDownEvent, MouseButton, PathPromptOptions,
+    Pixels, Render, Rgba, ScrollHandle, SharedString, Task, TextRun, Window, canvas, deferred, div,
+    ease_out_quint, font, point, prelude::*, px, rgba,
 };
 use tokio::runtime::Runtime;
 
@@ -31,9 +32,11 @@ use crate::commands::{
     Activate, CloseSurface, CommandId, MoveDown, MoveUp, OpenSettings, OpenWorktrees,
     ToggleHistory, UTILITY_CONTEXT,
 };
-const SETTINGS_WIDTH: f32 = 600.0;
-const SETTINGS_HEIGHT: f32 = 420.0;
-const SETTINGS_NAV_WIDTH: f32 = 150.0;
+const SETTINGS_CONTENT_MAX_WIDTH: f32 = 760.0;
+/// Settings is its own destination with a stable navigation measure. It must
+/// not inherit a workspace sidebar width the user enlarged for long sessions.
+const SETTINGS_RAIL_WIDTH: f32 = 248.0;
+const SETTINGS_TRANSITION_DURATION: Duration = Duration::from_millis(190);
 const SETTINGS_SECTION_GAP: f32 = 16.0;
 const SETTINGS_ROW_HEIGHT: f32 = 50.0;
 const RESULT_LIMIT: usize = 200;
@@ -261,6 +264,10 @@ pub struct UtilitySurfaces {
     history_error: Option<String>,
     worktrees: WorktreesSheet,
     settings_tab: SettingsTab,
+    settings_scroll: ScrollHandle,
+    settings_search: QueryEditor,
+    settings_search_active: bool,
+    settings_transition_generation: u64,
     settings_menu: Option<SettingsMenu>,
     agents_host: Option<String>,
     agent_path_editor: Option<AgentPathEditor>,
@@ -368,6 +375,10 @@ impl UtilitySurfaces {
             history_error: None,
             worktrees: WorktreesSheet::default(),
             settings_tab,
+            settings_scroll: ScrollHandle::new(),
+            settings_search: QueryEditor::default(),
+            settings_search_active: false,
+            settings_transition_generation: 0,
             settings_menu: None,
             agents_host,
             agent_path_editor: None,
@@ -1035,10 +1046,93 @@ impl UtilitySurfaces {
             .preferences()
             .clone();
         self.surface = Surface::Settings;
+        self.settings_scroll.set_offset(point(px(0.0), px(0.0)));
+        self.settings_search.clear();
+        self.settings_search_active = false;
+        self.settings_transition_generation = self.settings_transition_generation.wrapping_add(1);
         self.settings_menu = None;
         self.host_editor = None;
         self.agent_path_editor = None;
         cx.notify();
+    }
+
+    pub(crate) fn toggle_settings(&mut self, cx: &mut Context<Self>) {
+        if self.surface == Surface::Settings {
+            self.close_surface(cx);
+        } else {
+            self.open_settings(cx);
+        }
+    }
+
+    fn visible_settings_tabs(&self) -> Vec<SettingsTab> {
+        SettingsTab::ALL
+            .into_iter()
+            .filter(|tab| settings_tab_matches(*tab, self.settings_search.text()))
+            .collect()
+    }
+
+    fn select_settings_tab(&mut self, tab: SettingsTab, cx: &mut Context<Self>) {
+        if self.settings_tab != tab {
+            self.settings_scroll.set_offset(point(px(0.0), px(0.0)));
+        }
+        self.settings_tab = tab;
+        self.settings_search_active = false;
+        self.settings_menu = None;
+        self.host_editor = None;
+        self.agent_path_editor = None;
+        if tab == SettingsTab::Remote {
+            self.reload_hosts();
+        } else if tab == SettingsTab::Agents {
+            self.store
+                .write()
+                .expect("session store lock poisoned")
+                .request_agent_catalog(self.agents_host.clone(), false);
+        }
+        cx.notify();
+    }
+
+    fn handle_settings_search_key(&mut self, event: &KeyDownEvent, cx: &mut Context<Self>) -> bool {
+        if self.surface != Surface::Settings || !self.settings_search_active {
+            return false;
+        }
+        match event.keystroke.key.as_str() {
+            "escape" => {
+                if self.settings_search.is_empty() {
+                    self.settings_search_active = false;
+                } else {
+                    self.settings_search.clear();
+                }
+                cx.notify();
+            }
+            "enter" => {
+                if let Some(tab) = self.visible_settings_tabs().first().copied() {
+                    self.select_settings_tab(tab, cx);
+                }
+            }
+            _ => {
+                let Some(edit) = query_editor::edit_for(&event.keystroke) else {
+                    return true;
+                };
+                match edit {
+                    Edit::Local(local) => {
+                        self.settings_search.apply(local);
+                    }
+                    Edit::Clipboard(ClipboardEdit::Copy) => {
+                        query_editor::copy_selection(&self.settings_search, cx);
+                    }
+                    Edit::Clipboard(ClipboardEdit::Cut) => {
+                        query_editor::cut_selection(&mut self.settings_search, cx);
+                    }
+                    Edit::Clipboard(ClipboardEdit::Paste) => {
+                        if let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) {
+                            self.settings_search.insert(&text);
+                        }
+                    }
+                }
+                cx.notify();
+            }
+        }
+        true
     }
 
     pub(crate) fn open_agent_settings(&mut self, host: Option<String>, cx: &mut Context<Self>) {
@@ -1087,6 +1181,10 @@ impl UtilitySurfaces {
             return;
         }
         if self.handle_agent_path_key(event, cx) || self.handle_host_editor_key(event, cx) {
+            return;
+        }
+        if self.handle_settings_search_key(event, cx) {
+            cx.stop_propagation();
             return;
         }
         let key = &event.keystroke;
@@ -1666,13 +1764,42 @@ impl UtilitySurfaces {
     }
 
     fn render_settings(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        /* ─────────────────────────────────────────────────────────
+         * SETTINGS SHELL STORYBOARD
+         *
+         *    0ms   workbench is replaced in place; rail begins 8px left
+         *   70ms   settings rail is legible; canvas follows from 12px right
+         *  190ms   both surfaces settle at their final positions and opacity
+         *
+         * Navigation stays spatially anchored to the old sidebar. Reduced
+         * motion mounts the final layout immediately.
+         * ───────────────────────────────────────────────────────── */
         let colors = self.settings_colors();
-        let tabs = SettingsTab::ALL
-            .into_iter()
-            .map(|tab| {
-                let selected = tab == self.settings_tab;
+        let visible_tabs = self.visible_settings_tabs();
+        let mut tabs = div().flex().flex_col();
+        let mut personal_started = false;
+        let mut system_started = false;
+        for tab in visible_tabs.iter().copied() {
+            let personal = matches!(
+                tab,
+                SettingsTab::General | SettingsTab::Agents | SettingsTab::Terminal
+            );
+            if personal && !personal_started {
+                tabs = tabs.child(settings_nav_section_header("Personal", 8.0, colors));
+                personal_started = true;
+            } else if !personal && !system_started {
+                tabs = tabs.child(settings_nav_section_header(
+                    "System",
+                    if personal_started { 14.0 } else { 8.0 },
+                    colors,
+                ));
+                system_started = true;
+            }
+            let selected = tab == self.settings_tab;
+            tabs = tabs.child(
                 div()
                     .id(SharedString::from(format!("settings-{}", tab.label())))
+                    .debug_selector(move || format!("SETTINGS_TAB_{}", tab.label()))
                     .h(px(30.0))
                     .px(px(8.0))
                     .rounded(px(Radius::ROW))
@@ -1688,29 +1815,25 @@ impl UtilitySurfaces {
                     .cursor_pointer()
                     .hover(move |style| style.bg(Fill::hover(colors, true)))
                     .on_click(cx.listener(move |this, _, _, cx| {
-                        this.settings_tab = tab;
-                        this.settings_menu = None;
-                        this.host_editor = None;
-                        this.agent_path_editor = None;
-                        if tab == SettingsTab::Remote {
-                            this.reload_hosts();
-                        } else if tab == SettingsTab::Agents {
-                            this.store
-                                .write()
-                                .expect("session store lock poisoned")
-                                .request_agent_catalog(this.agents_host.clone(), false);
-                        }
-                        cx.notify();
+                        this.select_settings_tab(tab, cx);
                     }))
-                    .child(sf_symbol(
-                        tab.icon(),
-                        13.0,
-                        if selected {
-                            colors.primary
-                        } else {
-                            colors.tertiary
-                        },
-                    ))
+                    .child(
+                        div()
+                            .w(px(16.0))
+                            .flex_none()
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .child(sf_symbol(
+                                tab.icon(),
+                                12.0,
+                                if selected {
+                                    colors.primary
+                                } else {
+                                    colors.tertiary
+                                },
+                            )),
+                    )
                     .child(
                         div()
                             .text_size(px(Typo::ROW.size))
@@ -1720,10 +1843,89 @@ impl UtilitySurfaces {
                                 FontWeight::NORMAL
                             })
                             .child(tab.label()),
-                    )
-                    .into_any_element()
-            })
-            .collect::<Vec<_>>();
+                    ),
+            );
+        }
+        if visible_tabs.is_empty() {
+            tabs = tabs.child(
+                div()
+                    .px(px(10.0))
+                    .pt(px(14.0))
+                    .text_size(px(Typo::META.size))
+                    .text_color(colors.tertiary)
+                    .child("No settings found"),
+            );
+        }
+        let search_content = if self.settings_search_active {
+            query_label(&self.settings_search)
+        } else if self.settings_search.is_empty() {
+            div()
+                .text_color(colors.tertiary)
+                .child("Search settings…")
+                .into_any_element()
+        } else {
+            div()
+                .text_color(colors.primary)
+                .child(self.settings_search.text().to_owned())
+                .into_any_element()
+        };
+        let search = div()
+            .id("settings-search")
+            .debug_selector(|| "settings-search".into())
+            .h(px(32.0))
+            .mx(px(4.0))
+            .mt(px(8.0))
+            .px(px(9.0))
+            .rounded(px(16.0))
+            .border_1()
+            .border_color(colors.primary.alpha(if self.settings_search_active {
+                0.22
+            } else {
+                0.11
+            }))
+            .bg(colors.primary.alpha(0.025))
+            .flex()
+            .items_center()
+            .gap(px(7.0))
+            .cursor(CursorStyle::IBeam)
+            .on_click(cx.listener(|this, _, window, cx| {
+                this.settings_search_active = true;
+                this.focus.focus(window, cx);
+                cx.notify();
+            }))
+            .child(sf_symbol("magnifyingglass", 12.0, colors.tertiary))
+            .child(
+                div()
+                    .flex_1()
+                    .min_w(px(0.0))
+                    .overflow_hidden()
+                    .whitespace_nowrap()
+                    .text_ellipsis()
+                    .text_size(px(Typo::ROW.size))
+                    .child(search_content),
+            )
+            .when(!self.settings_search.is_empty(), |search| {
+                search.child(
+                    div()
+                        .id("clear-settings-search")
+                        .debug_selector(|| "clear-settings-search".into())
+                        .size(px(18.0))
+                        .flex_none()
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .rounded_full()
+                        .cursor_pointer()
+                        .hover(move |style| style.bg(Fill::subtle(colors)))
+                        .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            this.settings_search.clear();
+                            this.settings_search_active = true;
+                            cx.notify();
+                        }))
+                        .child(sf_symbol("xmark", 8.0, colors.tertiary)),
+                )
+            });
         let pane = match self.settings_tab {
             SettingsTab::General => self.general_settings(cx).into_any_element(),
             SettingsTab::Agents => self.agents_settings(cx).into_any_element(),
@@ -1731,113 +1933,127 @@ impl UtilitySurfaces {
             SettingsTab::Resources => self.resource_settings(cx).into_any_element(),
             SettingsTab::Remote => self.remote_settings(cx).into_any_element(),
         };
-        FloatingSurface::new(
-            colors,
-            div()
-                .id("settings-dialog")
-                .debug_selector(|| "settings-dialog".into())
-                .w(px(SETTINGS_WIDTH))
-                .h(px(SETTINGS_HEIGHT))
-                .rounded(px(Radius::PANEL))
-                .overflow_hidden()
-                .flex()
-                // The dialog owns clicks within its bounds. When a select is
-                // open, any click elsewhere in Settings dismisses that select
-                // before the clicked control runs its own action.
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(|this, _, _, cx| {
-                        if this.settings_menu.take().is_some() {
-                            cx.notify();
-                        }
-                        cx.stop_propagation();
-                    }),
-                )
-                .child(
-                    div()
-                        .w(px(SETTINGS_NAV_WIDTH))
-                        .h_full()
-                        .bg(colors.primary.alpha(0.018))
-                        .flex()
-                        .flex_col()
-                        .child(
-                            div()
-                                .h(px(Metrics::TITLE_BAR))
-                                .px(px(Metrics::TOOLBAR_EDGE_INSET))
-                                .flex()
-                                .items_center()
-                                .gap(px(Metrics::TOOLBAR_ITEM_GAP))
-                                .child(sf_symbol("gearshape", 15.0, colors.secondary))
-                                .child(
-                                    div()
-                                        .text_size(px(Typo::TITLE.size))
-                                        .font_weight(Typo::TITLE.weight)
-                                        .child("Settings"),
-                                ),
-                        )
-                        .child(
-                            div()
-                                .px(px(Space::INSET))
-                                .pt(px(2.0))
-                                .pb(px(10.0))
-                                .flex_1()
-                                .flex()
-                                .flex_col()
-                                .gap(px(2.0))
-                                .children(tabs),
-                        )
-                        .child(
-                            div()
-                                .px(px(Metrics::TOOLBAR_EDGE_INSET))
-                                .pb(px(10.0))
-                                .text_size(px(Typo::META.size))
-                                .text_color(colors.tertiary)
-                                .child(format!("diri {}", crate::updates::CURRENT_VERSION)),
-                        ),
-                )
-                .child(HairlineDivider::vertical(colors))
-                .child(
-                    div()
-                        .relative()
-                        .flex_1()
-                        .min_w(px(0.0))
-                        .h_full()
-                        .child(
-                            div()
-                                .id("settings-pane")
-                                .debug_selector(|| "settings-pane".into())
-                                .absolute()
-                                .inset_0()
-                                .overflow_y_scroll()
-                                .child(pane),
-                        )
-                        .child(
-                            div()
-                                .id("close-settings")
-                                .debug_selector(|| "close-settings".into())
-                                .absolute()
-                                .top(px(8.0))
-                                .right(px(Metrics::TOOLBAR_EDGE_INSET))
-                                .size(px(Metrics::TOOLBAR_CONTROL_SIZE))
-                                .rounded(px(Radius::BADGE))
-                                .flex()
-                                .items_center()
-                                .justify_center()
-                                .cursor_pointer()
-                                .hover(move |style| style.bg(Fill::subtle(colors)))
-                                .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
-                                .on_click(cx.listener(|this, _, _, cx| {
-                                    this.close_surface(cx);
-                                }))
-                                .child(sf_symbol_weighted(
-                                    "xmark",
-                                    13.5,
-                                    SymbolWeight::Bold,
-                                    colors.secondary,
-                                )),
-                        ),
-                ),
-        )
+        let generation = self.settings_transition_generation;
+        let rail = div()
+            .id("settings-rail")
+            .debug_selector(|| "settings-rail".into())
+            .relative()
+            .w(px(SETTINGS_RAIL_WIDTH))
+            .h_full()
+            .bg(colors.sidebar_surface())
+            .border_r_1()
+            .border_color(colors.primary.alpha(0.07))
+            .flex()
+            .flex_col()
+            .child(
+                div()
+                    .pt(px(6.0))
+                    .child(
+                        div()
+                            .id("close-settings")
+                            .debug_selector(|| "close-settings".into())
+                            .h(px(30.0))
+                            .mx(px(12.0))
+                            .px(px(8.0))
+                            .rounded(px(Radius::ROW))
+                            .flex()
+                            .items_center()
+                            .gap(px(7.0))
+                            .cursor_pointer()
+                            .hover(move |style| style.bg(Fill::subtle(colors)))
+                            .on_click(cx.listener(|this, _, _, cx| this.close_surface(cx)))
+                            .child(sf_symbol("chevron.left", 9.5, colors.tertiary))
+                            .child(
+                                div()
+                                    .text_size(px(Typo::META.size))
+                                    .text_color(colors.secondary)
+                                    .child("Back to app"),
+                            ),
+                    )
+                    .child(search),
+            )
+            .child(
+                div()
+                    .id("settings-nav-scroll")
+                    .px(px(4.0))
+                    .flex_1()
+                    .min_h(px(0.0))
+                    .overflow_y_scroll()
+                    .child(tabs),
+            )
+            .child(
+                div()
+                    .px(px(Metrics::TOOLBAR_EDGE_INSET))
+                    .pb(px(12.0))
+                    .text_size(px(Typo::META.size))
+                    .text_color(colors.tertiary)
+                    .child(format!("diri {}", crate::updates::CURRENT_VERSION)),
+            );
+        let rail = if cx.reduce_motion() {
+            rail.into_any_element()
+        } else {
+            rail.with_animation(
+                SharedString::from(format!("settings-rail-enter-{generation}")),
+                Animation::new(SETTINGS_TRANSITION_DURATION).with_easing(ease_out_quint()),
+                |rail, delta| {
+                    rail.left(px((1.0 - delta) * -8.0))
+                        .opacity(0.72 + 0.28 * delta)
+                },
+            )
+            .into_any_element()
+        };
+        let pane = div()
+            .id("settings-pane")
+            .debug_selector(|| "settings-pane".into())
+            .relative()
+            .track_scroll(&self.settings_scroll)
+            .flex_1()
+            .min_w(px(0.0))
+            .h_full()
+            .overflow_y_scroll()
+            .bg(colors.background)
+            .child(
+                div()
+                    .w_full()
+                    .max_w(px(SETTINGS_CONTENT_MAX_WIDTH))
+                    .mx_auto()
+                    .child(pane),
+            );
+        let pane = if cx.reduce_motion() {
+            pane.into_any_element()
+        } else {
+            pane.with_animation(
+                SharedString::from(format!("settings-canvas-enter-{generation}")),
+                Animation::new(SETTINGS_TRANSITION_DURATION).with_easing(ease_out_quint()),
+                |pane, delta| {
+                    pane.left(px((1.0 - delta) * 12.0))
+                        .opacity(0.64 + 0.36 * delta)
+                },
+            )
+            .into_any_element()
+        };
+
+        div()
+            .id("settings-shell")
+            .debug_selector(|| "settings-shell".into())
+            .size_full()
+            .pt(px(Metrics::TITLE_BAR))
+            .overflow_hidden()
+            .bg(colors.background)
+            .flex()
+            // Settings owns the whole workbench. Clicking inside still closes
+            // any open select before the clicked control handles its action.
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, _, cx| {
+                    if this.settings_menu.take().is_some() {
+                        cx.notify();
+                    }
+                    cx.stop_propagation();
+                }),
+            )
+            .child(rail)
+            .child(pane)
     }
 
     fn general_settings(&self, cx: &mut Context<Self>) -> impl IntoElement {
@@ -3881,7 +4097,8 @@ impl Render for UtilitySurfaces {
                 this.open_worktrees(cx);
             }))
             .on_action(cx.listener(|this, _: &OpenSettings, _, cx| {
-                this.open_settings(cx);
+                this.toggle_settings(cx);
+                cx.stop_propagation();
             }))
             .on_action(cx.listener(|this, _: &CloseSurface, _, cx| this.close_surface(cx)))
             .on_action(cx.listener(|this, _: &MoveUp, _, cx| this.move_history(-1, cx)))
@@ -3896,40 +4113,54 @@ impl Render for UtilitySurfaces {
             .size_full()
             .text_color(self.colors().primary);
         if let Some(overlay) = overlay {
-            root.inset_0().child(
-                div()
-                    .absolute()
-                    .when(leave_sidebar_exposed, |backdrop| {
-                        backdrop
-                            .top(px(0.0))
-                            .right(px(0.0))
-                            .bottom(px(0.0))
-                            .left(px(sidebar_width))
-                    })
-                    .when(!leave_sidebar_exposed, |backdrop| backdrop.inset_0())
-                    .debug_selector(|| "surface-backdrop".into())
-                    // The modal backdrop dismisses the topmost surface while
-                    // still protecting terminal selection and scrollback.
-                    .occlude()
-                    .on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(|this, _, _, cx| {
-                            this.close_surface(cx);
-                            cx.stop_propagation();
-                        }),
-                    )
-                    .on_scroll_wheel(|_, _, cx| cx.stop_propagation())
-                    .bg(rgba(0x00000040))
-                    .flex()
-                    .items_center()
-                    .justify_center()
-                    .child(
-                        div()
-                            .occlude()
-                            .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
-                            .child(overlay),
-                    ),
-            )
+            if self.surface == Surface::Settings {
+                root.inset_0().child(
+                    div()
+                        .absolute()
+                        .inset_0()
+                        .debug_selector(|| "surface-backdrop".into())
+                        .occlude()
+                        .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+                        .on_scroll_wheel(|_, _, cx| cx.stop_propagation())
+                        .bg(self.colors().background)
+                        .child(overlay),
+                )
+            } else {
+                root.inset_0().child(
+                    div()
+                        .absolute()
+                        .when(leave_sidebar_exposed, |backdrop| {
+                            backdrop
+                                .top(px(0.0))
+                                .right(px(0.0))
+                                .bottom(px(0.0))
+                                .left(px(sidebar_width))
+                        })
+                        .when(!leave_sidebar_exposed, |backdrop| backdrop.inset_0())
+                        .debug_selector(|| "surface-backdrop".into())
+                        // Modal sheets still dismiss from their backdrop;
+                        // Settings is the full workbench branch above.
+                        .occlude()
+                        .on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(|this, _, _, cx| {
+                                this.close_surface(cx);
+                                cx.stop_propagation();
+                            }),
+                        )
+                        .on_scroll_wheel(|_, _, cx| cx.stop_propagation())
+                        .bg(rgba(0x00000040))
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .child(
+                            div()
+                                .occlude()
+                                .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+                                .child(overlay),
+                        ),
+                )
+            }
         } else {
             root.size(px(0.0))
         }
@@ -4278,6 +4509,47 @@ fn settings_note(
                         .child(wrappable_setting_copy(body.into())),
                 ),
         )
+        .into_any_element()
+}
+
+fn settings_tab_matches(tab: SettingsTab, query: &str) -> bool {
+    let query = query.trim().to_ascii_lowercase();
+    if query.is_empty() {
+        return true;
+    }
+    let searchable = match tab {
+        SettingsTab::General => {
+            "general default startup login sessions close confirmation sounds chimes support diagnostics quick open search roots updates"
+        }
+        SettingsTab::Agents => {
+            "agents codex claude cursor gemini executable installed command line quick create default"
+        }
+        SettingsTab::Terminal => "terminal appearance color theme font text size zoom",
+        SettingsTab::Resources => {
+            "resources idle sessions hibernate freeze memory limit performance"
+        }
+        SettingsTab::Remote => {
+            "remote ssh openssh hosts machines connections execution tailscale network"
+        }
+    };
+    query
+        .split_whitespace()
+        .all(|word| searchable.contains(word))
+}
+
+fn settings_nav_section_header(
+    title: &'static str,
+    top_padding: f32,
+    colors: SemanticColors,
+) -> AnyElement {
+    div()
+        .px(px(8.0))
+        .pt(px(top_padding))
+        .pb(px(5.0))
+        .text_size(px(Typo::SECTION_HEADER.size))
+        .font_weight(Typo::SECTION_HEADER.weight)
+        .text_color(colors.tertiary)
+        .child(title)
         .into_any_element()
 }
 
@@ -4663,6 +4935,59 @@ mod tests {
             .expect("save diagnostics screenshot");
     }
 
+    /// Renders the full settings workbench after its entrance transition, so
+    /// layout and visual hierarchy can be reviewed without live user state.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "writes the deterministic settings-shell screenshot artifact"]
+    fn render_settings_shell_preview_screenshot() {
+        let output = std::env::var_os("DIRI_VISUAL_OUTPUT")
+            .map(PathBuf::from)
+            .expect("set DIRI_VISUAL_OUTPUT to the target PNG path");
+        let platform = gpui_platform::current_platform(true);
+        let mut cx = HeadlessAppContext::with_platform(
+            platform.text_system(),
+            Arc::new(diri_ui::IconAssets),
+            gpui_platform::current_headless_renderer,
+        );
+        cx.update(|cx| crate::fonts::init(cx));
+
+        let runtime = Arc::new(StoreRuntime::inert());
+        let tokio = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime"),
+        );
+        let updates = crate::updates::inert();
+        let window = cx
+            .open_window(size(px(1200.0), px(800.0)), move |window, cx| {
+                let surfaces = cx.new(|cx| {
+                    let mut surfaces = UtilitySurfaces::new(runtime, tokio, updates, window, cx);
+                    surfaces.open_settings(cx);
+                    // Exercise the user-reported state: Remote selected after
+                    // the workspace sidebar had previously been widened.
+                    surfaces.settings_tab = SettingsTab::Remote;
+                    surfaces.prefs.sidebar_width = 400.0;
+                    surfaces
+                });
+                cx.new(|_| CachedOverlayHarness { surfaces })
+            })
+            .expect("open headless settings window");
+        cx.run_until_parked();
+        cx.advance_clock(SETTINGS_TRANSITION_DURATION + Duration::from_millis(10));
+        cx.update_window(window.into(), |_, window, _| window.refresh())
+            .expect("refresh settings window");
+        cx.run_until_parked();
+        let screenshot = cx
+            .capture_screenshot(window.into())
+            .expect("capture settings screenshot");
+        if let Some(parent) = output.parent() {
+            std::fs::create_dir_all(parent).expect("create screenshot directory");
+        }
+        screenshot.save(output).expect("save settings screenshot");
+    }
+
     struct SettingsModalHarness {
         surfaces: Entity<UtilitySurfaces>,
         background_events: Arc<AtomicUsize>,
@@ -4950,6 +5275,9 @@ mod tests {
                 background_events: Arc::new(AtomicUsize::new(0)),
             }
         });
+        cx.executor()
+            .advance_clock(SETTINGS_TRANSITION_DURATION + Duration::from_millis(10));
+        cx.run_until_parked();
         let surfaces = view.read_with(cx, |harness, _| harness.surfaces.clone());
         let field = cx.debug_bounds("HOST_FIELD_NAME").expect("name field");
 
@@ -5022,7 +5350,7 @@ mod tests {
     }
 
     #[gpui::test]
-    fn cached_settings_modal_stays_inside_window(cx: &mut TestAppContext) {
+    fn cached_settings_shell_fills_the_window(cx: &mut TestAppContext) {
         let runtime = Arc::new(StoreRuntime::inert());
         let tokio = Arc::new(
             tokio::runtime::Builder::new_current_thread()
@@ -5043,17 +5371,15 @@ mod tests {
         let root = cx
             .debug_bounds("cached-settings-root")
             .expect("settings root should render");
-        let dialog = cx
-            .debug_bounds("settings-dialog")
-            .expect("settings dialog should render");
+        let shell = cx
+            .debug_bounds("settings-shell")
+            .expect("settings shell should render");
 
-        assert_eq!(dialog.center(), root.center());
-        assert!(dialog.top() >= root.top());
-        assert!(dialog.bottom() <= root.bottom());
+        assert_eq!(shell, root);
     }
 
     #[gpui::test]
-    fn settings_modal_blocks_background_selection_and_scroll(cx: &mut TestAppContext) {
+    fn settings_shell_blocks_background_selection_and_scroll(cx: &mut TestAppContext) {
         let runtime = Arc::new(StoreRuntime::inert());
         let tokio = Arc::new(
             tokio::runtime::Builder::new_current_thread()
@@ -5089,10 +5415,9 @@ mod tests {
         assert_eq!(background_events.load(Ordering::Relaxed), 0);
         assert_eq!(
             surfaces.read_with(cx, |surfaces, _| surfaces.surface),
-            Surface::None
+            Surface::Settings
         );
 
-        surfaces.update(cx, |surfaces, cx| surfaces.open_settings(cx));
         cx.simulate_event(ScrollWheelEvent {
             position: outside_panel,
             delta: ScrollDelta::Pixels(point(px(0.0), px(-40.0))),
@@ -5133,13 +5458,10 @@ mod tests {
             }
         });
 
-        let dialog = cx
-            .debug_bounds("settings-dialog")
-            .expect("settings dialog should render");
-        cx.simulate_click(
-            point(dialog.center().x, dialog.top() + px(29.0)),
-            Modifiers::default(),
-        );
+        let pane = cx
+            .debug_bounds("settings-pane")
+            .expect("settings pane should render");
+        cx.simulate_click(pane.center(), Modifiers::default());
 
         let surfaces = view.read_with(cx, |harness, _| harness.surfaces.clone());
         assert_eq!(
@@ -5154,7 +5476,7 @@ mod tests {
     }
 
     #[gpui::test]
-    fn settings_dialog_centers_in_the_window_through_the_cached_wrapper(cx: &mut TestAppContext) {
+    fn settings_shell_keeps_the_sidebar_rail_in_the_cached_wrapper(cx: &mut TestAppContext) {
         let runtime = Arc::new(StoreRuntime::inert());
         let tokio = Arc::new(
             tokio::runtime::Builder::new_current_thread()
@@ -5175,25 +5497,27 @@ mod tests {
         let viewport = size(px(1200.0), px(800.0));
         cx.simulate_resize(viewport);
 
-        // The backdrop must cover the window. A collapsed root leaves it
-        // 1200x0, which dims nothing and blocks nothing.
         let backdrop = cx
             .debug_bounds("surface-backdrop")
-            .expect("modal backdrop should render");
+            .expect("settings backdrop should render");
         assert_eq!(backdrop.size, viewport);
 
-        let dialog = cx
-            .debug_bounds("settings-dialog")
-            .expect("settings dialog should render");
-        assert_eq!(dialog.size.width, px(SETTINGS_WIDTH));
-        assert_eq!(dialog.size.height, px(SETTINGS_HEIGHT));
-
-        // The dialog is taller than a collapsed root, so a zero-height root
-        // parks it half above the window instead of in the middle.
-        let center = dialog.center();
-        assert_eq!(center.x, viewport.width / 2.0);
-        assert_eq!(center.y, viewport.height / 2.0);
-        assert!(dialog.top() > px(0.0), "dialog hangs above the window top");
+        let shell = cx
+            .debug_bounds("settings-shell")
+            .expect("settings shell should render");
+        let rail = cx
+            .debug_bounds("settings-rail")
+            .expect("settings rail should render");
+        let pane = cx
+            .debug_bounds("settings-pane")
+            .expect("settings pane should render");
+        assert_eq!(shell.size, viewport);
+        assert_eq!(rail.size.width, px(248.0));
+        assert!(rail.left() >= shell.left() - px(8.0));
+        assert!(rail.left() <= shell.left());
+        assert!(pane.left() >= rail.right());
+        assert!(pane.left() <= rail.right() + px(20.0));
+        assert_eq!(rail.top(), px(Metrics::TITLE_BAR));
     }
 
     #[gpui::test]
@@ -5227,6 +5551,188 @@ mod tests {
         assert_eq!(
             surfaces.read_with(cx, |surfaces, _| surfaces.surface),
             Surface::None
+        );
+    }
+
+    #[gpui::test]
+    fn settings_shortcut_action_toggles_the_shell(cx: &mut TestAppContext) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        let tokio = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime"),
+        );
+        let updates = crate::updates::inert();
+        let (view, cx) = cx.add_window_view(move |window, cx| {
+            let surfaces = cx.new(|cx| UtilitySurfaces::new(runtime, tokio, updates, window, cx));
+            SettingsModalHarness {
+                surfaces,
+                background_events: Arc::new(AtomicUsize::new(0)),
+            }
+        });
+        let surfaces = view.read_with(cx, |harness, _| harness.surfaces.clone());
+        surfaces.update_in(cx, |surfaces, window, cx| {
+            surfaces.focus.focus(window, cx);
+        });
+
+        cx.dispatch_action(OpenSettings);
+        assert_eq!(
+            surfaces.read_with(cx, |surfaces, _| surfaces.surface),
+            Surface::Settings
+        );
+
+        cx.dispatch_action(OpenSettings);
+        assert_eq!(
+            surfaces.read_with(cx, |surfaces, _| surfaces.surface),
+            Surface::None,
+            "a second Command-, action should return to the app"
+        );
+    }
+
+    #[gpui::test]
+    fn settings_rail_does_not_inherit_a_resized_workspace_sidebar(cx: &mut TestAppContext) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        let tokio = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime"),
+        );
+        let updates = crate::updates::inert();
+        let (_, cx) = cx.add_window_view(move |window, cx| {
+            let surfaces = cx.new(|cx| {
+                let mut surfaces = UtilitySurfaces::new(runtime, tokio, updates, window, cx);
+                surfaces.open_settings(cx);
+                surfaces.prefs.sidebar_width = 400.0;
+                surfaces
+            });
+            CachedOverlayHarness { surfaces }
+        });
+        cx.simulate_resize(size(px(1200.0), px(800.0)));
+
+        let rail = cx
+            .debug_bounds("settings-rail")
+            .expect("settings rail should render");
+        assert_eq!(
+            rail.size.width,
+            px(248.0),
+            "settings navigation should keep its own stable measure"
+        );
+    }
+
+    #[test]
+    fn settings_search_matches_page_copy_not_only_tab_titles() {
+        assert!(settings_tab_matches(SettingsTab::Remote, "ssh"));
+        assert!(settings_tab_matches(SettingsTab::Resources, "memory"));
+        assert!(settings_tab_matches(SettingsTab::General, "login"));
+        assert!(!settings_tab_matches(SettingsTab::Terminal, "ssh"));
+    }
+
+    #[gpui::test]
+    fn settings_search_filters_and_opens_the_first_result(cx: &mut TestAppContext) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        let tokio = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime"),
+        );
+        let updates = crate::updates::inert();
+        let (view, cx) = cx.add_window_view(move |window, cx| {
+            let surfaces = cx.new(|cx| {
+                let mut surfaces = UtilitySurfaces::new(runtime, tokio, updates, window, cx);
+                surfaces.open_settings(cx);
+                surfaces
+            });
+            SettingsModalHarness {
+                surfaces,
+                background_events: Arc::new(AtomicUsize::new(0)),
+            }
+        });
+        cx.executor()
+            .advance_clock(SETTINGS_TRANSITION_DURATION + Duration::from_millis(10));
+        cx.run_until_parked();
+
+        let search = cx
+            .debug_bounds("settings-search")
+            .expect("settings search should render");
+        cx.simulate_click(search.center(), Modifiers::default());
+        cx.simulate_input("ssh");
+
+        assert!(cx.debug_bounds("SETTINGS_TAB_Remote").is_some());
+        assert!(cx.debug_bounds("SETTINGS_TAB_General").is_none());
+        let surfaces = view.read_with(cx, |harness, _| harness.surfaces.clone());
+        surfaces.read_with(cx, |surfaces, _| {
+            assert_eq!(surfaces.settings_search.text(), "ssh");
+            assert!(surfaces.settings_search_active);
+        });
+
+        cx.simulate_keystrokes("enter");
+        surfaces.read_with(cx, |surfaces, _| {
+            assert_eq!(surfaces.settings_tab, SettingsTab::Remote);
+            assert!(!surfaces.settings_search_active);
+        });
+        assert!(cx.debug_bounds("SETTINGS_NOTE_COPY").is_some());
+    }
+
+    #[gpui::test]
+    fn changing_settings_tabs_resets_the_shared_pane_scroll(cx: &mut TestAppContext) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        let tokio = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime"),
+        );
+        let updates = crate::updates::inert();
+        let (view, cx) = cx.add_window_view(move |window, cx| {
+            let surfaces = cx.new(|cx| {
+                let mut surfaces = UtilitySurfaces::new(runtime, tokio, updates, window, cx);
+                surfaces.open_settings(cx);
+                surfaces
+            });
+            SettingsModalHarness {
+                surfaces,
+                background_events: Arc::new(AtomicUsize::new(0)),
+            }
+        });
+        cx.simulate_resize(size(px(900.0), px(520.0)));
+        cx.executor()
+            .advance_clock(SETTINGS_TRANSITION_DURATION + Duration::from_millis(10));
+        cx.run_until_parked();
+
+        let pane = cx
+            .debug_bounds("settings-pane")
+            .expect("settings pane should render");
+        for _ in 0..8 {
+            cx.simulate_event(ScrollWheelEvent {
+                position: pane.center(),
+                delta: ScrollDelta::Pixels(point(px(0.0), px(-120.0))),
+                ..ScrollWheelEvent::default()
+            });
+        }
+
+        let remote = cx
+            .debug_bounds("SETTINGS_TAB_Remote")
+            .expect("Remote tab should render");
+        cx.simulate_click(remote.center(), Modifiers::default());
+
+        let surfaces = view.read_with(cx, |harness, _| harness.surfaces.clone());
+        surfaces.read_with(cx, |surfaces, _| {
+            assert_eq!(surfaces.settings_tab, SettingsTab::Remote);
+            assert_eq!(surfaces.settings_scroll.offset(), point(px(0.0), px(0.0)));
+        });
+
+        let pane = cx
+            .debug_bounds("settings-pane")
+            .expect("settings pane should remain visible");
+        let copy = cx
+            .debug_bounds("SETTINGS_NOTE_COPY")
+            .expect("Remote page content should render");
+        assert!(
+            copy.bottom() > pane.top() && copy.top() < pane.bottom(),
+            "switching tabs left the Remote page scrolled out of view: {copy:?} vs {pane:?}"
         );
     }
 }

--- a/diri/crates/diri-ui/assets/icons/chevron-left.svg
+++ b/diri/crates/diri-ui/assets/icons/chevron-left.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9" viewBox="0 0 24 24"><path d="m15 6.5-5.5 5.5 5.5 5.5"/></svg>

--- a/diri/crates/diri-ui/src/components.rs
+++ b/diri/crates/diri-ui/src/components.rs
@@ -248,6 +248,8 @@ impl RowFill {
 pub struct FloatingSurface {
     colors: SemanticColors,
     child: AnyElement,
+    radius: f32,
+    animate_entry: bool,
 }
 
 impl FloatingSurface {
@@ -255,16 +257,30 @@ impl FloatingSurface {
         Self {
             colors,
             child: child.into_any_element(),
+            radius: Radius::PANEL,
+            animate_entry: true,
         }
+    }
+
+    pub const fn radius(mut self, radius: f32) -> Self {
+        self.radius = radius;
+        self
+    }
+
+    pub const fn animate_entry(mut self, animate: bool) -> Self {
+        self.animate_entry = animate;
+        self
     }
 }
 
 impl RenderOnce for FloatingSurface {
     fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
         let colors = self.colors;
+        let animate_entry = self.animate_entry;
         let surface = div()
             .relative()
-            .rounded(px(Radius::PANEL))
+            .rounded(px(self.radius))
+            .overflow_hidden()
             // Floating chrome keeps the sidebar hue but uses a denser material
             // so live terminal content never competes with labels or controls.
             .bg(colors.floating_surface())
@@ -287,7 +303,9 @@ impl RenderOnce for FloatingSurface {
                 },
             ])
             .child(self.child);
-        if floating_surface_motion(cx.reduce_motion()) == FloatingSurfaceMotion::Immediate {
+        if !animate_entry
+            || floating_surface_motion(cx.reduce_motion()) == FloatingSurfaceMotion::Immediate
+        {
             surface.into_any_element()
         } else {
             surface

--- a/diri/crates/diri-ui/src/icon.rs
+++ b/diri/crates/diri-ui/src/icon.rs
@@ -54,6 +54,7 @@ pub enum IconName {
     CheckCircle,
     Checklist,
     ChevronDown,
+    ChevronLeft,
     ChevronRight,
     ChevronUp,
     ChevronUpDown,
@@ -95,7 +96,7 @@ pub enum IconName {
 }
 
 impl IconName {
-    pub const ALL: [Self; 46] = [
+    pub const ALL: [Self; 47] = [
         Self::Activity,
         Self::Archive,
         Self::ArrowDown,
@@ -104,6 +105,7 @@ impl IconName {
         Self::CheckCircle,
         Self::Checklist,
         Self::ChevronDown,
+        Self::ChevronLeft,
         Self::ChevronRight,
         Self::ChevronUp,
         Self::ChevronUpDown,
@@ -154,6 +156,7 @@ impl IconName {
             Self::CheckCircle => "icons/check-circle.svg",
             Self::Checklist => "icons/checklist.svg",
             Self::ChevronDown => "icons/chevron-down.svg",
+            Self::ChevronLeft => "icons/chevron-left.svg",
             Self::ChevronRight => "icons/chevron-right.svg",
             Self::ChevronUp => "icons/chevron-up.svg",
             Self::ChevronUpDown => "icons/chevron-up-down.svg",
@@ -207,6 +210,7 @@ impl IconName {
             "checkmark.circle" | "checkmark.circle.fill" => Self::CheckCircle,
             "checklist" => Self::Checklist,
             "chevron.down" => Self::ChevronDown,
+            "arrow.left" | "chevron.left" => Self::ChevronLeft,
             "chevron.right" => Self::ChevronRight,
             "chevron.up" => Self::ChevronUp,
             "chevron.up.chevron.down" => Self::ChevronUpDown,
@@ -310,6 +314,7 @@ fn embedded_svg(path: &str) -> Option<&'static [u8]> {
         "icons/check-circle.svg" => include_bytes!("../assets/icons/check-circle.svg"),
         "icons/checklist.svg" => include_bytes!("../assets/icons/checklist.svg"),
         "icons/chevron-down.svg" => include_bytes!("../assets/icons/chevron-down.svg"),
+        "icons/chevron-left.svg" => include_bytes!("../assets/icons/chevron-left.svg"),
         "icons/chevron-right.svg" => include_bytes!("../assets/icons/chevron-right.svg"),
         "icons/chevron-up.svg" => include_bytes!("../assets/icons/chevron-up.svg"),
         "icons/chevron-up-down.svg" => include_bytes!("../assets/icons/chevron-up-down.svg"),
@@ -418,6 +423,7 @@ mod tests {
             "checkmark.circle",
             "checkmark.circle.fill",
             "chevron.down",
+            "chevron.left",
             "chevron.left.forwardslash.chevron.right",
             "chevron.right",
             "chevron.up",


### PR DESCRIPTION
## Summary
- redesign the bottom account menu with identity, pricing, usage, remote, update, and settings actions
- move settings into the main workbench with an animated compact rail, functional search, scroll restoration, and a toggling Command-comma shortcut
- rework Command-K into a tighter searchable chat and command palette with real shortcut ordering

## Verification
- cargo fmt --all -- --check
- cargo test -p diri-app: 441 passed, 0 failed, 5 ignored
- deterministic settings-shell screenshot test
- combined dev build launched for interactive verification