### PR TITLE
app: navigate settings from the app sidebar

### DIFF
--- a/diri/Cargo.lock
+++ b/diri/Cargo.lock
@@ -3225,16 +3225,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-wsl"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
-dependencies = [
- "is-docker",
- "once_cell",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3243,6 +3233,16 @@ dependencies = [
  "hermit-abi",
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -4272,6 +4272,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "open"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4280,12 +4286,6 @@ dependencies = [
  "is-wsl",
  "libc",
 ]
-
-[[package]]
-name = "oorandom"
-version = "11.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "option-ext"

--- a/diri/crates/diri-app/src/launcher.rs
+++ b/diri/crates/diri-app/src/launcher.rs
@@ -3685,6 +3685,8 @@ mod tests {
             updates: crate::updates::inert(),
             tokio,
             dev_build: None,
+            #[cfg(unix)]
+            daemon_startup: None,
         })
     }
 
@@ -3778,6 +3780,8 @@ mod tests {
             updates: crate::updates::inert(),
             tokio,
             dev_build: None,
+            #[cfg(unix)]
+            daemon_startup: None,
         });
         let (launcher, cx) =
             cx.add_window_view(move |_window, cx| LauncherOverlay::new(services, true, cx));
@@ -4320,6 +4324,8 @@ mod tests {
             updates: crate::updates::inert(),
             tokio,
             dev_build: None,
+            #[cfg(unix)]
+            daemon_startup: None,
         });
         let window = cx
             .open_window(gpui::size(px(760.0), px(560.0)), move |window, cx| {

--- a/diri/crates/diri-app/src/navigation.rs
+++ b/diri/crates/diri-app/src/navigation.rs
@@ -1508,10 +1508,13 @@ mod tests {
     use gpui::HeadlessAppContext;
     use gpui::{Entity, ScrollDelta, ScrollWheelEvent, TestAppContext, point};
 
+    /// Mounted only by the screenshot fixture, which is macOS-only.
+    #[cfg(target_os = "macos")]
     struct CommandPalettePreviewHarness {
         overlay: Entity<NavigationOverlay>,
     }
 
+    #[cfg(target_os = "macos")]
     impl Render for CommandPalettePreviewHarness {
         fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
             div()

--- a/diri/crates/diri-app/src/navigation.rs
+++ b/diri/crates/diri-app/src/navigation.rs
@@ -1279,9 +1279,14 @@ const fn command_row_child_index(
         child += 1;
     }
     if row >= session_count {
-        if show_quick_section && quick_count > 0 {
-            child += 1;
-        } else if !show_quick_section && action_count > 0 {
+        // Whichever section comes first below the chats contributes a header:
+        // the quick actions when they are shown, the command list otherwise.
+        let leading_count = if show_quick_section {
+            quick_count
+        } else {
+            action_count
+        };
+        if leading_count > 0 {
             child += 1;
         }
         if show_quick_section && row >= session_count + quick_count && action_count > quick_count {

--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -47,6 +47,54 @@ pub(crate) fn cached_window_overlay<T: Render>(view: Entity<T>) -> impl IntoElem
     view.cached(StyleRefinement::default().absolute().inset_0())
 }
 
+/// Joins the two halves of the settings destination: the surface owns the
+/// state and paints the page, the sidebar paints the navigation beside it.
+///
+/// The mirror is one-directional -- the surface's state projects into the
+/// sidebar, and the sidebar reports clicks back -- so the list and the page
+/// cannot drift into disagreeing about the selected page or the search text.
+/// RootView wires this for the window; tests wire the same two entities.
+pub(crate) fn wire_settings_navigation<V: 'static>(
+    sidebar: Entity<Sidebar>,
+    surfaces: Entity<UtilitySurfaces>,
+    window: &mut Window,
+    cx: &mut Context<V>,
+) -> [Subscription; 2] {
+    let mirror = {
+        let sidebar = sidebar.clone();
+        cx.observe(&surfaces, move |_, surfaces, cx| {
+            let nav = surfaces.read(cx).settings_nav();
+            sidebar.update(cx, |sidebar, cx| sidebar.set_settings_nav(nav, cx));
+            cx.notify();
+        })
+    };
+    let clicks = cx.subscribe_in(
+        &sidebar,
+        window,
+        move |_, _, event, window, cx| match event {
+            SidebarEvent::SettingsTabSelected(tab) => {
+                let tab = *tab;
+                surfaces.update(cx, |surfaces, cx| surfaces.open_settings_tab(tab, cx));
+            }
+            SidebarEvent::SettingsSearchFocused => {
+                surfaces.update(cx, |surfaces, cx| {
+                    surfaces.focus_settings_search(window, cx)
+                });
+            }
+            SidebarEvent::SettingsSearchCleared => {
+                surfaces.update(cx, |surfaces, cx| {
+                    surfaces.clear_settings_search(window, cx)
+                });
+            }
+            SidebarEvent::SettingsDismissed => {
+                surfaces.update(cx, |surfaces, cx| surfaces.dismiss(cx));
+            }
+            _ => {}
+        },
+    );
+    [mirror, clicks]
+}
+
 #[cfg(target_os = "macos")]
 use crate::macos::{menu_bar::NativeMenuBar, notifier::NativeNotifier};
 
@@ -163,6 +211,9 @@ pub struct RootView {
     quote_target_picker: Option<QuoteTargetPicker>,
     last_quote_surface: QuoteSurface,
     sound_gate: SoundGate,
+    /// Set when opening settings had to reveal a hidden sidebar to put its
+    /// navigation somewhere, so closing settings can hide it again.
+    sidebar_revealed_for_settings: bool,
     preview: bool,
     preview_scenario: PreviewScenario,
     #[cfg(target_os = "macos")]
@@ -320,10 +371,39 @@ impl RootView {
             }
             if matches!(event, SidebarEvent::VisibilityChanged) {
                 this.begin_sidebar_slide(cx);
+                // Settings navigation lives in the sidebar, so hiding the
+                // sidebar is also the way out of settings.
+                if !this.sidebar.read(cx).is_visible()
+                    && let Some(surfaces) = &this.utility_surfaces
+                    && surfaces.read(cx).is_settings_open()
+                {
+                    this.sidebar_revealed_for_settings = false;
+                    surfaces.update(cx, |surfaces, cx| surfaces.dismiss(cx));
+                }
             }
             cx.notify();
         })
         .detach();
+        if let Some(surfaces) = &utility_surfaces {
+            // Settings navigation is painted by the sidebar, so a settings
+            // that opened onto a hidden sidebar has to bring it back -- and
+            // give it up again on the way out.
+            cx.observe(surfaces, |this, surfaces, cx| {
+                let open = surfaces.read(cx).is_settings_open();
+                if open && !this.sidebar.read(cx).is_visible() {
+                    this.sidebar_revealed_for_settings = true;
+                    this.sidebar.update(cx, |sidebar, cx| sidebar.reveal(cx));
+                } else if !open && std::mem::take(&mut this.sidebar_revealed_for_settings) {
+                    this.sidebar.update(cx, |sidebar, cx| sidebar.conceal(cx));
+                }
+            })
+            .detach();
+            for subscription in
+                wire_settings_navigation(sidebar.clone(), surfaces.clone(), window, cx)
+            {
+                subscription.detach();
+            }
+        }
         cx.subscribe_in(
             &launcher,
             window,
@@ -605,6 +685,7 @@ impl RootView {
             quote_target_picker: None,
             last_quote_surface: QuoteSurface::default(),
             sound_gate: SoundGate::default(),
+            sidebar_revealed_for_settings: false,
             preview,
             preview_scenario,
             #[cfg(target_os = "macos")]
@@ -2837,7 +2918,16 @@ impl Render for RootView {
             root = root.child(cached_window_overlay(surfaces.clone()));
         }
         if let Some(surfaces) = &self.utility_surfaces {
-            root = root.child(cached_window_overlay(surfaces.clone()));
+            // Settings is not a sheet floating over the workbench: it replaces
+            // it, and the sidebar it navigates from stays put beside it. Laying
+            // it out against the live seam -- rather than a width settings
+            // snapshotted for itself -- keeps the two edges together while the
+            // sidebar slides or is dragged wider.
+            let mut placement = StyleRefinement::default().absolute().inset_0();
+            if surfaces.read(cx).is_settings_open() {
+                placement = placement.left(px(seam));
+            }
+            root = root.child(surfaces.clone().cached(placement));
         }
         if let Some(navigation) = &self.navigation {
             root = root.child(cached_window_overlay(navigation.clone()));

--- a/diri/crates/diri-app/src/settings.rs
+++ b/diri/crates/diri-app/src/settings.rs
@@ -6,7 +6,38 @@
 use diri_proto::{HostEntry, HostNodeConfig};
 use diri_term::theme::TermTheme;
 
+use crate::query_editor::QueryEditor;
 use crate::store::Prefs;
+
+/// The two groups the navigation list is split into.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SettingsSection {
+    Personal,
+    System,
+}
+
+impl SettingsSection {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Personal => "Personal",
+            Self::System => "System",
+        }
+    }
+}
+
+/// Everything the window sidebar needs to paint settings navigation.
+///
+/// Settings state itself stays in `UtilitySurfaces`, which owns the page the
+/// navigation drives. The sidebar renders this projection rather than keeping
+/// a second copy, so the list and the page can never disagree about which tab
+/// is selected or what the search field says.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SettingsNav {
+    pub tabs: Vec<SettingsTab>,
+    pub active: SettingsTab,
+    pub search: QueryEditor,
+    pub search_active: bool,
+}
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum SettingsTab {
@@ -44,6 +75,15 @@ impl SettingsTab {
             Self::Terminal => "Appearance and text size",
             Self::Resources => "Idle sessions and memory",
             Self::Remote => "SSH execution hosts",
+        }
+    }
+
+    /// Personal pages change how diri behaves for this user; System pages
+    /// describe the machines and resources sessions run on.
+    pub const fn section(self) -> SettingsSection {
+        match self {
+            Self::General | Self::Agents | Self::Terminal => SettingsSection::Personal,
+            Self::Resources | Self::Remote => SettingsSection::System,
         }
     }
 

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -30,6 +30,7 @@ use crate::icons::{SymbolWeight, sf_symbol, sf_symbol_weighted};
 use crate::navigation::query_label;
 use crate::query_editor::{self, ClipboardEdit, Edit};
 use crate::seam::toggle_has_settled;
+use crate::settings::{SettingsNav, SettingsSection, SettingsTab};
 use crate::store::{
     ClickModifiers, DirectoryListingState, SessionStore, SpawnOptions, StoreEffect, StoreRuntime,
 };
@@ -42,6 +43,49 @@ use super::{
 };
 
 const PREVIEW_USAGE: f64 = 4.82;
+
+/// How far a swapped-in body travels before it settles, and how long the
+/// whole swap takes. The travel is deliberately short: the sidebar itself
+/// never moves, so this reads as its contents changing, not the panel.
+const BODY_SWAP_TRAVEL: f32 = 14.0;
+const BODY_SWAP_DURATION: Duration = Duration::from_millis(260);
+/// How much later each row starts than the one above it, as a fraction of the
+/// transition. Capped below so a long list still finishes on time.
+const BODY_SWAP_STAGGER: f32 = 0.055;
+const BODY_SWAP_STAGGER_CEILING: f32 = 0.55;
+
+/// How far into its own arrival the row `step` beats down the body is, at
+/// `delta` of the shared transition. Every row settles by the end of the
+/// transition however deep it sits, so the list arrives as one motion rather
+/// than trailing a straggler.
+fn body_swap_progress(delta: f32, step: usize) -> f32 {
+    let start = (step as f32 * BODY_SWAP_STAGGER).min(BODY_SWAP_STAGGER_CEILING);
+    let local = ((delta.clamp(0.0, 1.0) - start) / (1.0 - start)).clamp(0.0, 1.0);
+    Motion::SETTLE.settle(local)
+}
+
+/// Fades and slides one row of a swapped-in sidebar body into place, `step`
+/// beats behind the top of that body.
+fn slide_in<E>(element: E, key: String, step: usize, reduce_motion: bool) -> AnyElement
+where
+    E: IntoElement + Styled + 'static,
+{
+    if reduce_motion {
+        return element.into_any_element();
+    }
+    element
+        .with_animation(
+            SharedString::from(key),
+            Animation::new(BODY_SWAP_DURATION),
+            move |element, delta| {
+                let settled = body_swap_progress(delta, step);
+                element
+                    .left(px((1.0 - settled) * BODY_SWAP_TRAVEL))
+                    .opacity(settled)
+            },
+        )
+        .into_any_element()
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct FocusRow {
@@ -90,6 +134,17 @@ pub(crate) enum SidebarEvent {
     /// A row-to-row drop or its keyboard equivalent produced an editable
     /// handoff. Root owns the composer destination and opens it for review.
     HandoffProposed(HandoffProposal),
+    /// Settings navigation is painted here but owned by the settings surface,
+    /// so a click on a page has to travel back out to it.
+    SettingsTabSelected(SettingsTab),
+    /// The settings search field was clicked. Keyboard focus belongs to the
+    /// settings surface, which reads the keys the field then shows.
+    SettingsSearchFocused,
+    SettingsSearchCleared,
+    /// The back control in the title bar. Settings is dismissed directly
+    /// rather than by re-dispatching the toggle, so the way out does not
+    /// depend on where keyboard focus happens to be.
+    SettingsDismissed,
 }
 
 #[derive(Clone)]
@@ -158,6 +213,13 @@ pub struct Sidebar {
     /// drops. It remains until dismissed or replaced by the next drop so an
     /// error can never disappear between mouse-up and the next frame.
     external_drop_feedback: Option<String>,
+    /// Settings navigation, mirrored from the settings surface while it owns
+    /// the workbench. `Some` swaps this panel's body from sessions to pages;
+    /// the sidebar itself -- its measure, its chrome, its footer -- stays put.
+    settings_nav: Option<SettingsNav>,
+    /// Bumped whenever the body swaps between sessions and settings, so the
+    /// slide restarts on each swap instead of replaying a finished animation.
+    body_generation: u64,
 }
 
 /// The sidebar state that asked for a native folder pick, captured when the
@@ -244,6 +306,8 @@ impl Sidebar {
             preview,
             directory_picker_open: false,
             external_drop_feedback: None,
+            settings_nav: None,
+            body_generation: 0,
         };
         sidebar.ui.preview_account = preview;
         // Preview-only hook so headless screenshots can verify popover layout.
@@ -392,6 +456,52 @@ impl Sidebar {
         }
         cx.emit(SidebarEvent::VisibilityChanged);
         cx.notify();
+    }
+
+    /// Hides the sidebar without the toggle's debounce, for the callers that
+    /// revealed it themselves and are now putting it back.
+    pub fn conceal(&mut self, cx: &mut Context<Self>) {
+        if !self.ui.visible {
+            return;
+        }
+        self.ui.visible = false;
+        if let Err(error) = self
+            .store
+            .write()
+            .expect("session store lock poisoned")
+            .update_preferences(|prefs| prefs.sidebar_visible = false)
+        {
+            eprintln!("diri: could not remember sidebar visibility: {error}");
+        }
+        cx.emit(SidebarEvent::VisibilityChanged);
+        cx.emit(SidebarEvent::FocusTerminal);
+        cx.notify();
+    }
+
+    /// Mirrors the settings surface's navigation into this panel. Passing
+    /// `None` returns the body to the session list.
+    pub fn set_settings_nav(&mut self, nav: Option<SettingsNav>, cx: &mut Context<Self>) {
+        if self.settings_nav == nav {
+            return;
+        }
+        if self.settings_nav.is_some() != nav.is_some() {
+            self.body_generation = self.body_generation.wrapping_add(1);
+            // A popover anchored to a session row has nothing to point at once
+            // the rows are gone.
+            self.ui.popover = None;
+            self.ui.hover_card = None;
+        }
+        self.settings_nav = nav;
+        cx.notify();
+    }
+
+    pub fn shows_settings(&self) -> bool {
+        self.settings_nav.is_some()
+    }
+
+    /// The page the mirrored navigation is showing as current, if any.
+    pub fn settings_page(&self) -> Option<SettingsTab> {
+        self.settings_nav.as_ref().map(|nav| nav.active)
     }
 
     pub fn show_new_agent(&mut self, cx: &mut Context<Self>) {
@@ -854,6 +964,7 @@ impl Sidebar {
         };
         div()
             .id("new-agent")
+            .debug_selector(|| "new-agent".into())
             .mx(px(Space::INSET))
             .mb(px(4.0))
             .px(px(Space::ROW_H))
@@ -920,8 +1031,16 @@ impl Sidebar {
     }
 
     fn top_bar(&self, colors: SemanticColors, cx: &mut Context<Self>) -> AnyElement {
+        let in_settings = self.settings_nav.is_some();
         let settings_hover = self.ui.hovered_control == Some("settings");
         let toggle_hover = self.ui.hovered_control == Some("sidebar-toggle");
+        // The same control, the same place: it opens settings, and while
+        // settings is open it is the way back out of it.
+        let (settings_id, settings_symbol) = if in_settings {
+            ("close-settings", "chevron.left")
+        } else {
+            ("settings", "gearshape")
+        };
         div()
             .h(px(Metrics::TITLE_BAR))
             .flex_none()
@@ -931,13 +1050,17 @@ impl Sidebar {
             .pr(px(Metrics::TOOLBAR_EDGE_INSET))
             .gap(px(Metrics::TOOLBAR_COMPACT_GAP))
             .child(icon_button(
-                "settings",
-                "gearshape",
+                settings_id,
+                settings_symbol,
                 settings_hover,
                 colors,
-                cx.listener(|this, _, window, cx| {
+                cx.listener(move |this, _, window, cx| {
                     this.ui.popover = None;
-                    window.dispatch_action(Box::new(OpenSettings), cx);
+                    if in_settings {
+                        cx.emit(SidebarEvent::SettingsDismissed);
+                    } else {
+                        window.dispatch_action(Box::new(OpenSettings), cx);
+                    }
                 }),
                 cx.listener(|this, hovered: &bool, _, cx| {
                     this.ui.hovered_control = hovered.then_some("settings");
@@ -956,6 +1079,234 @@ impl Sidebar {
                 }),
             ))
             .into_any_element()
+    }
+
+    /* ─────────────────────────────────────────────────────────
+     * SIDEBAR BODY SWAP STORYBOARD
+     *
+     *    0ms   the panel keeps its chrome -- title bar, measure, footer --
+     *          and the new body starts 14px inboard and transparent
+     *   40ms   the search field has landed; the first page follows it
+     *  260ms   the last page settles, alongside the settings canvas
+     *
+     * The rows run on the shared `SETTLE` spring, each one a beat behind the
+     * row above, so navigation reads as content sliding out from inside the
+     * sidebar rather than one surface being swapped for another.
+     * ───────────────────────────────────────────────────────── */
+    fn settings_body(
+        &self,
+        nav: &SettingsNav,
+        colors: SemanticColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let reduce_motion = cx.reduce_motion();
+        let generation = self.body_generation;
+        let mut step = 0;
+        let search = self.settings_search_field(nav, colors, cx);
+        let mut pages = div().flex().flex_col();
+        let mut section: Option<SettingsSection> = None;
+        for tab in nav.tabs.iter().copied() {
+            if section != Some(tab.section()) {
+                let first = section.is_none();
+                section = Some(tab.section());
+                step += 1;
+                pages = pages.child(slide_in(
+                    div()
+                        .relative()
+                        .px(px(Space::ROW_H))
+                        .pt(px(if first { 6.0 } else { 14.0 }))
+                        .pb(px(5.0))
+                        .text_size(px(Typo::SECTION_HEADER.size))
+                        .font_weight(Typo::SECTION_HEADER.weight)
+                        .text_color(colors.tertiary)
+                        .child(tab.section().label()),
+                    format!("settings-section-{generation}-{step}"),
+                    step,
+                    reduce_motion,
+                ));
+            }
+            step += 1;
+            pages = pages.child(slide_in(
+                self.settings_page_row(tab, tab == nav.active, colors, cx),
+                format!("settings-page-{generation}-{step}"),
+                step,
+                reduce_motion,
+            ));
+        }
+        if nav.tabs.is_empty() {
+            pages = pages.child(
+                div()
+                    .px(px(10.0))
+                    .pt(px(14.0))
+                    .text_size(px(Typo::META.size))
+                    .text_color(colors.tertiary)
+                    .child("No settings found"),
+            );
+        }
+        div()
+            .id("sidebar-settings")
+            .debug_selector(|| "sidebar-settings".into())
+            .flex_1()
+            .min_h(px(0.0))
+            .flex()
+            .flex_col()
+            .child(slide_in(
+                search,
+                format!("settings-search-{generation}"),
+                0,
+                reduce_motion,
+            ))
+            .child(
+                div()
+                    .id("settings-nav-scroll")
+                    .px(px(Space::INSET))
+                    .flex_1()
+                    .min_h(px(0.0))
+                    .overflow_y_scroll()
+                    .child(pages),
+            )
+            .child(
+                div()
+                    .px(px(Metrics::TOOLBAR_EDGE_INSET))
+                    .pb(px(6.0))
+                    .text_size(px(Typo::META.size))
+                    .text_color(colors.tertiary)
+                    .child(format!("diri {}", crate::updates::CURRENT_VERSION)),
+            )
+            .into_any_element()
+    }
+
+    fn settings_page_row(
+        &self,
+        tab: SettingsTab,
+        selected: bool,
+        colors: SemanticColors,
+        cx: &mut Context<Self>,
+    ) -> gpui::Stateful<gpui::Div> {
+        div()
+            .id(SharedString::from(format!("settings-{}", tab.label())))
+            .debug_selector(move || format!("SETTINGS_TAB_{}", tab.label()))
+            .relative()
+            .h(px(30.0))
+            .px(px(Space::ROW_H))
+            .rounded(px(Radius::ROW))
+            .flex()
+            .items_center()
+            .gap(px(8.0))
+            .bg(Fill::selected(colors, selected))
+            .text_color(if selected {
+                colors.primary
+            } else {
+                colors.secondary
+            })
+            .cursor_pointer()
+            .hover(move |style| style.bg(Fill::hover(colors, true)))
+            .on_click(cx.listener(move |_, _, _, cx| {
+                cx.emit(SidebarEvent::SettingsTabSelected(tab));
+            }))
+            .child(
+                div()
+                    .w(px(16.0))
+                    .flex_none()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .child(sf_symbol(
+                        tab.icon(),
+                        12.0,
+                        if selected {
+                            colors.primary
+                        } else {
+                            colors.tertiary
+                        },
+                    )),
+            )
+            .child(
+                div()
+                    .text_size(px(Typo::ROW.size))
+                    .font_weight(if selected {
+                        FontWeight::MEDIUM
+                    } else {
+                        FontWeight::NORMAL
+                    })
+                    .child(tab.label()),
+            )
+    }
+
+    fn settings_search_field(
+        &self,
+        nav: &SettingsNav,
+        colors: SemanticColors,
+        cx: &mut Context<Self>,
+    ) -> gpui::Stateful<gpui::Div> {
+        let content = if nav.search_active {
+            query_label(&nav.search)
+        } else if nav.search.is_empty() {
+            div()
+                .text_color(colors.tertiary)
+                .child("Search settings…")
+                .into_any_element()
+        } else {
+            div()
+                .text_color(colors.primary)
+                .child(nav.search.text().to_owned())
+                .into_any_element()
+        };
+        div()
+            .id("settings-search")
+            .debug_selector(|| "settings-search".into())
+            .relative()
+            .h(px(32.0))
+            .mx(px(Space::INSET))
+            .mt(px(2.0))
+            .mb(px(6.0))
+            .px(px(9.0))
+            .rounded(px(16.0))
+            .border_1()
+            .border_color(
+                colors
+                    .primary
+                    .alpha(if nav.search_active { 0.22 } else { 0.11 }),
+            )
+            .bg(colors.primary.alpha(0.025))
+            .flex()
+            .items_center()
+            .gap(px(7.0))
+            .cursor(CursorStyle::IBeam)
+            .on_click(cx.listener(|_, _, _, cx| {
+                cx.emit(SidebarEvent::SettingsSearchFocused);
+            }))
+            .child(sf_symbol("magnifyingglass", 12.0, colors.tertiary))
+            .child(
+                div()
+                    .flex_1()
+                    .min_w(px(0.0))
+                    .overflow_hidden()
+                    .whitespace_nowrap()
+                    .text_ellipsis()
+                    .text_size(px(Typo::ROW.size))
+                    .child(content),
+            )
+            .when(!nav.search.is_empty(), |search| {
+                search.child(
+                    div()
+                        .id("clear-settings-search")
+                        .debug_selector(|| "clear-settings-search".into())
+                        .size(px(18.0))
+                        .flex_none()
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .rounded_full()
+                        .cursor_pointer()
+                        .hover(move |style| style.bg(Fill::subtle(colors)))
+                        .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+                        .on_click(cx.listener(|_, _, _, cx| {
+                            cx.emit(SidebarEvent::SettingsSearchCleared);
+                        }))
+                        .child(sf_symbol("xmark", 8.0, colors.tertiary)),
+                )
+            })
     }
 
     fn external_drop(
@@ -4589,68 +4940,75 @@ impl Render for Sidebar {
             }
         }
         retain_live_glyphs(&mut self.glyphs, &projection.display_order);
-        let mut list = div()
-            .id("sidebar-list")
-            .track_scroll(&self.list_scroll)
-            .flex_1()
-            .min_h(px(0.0))
-            .overflow_y_scroll()
-            .px(px(Space::INSET))
-            .pt(px(2.0))
-            .pb(px(Metrics::ROW_HEIGHT + 17.0))
-            .flex()
-            .flex_col()
-            .gap(px(2.0))
-            .drag_over::<DraggedSidebarItem>(|element, dragged, _, _| {
-                if dragged.session_id().is_some() {
-                    element
-                        .bg(Palette::CLAY.alpha(0.055))
-                        .cursor(CursorStyle::DragCopy)
-                } else {
-                    element
-                }
-            })
-            .on_drop(cx.listener(|this, dragged: &DraggedSidebarItem, _, cx| {
-                if let Some(source_id) = dragged.session_id() {
-                    let proposal = {
-                        let store = this.store.read().expect("session store lock poisoned");
-                        store.sessions().get(source_id).map_or_else(
-                            || {
-                                Err(crate::delegation::DelegationRefusal(
-                                    "The dragged session no longer exists.".to_owned(),
-                                ))
-                            },
-                            |source| {
-                                store.projects().get(&source.project_id).map_or_else(
-                                    || {
-                                        Err(crate::delegation::DelegationRefusal(
-                                            "The session's project no longer exists.".to_owned(),
-                                        ))
-                                    },
-                                    |project| sibling_proposal(source, project),
-                                )
-                            },
-                        )
-                    };
-                    match proposal {
-                        Ok(proposal) => {
-                            this.ui.pending_sibling = Some(proposal);
-                            this.ui.delegation_notice = None;
-                        }
-                        Err(refusal) => this.ui.delegation_notice = Some(refusal.0),
+        // The session list is the sidebar's most expensive frame work,
+        // and settings has no use for it.
+        let list = self.settings_nav.is_none().then(|| {
+            let mut list = div()
+                .id("sidebar-list")
+                .track_scroll(&self.list_scroll)
+                .flex_1()
+                .min_h(px(0.0))
+                .overflow_y_scroll()
+                .px(px(Space::INSET))
+                .pt(px(2.0))
+                .pb(px(Metrics::ROW_HEIGHT + 17.0))
+                .flex()
+                .flex_col()
+                .gap(px(2.0))
+                .drag_over::<DraggedSidebarItem>(|element, dragged, _, _| {
+                    if dragged.session_id().is_some() {
+                        element
+                            .bg(Palette::CLAY.alpha(0.055))
+                            .cursor(CursorStyle::DragCopy)
+                    } else {
+                        element
                     }
-                }
-                this.finish_drag();
-                cx.stop_propagation();
-                cx.notify();
-            }));
-        for group in &projection.projects {
-            list = list.child(self.project_section(group, colors, window, cx));
-        }
-        list = list.child(self.empty_space_drop_target(cx));
+                })
+                .on_drop(cx.listener(|this, dragged: &DraggedSidebarItem, _, cx| {
+                    if let Some(source_id) = dragged.session_id() {
+                        let proposal = {
+                            let store = this.store.read().expect("session store lock poisoned");
+                            store.sessions().get(source_id).map_or_else(
+                                || {
+                                    Err(crate::delegation::DelegationRefusal(
+                                        "The dragged session no longer exists.".to_owned(),
+                                    ))
+                                },
+                                |source| {
+                                    store.projects().get(&source.project_id).map_or_else(
+                                        || {
+                                            Err(crate::delegation::DelegationRefusal(
+                                                "The session's project no longer exists."
+                                                    .to_owned(),
+                                            ))
+                                        },
+                                        |project| sibling_proposal(source, project),
+                                    )
+                                },
+                            )
+                        };
+                        match proposal {
+                            Ok(proposal) => {
+                                this.ui.pending_sibling = Some(proposal);
+                                this.ui.delegation_notice = None;
+                            }
+                            Err(refusal) => this.ui.delegation_notice = Some(refusal.0),
+                        }
+                    }
+                    this.finish_drag();
+                    cx.stop_propagation();
+                    cx.notify();
+                }));
+            for group in &projection.projects {
+                list = list.child(self.project_section(group, colors, window, cx));
+            }
+            list = list.child(self.empty_space_drop_target(cx));
+            list
+        });
 
         let mut root = div()
             .id("sidebar")
+            .debug_selector(|| "sidebar".into())
             .relative()
             .size_full()
             .flex()
@@ -4668,23 +5026,41 @@ impl Render for Sidebar {
                     }
                 }),
             )
-            .child(self.top_bar(colors, cx))
-            .child(self.new_agent_row(colors, cx));
-        if projection.projects.is_empty() {
-            root = root.child(self.empty_state(colors, cx));
+            .child(self.top_bar(colors, cx));
+        if let Some(nav) = self.settings_nav.clone() {
+            root = root.child(self.settings_body(&nav, colors, cx));
         } else {
-            // Rows dissolve into the chrome at both ends of the scroll instead
-            // of being sliced off by the container edge.
-            root = root.child(
-                div()
-                    .relative()
-                    .flex_1()
-                    .min_h(px(0.0))
-                    .flex()
-                    .flex_col()
-                    .child(list)
-                    .children(self.scroll_fades(colors)),
-            );
+            let mut body = div()
+                .relative()
+                .flex_1()
+                .min_h(px(0.0))
+                .flex()
+                .flex_col()
+                .child(self.new_agent_row(colors, cx));
+            if projection.projects.is_empty() {
+                body = body.child(self.empty_state(colors, cx));
+            } else {
+                // Rows dissolve into the chrome at both ends of the scroll
+                // instead of being sliced off by the container edge.
+                body = body.child(
+                    div()
+                        .relative()
+                        .flex_1()
+                        .min_h(px(0.0))
+                        .flex()
+                        .flex_col()
+                        .children(list)
+                        .children(self.scroll_fades(colors)),
+                );
+            }
+            // The first paint of the window is not a swap, so the sessions
+            // body only travels when it is coming back from settings.
+            root = root.child(slide_in(
+                body,
+                format!("sidebar-sessions-{}", self.body_generation),
+                0,
+                cx.reduce_motion() || self.body_generation == 0,
+            ));
         }
         if let Some(feedback) = self.external_drop_feedback(colors, cx) {
             root = root.child(feedback);
@@ -4715,6 +5091,7 @@ fn icon_button(
 ) -> AnyElement {
     div()
         .id(id)
+        .debug_selector(move || id.into())
         .size(px(Metrics::TOOLBAR_CONTROL_SIZE))
         .flex()
         .items_center()
@@ -5273,6 +5650,27 @@ mod tests {
                 .size_full()
                 .child(div().h_full().w(px(248.0)).child(self.sidebar.clone()))
         }
+    }
+
+    #[test]
+    fn the_body_swap_staggers_rows_but_lands_them_together() {
+        // Nothing is visible before the transition starts, and every row --
+        // however deep in the list -- is fully settled when it ends. A row
+        // that finished late would leave the panel visibly assembling itself
+        // after the page beside it had already arrived.
+        for step in 0..12 {
+            assert_eq!(body_swap_progress(0.0, step), 0.0);
+            assert_eq!(body_swap_progress(1.0, step), 1.0);
+        }
+        // Deeper rows trail the ones above them rather than moving as a block.
+        let head = body_swap_progress(0.3, 0);
+        let middle = body_swap_progress(0.3, 3);
+        let tail = body_swap_progress(0.3, 6);
+        assert!(head > middle, "{head} vs {middle}");
+        assert!(middle > tail, "{middle} vs {tail}");
+        // The stagger is capped, so an arbitrarily long list cannot push a row
+        // past the point where it has no time left to travel.
+        assert!(body_swap_progress(0.8, 200) > 0.0);
     }
 
     #[test]

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -9,7 +9,7 @@ use crate::delegation::worktree_move_proposal;
 use crate::icons::{SymbolWeight, sf_symbol, sf_symbol_weighted};
 use crate::navigation::query_label;
 use crate::query_editor::{self, ClipboardEdit, Edit, QueryEditor};
-use crate::settings::{HostDraft, SettingsTab, theme};
+use crate::settings::{HostDraft, SettingsNav, SettingsTab, theme};
 use crate::sidebar::DraggedSidebarItem;
 use crate::store::{Prefs, SessionStore, StoreRuntime};
 use crate::updates::{UpdateCommand, UpdateHandle, UpdatePhase};
@@ -33,9 +33,6 @@ use crate::commands::{
     ToggleHistory, UTILITY_CONTEXT,
 };
 const SETTINGS_CONTENT_MAX_WIDTH: f32 = 760.0;
-/// Settings is its own destination with a stable navigation measure. It must
-/// not inherit a workspace sidebar width the user enlarged for long sessions.
-const SETTINGS_RAIL_WIDTH: f32 = 248.0;
 const SETTINGS_TRANSITION_DURATION: Duration = Duration::from_millis(190);
 const SETTINGS_SECTION_GAP: f32 = 16.0;
 const SETTINGS_ROW_HEIGHT: f32 = 50.0;
@@ -1071,6 +1068,52 @@ impl UtilitySurfaces {
             .collect()
     }
 
+    pub(crate) fn is_settings_open(&self) -> bool {
+        self.surface == Surface::Settings
+    }
+
+    /// What the app sidebar paints while settings owns the workbench. `None`
+    /// puts the sidebar back on sessions.
+    pub(crate) fn settings_nav(&self) -> Option<SettingsNav> {
+        (self.surface == Surface::Settings).then(|| SettingsNav {
+            tabs: self.visible_settings_tabs(),
+            active: self.settings_tab,
+            search: self.settings_search.clone(),
+            search_active: self.settings_search_active,
+        })
+    }
+
+    /// The sidebar rendered the navigation, so it is the sidebar that reports
+    /// a click on it. Every other entry point into a page goes through the
+    /// same method.
+    pub(crate) fn open_settings_tab(&mut self, tab: SettingsTab, cx: &mut Context<Self>) {
+        if self.surface != Surface::Settings {
+            return;
+        }
+        self.select_settings_tab(tab, cx);
+    }
+
+    /// Clicking the sidebar's search field types into settings, so keyboard
+    /// focus has to come back across with it.
+    pub(crate) fn focus_settings_search(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.surface != Surface::Settings {
+            return;
+        }
+        self.settings_search_active = true;
+        self.focus.focus(window, cx);
+        cx.notify();
+    }
+
+    pub(crate) fn clear_settings_search(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.surface != Surface::Settings {
+            return;
+        }
+        self.settings_search.clear();
+        self.settings_search_active = true;
+        self.focus.focus(window, cx);
+        cx.notify();
+    }
+
     fn select_settings_tab(&mut self, tab: SettingsTab, cx: &mut Context<Self>) {
         if self.settings_tab != tab {
             self.settings_scroll.set_offset(point(px(0.0), px(0.0)));
@@ -1767,240 +1810,24 @@ impl UtilitySurfaces {
         /* ─────────────────────────────────────────────────────────
          * SETTINGS SHELL STORYBOARD
          *
-         *    0ms   workbench is replaced in place; rail begins 8px left
-         *   70ms   settings rail is legible; canvas follows from 12px right
-         *  190ms   both surfaces settle at their final positions and opacity
+         *    0ms   the workbench is replaced in place; the app sidebar swaps
+         *          its own body over to settings navigation
+         *   70ms   the page follows the navigation in, from 12px right
+         *  190ms   both surfaces settle at their final position and opacity
          *
-         * Navigation stays spatially anchored to the old sidebar. Reduced
-         * motion mounts the final layout immediately.
+         * Navigation is deliberately absent here: it is the window sidebar,
+         * which this surface is inset against, so settings never paints a
+         * second rail beside the app's own. Reduced motion mounts the final
+         * layout immediately.
          * ───────────────────────────────────────────────────────── */
         let colors = self.settings_colors();
-        let visible_tabs = self.visible_settings_tabs();
-        let mut tabs = div().flex().flex_col();
-        let mut personal_started = false;
-        let mut system_started = false;
-        for tab in visible_tabs.iter().copied() {
-            let personal = matches!(
-                tab,
-                SettingsTab::General | SettingsTab::Agents | SettingsTab::Terminal
-            );
-            if personal && !personal_started {
-                tabs = tabs.child(settings_nav_section_header("Personal", 8.0, colors));
-                personal_started = true;
-            } else if !personal && !system_started {
-                tabs = tabs.child(settings_nav_section_header(
-                    "System",
-                    if personal_started { 14.0 } else { 8.0 },
-                    colors,
-                ));
-                system_started = true;
-            }
-            let selected = tab == self.settings_tab;
-            tabs = tabs.child(
-                div()
-                    .id(SharedString::from(format!("settings-{}", tab.label())))
-                    .debug_selector(move || format!("SETTINGS_TAB_{}", tab.label()))
-                    .h(px(30.0))
-                    .px(px(8.0))
-                    .rounded(px(Radius::ROW))
-                    .flex()
-                    .items_center()
-                    .gap(px(8.0))
-                    .bg(Fill::selected(colors, selected))
-                    .text_color(if selected {
-                        colors.primary
-                    } else {
-                        colors.secondary
-                    })
-                    .cursor_pointer()
-                    .hover(move |style| style.bg(Fill::hover(colors, true)))
-                    .on_click(cx.listener(move |this, _, _, cx| {
-                        this.select_settings_tab(tab, cx);
-                    }))
-                    .child(
-                        div()
-                            .w(px(16.0))
-                            .flex_none()
-                            .flex()
-                            .items_center()
-                            .justify_center()
-                            .child(sf_symbol(
-                                tab.icon(),
-                                12.0,
-                                if selected {
-                                    colors.primary
-                                } else {
-                                    colors.tertiary
-                                },
-                            )),
-                    )
-                    .child(
-                        div()
-                            .text_size(px(Typo::ROW.size))
-                            .font_weight(if selected {
-                                FontWeight::MEDIUM
-                            } else {
-                                FontWeight::NORMAL
-                            })
-                            .child(tab.label()),
-                    ),
-            );
-        }
-        if visible_tabs.is_empty() {
-            tabs = tabs.child(
-                div()
-                    .px(px(10.0))
-                    .pt(px(14.0))
-                    .text_size(px(Typo::META.size))
-                    .text_color(colors.tertiary)
-                    .child("No settings found"),
-            );
-        }
-        let search_content = if self.settings_search_active {
-            query_label(&self.settings_search)
-        } else if self.settings_search.is_empty() {
-            div()
-                .text_color(colors.tertiary)
-                .child("Search settings…")
-                .into_any_element()
-        } else {
-            div()
-                .text_color(colors.primary)
-                .child(self.settings_search.text().to_owned())
-                .into_any_element()
-        };
-        let search = div()
-            .id("settings-search")
-            .debug_selector(|| "settings-search".into())
-            .h(px(32.0))
-            .mx(px(4.0))
-            .mt(px(8.0))
-            .px(px(9.0))
-            .rounded(px(16.0))
-            .border_1()
-            .border_color(colors.primary.alpha(if self.settings_search_active {
-                0.22
-            } else {
-                0.11
-            }))
-            .bg(colors.primary.alpha(0.025))
-            .flex()
-            .items_center()
-            .gap(px(7.0))
-            .cursor(CursorStyle::IBeam)
-            .on_click(cx.listener(|this, _, window, cx| {
-                this.settings_search_active = true;
-                this.focus.focus(window, cx);
-                cx.notify();
-            }))
-            .child(sf_symbol("magnifyingglass", 12.0, colors.tertiary))
-            .child(
-                div()
-                    .flex_1()
-                    .min_w(px(0.0))
-                    .overflow_hidden()
-                    .whitespace_nowrap()
-                    .text_ellipsis()
-                    .text_size(px(Typo::ROW.size))
-                    .child(search_content),
-            )
-            .when(!self.settings_search.is_empty(), |search| {
-                search.child(
-                    div()
-                        .id("clear-settings-search")
-                        .debug_selector(|| "clear-settings-search".into())
-                        .size(px(18.0))
-                        .flex_none()
-                        .flex()
-                        .items_center()
-                        .justify_center()
-                        .rounded_full()
-                        .cursor_pointer()
-                        .hover(move |style| style.bg(Fill::subtle(colors)))
-                        .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
-                        .on_click(cx.listener(|this, _, _, cx| {
-                            this.settings_search.clear();
-                            this.settings_search_active = true;
-                            cx.notify();
-                        }))
-                        .child(sf_symbol("xmark", 8.0, colors.tertiary)),
-                )
-            });
+        let generation = self.settings_transition_generation;
         let pane = match self.settings_tab {
             SettingsTab::General => self.general_settings(cx).into_any_element(),
             SettingsTab::Agents => self.agents_settings(cx).into_any_element(),
             SettingsTab::Terminal => self.terminal_settings(cx).into_any_element(),
             SettingsTab::Resources => self.resource_settings(cx).into_any_element(),
             SettingsTab::Remote => self.remote_settings(cx).into_any_element(),
-        };
-        let generation = self.settings_transition_generation;
-        let rail = div()
-            .id("settings-rail")
-            .debug_selector(|| "settings-rail".into())
-            .relative()
-            .w(px(SETTINGS_RAIL_WIDTH))
-            .h_full()
-            .bg(colors.sidebar_surface())
-            .border_r_1()
-            .border_color(colors.primary.alpha(0.07))
-            .flex()
-            .flex_col()
-            .child(
-                div()
-                    .pt(px(6.0))
-                    .child(
-                        div()
-                            .id("close-settings")
-                            .debug_selector(|| "close-settings".into())
-                            .h(px(30.0))
-                            .mx(px(12.0))
-                            .px(px(8.0))
-                            .rounded(px(Radius::ROW))
-                            .flex()
-                            .items_center()
-                            .gap(px(7.0))
-                            .cursor_pointer()
-                            .hover(move |style| style.bg(Fill::subtle(colors)))
-                            .on_click(cx.listener(|this, _, _, cx| this.close_surface(cx)))
-                            .child(sf_symbol("chevron.left", 9.5, colors.tertiary))
-                            .child(
-                                div()
-                                    .text_size(px(Typo::META.size))
-                                    .text_color(colors.secondary)
-                                    .child("Back to app"),
-                            ),
-                    )
-                    .child(search),
-            )
-            .child(
-                div()
-                    .id("settings-nav-scroll")
-                    .px(px(4.0))
-                    .flex_1()
-                    .min_h(px(0.0))
-                    .overflow_y_scroll()
-                    .child(tabs),
-            )
-            .child(
-                div()
-                    .px(px(Metrics::TOOLBAR_EDGE_INSET))
-                    .pb(px(12.0))
-                    .text_size(px(Typo::META.size))
-                    .text_color(colors.tertiary)
-                    .child(format!("diri {}", crate::updates::CURRENT_VERSION)),
-            );
-        let rail = if cx.reduce_motion() {
-            rail.into_any_element()
-        } else {
-            rail.with_animation(
-                SharedString::from(format!("settings-rail-enter-{generation}")),
-                Animation::new(SETTINGS_TRANSITION_DURATION).with_easing(ease_out_quint()),
-                |rail, delta| {
-                    rail.left(px((1.0 - delta) * -8.0))
-                        .opacity(0.72 + 0.28 * delta)
-                },
-            )
-            .into_any_element()
         };
         let pane = div()
             .id("settings-pane")
@@ -2041,8 +1868,9 @@ impl UtilitySurfaces {
             .overflow_hidden()
             .bg(colors.background)
             .flex()
-            // Settings owns the whole workbench. Clicking inside still closes
-            // any open select before the clicked control handles its action.
+            // Settings owns the workbench beside the sidebar. Clicking inside
+            // still closes any open select before the clicked control handles
+            // its action.
             .on_mouse_down(
                 MouseButton::Left,
                 cx.listener(|this, _, _, cx| {
@@ -2052,7 +1880,6 @@ impl UtilitySurfaces {
                     cx.stop_propagation();
                 }),
             )
-            .child(rail)
             .child(pane)
     }
 
@@ -4537,22 +4364,6 @@ fn settings_tab_matches(tab: SettingsTab, query: &str) -> bool {
         .all(|word| searchable.contains(word))
 }
 
-fn settings_nav_section_header(
-    title: &'static str,
-    top_padding: f32,
-    colors: SemanticColors,
-) -> AnyElement {
-    div()
-        .px(px(8.0))
-        .pt(px(top_padding))
-        .pb(px(5.0))
-        .text_size(px(Typo::SECTION_HEADER.size))
-        .font_weight(Typo::SECTION_HEADER.weight)
-        .text_color(colors.tertiary)
-        .child(title)
-        .into_any_element()
-}
-
 fn settings_page(
     title: &'static str,
     content: impl IntoElement,
@@ -4935,8 +4746,9 @@ mod tests {
             .expect("save diagnostics screenshot");
     }
 
-    /// Renders the full settings workbench after its entrance transition, so
-    /// layout and visual hierarchy can be reviewed without live user state.
+    /// Renders the full settings destination -- navigation in the app sidebar,
+    /// page beside it -- after its entrance transition, so layout and visual
+    /// hierarchy can be reviewed without live user state.
     #[cfg(target_os = "macos")]
     #[test]
     #[ignore = "writes the deterministic settings-shell screenshot artifact"]
@@ -4950,32 +4762,30 @@ mod tests {
             Arc::new(diri_ui::IconAssets),
             gpui_platform::current_headless_renderer,
         );
-        cx.update(|cx| crate::fonts::init(cx));
+        cx.update(|cx| {
+            crate::fonts::init(cx);
+            // Entrance animations run on the wall clock, which a headless
+            // capture does not advance. Reduced motion mounts the settled
+            // layout, which is the only thing a still image can show anyway.
+            cx.set_reduce_motion(true);
+        });
 
-        let runtime = Arc::new(StoreRuntime::inert());
-        let tokio = Arc::new(
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("test runtime"),
-        );
-        let updates = crate::updates::inert();
         let window = cx
             .open_window(size(px(1200.0), px(800.0)), move |window, cx| {
-                let surfaces = cx.new(|cx| {
-                    let mut surfaces = UtilitySurfaces::new(runtime, tokio, updates, window, cx);
-                    surfaces.open_settings(cx);
-                    // Exercise the user-reported state: Remote selected after
-                    // the workspace sidebar had previously been widened.
-                    surfaces.settings_tab = SettingsTab::Remote;
-                    surfaces.prefs.sidebar_width = 400.0;
-                    surfaces
+                // Exercise the user-reported state: Remote selected, from a
+                // sidebar the user had previously widened.
+                let harness =
+                    cx.new(|cx| SettingsWorkbenchHarness::open_at(SettingsTab::Remote, window, cx));
+                harness.update(cx, |harness, cx| {
+                    harness
+                        .sidebar
+                        .update(cx, |sidebar, cx| sidebar.set_width(320.0, cx));
                 });
-                cx.new(|_| CachedOverlayHarness { surfaces })
+                harness
             })
             .expect("open headless settings window");
         cx.run_until_parked();
-        cx.advance_clock(SETTINGS_TRANSITION_DURATION + Duration::from_millis(10));
+        cx.advance_clock(SETTINGS_TRANSITION_DURATION + Duration::from_millis(300));
         cx.update_window(window.into(), |_, window, _| window.refresh())
             .expect("refresh settings window");
         cx.run_until_parked();
@@ -5047,6 +4857,115 @@ mod tests {
 
     struct CachedSettingsModalHarness {
         surfaces: Entity<UtilitySurfaces>,
+    }
+
+    /// Settings as the window actually composes it: the app sidebar paints the
+    /// navigation, and the page is laid out beside it rather than over it.
+    struct SettingsWorkbenchHarness {
+        sidebar: Entity<crate::sidebar::Sidebar>,
+        surfaces: Entity<UtilitySurfaces>,
+        _subscriptions: [gpui::Subscription; 2],
+    }
+
+    impl SettingsWorkbenchHarness {
+        fn open(window: &mut Window, cx: &mut Context<Self>) -> Self {
+            Self::open_at(SettingsTab::General, window, cx)
+        }
+
+        fn open_at(tab: SettingsTab, window: &mut Window, cx: &mut Context<Self>) -> Self {
+            let runtime = Arc::new(StoreRuntime::inert());
+            let tokio = Arc::new(
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("test runtime"),
+            );
+            let sidebar = cx.new(|cx| {
+                crate::sidebar::Sidebar::new(
+                    Some(Arc::clone(&runtime)),
+                    false,
+                    crate::sidebar::PreviewScenario::Typical,
+                    cx,
+                )
+            });
+            let surfaces = cx.new(|cx| {
+                let mut surfaces = UtilitySurfaces::new(
+                    Arc::clone(&runtime),
+                    tokio,
+                    crate::updates::inert(),
+                    window,
+                    cx,
+                );
+                surfaces.open_settings(cx);
+                surfaces.settings_tab = tab;
+                surfaces
+            });
+            // RootView re-renders on the sidebar's own events; this harness
+            // only needs to notice its measure change.
+            cx.observe(&sidebar, |_, _, cx| cx.notify()).detach();
+            let subscriptions = crate::root::wire_settings_navigation(
+                sidebar.clone(),
+                surfaces.clone(),
+                window,
+                cx,
+            );
+            // The mirror runs on notifies; settings was already open before
+            // anything was watching it.
+            let nav = surfaces.read(cx).settings_nav();
+            sidebar.update(cx, |sidebar, cx| sidebar.set_settings_nav(nav, cx));
+            Self {
+                sidebar,
+                surfaces,
+                _subscriptions: subscriptions,
+            }
+        }
+
+        fn sidebar_width(&self, cx: &App) -> f32 {
+            let sidebar = self.sidebar.read(cx);
+            if sidebar.is_visible() {
+                sidebar.width()
+            } else {
+                0.0
+            }
+        }
+    }
+
+    impl Render for SettingsWorkbenchHarness {
+        fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            let seam = self.sidebar_width(cx);
+            div()
+                .size_full()
+                .flex()
+                .child(
+                    div().flex_none().w(px(seam)).h_full().child(
+                        self.sidebar
+                            .clone()
+                            .cached(StyleRefinement::default().size_full()),
+                    ),
+                )
+                .child(
+                    self.surfaces.clone().cached(
+                        StyleRefinement::default()
+                            .absolute()
+                            .inset_0()
+                            .left(px(seam)),
+                    ),
+                )
+        }
+    }
+
+    fn open_settings_workbench(
+        cx: &mut TestAppContext,
+    ) -> (
+        Entity<SettingsWorkbenchHarness>,
+        &mut gpui::VisualTestContext,
+    ) {
+        let (harness, cx) = cx.add_window_view(SettingsWorkbenchHarness::open);
+        cx.simulate_resize(size(px(1200.0), px(800.0)));
+        cx.executor()
+            .advance_clock(SETTINGS_TRANSITION_DURATION + Duration::from_millis(300));
+        cx.run_until_parked();
+        (harness, cx)
     }
 
     struct SettingRowHarness;
@@ -5476,82 +5395,83 @@ mod tests {
     }
 
     #[gpui::test]
-    fn settings_shell_keeps_the_sidebar_rail_in_the_cached_wrapper(cx: &mut TestAppContext) {
-        let runtime = Arc::new(StoreRuntime::inert());
-        let tokio = Arc::new(
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("test runtime"),
-        );
-        let updates = crate::updates::inert();
-        let (_, cx) = cx.add_window_view(move |window, cx| {
-            let surfaces = cx.new(|cx| {
-                let mut surfaces = UtilitySurfaces::new(runtime, tokio, updates, window, cx);
-                surfaces.open_settings(cx);
-                surfaces
-            });
-            CachedOverlayHarness { surfaces }
-        });
+    fn settings_navigates_from_the_app_sidebar_rather_than_a_second_rail(cx: &mut TestAppContext) {
+        let (harness, cx) = open_settings_workbench(cx);
 
-        let viewport = size(px(1200.0), px(800.0));
-        cx.simulate_resize(viewport);
-
-        let backdrop = cx
-            .debug_bounds("surface-backdrop")
-            .expect("settings backdrop should render");
-        assert_eq!(backdrop.size, viewport);
-
+        let sidebar = cx
+            .debug_bounds("sidebar")
+            .expect("the app sidebar should stay mounted while settings is open");
+        let navigation = cx
+            .debug_bounds("sidebar-settings")
+            .expect("settings navigation should render inside the app sidebar");
         let shell = cx
             .debug_bounds("settings-shell")
             .expect("settings shell should render");
-        let rail = cx
-            .debug_bounds("settings-rail")
-            .expect("settings rail should render");
-        let pane = cx
-            .debug_bounds("settings-pane")
-            .expect("settings pane should render");
-        assert_eq!(shell.size, viewport);
-        assert_eq!(rail.size.width, px(248.0));
-        assert!(rail.left() >= shell.left() - px(8.0));
-        assert!(rail.left() <= shell.left());
-        assert!(pane.left() >= rail.right());
-        assert!(pane.left() <= rail.right() + px(20.0));
-        assert_eq!(rail.top(), px(Metrics::TITLE_BAR));
+        assert!(
+            cx.debug_bounds("settings-rail").is_none(),
+            "settings should navigate from the app sidebar, not a rail of its own"
+        );
+        assert_eq!(navigation.left(), sidebar.left());
+        assert_eq!(navigation.size.width, sidebar.size.width);
+        assert_eq!(
+            shell.left(),
+            sidebar.right(),
+            "the settings page should begin where the sidebar ends"
+        );
+        assert_eq!(shell.right(), px(1200.0));
+        assert!(cx.debug_bounds("SETTINGS_TAB_General").is_some());
+        harness.read_with(cx, |harness, cx| {
+            assert!(harness.sidebar.read(cx).shows_settings());
+        });
     }
 
     #[gpui::test]
-    fn settings_content_close_control_dismisses_the_surface(cx: &mut TestAppContext) {
-        let runtime = Arc::new(StoreRuntime::inert());
-        let tokio = Arc::new(
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("test runtime"),
+    fn opening_settings_swaps_the_sidebar_body_and_leaves_its_frame_alone(cx: &mut TestAppContext) {
+        let (harness, cx) = open_settings_workbench(cx);
+        let surfaces = harness.read_with(cx, |harness, _| harness.surfaces.clone());
+
+        let in_settings = cx.debug_bounds("sidebar").expect("sidebar");
+        assert!(
+            cx.debug_bounds("new-agent").is_none(),
+            "the session body should give way to navigation"
         );
-        let updates = crate::updates::inert();
-        let (view, cx) = cx.add_window_view(move |window, cx| {
-            let surfaces = cx.new(|cx| {
-                let mut surfaces = UtilitySurfaces::new(runtime, tokio, updates, window, cx);
-                surfaces.open_settings(cx);
-                surfaces
-            });
-            SettingsModalHarness {
-                surfaces,
-                background_events: Arc::new(AtomicUsize::new(0)),
-            }
+
+        surfaces.update(cx, |surfaces, cx| surfaces.dismiss(cx));
+        cx.executor()
+            .advance_clock(SETTINGS_TRANSITION_DURATION + Duration::from_millis(300));
+        cx.run_until_parked();
+
+        let in_sessions = cx.debug_bounds("sidebar").expect("sidebar");
+        assert_eq!(
+            in_settings, in_sessions,
+            "the panel itself should hold still while its body swaps"
+        );
+        assert!(
+            cx.debug_bounds("sidebar-settings").is_none(),
+            "leaving settings should return the sidebar to sessions"
+        );
+        assert!(cx.debug_bounds("new-agent").is_some());
+    }
+
+    #[gpui::test]
+    fn the_sidebar_back_control_dismisses_settings(cx: &mut TestAppContext) {
+        let (harness, cx) = open_settings_workbench(cx);
+        let surfaces = harness.read_with(cx, |harness, _| harness.surfaces.clone());
+        surfaces.update_in(cx, |surfaces, window, cx| {
+            surfaces.focus.focus(window, cx);
         });
 
-        let surfaces = view.read_with(cx, |harness, _| harness.surfaces.clone());
-        let close = cx
+        let back = cx
             .debug_bounds("close-settings")
-            .expect("settings close control should render");
-        cx.simulate_click(close.center(), Modifiers::default());
+            .expect("the sidebar should offer the way back out of settings");
+        cx.simulate_click(back.center(), Modifiers::default());
+        cx.run_until_parked();
 
         assert_eq!(
             surfaces.read_with(cx, |surfaces, _| surfaces.surface),
             Surface::None
         );
+        assert!(!harness.read_with(cx, |harness, cx| harness.sidebar.read(cx).shows_settings()));
     }
 
     #[gpui::test]
@@ -5591,33 +5511,28 @@ mod tests {
     }
 
     #[gpui::test]
-    fn settings_rail_does_not_inherit_a_resized_workspace_sidebar(cx: &mut TestAppContext) {
-        let runtime = Arc::new(StoreRuntime::inert());
-        let tokio = Arc::new(
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("test runtime"),
-        );
-        let updates = crate::updates::inert();
-        let (_, cx) = cx.add_window_view(move |window, cx| {
-            let surfaces = cx.new(|cx| {
-                let mut surfaces = UtilitySurfaces::new(runtime, tokio, updates, window, cx);
-                surfaces.open_settings(cx);
-                surfaces.prefs.sidebar_width = 400.0;
-                surfaces
-            });
-            CachedOverlayHarness { surfaces }
-        });
-        cx.simulate_resize(size(px(1200.0), px(800.0)));
+    fn settings_navigation_takes_the_workspace_sidebar_measure(cx: &mut TestAppContext) {
+        let (harness, cx) = open_settings_workbench(cx);
+        let sidebar = harness.read_with(cx, |harness, _| harness.sidebar.clone());
 
-        let rail = cx
-            .debug_bounds("settings-rail")
-            .expect("settings rail should render");
+        sidebar.update(cx, |sidebar, cx| sidebar.set_width(320.0, cx));
+        cx.run_until_parked();
+
+        let navigation = cx
+            .debug_bounds("sidebar-settings")
+            .expect("settings navigation should render inside the app sidebar");
+        let shell = cx
+            .debug_bounds("settings-shell")
+            .expect("settings shell should render");
         assert_eq!(
-            rail.size.width,
-            px(248.0),
-            "settings navigation should keep its own stable measure"
+            navigation.size.width,
+            px(320.0),
+            "navigation shares the sidebar the user sized, rather than a measure of its own"
+        );
+        assert_eq!(
+            shell.left(),
+            px(320.0),
+            "the page stays against the sidebar as the seam is dragged"
         );
     }
 
@@ -5630,39 +5545,20 @@ mod tests {
     }
 
     #[gpui::test]
-    fn settings_search_filters_and_opens_the_first_result(cx: &mut TestAppContext) {
-        let runtime = Arc::new(StoreRuntime::inert());
-        let tokio = Arc::new(
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("test runtime"),
-        );
-        let updates = crate::updates::inert();
-        let (view, cx) = cx.add_window_view(move |window, cx| {
-            let surfaces = cx.new(|cx| {
-                let mut surfaces = UtilitySurfaces::new(runtime, tokio, updates, window, cx);
-                surfaces.open_settings(cx);
-                surfaces
-            });
-            SettingsModalHarness {
-                surfaces,
-                background_events: Arc::new(AtomicUsize::new(0)),
-            }
-        });
-        cx.executor()
-            .advance_clock(SETTINGS_TRANSITION_DURATION + Duration::from_millis(10));
-        cx.run_until_parked();
+    fn the_sidebar_search_field_filters_settings_and_opens_the_first_result(
+        cx: &mut TestAppContext,
+    ) {
+        let (harness, cx) = open_settings_workbench(cx);
+        let surfaces = harness.read_with(cx, |harness, _| harness.surfaces.clone());
 
         let search = cx
             .debug_bounds("settings-search")
-            .expect("settings search should render");
+            .expect("settings search should render in the sidebar");
         cx.simulate_click(search.center(), Modifiers::default());
         cx.simulate_input("ssh");
 
         assert!(cx.debug_bounds("SETTINGS_TAB_Remote").is_some());
         assert!(cx.debug_bounds("SETTINGS_TAB_General").is_none());
-        let surfaces = view.read_with(cx, |harness, _| harness.surfaces.clone());
         surfaces.read_with(cx, |surfaces, _| {
             assert_eq!(surfaces.settings_search.text(), "ssh");
             assert!(surfaces.settings_search_active);
@@ -5677,34 +5573,19 @@ mod tests {
     }
 
     #[gpui::test]
-    fn changing_settings_tabs_resets_the_shared_pane_scroll(cx: &mut TestAppContext) {
-        let runtime = Arc::new(StoreRuntime::inert());
-        let tokio = Arc::new(
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("test runtime"),
-        );
-        let updates = crate::updates::inert();
-        let (view, cx) = cx.add_window_view(move |window, cx| {
-            let surfaces = cx.new(|cx| {
-                let mut surfaces = UtilitySurfaces::new(runtime, tokio, updates, window, cx);
-                surfaces.open_settings(cx);
-                surfaces
-            });
-            SettingsModalHarness {
-                surfaces,
-                background_events: Arc::new(AtomicUsize::new(0)),
-            }
-        });
-        cx.simulate_resize(size(px(900.0), px(520.0)));
-        cx.executor()
-            .advance_clock(SETTINGS_TRANSITION_DURATION + Duration::from_millis(10));
-        cx.run_until_parked();
+    fn choosing_a_page_in_the_sidebar_resets_the_shared_pane_scroll(cx: &mut TestAppContext) {
+        let (harness, cx) = open_settings_workbench(cx);
+        let surfaces = harness.read_with(cx, |harness, _| harness.surfaces.clone());
 
         let pane = cx
             .debug_bounds("settings-pane")
             .expect("settings pane should render");
+        // Read the row before scrolling: a cached view that is reused rather
+        // than re-rendered leaves no debug bounds behind, and the sidebar has
+        // no reason to re-render while the page scrolls.
+        let remote = cx
+            .debug_bounds("SETTINGS_TAB_Remote")
+            .expect("the Remote page should be listed in the sidebar");
         for _ in 0..8 {
             cx.simulate_event(ScrollWheelEvent {
                 position: pane.center(),
@@ -5713,16 +5594,18 @@ mod tests {
             });
         }
 
-        let remote = cx
-            .debug_bounds("SETTINGS_TAB_Remote")
-            .expect("Remote tab should render");
         cx.simulate_click(remote.center(), Modifiers::default());
+        cx.run_until_parked();
 
-        let surfaces = view.read_with(cx, |harness, _| harness.surfaces.clone());
         surfaces.read_with(cx, |surfaces, _| {
             assert_eq!(surfaces.settings_tab, SettingsTab::Remote);
             assert_eq!(surfaces.settings_scroll.offset(), point(px(0.0), px(0.0)));
         });
+        assert_eq!(
+            harness.read_with(cx, |harness, cx| harness.sidebar.read(cx).settings_page()),
+            Some(SettingsTab::Remote),
+            "the sidebar should show the page the click opened as current"
+        );
 
         let pane = cx
             .debug_bounds("settings-pane")
@@ -5732,7 +5615,7 @@ mod tests {
             .expect("Remote page content should render");
         assert!(
             copy.bottom() > pane.top() && copy.top() < pane.bottom(),
-            "switching tabs left the Remote page scrolled out of view: {copy:?} vs {pane:?}"
+            "switching pages left the Remote page scrolled out of view: {copy:?} vs {pane:?}"
         );
     }
 }

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -4676,10 +4676,15 @@ mod tests {
     /// entity root is laid out independently of its content, so mount the
     /// surfaces the way the app does -- not bare -- and a root that cannot size
     /// itself fails here instead of on screen.
+    ///
+    /// Only the screenshot fixtures mount a surface this way now; the settings
+    /// tests compose it against a real sidebar, which is what the window does.
+    #[cfg(target_os = "macos")]
     struct CachedOverlayHarness {
         surfaces: Entity<UtilitySurfaces>,
     }
 
+    #[cfg(target_os = "macos")]
     impl Render for CachedOverlayHarness {
         fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
             div().size_full().child(


### PR DESCRIPTION
Settings had a second sidebar. Opening it replaced the whole workbench with a rail of its own: a fixed 248pt navigation list that ignored the width you had dragged the real sidebar to, with the account footer and the rest of the panel it stood in front of simply gone.

Now settings navigates from the sidebar that is already there.

## What changed

- **One sidebar.** While settings owns the workbench, the app sidebar swaps its body from sessions to settings pages and keeps everything else — its measure, its title bar, its account footer. The gear in the title bar becomes the way back out.
- **The page is laid out beside it**, against the live seam rather than a width settings snapshotted for itself, so dragging the sidebar wider while in settings moves both edges together.
- **The swap is animated.** Each row fades and slides 14pt in on the shared `SETTLE` spring, a beat behind the row above it, so navigation reads as content sliding out from inside the panel; the page arrives alongside it on the existing 190ms canvas transition. Reduced motion mounts the settled layout.
- **State did not move.** Settings state stays in `UtilitySurfaces`; the sidebar renders a projection (`SettingsNav`) and reports clicks back through `wire_settings_navigation`, so the list and the page cannot disagree about the current page or the search text.
- **Visibility.** Opening settings onto a hidden sidebar reveals it and closing gives it back. Hiding the sidebar while in settings leaves settings, since that is where its navigation lives.

## Drive-by fixes to the main-branch gate

`cargo test --workspace` and `cargo clippy -- -D warnings` were both failing on `main` before this change, so they are fixed here to get a green run:

- three `AppServices` test initializers in `launcher.rs` were missing the `cfg(unix)` `daemon_startup` field (semantic conflict between #116 and #117)
- clippy rejected a pair of identical branches in the command palette's row indexing

## Testing

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` — all green.
- The five settings tests that asserted the old rail were rewritten against a harness that composes the real sidebar and the real surface with the real wiring, covering: navigation renders in the sidebar and no rail exists; the page begins at the sidebar's right edge; navigation takes the sidebar's user-set measure; the back control dismisses; the search field filters and opens the first result; clicking a page resets the shared pane scroll and the sidebar shows it as current.
- New: the panel's own frame does not move when its body swaps, and the stagger curve starts at zero and lands every row by the end of the transition.
- Verified visually with the headless screenshot fixture, including a mid-transition frame to check the cascade. No daemon behavior changes: existing sessions are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)