### PR TITLE
scripts: edit the Homebrew cask with a portable sed

### DIFF
--- a/diri/scripts/publish-homebrew-cask.sh
+++ b/diri/scripts/publish-homebrew-cask.sh
@@ -73,10 +73,17 @@ remote_branch="${upstream#*/}"
 # or stops here. A non-fast-forward push below is the second race barrier.
 git -C "${tap_dir}" pull --ff-only --quiet "${remote}" "${remote_branch}"
 
-/usr/bin/sed -i '' -E \
+# Edited through a temporary file rather than `sed -i`, whose in-place syntax
+# differs between BSD and GNU: `-i ''` means an empty suffix on macOS and an
+# input filename everywhere else. Writing the result back with `cat` keeps the
+# original file's mode and inode.
+cask_edit="$(mktemp)"
+/usr/bin/sed -E \
     -e "s|^  version \".*\"$|  version \"${version}\"|" \
     -e "s|^  sha256 \".*\"$|  sha256 \"${local_sha}\"|" \
-    "${tap_dir}/${cask_relative}"
+    "${tap_dir}/${cask_relative}" >"${cask_edit}"
+cat "${cask_edit}" >"${tap_dir}/${cask_relative}"
+rm -f "${cask_edit}"
 
 if ! grep -q "^  version \"${version}\"$" "${tap_dir}/${cask_relative}" \
     || ! grep -q "^  sha256 \"${local_sha}\"$" "${tap_dir}/${cask_relative}"; then

--- a/diri/scripts/test-publish-homebrew-cask.sh
+++ b/diri/scripts/test-publish-homebrew-cask.sh
@@ -55,9 +55,13 @@ chmod +x "${fake_gh}"
 # Reproduce issue #9 exactly: the cask edit is committed locally, but the tap's
 # remote branch still serves the old checksum. The publisher must push even
 # when there is no new diff to commit during this recovery run.
-/usr/bin/sed -i '' -E \
+# See the publisher: `sed -i` is not portable, and this test runs on Linux.
+stale_edit="$(mktemp)"
+/usr/bin/sed -E \
     -e "s|^  sha256 \".*\"$|  sha256 \"${expected_sha}\"|" \
-    "${checkout}/Casks/diri.rb"
+    "${checkout}/Casks/diri.rb" >"${stale_edit}"
+cat "${stale_edit}" >"${checkout}/Casks/diri.rb"
+rm -f "${stale_edit}"
 git -C "${checkout}" add Casks/diri.rb
 git -C "${checkout}" commit -q -m "diri 0.4.6"
 


### PR DESCRIPTION
The `Lints` job has been failing on `main` with:

```
/usr/bin/sed: can't read : No such file or directory
```

`sed -i ''` is BSD syntax: on macOS the `''` is an empty backup suffix, while GNU sed takes the suffix attached to `-i` and reads the empty argument as an input filename. The Lints job runs on Linux, so `scripts/test-publish-homebrew-cask.sh` — and the publisher it exercises — could never pass there.

Both now edit through a temporary file. The result is written back with `cat` rather than `mv`, which keeps the cask's mode and inode, so the publisher behaves exactly as before on macOS where releases actually run.

Verified by running `scripts/test-publish-homebrew-cask.sh` locally:

```
    Homebrew cask pushed and verified at origin/main
publish-homebrew-cask regression test passed
```

Unrelated to the terminal performance work; it was simply the other thing keeping CI red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)