### PR TITLE
engine: bound how far output may run ahead of the pump that parses it

### DIFF
--- a/diri/crates/diri-engine/src/holder/server.rs
+++ b/diri/crates/diri-engine/src/holder/server.rs
@@ -39,7 +39,7 @@ const MAX_SIGNAL: i32 = 65;
 /// How many PTY chunks may be waiting to be written before the reader has to
 /// wait for the writer. At 64 KiB a chunk this absorbs a multi-megabyte stall
 /// without letting a wedged filesystem grow the queue without bound.
-const WRITE_QUEUE_DEPTH: usize = 256;
+const WRITE_QUEUE_DEPTH: usize = 16;
 
 /// How much queued output one disk write may carry. Larger writes cost the
 /// filesystem far less per byte than many small ones.

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -174,7 +174,12 @@ const OUTPUT_BATCH_BYTES: usize = 1 << 20;
 /// How much of a held session's log the follow pump reads per pass. A full
 /// read means more is already waiting, which is how that pump recognizes a
 /// repaint it has only half consumed.
-const LOG_READ_BUDGET: usize = 64 << 10;
+const LOG_READ_BUDGET: usize = 512 << 10;
+
+/// How often status detection may run while output is still backed up. Reading
+/// is what keeps the pump close behind the holder, and a screen that changed
+/// twice within one frame is not two observations worth having.
+const EVAL_INTERVAL: Duration = Duration::from_millis(16);
 
 /// What a session looks like from the outside.
 #[derive(Clone, Debug)]
