### PR TITLE
Adopt safer session lifecycle foundations

### DIFF
--- a/diri/REMOTE_PORT.md
+++ b/diri/REMOTE_PORT.md
@@ -437,6 +437,12 @@ continues parsing terminal state but does not construct or serialize diffs. If
 an attached client falls behind, stale updates are discarded and the connection
 is reseeded from a complete snapshot after reconnect.
 
+The Engine reconciles raw-output offsets before feeding any local observer:
+duplicates are skipped, overlaps feed only the unseen suffix, and a forward gap
+on the live stream forces reconnect. Bounded replay may contain a gap because
+the Holder follows it with an authoritative `FullSnapshot`; replay bytes are
+logged for continuity but never treated as a second live status observation.
+
 One owner/event loop handles PTY drain, terminal parsing, diff construction, and
 attach writes. The hot path does not put an `Arc<Mutex<Terminal>>` across tasks.
 Buffers are reused where practical, and idle Holders do not poll, heartbeat, or
@@ -471,6 +477,11 @@ Only the current epoch may send:
 - `Signal`;
 - `Scroll`;
 - session termination requests.
+
+Input and signals are at-most-once effects. If a write fails before accepting
+any frame byte, input may be retained for a later controller lease. A partial
+write or lost flush acknowledgement has an unknown outcome: the Engine surfaces
+the transport error and never queues or replays that effect.
 
 Stale epochs fail with a structured protocol error. Multiple read-only observers
 are a future enhancement and are not part of the completed baseline.

--- a/diri/crates/diri-app/src/delegation.rs
+++ b/diri/crates/diri-app/src/delegation.rs
@@ -12,8 +12,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use diri_proto::{
-    AgentKind, Project, ProjectId, Resumability, SessionId, SessionRecord, SessionStatus,
-    WorktreeOverviewEntry,
+    AgentKind, Project, ProjectId, SessionId, SessionRecord, SessionStatus, WorktreeOverviewEntry,
 };
 use serde_json::Value;
 
@@ -152,7 +151,7 @@ pub fn worktree_move_proposal(
             "Stop or archive the session before moving it to another worktree.".to_owned(),
         ));
     }
