### PR TITLE
fix: stop reinjecting collapsed initial prompts

### DIFF
--- a/diri/crates/diri-engine/src/control.rs
+++ b/diri/crates/diri-engine/src/control.rs
@@ -3376,18 +3376,22 @@ fn screen_settled(registry: &Arc<Mutex<Registry>>, session_id: &str) -> bool {
 ///
 /// It has to be a WHOLE word, not a leading slice: composers soft-wrap, and
 /// wrapping happens at word boundaries, so any prefix of the prompt can be
-/// split across two screen lines while a single word survives intact. It also
-/// has to be absent from `before`, or a word the banner already displays
-/// would read as an echo the instant we looked. `None` when the prompt offers
-/// nothing that qualifies — a prompt made entirely of words already on
-/// screen, or of words too long to escape wrapping.
+/// split across two screen lines while a single word survives intact. Prefer
+/// the earliest line that offers a usable word because Codex collapses long
+/// pasted prompts to a leading summary; a probe from the middle can disappear
+/// even though the composer accepted the paste. The word also has to be absent
+/// from `before`, or a word the banner already displays would read as an echo
+/// the instant we looked. `None` when the prompt offers nothing that qualifies
+/// — a prompt made entirely of words already on screen, or of words too long
+/// to escape wrapping.
 fn verification_probe(prompt: &str, before: &str) -> Option<String> {
-    prompt
-        .split_whitespace()
-        .filter(|word| (MIN_PROBE_CHARS..=MAX_PROBE_CHARS).contains(&word.chars().count()))
-        .filter(|word| !before.contains(*word))
-        .max_by_key(|word| word.chars().count())
-        .map(str::to_owned)
+    prompt.lines().find_map(|line| {
+        line.split_whitespace()
+            .filter(|word| (MIN_PROBE_CHARS..=MAX_PROBE_CHARS).contains(&word.chars().count()))
+            .filter(|word| !before.contains(*word))
+            .max_by_key(|word| word.chars().count())
+            .map(str::to_owned)
+    })
 }
 
 /// Short words appear by coincidence; long ones are the ones a narrow

--- a/diri/crates/diri-engine/tests/inject_prompt.rs
+++ b/diri/crates/diri-engine/tests/inject_prompt.rs
@@ -303,3 +303,53 @@ fn a_prompt_swallowed_behind_a_repainting_banner_still_lands() {
 
     control.request("session.kill", json!({ "sessionID": id }));
 }
+
+/// Codex collapses long pasted prompts in its composer. The visible summary
+/// keeps the first line but can omit a probe chosen from the middle of the
+/// prompt. Once Enter submits that accepted paste, losing the middle probe
+/// from the viewport must not make the injector submit the prompt again.
+#[test]
+fn a_collapsed_long_prompt_is_submitted_once() {
+    let temp = tempfile::tempdir().expect("temp");
+    let server = start_server(temp.path());
+    let mut control = Control::connect(&server);
+
+    let prompt = "Verify PR 5669\nhidden-probe-1234567\nprint the final report";
+    let framed_len = prompt.len() + "\x1b[200~".len() + "\x1b[201~".len();
+    let script = format!(
+        r#"stty -echo -icanon min 1 time 0
+printf '\033[?2004hREADY'
+dd if=/dev/stdin of=/dev/null bs=1 count={framed_len} 2>/dev/null
+printf '\r\033[2KVerify PR 5669'
+dd if=/dev/stdin of=/dev/null bs=1 count=1 2>/dev/null
+printf '\r\033[2KSUBMISSIONS=1'
+dd if=/dev/stdin of=/dev/null bs=1 count=1 2>/dev/null
+dd if=/dev/stdin of=/dev/null bs=1 count={framed_len} 2>/dev/null
+printf '\r\033[2KVerify PR 5669'
+dd if=/dev/stdin of=/dev/null bs=1 count=1 2>/dev/null
+printf '\r\033[2KSUBMISSIONS=2 hidden-probe-1234567'
+while :; do sleep 1; done"#
+    );
+    let id = spawn(
+        &mut control,
+        // Simulate a raw-mode TUI that renders only the first line while a
+        // bracketed paste is in its composer. After submission it replaces
+        // that summary with a counter. The second submission exposes the
+        // hidden middle probe so the buggy retry loop terminates quickly.
+        &script,
+        "/bin/bash",
+        prompt,
+    );
+
+    let text = screen(&mut control, &id);
+    assert!(
+        text.contains("SUBMISSIONS=1"),
+        "an accepted collapsed prompt was submitted more than once: {text:?}"
+    );
+    assert!(
+        !text.contains("hidden-probe-1234567"),
+        "the injector retried until its off-screen probe appeared: {text:?}"
+    );
+
+    control.request("session.kill", json!({ "sessionID": id }));
+}


### PR DESCRIPTION
## Summary\n\n- choose the initial-prompt verification probe from the earliest usable prompt line\n- keep the existing whole-word, length, and pre-paste collision safeguards\n- add a raw-mode TUI regression proving a collapsed long prompt is submitted exactly once\n\n## Root cause\n\nThe injector previously selected the longest eligible word anywhere in the prompt. Codex collapses long pasted prompts to a leading summary, so a middle-of-prompt probe could disappear after a successful paste. The verifier then mistook the accepted prompt for a swallowed paste and submitted it repeatedly.\n\n## Verification\n\n- regression test failed twice before the fix with SUBMISSIONS=2 and passes after the fix\n- cargo test -p diri-engine: pass\n- cargo test -p diri-engine --test inject_prompt: 6 passed\n- cargo clippy -p diri-engine --all-targets -- -D warnings: pass\n- cargo fmt --all -- --check: pass\n- cargo build --workspace --release: pass\n- post-rebase focused regression: pass\n\n## Existing main-branch gate failures\n\nThe workspace-wide test and Clippy gates reach unrelated diri-app issues already present outside this diff: three AppServices test initializers are missing daemon_startup in launcher.rs, and workspace Clippy also reports an if_same_then_else warning in navigation.rs.