@@ -2631,6 +2636,7 @@ fn pump_held(
     let mut checkpoint_dirty_at: Option<Instant> = None;
     let mut last_liveness = Instant::now();
     let mut last_eval_seq = 0u64;
+    let mut last_eval_at: Option<Instant> = None;
     let mut last_scan_at = None;
     let mut last_scan_seq = 0u64;
     let mut exit_status: Option<HolderExitStatus> = None;
@@ -2762,20 +2768,33 @@ fn pump_held(
 
         if !output.is_empty() {
             checkpoint_dirty_at = Some(Instant::now());
+            // Detection snapshots the whole screen and walks it with the
+            // manifest's patterns. That is cheap per screen and ruinous per
+            // read: a session streaming output produces thousands of reads a
+            // second, and paying for it on each one puts the pump behind the
+            // holder — which shows up as latency, because a query the child
+            // makes cannot be answered until the pump reaches it. While output
+            // is still backed up it runs on a timer, and the moment the pump
+            // catches up it runs again, so a settled screen is never stale.
+            let evaluate_now =
+                caught_up || last_eval_at.is_none_or(|at: Instant| at.elapsed() >= EVAL_INTERVAL);
             let (observation, replies) = {
                 let mut screen = shared.screen.lock().expect("screen");
                 screen.feed(&output);
                 let replies = screen.take_replies();
-                (
+                let observation = if evaluate_now {
+                    last_eval_at = Some(Instant::now());
                     evaluate_if_screen_changed(
                         &shared,
                         &mut screen,
                         &engine,
                         &manifest_id,
                         &mut last_eval_seq,
-                    ),
-                    replies,
-                )
+                    )
+                } else {
+                    None
+                };
+                (observation, replies)
             };
             // The child is blocked reading the answer to its query, so send it
             // through the holder's input path before publishing anything.

--- a/diri/scripts/termbench/README.md
+++ b/diri/scripts/termbench/README.md
@@ -1,0 +1,66 @@
+# termbench
+
+Compares diri against other terminal emulators on the same machine, by
+replaying identical byte streams into each and timing how long each takes to
+*finish parsing* them.
+
+## Why it is built this way
+
+Timing `cat` alone measures how fast a terminal drains the PTY, which a
+terminal can win by buffering and parsing later. Every measurement here queues
+a cursor-position request (`CSI 6n`) behind the payload and waits for the
+answer, so the clock stops only once the terminal has actually processed
+everything ahead of it. That is `t_sync`; `t_cat` is reported alongside it for
+comparison, and the two diverging is itself informative — it means the terminal
+accepted bytes faster than it consumed them.
+
+Terminals are measured one at a time. Two running at once measures the
+contention between them.
+
+Runs are short and the machine is not quiet, so every workload runs several
+times and the **fastest** run is reported: interference only ever makes a run
+slower, so the minimum is the closest estimate of what the terminal costs.
+Medians looked stable in early runs and were not — individual passes varied by
+up to 2.4x until the payloads were grown to 40 MB.
+
+## Running it
+
+```sh
+# One-time: the plain-text workload replays a large public-domain text file.
+mkdir -p /tmp/termbench-src && curl -o /tmp/termbench-src/shakespeare.txt <url>
+
+python3 gen_workloads.py /tmp/termbench      # write the byte streams
+cargo build --release -p diri-engine --examples --bins
+
+# All three terminals, sequentially:
+RUNS=5 ./compare_all.sh
+python3 table.py results
+```
+
+To measure one terminal, run `suite.sh <name>` *inside* it. For diri there is
+no window to run inside, so `examples/runbench` spawns a real held session and
+runs the same script there — the same PTY, holder, log and emulator the daemon
+uses, with no renderer attached.
+
+## Workloads
+
+Each is a recording of what some real program writes: plain text scroll, dense
+truecolor SGR, scattered cursor motion, unbroken lines that force wrapping,
+scroll regions with inserts and deletes, wide CJK, decomposed combining marks,
+erase-and-redraw churn, alternate-screen switching, synchronized updates
+(DECSET 2026), a build-log mix, and a captured DOOM-fire animation.
+
+## Latency
+
+`dsr_latency.py` measures query round trip on an idle terminal.
+`latency_under_load.py` measures the same thing while a payload streams, which
+is the number that corresponds to typing while a build log scrolls. The gap
+between the two is the interesting part: a terminal whose idle latency is
+microseconds and whose loaded latency is tens of milliseconds will *feel* slow
+exactly when a user is most likely to be interacting with it.
+
+For diri specifically, loaded latency is governed by how far the holder may run
+ahead of the daemon that parses its output — see `WRITE_QUEUE_DEPTH` in
+`holder/server.rs`. Deepening that queue raises throughput and worsens the
+latency tail, one for one. The queue is also why a benchmark payload smaller
+than the queue reports a rate the pipeline cannot sustain.

--- a/diri/scripts/termbench/compare_all.sh
+++ b/diri/scripts/termbench/compare_all.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Runs the identical suite through all three terminals, one at a time.
+#
+# Sequential on purpose: two terminals benchmarking at once would measure the
+# contention between them, not the terminals.
+set -u
+B="$(cd "$(dirname "$0")" && pwd)"
+RUNS="${RUNS:-3}"
+CAP="${CAP:-30}"
+rm -f /tmp/suite-driver.done
+
+run_env="RUNS=$RUNS IO_BENCH_TIMEOUT=$CAP"
+
+echo "=== dirijor ==="
+RUNBENCH_TIMEOUT_SECS=2400 env $run_env \
+  DIRI_HOLDER_BIN=${DIRI_HOLDER_BIN:-/tmp/diri-shared-target/release/diri-holder} ${RUNBENCH:-/tmp/diri-shared-target/release/examples/runbench} 153 39 "$run_env bash $B/suite.sh dirijor" \
+  >/tmp/suite-dirijor.log 2>&1
+
+echo "=== ghostty ==="
+/Applications/Ghostty.app/Contents/MacOS/ghostty --window-width=153 --window-height=39 \
+  -e bash -c "$run_env bash $B/suite.sh ghostty" >/tmp/suite-ghostty.log 2>&1
+
+echo "=== kitty ==="
+/Applications/kitty.app/Contents/MacOS/kitty -o initial_window_width=153c \
+  -o initial_window_height=39c -o confirm_os_window_close=0 \
+  bash -c "$run_env bash $B/suite.sh kitty" >/tmp/suite-kitty.log 2>&1
+
+echo DONE >/tmp/suite-driver.done

--- a/diri/scripts/termbench/dsr_latency.py
+++ b/diri/scripts/termbench/dsr_latency.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Terminal response latency: how long the emulator takes to answer a query.
+
+This is not keystroke-to-photon latency — that needs a high-speed camera. It is
+the software half of it: write a cursor-position request, wait for the reply.
+Every millisecond here is a millisecond the same terminal would take to notice
+and act on input, so it is the part of input latency that can be measured
+without hardware.
+
+Usage: dsr_latency.py <out.csv> [iterations]
+"""
+import os
+import select
+import statistics
+import sys
+import termios
+import time
+import tty
+
+out = sys.argv[1]
+iterations = int(sys.argv[2]) if len(sys.argv) > 2 else 200
+
+fd = os.open("/dev/tty", os.O_RDWR)
+old = termios.tcgetattr(fd)
+samples = []
+try:
+    tty.setraw(fd)
+    for _ in range(iterations):
+        termios.tcflush(fd, termios.TCIFLUSH)
+        start = time.perf_counter()
+        os.write(fd, b"\x1b[6n")
+        buf = b""
+        while not buf.endswith(b"R"):
+            if not select.select([fd], [], [], 1.0)[0]:
+                break
+            buf += os.read(fd, 32)
+        if buf.endswith(b"R"):
+            samples.append((time.perf_counter() - start) * 1000.0)
+        time.sleep(0.002)  # don't let one query's work overlap the next
+finally:
+    termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    os.close(fd)
+
+with open(out, "w") as f:
+    if not samples:
+        f.write("nan,nan,nan,0\n")
+    else:
+        f.write(
+            "%.3f,%.3f,%.3f,%d\n"
+            % (
+                statistics.median(samples),
+                min(samples),
+                statistics.quantiles(samples, n=100)[94] if len(samples) > 20 else max(samples),
+                len(samples),
+            )
+        )

--- a/diri/scripts/termbench/gen_workloads.py
+++ b/diri/scripts/termbench/gen_workloads.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Generate the byte streams the terminal suite replays.
+
+Each file is a recording of what a program would write to a terminal. Feeding
+identical bytes to every terminal is what makes the comparison fair: no
+terminal gets to be fast because it received less work.
+
+Sizes are chosen so a fast terminal spends a few hundred ms on each.
+"""
+import os
+import random
+import sys
+
+OUT = sys.argv[1] if len(sys.argv) > 1 else "/tmp/termbench"
+COLS, ROWS = 153, 39
+TARGET = 40 << 20  # ~40 MB per workload: small runs are dominated by system noise
+
+os.makedirs(OUT, exist_ok=True)
+rng = random.Random(0x5EED)
+
+
+def write(name, chunks):
+    path = os.path.join(OUT, name + ".bin")
+    total = 0
+    with open(path, "wb") as f:
+        for chunk in chunks:
+            f.write(chunk)
+            total += len(chunk)
+    print(f"{name:<16} {total/(1<<20):6.1f} MB")
+
+
+def until_target(make):
+    """Yield from make() until TARGET bytes have been produced."""
+    total = 0
+    while total < TARGET:
+        chunk = make()
+        total += len(chunk)
+        yield chunk
+
+
+def plain_ascii():
+    """Baseline scroll: the classic `cat a big text file`."""
+    src = open(
+        "/private/tmp/claude-501/-Users-giga-fun/dc68f650-1b85-4b6d-88b8-8f981781413d"
+        "/scratchpad/terminal-benchmark/test/shakespeare.txt", "rb"
+    ).read()
+    # Repeated to match the other workloads' size: a run short enough to be
+    # measured in tens of milliseconds is mostly measuring system noise.
+    return [src] * max(1, TARGET // len(src))
+
+
+def dense_sgr():
+    """Every cell its own truecolor: the worst case for SGR parsing."""
+    def row():
+        out = bytearray()
+        for col in range(COLS):
+            r, g, b = (col * 5) % 256, (col * 11) % 256, (col * 17) % 256
+            out += b"\x1b[38;2;%d;%d;%dm\x1b[48;2;%d;%d;%dm#" % (r, g, b, b, r, g)
+        out += b"\x1b[0m\n"
+        return bytes(out)
+    line = row()
+    return until_target(lambda: line)
+
+
+def cursor_motion():
+    """Absolute positioning with tiny writes — a TUI redrawing scattered cells."""
+    def burst():
+        out = bytearray()
+        for _ in range(256):
+            y, x = rng.randint(1, ROWS), rng.randint(1, COLS)
+            out += b"\x1b[%d;%dH" % (y, x)
+            out += bytes([rng.randint(65, 90)])
+        return bytes(out)
+    return until_target(burst)
+
+
+def long_lines():
+    """No newlines at all: pure wrapping, which forces a scroll per screenful."""
+    line = bytes([rng.randint(33, 126) for _ in range(8192)])
+    return until_target(lambda: line)
+
+
+def scroll_region():
+    """A pager's shape: a scrolling region with inserts and deletes."""
+    def burst():
+        out = bytearray(b"\x1b[2;%dr" % (ROWS - 1))
+        for i in range(64):
+            out += b"\x1b[%d;1H" % (rng.randint(2, ROWS - 1))
+            out += b"\x1b[L" if i % 2 else b"\x1b[M"
+            out += b"a line of replacement text in a scrolling region\n"
+        return bytes(out)
+    return until_target(burst)
+
+
+def unicode_cjk():
+    """Wide characters: two cells per glyph, and a different width path."""
+    line = ("汉字宽度测试 " * (COLS // 14) + "\n").encode()
+    return until_target(lambda: line)
+
+
+def combining():
+    """Base characters plus combining marks — the zero-width path."""
+    line = ("éàôü " * (COLS // 12) + "\n").encode()
+    return until_target(lambda: line)
+
+
+def erase_churn():
+    """Clear and redraw the screen over and over: erase-heavy, like a spinner."""
+    body = b"".join(b"\x1b[%d;1H" % y + b"x" * (COLS - 1) for y in range(1, ROWS + 1))
+    frame = b"\x1b[2J\x1b[H" + body
+    return until_target(lambda: frame)
+
+
+def alt_screen():
+    """Enter and leave the alternate screen repeatedly, painting each time."""
+    body = b"".join(b"\x1b[%d;1H" % y + b"alt screen content" for y in range(1, ROWS + 1))
+    frame = b"\x1b[?1049h" + body + b"\x1b[?1049l" + b"back on the primary screen\n"
+    return until_target(lambda: frame)
+
+
+def sync_update():
+    """Frames wrapped in DECSET 2026, the flicker-free repaint protocol."""
+    body = b"".join(
+        b"\x1b[%d;1H" % y + b"\x1b[38;5;%dm" % (y % 256) + b"synchronized frame row" * 3
+        for y in range(1, ROWS + 1)
+    )
+    frame = b"\x1b[?2026h\x1b[H" + body + b"\x1b[?2026l"
+    return until_target(lambda: frame)
+
+
+def mixed_log():
+    """What a build log actually looks like: color, timestamps, plain text."""
+    def burst():
+        out = bytearray()
+        for i in range(64):
+            out += b"\x1b[2m12:34:5%d\x1b[0m " % (i % 10)
+            out += b"\x1b[32mINFO\x1b[0m " if i % 3 else b"\x1b[33mWARN\x1b[0m "
+            out += b"compiling crate number %d with several flags set\n" % i
+        return bytes(out)
+    return until_target(burst)
+
+
+WORKLOADS = {
+    "plain_ascii": plain_ascii,
+    "dense_sgr": dense_sgr,
+    "cursor_motion": cursor_motion,
+    "long_lines": long_lines,
+    "scroll_region": scroll_region,
+    "unicode_cjk": unicode_cjk,
+    "combining": combining,
+    "erase_churn": erase_churn,
+    "alt_screen": alt_screen,
+    "sync_update": sync_update,
+    "mixed_log": mixed_log,
+}
+
+if __name__ == "__main__":
+    for name, make in WORKLOADS.items():
+        write(name, make())
+    print(f"\nwrote {len(WORKLOADS)} workloads to {OUT}")

--- a/diri/scripts/termbench/io_bench.py
+++ b/diri/scripts/termbench/io_bench.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Replay a recorded byte stream into the terminal and time it, twice over:
+
+  t_cat  - wall time until the writer exits (what a plain `time cat` measures;
+           it only proves the terminal drained the pty, not that it parsed it)
+  t_sync - wall time until the terminal answers a cursor-position report queued
+           *after* the payload, i.e. until everything has actually been parsed
+
+A terminal that never answers the query reports t_sync as `nan`; one that is
+too slow to finish the payload at all reports `timeout`.
+
+Usage: io_bench.py <file> <out.csv>
+"""
+import os
+import select
+import subprocess
+import sys
+import termios
+import time
+import tty
+
+path, out = sys.argv[1], sys.argv[2]
+# A terminal pathologically slow at one workload must not stall the whole
+# suite, so every run is capped.
+CAP = float(os.environ.get("IO_BENCH_TIMEOUT", "60"))
+# Terminals that answer DSR do so in well under a millisecond; one that does
+# not implement it never will, so don't sit on a long timeout.
+DSR_WAIT = 2.0
+
+tty_fd = os.open("/dev/tty", os.O_RDWR)
+old = termios.tcgetattr(tty_fd)
+try:
+    t0 = time.perf_counter()
+    child = subprocess.Popen(["cat", path], stdout=tty_fd)
+    try:
+        child.wait(timeout=CAP)
+        timed_out = False
+    except subprocess.TimeoutExpired:
+        child.kill()
+        child.wait()
+        timed_out = True
+    t_cat = time.perf_counter() - t0
+
+    if timed_out:
+        result = f"{t_cat * 1000:.1f},timeout"
+    else:
+        tty.setraw(tty_fd)
+        termios.tcflush(tty_fd, termios.TCIFLUSH)
+        os.write(tty_fd, b"\x1b[6n")
+        buf = b""
+        deadline = time.perf_counter() + DSR_WAIT
+        while not buf.endswith(b"R"):
+            left = deadline - time.perf_counter()
+            if left <= 0 or not select.select([tty_fd], [], [], left)[0]:
+                buf = b""  # terminal never answered
+                break
+            chunk = os.read(tty_fd, 32)
+            if not chunk:
+                break
+            buf += chunk
+        t_sync = (time.perf_counter() - t0) if buf else float("nan")
+        result = f"{t_cat * 1000:.1f},{t_sync * 1000:.1f}"
+finally:
+    termios.tcsetattr(tty_fd, termios.TCSADRAIN, old)
+    os.close(tty_fd)
+
+with open(out, "a") as f:
+    f.write(result + "\n")

--- a/diri/scripts/termbench/latency_under_load.py
+++ b/diri/scripts/termbench/latency_under_load.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Terminal response latency while output is streaming.
+
+An idle terminal answering a query in microseconds proves little: what a user
+feels is typing while a build log scrolls. This measures the same cursor-position
+round trip as `dsr_latency.py`, but with a large payload streaming into the
+terminal at the same time — which is when queues are full, the parser is busy,
+and (for a client/daemon split) the IPC path is under pressure.
+
+Reported as median / p95 / worst, in milliseconds, alongside the idle baseline
+measured immediately before, so the two are directly comparable.
+
+Usage: latency_under_load.py <payload.bin> <out.csv> [samples]
+"""
+import os
+import select
+import statistics
+import subprocess
+import sys
+import termios
+import time
+import tty
+
+payload, out = sys.argv[1], sys.argv[2]
+samples_wanted = int(sys.argv[3]) if len(sys.argv) > 3 else 150
+
+fd = os.open("/dev/tty", os.O_RDWR)
+old = termios.tcgetattr(fd)
+
+
+def probe(deadline_secs=1.0):
+    """One cursor-position round trip; None if the terminal does not answer."""
+    termios.tcflush(fd, termios.TCIFLUSH)
+    start = time.perf_counter()
+    os.write(fd, b"\x1b[6n")
+    buf = b""
+    while not buf.endswith(b"R"):
+        left = deadline_secs - (time.perf_counter() - start)
+        if left <= 0 or not select.select([fd], [], [], left)[0]:
+            return None
+        buf += os.read(fd, 64)
+    return (time.perf_counter() - start) * 1000.0
+
+
+def summarize(values):
+    if not values:
+        return (float("nan"),) * 3 + (0,)
+    ordered = sorted(values)
+    p95 = ordered[min(len(ordered) - 1, int(len(ordered) * 0.95))]
+    return statistics.median(ordered), p95, ordered[-1], len(ordered)
+
+
+try:
+    tty.setraw(fd)
+
+    # Baseline: nothing else is happening.
+    idle = [probe() for _ in range(samples_wanted)]
+    idle = [value for value in idle if value is not None]
+
+    # Under load: the payload streams for the whole measurement. `cat` is
+    # restarted if it finishes early so the terminal is never idle mid-run.
+    loaded = []
+    writer = None
+    try:
+        while len(loaded) < samples_wanted:
+            if writer is None or writer.poll() is not None:
+                writer = subprocess.Popen(["cat", payload], stdout=fd, stderr=subprocess.DEVNULL)
+            value = probe(deadline_secs=5.0)
+            loaded.append(value if value is not None else float("inf"))
+    finally:
+        if writer is not None and writer.poll() is None:
+            writer.kill()
+            writer.wait()
+        # Drain whatever the terminal still owes us before restoring the tty.
+        deadline = time.perf_counter() + 1.0
+        while time.perf_counter() < deadline and select.select([fd], [], [], 0.05)[0]:
+            os.read(fd, 65536)
+finally:
+    termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    os.close(fd)
+
+answered = [value for value in loaded if value != float("inf")]
+with open(out, "w") as f:
+    f.write("state,median_ms,p95_ms,worst_ms,samples\n")
+    f.write("idle,%.3f,%.3f,%.3f,%d\n" % summarize(idle))
+    f.write("loaded,%.3f,%.3f,%.3f,%d\n" % summarize(answered))
+    f.write("unanswered,%d\n" % (len(loaded) - len(answered)))

--- a/diri/scripts/termbench/suite.sh
+++ b/diri/scripts/termbench/suite.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Full terminal benchmark suite. Replays identical byte streams through the
+# terminal under test and records how long each takes to be fully parsed.
+#
+# Run INSIDE the terminal being measured:
+#   ./suite.sh ghostty
+#   ./suite.sh kitty
+#
+# Every workload is timed twice over: t_cat (the write side drained) and
+# t_sync (the terminal answered a query queued behind the payload, so it has
+# actually parsed everything). t_sync is the honest number.
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WORKLOADS="${WORKLOADS:-/tmp/termbench}"
+RESULTS="$HERE/results"
+RUNS="${RUNS:-5}"
+
+NAME="${1:-}"
+if [ -z "$NAME" ]; then
+  echo "usage: $0 <terminal-name>" >&2
+  exit 1
+fi
+mkdir -p "$RESULTS"
+SUMMARY="$RESULTS/$NAME.suite.csv"
+: >"$SUMMARY"
+
+size="$(stty size 2>/dev/null || echo "? ?")"
+rows="${size% *}"; cols="${size#* }"
+echo "suite: $NAME at ${cols}w x ${rows}h"
+
+for path in "$WORKLOADS"/*.bin; do
+  workload="$(basename "$path" .bin)"
+  bytes=$(wc -c <"$path" | tr -d ' ')
+  raw="$RESULTS/$NAME.$workload.csv"
+  : >"$raw"
+  # One unrecorded pass so page cache and terminal state are warm.
+  python3 "$HERE/io_bench.py" "$path" /dev/null >/dev/null 2>&1 || true
+  for _ in $(seq 1 "$RUNS"); do
+    python3 "$HERE/io_bench.py" "$path" "$raw"
+    sleep 1
+  done
+  printf '\033[2J\033[H'
+  # Median of the runs, reported as MB/s against the fully-parsed time.
+  python3 - "$raw" "$workload" "$bytes" >>"$SUMMARY" <<'PY'
+import statistics, sys
+raw, workload, size = sys.argv[1], sys.argv[2], int(sys.argv[3])
+rows = [line.split(",") for line in open(raw) if line.strip()]
+if any(r[1].strip() == "timeout" for r in rows):
+    # Unfinished within the cap: report the floor it failed to clear rather
+    # than a rate, so a timeout can never look like a fast result.
+    cat = statistics.median(float(r[0]) for r in rows)
+    print("%s,%.1f,timeout,0.0" % (workload, cat))
+else:
+    # Best of the runs, not the median: interference from the rest of the
+    # machine only ever makes a run slower, so the fastest one is the closest
+    # estimate of what the terminal actually costs.
+    cat = min(float(r[0]) for r in rows)
+    # A terminal that never answers the query has no sync time; fall back to
+    # t_cat and let the missing reply be reported separately.
+    sync = min(float(r[0]) if r[1].strip() == "nan" else float(r[1]) for r in rows)
+    print("%s,%.1f,%.1f,%.1f" % (workload, cat, sync, (size / 1048576) / (sync / 1000)))
+PY
+  tail -1 "$SUMMARY"
+done
+
+printf '\033[2J\033[H'
+echo "--- response latency (CSI 6n round trip, ms) ---"
+python3 "$HERE/dsr_latency.py" "$RESULTS/$NAME.latency.csv" 200
+cat "$RESULTS/$NAME.latency.csv"
+
+echo "--- memory (RSS) ---"
+ps -Ao pid=,rss=,comm= | grep -i "${2:-$NAME}" | grep -v -e suite.sh -e grep >"$RESULTS/$NAME.mem.txt"
+awk '{printf "%8.1f MB  %s\n", $2/1024, $3}' "$RESULTS/$NAME.mem.txt"
+
+echo "done: $SUMMARY"

--- a/diri/scripts/termbench/table.py
+++ b/diri/scripts/termbench/table.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Render the three-way comparison from the suite CSVs.
+
+Each row is one workload; the number is MB/s of fully-parsed throughput
+(bytes divided by the time until the terminal answered a query queued behind
+the payload). Higher is better. The winner of each row is marked.
+"""
+import os
+import sys
+
+RESULTS = sys.argv[1] if len(sys.argv) > 1 else os.path.join(os.path.dirname(__file__), "results")
+TERMS = ["dirijor", "ghostty", "kitty"]
+
+rates, times = {}, {}
+for term in TERMS:
+    path = os.path.join(RESULTS, f"{term}.suite.csv")
+    if not os.path.exists(path):
+        continue
+    for line in open(path):
+        parts = line.strip().split(",")
+        if len(parts) != 4:
+            continue
+        workload, _t_cat, t_sync, rate = parts
+        rates.setdefault(workload, {})[term] = float(rate)
+        times.setdefault(workload, {})[term] = t_sync
+
+present = [t for t in TERMS if any(t in v for v in rates.values())]
+width = max((len(w) for w in rates), default=10) + 2
+
+print(f"{'workload':<{width}}" + "".join(f"{t:>12}" for t in present) + "   winner")
+print("-" * (width + 12 * len(present) + 12))
+wins = dict.fromkeys(present, 0)
+for workload in sorted(rates):
+    row = rates[workload]
+    best = max(row, key=row.get) if row else None
+    if best:
+        wins[best] += 1
+    cells = ""
+    for term in present:
+        value = row.get(term)
+        cells += f"{value:>11.1f}{'*' if term == best else ' '}" if value else f"{'-':>12}"
+    print(f"{workload:<{width}}{cells}   {best or '-'}")
+
+print("-" * (width + 12 * len(present) + 12))
+print(f"{'row wins':<{width}}" + "".join(f"{wins[t]:>12}" for t in present))
+
+for term in present:
+    path = os.path.join(RESULTS, f"{term}.latency.csv")
+    if os.path.exists(path):
+        median, low, p95, count = open(path).read().strip().split(",")
+        print(f"{term:>10} query latency: median {median} ms, min {low} ms, p95 {p95} ms (n={count})")


### PR DESCRIPTION
Follow-up to #127. That PR made throughput fast; this one is about what happens to *input* while output is streaming.

## The problem

Answering a `CSI 6n` query takes **0.036 ms** on an idle session. While output streams, p95 is **66 ms** and the worst case **140 ms**. That is the terminal being quick right up until a build log scrolls — which is exactly when someone is typing into it.

| under load | median | p95 | worst |
|---|---:|---:|---:|
| this branch | 1.5 ms | **7 ms** | 17 ms |
| before | 0.27 ms | 66 ms | 140 ms |
| Ghostty | 0.05 ms | 0.32 ms | 0.67 ms |
| Kitty | 6.8 ms | 12.2 ms | 16.5 ms (+8 queries never answered) |

## Why it happened

A query cannot be answered until the pump has parsed the bytes ahead of it, so loaded latency is exactly how far behind the pump is allowed to fall. Three things put it there.

**Detection ran per read.** `evaluate_if_screen_changed` snapshots the whole screen and walks it with the manifest's patterns. Cheap per screen, ruinous per read — a streaming session produces thousands of reads a second. It now runs on a 16 ms timer while output is backed up, and immediately once the pump catches up, so a settled screen is never stale.

**Reads were 64 KiB.** Now 512 KiB, which cuts per-pass overhead (a `stat`, a lock, a marker scan) proportionally.

**The write queue was 16 MiB deep.** #127 added it to absorb filesystem stalls, and it does — but it also absorbed steady-state backlog, and the daemon cannot answer a query it has not read yet. Latency tracked queue depth almost linearly:

| depth | queued bytes | p95 under load | throughput |
|---|---:|---:|---:|
| 256 | 16 MiB | 55–85 ms | 134–152 MB/s |
| 64 | 4 MiB | 20 ms | 76–101 MB/s |
| 16 | 1 MiB | **6–8 ms** | 85–113 MB/s |

Set to 16.

## What this costs, honestly

Suite throughput drops from ~140 to ~115 MB/s. Some of that was never real: a 40 MB benchmark against a 16 MiB queue reports a rate the pipeline cannot sustain, because nearly half the payload was still sitting in memory when the clock stopped. The depth-16 numbers are closer to what a long-running session actually sees.

Against the other terminals at depth 16, per workload: still ahead of Ghostty on everything, and ahead of Kitty on everything except `unicode_cjk` (117.7 vs 140.5) and `long_lines` (a tie). Previously 11 of 12; now 10 of 12, with an 8x better latency tail.

## The real fix, not done here

Display latency should not depend on disk throughput at all. It does because an attached daemon learns about output by tailing a file the holder is still writing. If the holder streamed output to attached clients over the socket it already uses for input — keeping the log for durability and replay — the queue could be deep again without costing latency, and both numbers would improve together. That is a bigger change than this one and wants its own review.

## Also here

`scripts/termbench/` — the suite these numbers come from: workload generators, the two latency probes, the per-terminal runner, and the three-way comparison. The README documents what it measures and why the obvious ways to measure it are wrong (timing `cat` alone lets a terminal win by buffering; medians of short runs are dominated by machine noise).

## Testing

287 tests pass across 25 binaries; clippy and fmt clean. Latency figures are the median of three runs of 120 probes each; throughput is best-of-five per workload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)