-    if source.resumability != Resumability::Resumable {
+    if !source.can_resume() {
         return Err(DelegationRefusal(
             "This session cannot resume after moving to another worktree.".to_owned(),
         ));
@@ -390,7 +389,9 @@ fn read_tail(path: &Path, cap: u64) -> std::io::Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use diri_proto::{DateMillis, ExitInfo, ExitReason, PullRequestStatus, TitleSource};
+    use diri_proto::{
+        DateMillis, ExitInfo, ExitReason, PullRequestStatus, Resumability, TitleSource,
+    };
 
     fn session(id: &str, parent: Option<&str>) -> SessionRecord {
         SessionRecord {
@@ -409,6 +410,7 @@ mod tests {
             status_evidence: None,
             needs_input: None,
             resumability: Resumability::Live,
+            capabilities: None,
             parent: parent.map(SessionId::new),
             created_at: DateMillis(1.0),
             updated_at: DateMillis(2.0),

--- a/diri/crates/diri-app/src/menu_inbox.rs
+++ b/diri/crates/diri-app/src/menu_inbox.rs
@@ -148,6 +148,7 @@ mod tests {
             status_evidence: None,
             needs_input: None,
             resumability: diri_proto::Resumability::Live,
+            capabilities: None,
             parent: None,
             created_at: DateMillis(1.0),
             updated_at: DateMillis(1.0),

--- a/diri/crates/diri-app/src/notifications.rs
+++ b/diri/crates/diri-app/src/notifications.rs
@@ -607,6 +607,7 @@ mod tests {
                 occurred_at: DateMillis(1.0),
             }),
             resumability: Resumability::NotResumable,
+            capabilities: None,
             parent: None,
             created_at: DateMillis(1.0),
             updated_at: DateMillis(2.0),

--- a/diri/crates/diri-app/src/palette.rs
+++ b/diri/crates/diri-app/src/palette.rs
@@ -1072,6 +1072,7 @@ mod tests {
             status_evidence: None,
             needs_input: None,
             resumability: Resumability::Live,
+            capabilities: None,
             parent: None,
             created_at: DateMillis(1.0),
             updated_at: DateMillis(2.0),

--- a/diri/crates/diri-app/src/session_surfaces.rs
+++ b/diri/crates/diri-app/src/session_surfaces.rs
@@ -1526,6 +1526,7 @@ mod tests {
             status_evidence: None,
             needs_input: None,
             resumability: Resumability::Live,
+            capabilities: None,
             parent: None,
             created_at: DateMillis(index as f64),
             updated_at: DateMillis(index as f64),

--- a/diri/crates/diri-app/src/sidebar/fixture.rs
+++ b/diri/crates/diri-app/src/sidebar/fixture.rs
@@ -496,6 +496,7 @@ fn session(
         status_evidence: None,
         needs_input: None,
         resumability,
+        capabilities: None,
         parent: None,
         created_at: DateMillis(created),
         updated_at: DateMillis(created),

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -3987,7 +3987,7 @@ impl Sidebar {
                 .child(copy_session_id_row(id, colors, cx));
         } else {
             let running = !matches!(session.status, diri_proto::SessionStatus::Exited(_));
-            if !running && session.resumability == diri_proto::Resumability::Resumable {
+            if !running && session.can_resume() {
                 content = content.child(menu_row(
                     "Resume",
                     colors,

--- a/diri/crates/diri-app/src/store/mod.rs
+++ b/diri/crates/diri-app/src/store/mod.rs
@@ -16,7 +16,7 @@ use diri_proto::remote_pty::DirectoryListResult;
 use diri_proto::{
     AgentDescriptor, AgentKind, AgentReadinessResult, AttentionLevel, DateMillis, EventName,
     ExitReason, GovernorConfigureParams, HelloResult, HostEntry, HostsConfig, Project, ProjectId,
-    Resumability, SessionId, SessionListResult, SessionRecord, SessionSpawnParams, SessionStatus,
+    SessionId, SessionListResult, SessionRecord, SessionSpawnParams, SessionStatus,
 };
 use tokio::sync::{Notify, broadcast, mpsc};
 use tokio::task::JoinHandle;
@@ -1287,7 +1287,7 @@ impl SessionStore {
                 SessionStatus::Exited(info)
                     if info.reason == ExitReason::Exited
                         && info.code == Some(0)
-                        && session.resumability != Resumability::Resumable
+                        && !session.can_resume()
             )
             && previous
                 .as_deref()
@@ -1843,7 +1843,7 @@ impl SessionStore {
                 continue;
             }
             session.archived_at = None;
-            let resumable = session.resumability == Resumability::Resumable;
+            let resumable = session.can_resume();
             revived.push(id.clone());
             self.emit(if resumable {
                 StoreEffect::Resume {
@@ -1864,7 +1864,7 @@ impl SessionStore {
         let eligible = self.selected_session_id.as_ref() == Some(id)
             && self.sessions.get(id).is_some_and(|session| {
                 !session.is_archived()
-                    && session.resumability == Resumability::Resumable
+                    && session.can_resume()
                     && matches!(
                         &session.status,
                         SessionStatus::Exited(info) if info.reason == ExitReason::DaemonRestart

--- a/diri/crates/diri-app/src/store/tests.rs
+++ b/diri/crates/diri-app/src/store/tests.rs
@@ -45,6 +45,7 @@ fn session(value: &str, project: &str, created: f64) -> SessionRecord {
         status_evidence: None,
         needs_input: None,
         resumability: Resumability::Live,
+        capabilities: None,
         parent: None,
         created_at: DateMillis(created),
         updated_at: DateMillis(created),

--- a/diri/crates/diri-app/src/switcher.rs
+++ b/diri/crates/diri-app/src/switcher.rs
@@ -599,6 +599,7 @@ mod tests {
             status_evidence: None,
             needs_input: None,
             resumability: Resumability::Live,
+            capabilities: None,
             parent: None,
             created_at: DateMillis(0.0),
             updated_at: DateMillis(0.0),

--- a/diri/crates/diri-app/src/terminal_pane.rs
+++ b/diri/crates/diri-app/src/terminal_pane.rs
@@ -2820,7 +2820,7 @@ impl TerminalPane {
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let id = session.id.clone();
-        let resumable = session.resumability == Resumability::Resumable;
+        let resumable = session.can_resume();
         let mut pill = div()
             .id("exit-pill")
             .rounded(px(999.0))
@@ -3034,7 +3034,7 @@ impl TerminalPane {
     ) -> AnyElement {
         let id = session.id.clone();
         let content = centered_message("", &exit_description(session), colors);
-        if session.resumability == Resumability::Resumable {
+        if session.can_resume() {
             content
                 .child(primary_button(
                     "resume-conversation",

--- a/diri/crates/diri-engine/src/agent.rs
+++ b/diri/crates/diri-engine/src/agent.rs
@@ -135,6 +135,25 @@ pub struct AgentDescriptor {
 }
 
 impl AgentDescriptor {
+    /// Resolves the static manifest facts and the session's current lifecycle
+    /// into one wire value. This is the only place callers need to understand
+    /// which descriptor fields imply a supported verb.
+    pub fn session_capabilities(
+        &self,
+        resumability: diri_proto::Resumability,
+        status: &diri_proto::SessionStatus,
+        archived: bool,
+    ) -> diri_proto::SessionCapabilities {
+        let live = !archived && !matches!(status, diri_proto::SessionStatus::Exited(_));
+        diri_proto::SessionCapabilities {
+            resume: resumability == diri_proto::Resumability::Resumable,
+            archive: !archived,
+            send_text: live,
+            quick_approve: self.approve.is_some(),
+            reliable_completion: self.authority() != Authority::ProcessOnly,
+        }
+    }
+
     /// The reducer authority this agent declares, defaulting to the
     /// conservative one when a manifest does not say.
     pub fn authority(&self) -> Authority {
@@ -648,6 +667,28 @@ mod tests {
                 "{id} must resume"
             );
         }
+    }
+
+    #[test]
+    fn manifest_and_lifecycle_resolve_session_capabilities_once() {
+        let codex = descriptor("codex");
+        let exited = diri_proto::SessionStatus::Exited(diri_proto::ExitInfo {
+            reason: diri_proto::ExitReason::Exited,
+            code: Some(0),
+            signal: None,
+        });
+        let capabilities =
+            codex.session_capabilities(diri_proto::Resumability::Resumable, &exited, false);
+        assert!(capabilities.resume);
+        assert!(capabilities.archive);
+        assert!(!capabilities.send_text);
+        assert!(capabilities.quick_approve);
+        assert!(capabilities.reliable_completion);
+
+        let archived =
+            codex.session_capabilities(diri_proto::Resumability::Resumable, &exited, true);
+        assert!(archived.resume, "restore can re-enter the conversation");
+        assert!(!archived.archive);
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/control.rs
+++ b/diri/crates/diri-engine/src/control.rs
@@ -1784,7 +1784,6 @@ impl ControlServer {
         registry
             .remove(&p.session_id.0, &self.logs_dir)
             .map_err(io_control_error)?;
-        let _ = registry.persist();
         if let Some(store) = &self.remote_bindings {
             let _ = store.remove(&p.session_id.0);
         }
@@ -1831,7 +1830,6 @@ impl ControlServer {
         registry
             .archive(&p.session_id.0)
             .map_err(io_control_error)?;
-        let _ = registry.persist();
         self.publish_updated(&registry, &p.session_id.0);
         Ok(json!({}))
     }
@@ -1842,7 +1840,6 @@ impl ControlServer {
         registry
             .unarchive(&p.session_id.0)
             .map_err(io_control_error)?;
-        let _ = registry.persist();
         self.publish_updated(&registry, &p.session_id.0);
         Ok(json!({}))
     }
@@ -2808,6 +2805,7 @@ pub(crate) fn new_record(id: &str, kind: &str, cwd: &str) -> diri_proto::Session
         status_evidence: None,
         needs_input: None,
         resumability: Resumability::Live,
+        capabilities: None,
         parent: None,
         created_at: now,
         updated_at: now,
@@ -3434,6 +3432,7 @@ mod tests {
             status_evidence: None,
             needs_input: None,
             resumability: Resumability::NotResumable,
+            capabilities: None,
             parent: None,
             created_at: DateMillis(0.0),
             updated_at: DateMillis(0.0),

--- a/diri/crates/diri-engine/src/detect/mod.rs
+++ b/diri/crates/diri-engine/src/detect/mod.rs
@@ -139,6 +139,34 @@ impl ManifestEngine {
         self.manifests.get(id)
     }
 
+    /// Resolves frontend verbs from the same manifest that owns launch and
+    /// status behavior. Unknown Agents get a conservative, lifecycle-only
+    /// answer rather than being guessed from their command text.
+    pub fn session_capabilities(
+        &self,
+        record: &diri_proto::SessionRecord,
+    ) -> diri_proto::SessionCapabilities {
+        self.manifest(record.effective_kind().id())
+            .and_then(|manifest| manifest.agent.as_ref())
+            .map_or_else(
+                || diri_proto::SessionCapabilities {
+                    resume: false,
+                    archive: !record.is_archived(),
+                    send_text: !record.is_archived()
+                        && !matches!(record.status, diri_proto::SessionStatus::Exited(_)),
+                    quick_approve: false,
+                    reliable_completion: false,
+                },
+                |agent| {
+                    agent.session_capabilities(
+                        record.resumability,
+                        &record.status,
+                        record.is_archived(),
+                    )
+                },
+            )
+    }
+
     pub fn ids(&self) -> Vec<&str> {
         self.manifests.keys().map(String::as_str).collect()
     }

--- a/diri/crates/diri-engine/src/lib.rs
+++ b/diri/crates/diri-engine/src/lib.rs
@@ -37,6 +37,7 @@ pub mod hooks;
 pub mod hosts;
 pub mod inject;
 pub mod legacy_remote;
+mod lifecycle;
 pub mod log;
 pub mod mcp;
 pub mod migrate;
@@ -46,6 +47,7 @@ pub mod registry;
 pub mod remote;
 pub mod screen;
 pub mod session;
+mod state_file;
 pub mod status;
 
 pub use control::ControlServer;

--- a/diri/crates/diri-engine/src/lifecycle.rs
+++ b/diri/crates/diri-engine/src/lifecycle.rs
@@ -1,0 +1,165 @@
+//! Pure session-lifecycle planning.
+//!
+//! The control server asks the Registry for one lifecycle operation; this
+//! module owns the record invariants for that operation. Process termination,
+//! persistence, and log cleanup stay in the Registry, while tests exercise the
+//! same small planning interface production uses.
+
+use std::io;
+
+use diri_proto::{DateMillis, ExitInfo, ExitReason, SessionRecord, SessionStatus};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LifecycleAction {
+    Archive,
+    Restore,
+    Remove,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct LifecyclePlan {
+    pub(crate) replacement: Option<SessionRecord>,
+    pub(crate) terminate_live_session: bool,
+    pub(crate) retain_for_reopen: bool,
+    pub(crate) delete_output_log: bool,
+}
+
+impl LifecyclePlan {
+    pub(crate) fn for_record(
+        record: &SessionRecord,
+        action: LifecycleAction,
+        now: DateMillis,
+    ) -> io::Result<Self> {
+        match action {
+            LifecycleAction::Archive => {
+                let mut replacement = record.clone();
+                replacement.archived_at = Some(now);
+                replacement.updated_at = now;
+                if !matches!(replacement.status, SessionStatus::Exited(_)) {
+                    replacement.status = SessionStatus::Exited(ExitInfo {
+                        reason: ExitReason::Archived,
+                        code: None,
+                        signal: None,
+                    });
+                }
+                replacement.needs_input = None;
+                Ok(Self {
+                    replacement: Some(replacement),
+                    terminate_live_session: true,
+                    retain_for_reopen: false,
+                    delete_output_log: false,
+                })
+            }
+            LifecycleAction::Restore => {
+                let mut replacement = record.clone();
+                replacement.archived_at = None;
+                replacement.updated_at = now;
+                Ok(Self {
+                    replacement: Some(replacement),
+                    terminate_live_session: false,
+                    retain_for_reopen: false,
+                    delete_output_log: false,
+                })
+            }
+            LifecycleAction::Remove => Ok(Self {
+                replacement: None,
+                terminate_live_session: true,
+                retain_for_reopen: true,
+                delete_output_log: true,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use diri_proto::{AgentKind, ProjectId, Resumability, SessionId, SessionStatus, TitleSource};
+
+    use super::*;
+
+    fn record() -> SessionRecord {
+        SessionRecord {
+            id: SessionId::new("session"),
+            kind: AgentKind::CODEX,
+            cwd: "/repo".into(),
+            project_id: ProjectId::new("project"),
+            worktree_path: None,
+            git_branch: None,
+            title: "Work".into(),
+            title_source: TitleSource::AgentProvided,
+            originating_prompt: None,
+            agent_session_id: Some("conversation".into()),
+            transcript_path: None,
+            status: SessionStatus::Working,
+            status_evidence: None,
+            needs_input: None,
+            resumability: Resumability::Live,
+            capabilities: None,
+            parent: None,
+            created_at: DateMillis(1.0),
+            updated_at: DateMillis(1.0),
+            last_turn_completed_at: None,
+            last_seen_at: None,
+            pinned: true,
+            archived_at: None,
+            host: None,
+            remote_persistence: None,
+            hibernation: None,
+            memory_bytes: None,
+            artifacts: None,
+            pull_requests: None,
+            listening_ports: None,
+            foreground_agent: None,
+        }
+    }
+
+    #[test]
+    fn archive_preserves_identity_and_clears_attention() {
+        let original = record();
+        let plan = LifecyclePlan::for_record(&original, LifecycleAction::Archive, DateMillis(42.0))
+            .expect("plan");
+        let archived = plan.replacement.expect("replacement");
+
+        assert_eq!(archived.id, original.id);
+        assert_eq!(archived.agent_session_id, original.agent_session_id);
+        assert_eq!(archived.archived_at, Some(DateMillis(42.0)));
+        assert!(matches!(
+            archived.status,
+            SessionStatus::Exited(ExitInfo {
+                reason: ExitReason::Archived,
+                ..
+            })
+        ));
+        assert!(plan.terminate_live_session);
+        assert!(!plan.delete_output_log);
+    }
+
+    #[test]
+    fn remove_is_the_only_plan_that_drops_identity_and_output() {
+        let plan = LifecyclePlan::for_record(&record(), LifecycleAction::Remove, DateMillis(42.0))
+            .expect("plan");
+
+        assert!(plan.replacement.is_none());
+        assert!(plan.terminate_live_session);
+        assert!(plan.retain_for_reopen);
+        assert!(plan.delete_output_log);
+    }
+
+    #[test]
+    fn archiving_an_ended_session_preserves_its_exit_evidence() {
+        let mut original = record();
+        original.status = SessionStatus::Exited(ExitInfo {
+            reason: ExitReason::Signaled,
+            code: None,
+            signal: Some(9),
+        });
+
+        let archived =
+            LifecyclePlan::for_record(&original, LifecycleAction::Archive, DateMillis(42.0))
+                .expect("plan")
+                .replacement
+                .expect("replacement");
+
+        assert_eq!(archived.status, original.status);
+    }
+}

--- a/diri/crates/diri-engine/src/registry.rs
+++ b/diri/crates/diri-engine/src/registry.rs
@@ -13,7 +13,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::detect::ManifestEngine;
 use crate::holder::{HolderClient, HolderManagerPaths, HolderPaths};
+use crate::lifecycle::{LifecycleAction, LifecyclePlan};
 use crate::session::{HolderConfig, RemoteAdoptSpec, Session, SessionSpec, SessionView};
+use crate::state_file::JsonStateFile;
 
 /// The versioned on-disk snapshot.
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -45,7 +47,7 @@ pub struct Registry {
     projects: Vec<serde_json::Value>,
     /// Sessions the user closed, newest last — the "reopen closed tab" stack.
     recently_closed: Vec<SessionRecord>,
-    state_file: PathBuf,
+    state_file: JsonStateFile,
     /// Trailing-edge persistence: a mutation inside the debounce window marks
     /// dirty instead of rewriting the whole file (mark-seen fires on every
     /// tab switch), and the flusher or the next persist call writes it out.
@@ -93,7 +95,7 @@ impl Registry {
             records: HashMap::new(),
             projects: Vec::new(),
             recently_closed: Vec::new(),
-            state_file: state_file.into(),
+            state_file: JsonStateFile::new(state_file),
             dirty: false,
             last_persist: None,
         }
@@ -105,12 +107,23 @@ impl Registry {
     /// ignored: treating it as a fresh install would make the next write
     /// overwrite every session record the user had.
     pub fn load(&mut self) -> std::io::Result<usize> {
-        let bytes = match std::fs::read(&self.state_file) {
-            Ok(bytes) => bytes,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        let document = match self.state_file.read() {
+            Ok(Some(document)) => document,
+            Ok(None) => return Ok(0),
+            Err(error) if error.kind() == std::io::ErrorKind::InvalidData => {
+                let quarantine = self.state_file.path().with_extension("json.corrupt");
+                let _ = std::fs::rename(self.state_file.path(), &quarantine);
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "state file did not parse ({error}); quarantined at {}",
+                        quarantine.display()
+                    ),
+                ));
+            }
             Err(error) => return Err(error),
         };
-        match serde_json::from_slice::<PersistedState>(&bytes) {
+        match serde_json::from_value::<PersistedState>(serde_json::Value::Object(document)) {
             Ok(state) => {
                 self.projects = state.projects;
                 let project_roots = self
@@ -143,8 +156,8 @@ impl Registry {
                 Ok(self.records.len())
             }
             Err(error) => {
-                let quarantine = self.state_file.with_extension("json.corrupt");
-                let _ = std::fs::rename(&self.state_file, &quarantine);
+                let quarantine = self.state_file.path().with_extension("json.corrupt");
+                let _ = std::fs::rename(self.state_file.path(), &quarantine);
                 Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
                     format!(
@@ -193,14 +206,19 @@ impl Registry {
     /// Writes the current state atomically, unconditionally.
     fn persist_now(&mut self) -> std::io::Result<()> {
         let state = PersistedState::current(self.records_for_persistence(), self.projects.clone());
-        let bytes = serde_json::to_vec(&state)?;
-        let temp = self.state_file.with_extension("json.tmp");
-        if let Some(parent) = self.state_file.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        std::fs::write(&temp, &bytes)?;
-        // Rename is atomic, so a crash mid-write cannot truncate the real file.
-        std::fs::rename(&temp, &self.state_file)?;
+        let known = serde_json::to_value(state)?;
+        let known = known
+            .as_object()
+            .expect("PersistedState serializes as an object");
+        self.state_file.update(|document| {
+            for key in ["version", "projects", "sessions"] {
+                document.insert(
+                    key.to_owned(),
+                    known.get(key).cloned().expect("known persistence key"),
+                );
+            }
+            Ok(())
+        })?;
         self.dirty = false;
         self.last_persist = Some(std::time::Instant::now());
         Ok(())
@@ -209,9 +227,7 @@ impl Registry {
     fn records_for_persistence(&self) -> Vec<SessionRecord> {
         let mut records: Vec<SessionRecord> = self.records.values().cloned().collect();
         for record in &mut records {
-            if let Some(session) = self.sessions.get(&record.id.0) {
-                fold_session_status(record, &session.view());
-            }
+            self.fold_live(record);
         }
         records.sort_by(|a, b| a.id.0.cmp(&b.id.0));
         records
@@ -425,34 +441,7 @@ impl Registry {
         if let Some(session) = self.sessions.get(&record.id.0) {
             fold_session_view(record, &session.view());
         }
-        // `Live` only records that the agent named its conversation while it
-        // was running. Once the session is gone the question every Resume
-        // affordance asks is a different one — can that conversation be
-        // re-entered — so answer it here rather than leaving a stale `Live`
-        // that reads as "not resumable" to each of them.
-        if matches!(record.status, SessionStatus::Exited(_))
-            && record.resumability == diri_proto::Resumability::Live
-        {
-            record.resumability = if self.can_reenter(record) {
-                diri_proto::Resumability::Resumable
-            } else {
-                diri_proto::Resumability::NotResumable
-            };
-        }
-    }
-
-    /// Whether this record's agent can be relaunched back into its own
-    /// conversation — a known conversation id plus a manifest that declares
-    /// how to resume one.
-    fn can_reenter(&self, record: &SessionRecord) -> bool {
-        let Some(agent_session_id) = record.agent_session_id.as_deref() else {
-            return false;
-        };
-        self.engine
-            .manifest(record.kind.id())
-            .and_then(|manifest| manifest.agent.as_ref())
-            .and_then(|agent| agent.resume_args(Some(agent_session_id)))
-            .is_some()
+        fold_record_lifecycle(&self.engine, record);
     }
 
     /// Diffs live sessions' state versions against `published` (updating it in
@@ -474,22 +463,31 @@ impl Registry {
                 (published.get(id) != Some(&version)).then(|| (id.clone(), version, session.view()))
             })
             .collect::<Vec<_>>();
-        let mut title_changed = false;
+        let mut persistence_changed = false;
         for (id, version, view) in changed_views {
             published.insert(id.clone(), version);
             if let Some(record) = self.records.get_mut(&id) {
-                let previous_title = (record.title.clone(), record.title_source);
+                let previous_persisted = (
+                    record.title.clone(),
+                    record.title_source,
+                    record.last_turn_completed_at,
+                );
                 fold_session_view(record, &view);
-                let record_title_changed =
-                    previous_title != (record.title.clone(), record.title_source);
-                if record_title_changed {
+                fold_record_lifecycle(&self.engine, record);
+                let record_persistence_changed = previous_persisted
+                    != (
+                        record.title.clone(),
+                        record.title_source,
+                        record.last_turn_completed_at,
+                    );
+                if record_persistence_changed {
                     record.updated_at = DateMillis::from(std::time::SystemTime::now());
-                    title_changed = true;
+                    persistence_changed = true;
                 }
                 changed.push((id, record.clone()));
             }
         }
-        if title_changed {
+        if persistence_changed {
             self.dirty = true;
         }
         changed
@@ -533,18 +531,31 @@ impl Registry {
     /// Ends the session (if live), deletes its record AND its output log.
     /// This is the user closing a tab for good, not archiving.
     pub fn remove(&mut self, id: &str, logs_dir: &Path) -> std::io::Result<()> {
-        if self.sessions.contains_key(id) {
-            let _ = self.terminate(id, std::time::Duration::from_millis(500));
+        let record = self.records.get(id).cloned().ok_or_else(|| not_found(id))?;
+        let plan = LifecyclePlan::for_record(
+            &record,
+            LifecycleAction::Remove,
+            DateMillis::from(std::time::SystemTime::now()),
+        )?;
+        self.state_file.verify_editable()?;
+        if plan.terminate_live_session && self.sessions.contains_key(id) {
+            self.terminate(id, std::time::Duration::from_millis(500))?;
         }
-        let Some(record) = self.records.remove(id) else {
-            return Err(not_found(id));
-        };
-        self.recently_closed.push(record);
-        if self.recently_closed.len() > 10 {
-            self.recently_closed.remove(0);
+        self.records.remove(id);
+        if plan.retain_for_reopen {
+            self.recently_closed.push(record.clone());
+            if self.recently_closed.len() > 10 {
+                self.recently_closed.remove(0);
+            }
         }
-        self.sessions.remove(id);
-        let _ = std::fs::remove_file(logs_dir.join(format!("{id}.bin")));
+        if let Err(error) = self.persist_now() {
+            self.records.insert(id.to_owned(), record);
+            self.recently_closed.retain(|closed| closed.id.0 != id);
+            return Err(error);
+        }
+        if plan.delete_output_log {
+            let _ = std::fs::remove_file(logs_dir.join(format!("{id}.bin")));
+        }
         Ok(())
     }
 
@@ -938,32 +949,45 @@ impl Registry {
     /// Ends the session but keeps its record on the shelf: kill-tree,
     /// keep-record, stamp `archivedAt`.
     pub fn archive(&mut self, id: &str) -> std::io::Result<()> {
-        if !self.records.contains_key(id) {
-            return Err(not_found(id));
+        let original = self.records.get(id).cloned().ok_or_else(|| not_found(id))?;
+        let plan = LifecyclePlan::for_record(
+            &original,
+            LifecycleAction::Archive,
+            DateMillis::from(std::time::SystemTime::now()),
+        )?;
+        self.state_file.verify_editable()?;
+        if plan.terminate_live_session && self.sessions.contains_key(id) {
+            self.terminate(id, std::time::Duration::from_millis(500))?;
         }
-        if self.sessions.contains_key(id) {
-            let _ = self.terminate(id, std::time::Duration::from_millis(500));
+        self.records.insert(
+            id.to_owned(),
+            plan.replacement.expect("archive keeps the record"),
+        );
+        if let Err(error) = self.persist_now() {
+            self.records.insert(id.to_owned(), original);
+            return Err(error);
         }
-        let record = self.records.get_mut(id).expect("checked above");
-        record.archived_at = Some(DateMillis::from(std::time::SystemTime::now()));
-        if !matches!(record.status, SessionStatus::Exited(_)) {
-            record.status = SessionStatus::Exited(diri_proto::ExitInfo {
-                reason: diri_proto::ExitReason::Archived,
-                code: None,
-                signal: None,
-            });
-        }
-        record.needs_input = None;
         Ok(())
     }
 
     pub fn unarchive(&mut self, id: &str) -> std::io::Result<()> {
-        let record = self.records.get_mut(id).ok_or_else(|| not_found(id))?;
-        if record.archived_at.is_none() {
+        let original = self.records.get(id).cloned().ok_or_else(|| not_found(id))?;
+        if original.archived_at.is_none() {
             return Ok(());
         }
-        record.archived_at = None;
-        record.updated_at = DateMillis::from(std::time::SystemTime::now());
+        let plan = LifecyclePlan::for_record(
+            &original,
+            LifecycleAction::Restore,
+            DateMillis::from(std::time::SystemTime::now()),
+        )?;
+        self.records.insert(
+            id.to_owned(),
+            plan.replacement.expect("restore keeps the record"),
+        );
+        if let Err(error) = self.persist_now() {
+            self.records.insert(id.to_owned(), original);
+            return Err(error);
+        }
         Ok(())
     }
 
@@ -990,7 +1014,7 @@ impl Registry {
     }
 
     pub fn state_file(&self) -> &Path {
-        &self.state_file
+        self.state_file.path()
     }
 }
 
@@ -1050,6 +1074,38 @@ fn fold_session_status(record: &mut SessionRecord, view: &SessionView) {
         .filter(|evidence| evidence.status == view.status)
         .cloned();
     record.needs_input.clone_from(&view.needs_input);
+    if view.last_turn_completed_at > record.last_turn_completed_at {
+        record.last_turn_completed_at = view.last_turn_completed_at;
+    }
+}
+
+/// Resolves status-dependent facts at the one seam shared by snapshots and
+/// incremental events, so clients never have to reconstruct Agent behavior.
+fn fold_record_lifecycle(engine: &ManifestEngine, record: &mut SessionRecord) {
+    // `Live` only records that the agent named its conversation while it was
+    // running. After exit, Resume needs the stronger answer: whether that
+    // conversation can actually be re-entered through its manifest.
+    if matches!(record.status, SessionStatus::Exited(_))
+        && record.resumability == diri_proto::Resumability::Live
+    {
+        record.resumability = if can_reenter(engine, record) {
+            diri_proto::Resumability::Resumable
+        } else {
+            diri_proto::Resumability::NotResumable
+        };
+    }
+    record.capabilities = Some(engine.session_capabilities(record));
+}
+
+fn can_reenter(engine: &ManifestEngine, record: &SessionRecord) -> bool {
+    let Some(agent_session_id) = record.agent_session_id.as_deref() else {
+        return false;
+    };
+    engine
+        .manifest(record.kind.id())
+        .and_then(|manifest| manifest.agent.as_ref())
+        .and_then(|agent| agent.resume_args(Some(agent_session_id)))
+        .is_some()
 }
 
 fn normalize_agent_title(title: &str) -> Option<String> {
@@ -1128,6 +1184,7 @@ mod tests {
             status_evidence: None,
             needs_input: None,
             resumability: Resumability::NotResumable,
+            capabilities: None,
             parent: None,
             created_at: DateMillis(0.0),
             updated_at: DateMillis(0.0),
@@ -1242,6 +1299,27 @@ mod tests {
         assert_eq!(current.git_branch, original.git_branch);
         assert_eq!(current.updated_at, original.updated_at);
         assert!(!registry.dirty, "failed edit must not be flushed later");
+    }
+
+    #[test]
+    fn destructive_lifecycle_edits_stop_before_unwritable_state() {
+        let temp = tempfile::tempdir().expect("temp");
+        let blocked_parent = temp.path().join("not-a-directory");
+        std::fs::write(&blocked_parent, b"file").expect("blocking file");
+        let mut registry = Registry::new(engine(), blocked_parent.join("state.json"));
+        let original = record("guarded");
+        registry.insert_record(original.clone());
+
+        registry
+            .archive("guarded")
+            .expect_err("archive must not outrun persistence");
+        assert_eq!(registry.records.get("guarded"), Some(&original));
+
+        registry
+            .remove("guarded", temp.path())
+            .expect_err("remove must not outrun persistence");
+        assert_eq!(registry.records.get("guarded"), Some(&original));
+        assert!(registry.recently_closed.is_empty());
     }
 
     #[test]
@@ -1581,6 +1659,27 @@ mod tests {
     }
 
     #[test]
+    fn unknown_top_level_state_survives_a_registry_write() {
+        let temp = tempfile::tempdir().expect("temp");
+        let state_file = temp.path().join("state.json");
+        std::fs::write(
+            &state_file,
+            br#"{"version":1,"projects":[],"sessions":[],"future":{"theme":"plum"}}"#,
+        )
+        .expect("write");
+
+        let mut registry = Registry::new(engine(), &state_file);
+        registry.load().expect("load");
+        registry.insert_record(record("new"));
+        registry.persist().expect("persist");
+
+        let raw: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&state_file).expect("read")).expect("parse");
+        assert_eq!(raw["future"], serde_json::json!({"theme": "plum"}));
+        assert_eq!(raw["sessions"][0]["id"], "new");
+    }
+
+    #[test]
     fn project_identity_includes_the_execution_host() {
         let local = session_project_id("/workspace/app", None);
         let forge = session_project_id("/workspace/app", Some("forge"));
@@ -1723,6 +1822,7 @@ mod tests {
             status: SessionStatus::Working,
             status_evidence: None,
             needs_input: None,
+            last_turn_completed_at: None,
             title: Some("Repair remote attach".to_owned()),
             title_source: Some(TitleSource::AgentProvided),
             tail_offset: 0,
@@ -1784,5 +1884,27 @@ mod tests {
         assert!(repair_persisted_agent_title(&mut decorated));
         assert_eq!(decorated.title, AgentKind::CLAUDE_CODE_ID);
         assert_eq!(decorated.title_source, TitleSource::Placeholder);
+    }
+
+    #[test]
+    fn completed_turn_time_folds_into_attention_state() {
+        let mut session = record("completed");
+        session.status = SessionStatus::Working;
+        let view = SessionView {
+            id: "completed".to_owned(),
+            status: SessionStatus::Idle,
+            status_evidence: None,
+            needs_input: None,
+            last_turn_completed_at: Some(DateMillis(2_000.0)),
+            title: None,
+            title_source: None,
+            tail_offset: 0,
+            exited: false,
+        };
+
+        fold_session_status(&mut session, &view);
+
+        assert_eq!(session.last_turn_completed_at, Some(DateMillis(2_000.0)));
+        assert_eq!(session.attention(), diri_proto::AttentionLevel::DoneUnseen);
     }
 }

--- a/diri/crates/diri-engine/src/remote/client.rs
+++ b/diri/crates/diri-engine/src/remote/client.rs
@@ -15,6 +15,7 @@ use diri_proto::remote_pty::{
 };
 
 use super::binding::RemoteBindingStore;
+use super::effect::{EffectOutcome, EffectWriteError, write_at_most_once};
 use super::manager::{InstalledHelper, RemoteManager};
 
 const MAX_QUEUED_INPUT: usize = 1024 * 1024;
@@ -158,7 +159,15 @@ impl RemoteSessionClient {
         }
         if !writer.queued_input.is_empty() {
             let bytes = std::mem::take(&mut writer.queued_input);
-            write_message(&mut writer, &RemoteMessage::Terminal(Frame::input(bytes)))?;
+            if let Err(error) = write_effect_message(
+                &mut writer,
+                &RemoteMessage::Terminal(Frame::input(bytes.clone())),
+            ) {
+                if error.outcome() == EffectOutcome::NotApplied {
+                    writer.queued_input = bytes;
+                }
+                return Err(error.into());
+            }
         }
         Ok(())
     }
@@ -205,12 +214,17 @@ impl RemoteSessionClient {
             return queue_input(&mut writer, bytes);
         }
         let frame = terminal_input_frame(self.helper.protocol, bytes, mouse);
-        if let Err(error) = write_message(&mut writer, &RemoteMessage::Terminal(frame)) {
-            queue_input(&mut writer, bytes)?;
+        if let Err(error) = write_effect_message(&mut writer, &RemoteMessage::Terminal(frame)) {
+            let outcome = error.outcome();
+            let queue_result =
+                (outcome == EffectOutcome::NotApplied).then(|| queue_input(&mut writer, bytes));
             terminate_current(&mut writer);
             writer.controller_epoch = None;
-            let _ = error;
-            return Ok(());
+            return if outcome == EffectOutcome::NotApplied {
+                queue_result.expect("not-applied writes retain input")
+            } else {
+                Err(error.into())
+            };
         }
         Ok(())
     }
@@ -244,13 +258,14 @@ impl RemoteSessionClient {
                 "remote controller is reconnecting",
             )
         })?;
-        write_message(
+        write_effect_message(
             &mut writer,
             &RemoteMessage::Signal(Signal {
                 controller_epoch: epoch,
                 signal,
             }),
         )
+        .map_err(Into::into)
     }
 
     pub fn kill(&self) -> io::Result<()> {
@@ -403,6 +418,21 @@ fn write_message(writer: &mut WriterState, message: &RemoteMessage) -> io::Resul
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotConnected, "SSH channel is closed"))?;
     input.write_all(&encoded)?;
     input.flush()
+}
+
+fn write_effect_message(
+    writer: &mut WriterState,
+    message: &RemoteMessage,
+) -> Result<(), EffectWriteError> {
+    let encoded = RemoteCodec::encode(message)
+        .map_err(|error| EffectWriteError::not_applied(io::Error::other(error)))?;
+    let input = writer.input.as_mut().ok_or_else(|| {
+        EffectWriteError::not_applied(io::Error::new(
+            io::ErrorKind::NotConnected,
+            "SSH channel is closed",
+        ))
+    })?;
+    write_at_most_once(input, &encoded)
 }
 
 fn terminal_input_frame(protocol: ProtocolVersion, bytes: &[u8], mouse: bool) -> Frame {

--- a/diri/crates/diri-engine/src/remote/effect.rs
+++ b/diri/crates/diri-engine/src/remote/effect.rs
@@ -1,0 +1,172 @@
+//! At-most-once writes for remote side effects.
+//!
+//! A failed write before any byte was accepted is safe to retry. Once even one
+//! byte was accepted, the Holder may have applied the complete frame while the
+//! acknowledgement path failed; replaying it could duplicate input or a
+//! signal. This module makes that distinction explicit and testable.
+
+use std::fmt;
+use std::io::{self, Write};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum EffectOutcome {
+    NotApplied,
+    Unknown,
+}
+
+#[derive(Debug)]
+pub(crate) struct EffectWriteError {
+    outcome: EffectOutcome,
+    source: io::Error,
+}
+
+impl EffectWriteError {
+    pub(crate) fn not_applied(source: io::Error) -> Self {
+        Self {
+            outcome: EffectOutcome::NotApplied,
+            source,
+        }
+    }
+
+    pub(crate) fn outcome(&self) -> EffectOutcome {
+        self.outcome
+    }
+}
+
+impl fmt::Display for EffectWriteError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.outcome {
+            EffectOutcome::NotApplied => {
+                write!(formatter, "remote effect was not applied: {}", self.source)
+            }
+            EffectOutcome::Unknown => write!(
+                formatter,
+                "remote effect outcome is unknown and must not be retried: {}",
+                self.source
+            ),
+        }
+    }
+}
+
+impl std::error::Error for EffectWriteError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+impl From<EffectWriteError> for io::Error {
+    fn from(error: EffectWriteError) -> Self {
+        io::Error::other(error)
+    }
+}
+
+pub(crate) fn write_at_most_once(
+    writer: &mut impl Write,
+    bytes: &[u8],
+) -> Result<(), EffectWriteError> {
+    let mut written = 0;
+    while written < bytes.len() {
+        match writer.write(&bytes[written..]) {
+            Ok(0) => {
+                return Err(classify(
+                    written,
+                    io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "remote effect write returned zero",
+                    ),
+                ));
+            }
+            Ok(count) => written += count,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(classify(written, error)),
+        }
+    }
+    writer.flush().map_err(|error| EffectWriteError {
+        // All bytes entered the transport, so the Holder may have applied them.
+        outcome: EffectOutcome::Unknown,
+        source: error,
+    })
+}
+
+fn classify(written: usize, source: io::Error) -> EffectWriteError {
+    EffectWriteError {
+        outcome: if written == 0 {
+            EffectOutcome::NotApplied
+        } else {
+            EffectOutcome::Unknown
+        },
+        source,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FailingWriter {
+        accept: usize,
+        accepted: usize,
+        fail_flush: bool,
+    }
+
+    impl Write for FailingWriter {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            if self.accepted >= self.accept {
+                return Err(io::Error::new(io::ErrorKind::BrokenPipe, "disconnected"));
+            }
+            let count = bytes.len().min(self.accept - self.accepted);
+            self.accepted += count;
+            Ok(count)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            if self.fail_flush {
+                Err(io::Error::new(io::ErrorKind::BrokenPipe, "lost receipt"))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    #[test]
+    fn failure_before_the_first_byte_is_safe_to_retry() {
+        let error = write_at_most_once(
+            &mut FailingWriter {
+                accept: 0,
+                accepted: 0,
+                fail_flush: false,
+            },
+            b"effect",
+        )
+        .expect_err("write fails");
+        assert_eq!(error.outcome(), EffectOutcome::NotApplied);
+    }
+
+    #[test]
+    fn partial_write_has_an_unknown_outcome() {
+        let error = write_at_most_once(
+            &mut FailingWriter {
+                accept: 2,
+                accepted: 0,
+                fail_flush: false,
+            },
+            b"effect",
+        )
+        .expect_err("write fails");
+        assert_eq!(error.outcome(), EffectOutcome::Unknown);
+    }
+
+    #[test]
+    fn a_lost_flush_receipt_has_an_unknown_outcome() {
+        let error = write_at_most_once(
+            &mut FailingWriter {
+                accept: usize::MAX,
+                accepted: 0,
+                fail_flush: true,
+            },
+            b"effect",
+        )
+        .expect_err("flush fails");
+        assert_eq!(error.outcome(), EffectOutcome::Unknown);
+    }
+}

--- a/diri/crates/diri-engine/src/remote/mod.rs
+++ b/diri/crates/diri-engine/src/remote/mod.rs
@@ -11,9 +11,11 @@ use diri_proto::ControlError;
 pub mod binding;
 pub mod bootstrap;
 pub mod client;
+mod effect;
 pub mod executor;
 pub mod manager;
 pub mod ssh;
+pub(crate) mod stream;
 
 pub const TRANSPORT_UNAVAILABLE_CODE: &str = "remote_transport_unavailable";
 

--- a/diri/crates/diri-engine/src/remote/stream.rs
+++ b/diri/crates/diri-engine/src/remote/stream.rs
@@ -1,0 +1,54 @@
+//! Pure reconciliation for offset-addressed remote output frames.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum OutputFrameAction {
+    Feed,
+    FeedSuffix { drop_leading: usize },
+    Skip,
+    Gap { from: u64, up_to: u64 },
+}
+
+pub(crate) fn reconcile_output_frame(
+    held: u64,
+    frame_offset: u64,
+    frame_length: usize,
+) -> OutputFrameAction {
+    if frame_offset == held {
+        return OutputFrameAction::Feed;
+    }
+    if frame_offset > held {
+        return OutputFrameAction::Gap {
+            from: held,
+            up_to: frame_offset,
+        };
+    }
+    let frame_end = frame_offset.saturating_add(frame_length as u64);
+    if frame_end <= held {
+        return OutputFrameAction::Skip;
+    }
+    OutputFrameAction::FeedSuffix {
+        drop_leading: held.saturating_sub(frame_offset) as usize,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_duplicate_overlap_and_gap_are_distinct() {
+        assert_eq!(reconcile_output_frame(10, 10, 5), OutputFrameAction::Feed);
+        assert_eq!(reconcile_output_frame(10, 0, 10), OutputFrameAction::Skip);
+        assert_eq!(
+            reconcile_output_frame(10, 8, 5),
+            OutputFrameAction::FeedSuffix { drop_leading: 2 }
+        );
+        assert_eq!(
+            reconcile_output_frame(10, 14, 5),
+            OutputFrameAction::Gap {
+                from: 10,
+                up_to: 14
+            }
+        );
+    }
+}

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -43,6 +43,7 @@ use crate::pty::{Exit, Pty, PtySpec};
 use crate::remote::binding::{RemoteBinding, RemoteBindingStore};
 use crate::remote::client::RemoteSessionClient;
 use crate::remote::manager::{InstalledHelper, RemoteManager};
+use crate::remote::stream::{OutputFrameAction, reconcile_output_frame};
 use crate::screen::HeadlessScreen;
 use crate::status::{Authority, ClaudeHook, ReducerOutcome, StatusReducer, StatusSignal};
 
@@ -188,6 +189,7 @@ pub struct SessionView {
     pub status: SessionStatus,
     pub status_evidence: Option<diri_proto::StatusEvidence>,
     pub needs_input: Option<NeedsInputDetail>,
+    pub last_turn_completed_at: Option<diri_proto::DateMillis>,
     pub title: Option<String>,
     pub title_source: Option<diri_proto::TitleSource>,
     pub tail_offset: u64,
@@ -252,6 +254,7 @@ struct Shared {
     id: String,
     status: Mutex<SessionStatus>,
     needs_input: Mutex<Option<NeedsInputDetail>>,
+    last_turn_completed_at: Mutex<Option<diri_proto::DateMillis>>,
     title: Mutex<Option<String>>,
     prompt_title: Mutex<Option<String>>,
     prompt_input: Mutex<PromptInputState>,
@@ -1101,6 +1104,11 @@ impl Session {
                 .evidence()
                 .cloned(),
             needs_input: self.shared.needs_input.lock().expect("needs input").clone(),
+            last_turn_completed_at: *self
+                .shared
+                .last_turn_completed_at
+                .lock()
+                .expect("last turn completed"),
             title,
             title_source,
             tail_offset: self.shared.log.lock().expect("log").tail_offset(),
@@ -1732,6 +1740,7 @@ fn new_shared(spec: &SessionSpec, log: OutputLog, engine: &ManifestEngine) -> Ar
         id: spec.id.clone(),
         status: Mutex::new(SessionStatus::Starting),
         needs_input: Mutex::new(None),
+        last_turn_completed_at: Mutex::new(None),
         title: Mutex::new(None),
         prompt_title: Mutex::new(None),
         prompt_input: Mutex::new(PromptInputState::default()),
@@ -1818,6 +1827,13 @@ fn apply(shared: &Shared, outcome: &ReducerOutcome) {
             *current = Some(detail.clone());
             changed = true;
         }
+    }
+    if outcome.turn_completed {
+        *shared
+            .last_turn_completed_at
+            .lock()
+            .expect("last turn completed") = Some(diri_proto::DateMillis::from(SystemTime::now()));
+        changed = true;
     }
     // The reducer already suppresses evidence with unchanged structured
     // meaning, so an emitted value always warrants a record/UI refresh.
@@ -2085,8 +2101,7 @@ fn handle_remote_message(
                 let Some((offset, bytes)) = frame.output_payload() else {
                     return RemoteConnectionDisposition::Fatal;
                 };
-                client.observe_output_offset(offset.saturating_add(bytes.len() as u64));
-                apply_remote_output(
+                match apply_remote_output(
                     shared,
                     engine,
                     manifest_id,
@@ -2094,8 +2109,13 @@ fn handle_remote_message(
                     offset,
                     bytes,
                     *replaying,
-                );
-                RemoteConnectionDisposition::Continue
+                ) {
+                    Some(next_offset) => {
+                        client.observe_output_offset(next_offset);
+                        RemoteConnectionDisposition::Continue
+                    }
+                    None => RemoteConnectionDisposition::Reconnect,
+                }
             }
             _ => RemoteConnectionDisposition::Fatal,
         },
@@ -2149,24 +2169,32 @@ fn apply_remote_output(
     offset: u64,
     bytes: &[u8],
     replaying: bool,
-) {
+) -> Option<u64> {
     let expected = shared.remote_output_offset.load(Ordering::SeqCst);
     let end = offset.saturating_add(bytes.len() as u64);
-    if end <= expected {
-        return;
-    }
-    let skip = expected.saturating_sub(offset).min(bytes.len() as u64) as usize;
-    let bytes = &bytes[skip..];
+    let bytes = match reconcile_output_frame(expected, offset, bytes.len()) {
+        OutputFrameAction::Feed => bytes,
+        OutputFrameAction::FeedSuffix { drop_leading } => &bytes[drop_leading..],
+        OutputFrameAction::Skip => return Some(expected),
+        // Replay is bounded by the Holder. If older bytes have already fallen
+        // out of that bound, the FullSnapshot queued after ReplayEnd is the
+        // authoritative recovery. A gap in the live stream instead means the
+        // connection must be reseeded before more output is consumed.
+        OutputFrameAction::Gap { .. } if replaying => bytes,
+        OutputFrameAction::Gap { .. } => return None,
+    };
     if bytes.is_empty() {
-        return;
+        return Some(expected);
     }
     shared.remote_output_offset.store(end, Ordering::SeqCst);
     let _ = shared.log.lock().expect("log").append(bytes);
-    let observation = {
-        let mut screen = shared.screen.lock().expect("screen");
-        screen.feed(bytes);
-        evaluate_if_screen_changed(shared, &mut screen, engine, manifest_id, last_eval_seq)
-    };
+    let observation = (!replaying)
+        .then(|| {
+            let mut screen = shared.screen.lock().expect("screen");
+            screen.feed(bytes);
+            evaluate_if_screen_changed(shared, &mut screen, engine, manifest_id, last_eval_seq)
+        })
+        .flatten();
     let now = SystemTime::now();
     let mut reducer = shared.reducer.lock().expect("reducer");
     if !replaying {
@@ -2178,6 +2206,7 @@ fn apply_remote_output(
         drop(reducer);
         apply(shared, &outcome);
     }
+    Some(end)
 }
 
 fn apply_remote_snapshot(

--- a/diri/crates/diri-engine/src/state_file.rs
+++ b/diri/crates/diri-engine/src/state_file.rs
@@ -1,0 +1,216 @@
+//! Guarded access to the Engine's shared JSON state file.
+//!
+//! Atomic rename prevents torn documents; the adjacent advisory lock prevents
+//! interleaved writes when compatible processes update disjoint owned keys at
+//! the same time. Callers update only the keys they own, so fields written by
+//! a newer Engine or another frontend survive unchanged.
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde_json::{Map, Value};
+
+pub(crate) struct JsonStateFile {
+    path: PathBuf,
+}
+
+impl JsonStateFile {
+    pub(crate) fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Reads one complete document. A missing file is a fresh install; a file
+    /// that exists but cannot be understood is an error and must not be
+    /// replaced with an empty state.
+    pub(crate) fn read(&self) -> io::Result<Option<Map<String, Value>>> {
+        read_object(&self.path)
+    }
+
+    /// Verifies that a destructive lifecycle operation can safely begin. This
+    /// catches an unreadable/corrupt document before a process is terminated;
+    /// the subsequent update still repeats the check under the same lock rules.
+    pub(crate) fn verify_editable(&self) -> io::Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let _lock = FileLock::exclusive(&self.path)?;
+        let _ = read_object(&self.path)?;
+        Ok(())
+    }
+
+    /// Locks, reloads, mutates, and atomically replaces the document. Reloading
+    /// after acquiring the lock is what preserves another writer's completed
+    /// update instead of applying the mutation to a stale startup snapshot.
+    pub(crate) fn update(
+        &self,
+        mutate: impl FnOnce(&mut Map<String, Value>) -> io::Result<()>,
+    ) -> io::Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let _lock = FileLock::exclusive(&self.path)?;
+        let mut document = read_object(&self.path)?.unwrap_or_default();
+        mutate(&mut document)?;
+        write_object(&self.path, &document)
+    }
+}
+
+fn read_object(path: &Path) -> io::Result<Option<Map<String, Value>>> {
+    let bytes = match std::fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let value: Value = serde_json::from_slice(&bytes)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    value.as_object().cloned().map(Some).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "state file root is not a JSON object",
+        )
+    })
+}
+
+fn write_object(path: &Path, document: &Map<String, Value>) -> io::Result<()> {
+    static NEXT_TEMPORARY: AtomicU64 = AtomicU64::new(0);
+
+    let body = serde_json::to_vec(&Value::Object(document.clone()))?;
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("state.json");
+    let temporary = path.with_file_name(format!(
+        ".{file_name}.tmp-{}-{}",
+        std::process::id(),
+        NEXT_TEMPORARY.fetch_add(1, Ordering::Relaxed)
+    ));
+    let mut options = OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(&temporary)?;
+    if let Err(error) = file.write_all(&body).and_then(|()| file.sync_all()) {
+        drop(file);
+        let _ = std::fs::remove_file(&temporary);
+        return Err(error);
+    }
+    drop(file);
+    if let Err(error) = std::fs::rename(&temporary, path) {
+        let _ = std::fs::remove_file(temporary);
+        return Err(error);
+    }
+    Ok(())
+}
+
+struct FileLock(#[allow(dead_code)] File);
+
+impl FileLock {
+    fn exclusive(target: &Path) -> io::Result<Self> {
+        let lock_path = target.with_extension("lock");
+        let mut options = OpenOptions::new();
+        options.create(true).truncate(false).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let file = options.open(lock_path)?;
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+            if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } != 0 {
+                return Err(io::Error::last_os_error());
+            }
+        }
+        Ok(Self(file))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Barrier};
+
+    use super::*;
+
+    #[test]
+    fn update_refuses_to_clobber_an_unparseable_document() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let path = directory.path().join("state.json");
+        std::fs::write(&path, b"{ not json").expect("broken fixture");
+        let state = JsonStateFile::new(&path);
+
+        let error = state
+            .update(|document| {
+                document.insert("sessions".into(), Value::Array(Vec::new()));
+                Ok(())
+            })
+            .expect_err("broken state must be preserved");
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(
+            std::fs::read(path).expect("original remains"),
+            b"{ not json"
+        );
+    }
+
+    #[test]
+    fn update_preserves_keys_the_caller_does_not_own() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let path = directory.path().join("state.json");
+        std::fs::write(
+            &path,
+            br#"{"version":1,"sessions":[],"future":{"theme":"plum"}}"#,
+        )
+        .expect("fixture");
+        let state = JsonStateFile::new(&path);
+
+        state
+            .update(|document| {
+                document.insert("sessions".into(), serde_json::json!([{"id":"new"}]));
+                Ok(())
+            })
+            .expect("update");
+
+        let written = state.read().expect("read").expect("document");
+        assert_eq!(written["future"], serde_json::json!({"theme":"plum"}));
+        assert_eq!(written["sessions"][0]["id"], "new");
+    }
+
+    #[test]
+    fn concurrent_disjoint_updates_do_not_lose_each_other() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let state = Arc::new(JsonStateFile::new(directory.path().join("state.json")));
+        let barrier = Arc::new(Barrier::new(3));
+        let mut writers = Vec::new();
+        for (key, value) in [("desktop", 1), ("cli", 2)] {
+            let state = Arc::clone(&state);
+            let barrier = Arc::clone(&barrier);
+            writers.push(std::thread::spawn(move || {
+                barrier.wait();
+                state
+                    .update(|document| {
+                        document.insert(key.into(), Value::from(value));
+                        Ok(())
+                    })
+                    .expect("concurrent update");
+            }));
+        }
+        barrier.wait();
+        for writer in writers {
+            writer.join().expect("writer");
+        }
+
+        let written = state.read().expect("read").expect("document");
+        assert_eq!(written["desktop"], 1);
+        assert_eq!(written["cli"], 2);
+    }
+}

--- a/diri/crates/diri-engine/src/status/mod.rs
+++ b/diri/crates/diri-engine/src/status/mod.rs
@@ -47,6 +47,12 @@ pub struct ReducerTiming {
     pub hook_authority_window: Duration,
     pub blocker_clear_scans: u32,
     pub staleness_timeout: Duration,
+    /// Ignore the terminal's ordinary repaint immediately after Codex reports
+    /// completion. Output after this grace means the turn was not actually
+    /// settled yet and re-arms working without completing the turn twice.
+    pub codex_stop_rearm_grace: Duration,
+    /// A late repaint should not resurrect an old, genuinely idle turn.
+    pub codex_stop_rearm_window: Duration,
 }
 
 impl Default for ReducerTiming {
@@ -59,6 +65,8 @@ impl Default for ReducerTiming {
             hook_authority_window: Duration::from_secs(7),
             blocker_clear_scans: 2,
             staleness_timeout: Duration::from_secs(60),
+            codex_stop_rearm_grace: Duration::from_secs(5),
+            codex_stop_rearm_window: Duration::from_secs(90),
         }
     }
 }
@@ -139,6 +147,9 @@ struct InternalState {
     idle_strong: bool,
     /// Fire `turn_completed` exactly once on the next committed working→idle.
     pending_turn_completed: bool,
+    /// The last strong Codex completion signal. Kept briefly so sufficiently
+    /// late PTY output can correct an optimistic idle decision.
+    last_codex_completion_at: Option<SystemTime>,
 
     // On-screen blocker tracking.
     screen_blocker_active: bool,
@@ -168,6 +179,7 @@ impl InternalState {
             idle_confirms: 0,
             idle_strong: false,
             pending_turn_completed: false,
+            last_codex_completion_at: None,
             screen_blocker_active: false,
             blocker_miss_scans: 0,
             screen_belief: None,
@@ -316,12 +328,20 @@ impl StatusReducer {
         match signal {
             StatusSignal::ProcessExit { .. } => {} // handled above
             StatusSignal::PtyOutputActivity => {
-                // Refreshes the recency of `working`; for full status models it
-                // never by itself means work is happening.
+                // PTY activity is normally recency-only for full status
+                // models. One exception matters: Codex can report completion
+                // before its terminal has truly settled. A repaint outside the
+                // short grace period re-arms working, but keeps the completed
+                // turn consumed so callers do not notify twice.
+                if self.status == SessionStatus::Idle && self.codex_output_rearms_working(now) {
+                    self.cancel_idle_candidacy();
+                    self.set_status(SessionStatus::Working, &mut outcome);
+                }
                 self.state.last_signal_at = now;
             }
             StatusSignal::UserKeystroke => {
                 self.state.last_signal_at = now;
+                self.state.last_codex_completion_at = None;
                 if matches!(self.status, SessionStatus::NeedsInput(_)) {
                     self.state.responding_since = Some(now);
                 }
@@ -331,6 +351,9 @@ impl StatusReducer {
             }
             StatusSignal::CodexTurnComplete => {
                 self.state.last_signal_at = now;
+                if self.status == SessionStatus::Working {
+                    self.state.last_codex_completion_at = Some(now);
+                }
                 self.handle_strong_idle(now, &mut outcome);
             }
             StatusSignal::Screen(observation) => self.handle_screen(observation, now, &mut outcome),
@@ -483,8 +506,21 @@ impl StatusReducer {
             self.state.blocker_miss_scans = 0;
         }
         self.state.turn_in_flight = true;
+        self.state.last_codex_completion_at = None;
         self.state.last_signal_at = now;
         self.set_status(SessionStatus::Working, outcome);
+    }
+
+    fn codex_output_rearms_working(&mut self, now: SystemTime) -> bool {
+        let Some(completed_at) = self.state.last_codex_completion_at else {
+            return false;
+        };
+        let elapsed = now.duration_since(completed_at).unwrap_or_default();
+        if elapsed > self.timing.codex_stop_rearm_window {
+            self.state.last_codex_completion_at = None;
+            return false;
+        }
+        elapsed >= self.timing.codex_stop_rearm_grace
     }
 
     /// A strong idle signal. Commits immediately when the screen already reads

--- a/diri/crates/diri-engine/src/status/tests.rs
+++ b/diri/crates/diri-engine/src/status/tests.rs
@@ -473,6 +473,55 @@ fn codex_turn_complete_then_a_tick_settles_to_idle() {
 }
 
 #[test]
+fn late_codex_output_rearms_working_without_completing_twice() {
+    let mut reducer = StatusReducer::new(Authority::ScreenPrimary, t0());
+    let now = settled(&mut reducer, t0());
+    reducer.reduce(
+        StatusSignal::Screen(observation(ManifestState::Working, 1)),
+        now,
+    );
+
+    let completed_at = now + Duration::from_millis(100);
+    reducer.reduce(StatusSignal::CodexTurnComplete, completed_at);
+    let settled = reducer.reduce(
+        StatusSignal::Tick,
+        completed_at + Duration::from_millis(100),
+    );
+    assert_eq!(settled.status_change, Some(SessionStatus::Idle));
+    assert!(settled.turn_completed);
+
+    let repaint = reducer.reduce(
+        StatusSignal::PtyOutputActivity,
+        completed_at + Duration::from_secs(4),
+    );
+    assert_eq!(
+        repaint.status_change, None,
+        "ordinary stop repaint is ignored"
+    );
+
+    let continuing = reducer.reduce(
+        StatusSignal::PtyOutputActivity,
+        completed_at + Duration::from_secs(6),
+    );
+    assert_eq!(continuing.status_change, Some(SessionStatus::Working));
+    assert!(!continuing.turn_completed);
+
+    reducer.reduce(
+        StatusSignal::CodexTurnComplete,
+        completed_at + Duration::from_secs(7),
+    );
+    let settled_again = reducer.reduce(
+        StatusSignal::Tick,
+        completed_at + Duration::from_secs(7) + Duration::from_millis(100),
+    );
+    assert_eq!(settled_again.status_change, Some(SessionStatus::Idle));
+    assert!(
+        !settled_again.turn_completed,
+        "rearming the same logical turn must not notify twice"
+    );
+}
+
+#[test]
 fn a_process_only_agent_goes_working_on_first_output_then_exits() {
     let mut reducer = StatusReducer::new(Authority::ProcessOnly, t0());
     let now = t0() + Duration::from_secs(1);

--- a/diri/crates/diri-engine/tests/checkpoint.rs
+++ b/diri/crates/diri-engine/tests/checkpoint.rs
@@ -75,6 +75,7 @@ fn record(id: &str) -> diri_proto::SessionRecord {
         status_evidence: None,
         needs_input: None,
         resumability: Resumability::NotResumable,
+        capabilities: None,
         parent: None,
         created_at: DateMillis(0.0),
         updated_at: DateMillis(0.0),

--- a/diri/crates/diri-engine/tests/holder_session.rs
+++ b/diri/crates/diri-engine/tests/holder_session.rs
@@ -214,6 +214,7 @@ fn record(id: &str) -> diri_proto::SessionRecord {
         status_evidence: None,
         needs_input: None,
         resumability: Resumability::NotResumable,
+        capabilities: None,
         parent: None,
         created_at: DateMillis(0.0),
         updated_at: DateMillis(0.0),

--- a/diri/crates/diri-engine/tests/legacy_remote.rs
+++ b/diri/crates/diri-engine/tests/legacy_remote.rs
@@ -57,6 +57,7 @@ fn record(id: &str, host: Option<&str>, agent_session_id: Option<&str>) -> Sessi
         status_evidence: None,
         needs_input: None,
         resumability: Resumability::Live,
+        capabilities: None,
         parent: None,
         created_at: DateMillis(0.0),
         updated_at: DateMillis(0.0),

--- a/diri/crates/diri-engine/tests/mcp_tools.rs
+++ b/diri/crates/diri-engine/tests/mcp_tools.rs
@@ -50,6 +50,7 @@ fn record(id: &str, parent: Option<&str>) -> SessionRecord {
         status_evidence: None,
         needs_input: None,
         resumability: Resumability::Live,
+        capabilities: None,
         parent: parent.map(|value| SessionId(value.into())),
         created_at: DateMillis(0.0),
         updated_at: DateMillis(0.0),

--- a/diri/crates/diri-proto/src/model.rs
+++ b/diri/crates/diri-proto/src/model.rs
@@ -693,6 +693,21 @@ pub struct PortInfo {
     pub process_name: String,
 }
 
+/// Verbs the authoritative Engine has resolved for one concrete session.
+///
+/// Clients consume this value instead of re-parsing commands or hard-coding
+/// Agent names. The field on [`SessionRecord`] is optional so an older Engine
+/// still degrades to the established resumability behavior.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionCapabilities {
+    pub resume: bool,
+    pub archive: bool,
+    pub send_text: bool,
+    pub quick_approve: bool,
+    pub reliable_completion: bool,
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionRecord {
@@ -724,6 +739,8 @@ pub struct SessionRecord {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub needs_input: Option<NeedsInputDetail>,
     pub resumability: Resumability,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<SessionCapabilities>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent: Option<SessionId>,
     pub created_at: DateMillis,
@@ -764,6 +781,14 @@ impl SessionRecord {
 
     pub fn is_archived(&self) -> bool {
         self.archived_at.is_some()
+    }
+
+    /// Mixed-version-safe answer used by every Resume surface.
+    pub fn can_resume(&self) -> bool {
+        self.capabilities
+            .map_or(self.resumability == Resumability::Resumable, |value| {
+                value.resume
+            })
     }
 
     pub fn attention(&self) -> AttentionLevel {

--- a/diri/crates/dirijor-mcp/src/bin/dirijor.rs
+++ b/diri/crates/dirijor-mcp/src/bin/dirijor.rs
@@ -1197,6 +1197,7 @@ mod tests {
             status_evidence: None,
             needs_input: None,
             resumability: Resumability::Live,
+            capabilities: None,
             parent: None,
             created_at: DateMillis(0.0),
             updated_at: DateMillis(0.0),

--- a/diri/crates/dirijor-mcp/src/bridge.rs
+++ b/diri/crates/dirijor-mcp/src/bridge.rs
@@ -919,6 +919,7 @@ mod tests {
             status_evidence: None,
             needs_input: None,
             resumability: Resumability::Live,
+            capabilities: None,
             parent: parent.map(SessionId::new),
             created_at: DateMillis(0.0),
             updated_at: DateMillis(0.0),


### PR DESCRIPTION
## Summary

- add a guarded JSON state-file module with advisory locking, fresh-under-lock reads, atomic owner-only writes, corruption protection, and preservation of unknown top-level fields
- centralize archive, restore, and remove invariants in a lifecycle planner; destructive requests now fail before process termination when state cannot be persisted, and persistence errors are propagated
- derive per-session capabilities from Agent manifests and lifecycle state, expose them additively on the wire, and consume mixed-version-safe resume capability throughout the app
- classify remote side-effect writes as definitely-not-applied or unknown so ambiguous input/signals are never replayed; reconcile duplicate, overlap, and gap output frames explicitly
- persist turn completion into session records and re-arm premature Codex idle decisions when late output proves the turn is still active, without duplicate completion notifications

These changes take inspiration from Unpeel's code-level patterns while keeping Diri's existing Engine/Holder architecture and remote invariants.

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo build --workspace --release
- local PTY throughput gate: 137.4 MB/s against a 40 MB/s floor
