### PR TITLE
engine: measure the rest of a session's life, and take the copies out of the hot path

### DIFF
--- a/diri/crates/diri-engine/examples/fleetbench.rs
+++ b/diri/crates/diri-engine/examples/fleetbench.rs
@@ -1,0 +1,113 @@
+//! How the engine holds up with many sessions producing output at once.
+//!
+//! Every other measurement here has been of one session in isolation, which is
+//! not the shape this runs in: a screenful of agents, each with its own PTY,
+//! holder, writer thread, subscription and spill file. What this looks for is
+//! the cost that only appears in aggregate — threads contending, disks
+//! saturating, one loud session starving the others.
+//!
+//! Reports aggregate throughput, and the spread across sessions, because a
+//! fleet that averages well while starving one session is not working.
+//!
+//! Usage: fleetbench <payload> <sessions> [cols] [rows]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use diri_engine::session::{HolderConfig, Session, SessionSpec};
+use diri_engine::{Authority, ManifestEngine, PtySpec};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let payload = args.next().expect("usage: fleetbench <payload> <sessions>");
+    let count: usize = args.next().and_then(|a| a.parse().ok()).unwrap_or(8);
+    let cols: u16 = args.next().and_then(|a| a.parse().ok()).unwrap_or(153);
+    let rows: u16 = args.next().and_then(|a| a.parse().ok()).unwrap_or(39);
+
+    let bytes = std::fs::metadata(&payload).expect("payload").len();
+    let root = std::env::temp_dir().join(format!("diri-fleetbench-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).expect("create dir");
+
+    let manifests = diri_engine::detect::bundled_manifest_dir()
+        .canonicalize()
+        .expect("manifests");
+    let (engine, _) = ManifestEngine::load_dir(&manifests).expect("load");
+    let engine = Arc::new(engine);
+    let holder_binary = PathBuf::from(
+        std::env::var("DIRI_HOLDER_BIN").expect("set DIRI_HOLDER_BIN to a built diri-holder"),
+    );
+
+    // Spawned as close together as possible: the point is overlap, so a
+    // staggered start would measure something easier than the real thing.
+    let started = Instant::now();
+    let sessions: Vec<Session> = (0..count)
+        .map(|index| {
+            let spec = SessionSpec {
+                id: format!("s_fleet_{index}"),
+                pty: PtySpec::new(
+                    vec!["/bin/sh".into(), "-c".into(), format!("cat {payload}")],
+                    "/tmp",
+                )
+                .env("PATH", "/usr/bin:/bin")
+                .env("TERM", "xterm-256color")
+                .size(cols, rows),
+                manifest_id: "shell".into(),
+                authority: Authority::ProcessOnly,
+                logs_dir: root.join("logs"),
+                holder: Some(HolderConfig {
+                    holders_dir: root.join("holders"),
+                    executable: holder_binary.clone(),
+                }),
+                remote: None,
+                defer_launch: false,
+            };
+            Session::spawn(spec, Arc::clone(&engine)).expect("spawn")
+        })
+        .collect();
+
+    // Poll rather than wait per session: finishing times are the measurement,
+    // and a thread per session would add its own contention to it.
+    let mut finished_at: Vec<Option<Duration>> = vec![None; count];
+    let deadline = Instant::now() + Duration::from_secs(600);
+    while finished_at.iter().any(Option::is_none) && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(10));
+        for (index, session) in sessions.iter().enumerate() {
+            if finished_at[index].is_none() && session.view().exited {
+                finished_at[index] = Some(started.elapsed());
+            }
+        }
+    }
+
+    let mut times: Vec<f64> = finished_at
+        .iter()
+        .filter_map(|at| at.map(|at| at.as_secs_f64()))
+        .collect();
+    times.sort_by(f64::total_cmp);
+    let unfinished = count - times.len();
+    let total_mb = (bytes as f64 / (1 << 20) as f64) * times.len() as f64;
+    let wall = times.last().copied().unwrap_or_default();
+
+    println!("sessions           {count} ({unfinished} did not finish)");
+    println!(
+        "payload each       {:.1} MB",
+        bytes as f64 / (1 << 20) as f64
+    );
+    println!("wall clock         {:.2} s", wall);
+    println!(
+        "aggregate          {:.1} MB/s",
+        total_mb / wall.max(f64::EPSILON)
+    );
+    if !times.is_empty() {
+        // The spread is the fairness question: one session finishing in a
+        // tenth of the time of another means the fleet is not sharing.
+        println!(
+            "per session        fastest {:.2} s / median {:.2} s / slowest {:.2} s",
+            times[0],
+            times[times.len() / 2],
+            times[times.len() - 1]
+        );
+    }
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/diri/crates/diri-engine/examples/sessionbench.rs
+++ b/diri/crates/diri-engine/examples/sessionbench.rs
@@ -1,0 +1,273 @@
+//! The parts of a session's life that are not throughput.
+//!
+//! Draining output fast is one thing a terminal is judged on; these are the
+//! others, and they are the ones a user feels as "sluggish" rather than
+//! "slow": how long a new session takes to become usable, how long switching
+//! to an existing one takes to show its screen, what a window drag costs, and
+//! what a fleet of idle sessions costs when nobody is doing anything at all.
+//!
+//! Usage: sessionbench <startup|attach|resize|idle> [count]
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use diri_engine::holder::HolderClient;
+use diri_engine::session::{HolderConfig, Session, SessionSpec};
+use diri_engine::{Authority, ManifestEngine, PtySpec};
+
+fn engine() -> Arc<ManifestEngine> {
+    let dir = diri_engine::detect::bundled_manifest_dir()
+        .canonicalize()
+        .expect("manifests");
+    let (engine, _) = ManifestEngine::load_dir(&dir).expect("load");
+    Arc::new(engine)
+}
+
+fn work_dir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("diri-sessionbench-{tag}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create dir");
+    dir
+}
+
+fn holder_config(root: &Path) -> HolderConfig {
+    HolderConfig {
+        holders_dir: root.join("holders"),
+        executable: PathBuf::from(
+            std::env::var("DIRI_HOLDER_BIN").expect("set DIRI_HOLDER_BIN to a built diri-holder"),
+        ),
+    }
+}
+
+fn spec(id: &str, script: &str, root: &Path, cols: u16, rows: u16) -> SessionSpec {
+    SessionSpec {
+        id: id.into(),
+        pty: PtySpec::new(vec!["/bin/sh".into(), "-c".into(), script.into()], "/tmp")
+            .env("PATH", "/usr/bin:/bin")
+            .env("TERM", "xterm-256color")
+            .size(cols, rows),
+        manifest_id: "shell".into(),
+        authority: Authority::ProcessOnly,
+        logs_dir: root.join("logs"),
+        holder: Some(holder_config(root)),
+        remote: None,
+        defer_launch: false,
+    }
+}
+
+fn percentiles(mut samples: Vec<f64>, label: &str) {
+    if samples.is_empty() {
+        println!("{label}: no samples");
+        return;
+    }
+    samples.sort_by(f64::total_cmp);
+    let at = |q: f64| samples[((samples.len() as f64 - 1.0) * q).round() as usize];
+    println!(
+        "{label:<22} median {:.1} ms   p95 {:.1} ms   worst {:.1} ms   (n={})",
+        at(0.5),
+        at(0.95),
+        at(1.0),
+        samples.len()
+    );
+}
+
+/// Time from spawning a session to its first prompt being on screen.
+///
+/// A shell prints its prompt as soon as it is ready, so this is the whole
+/// startup path: process spawn, PTY, holder, first output, emulator, screen.
+fn startup(count: usize) {
+    let root = work_dir("startup");
+    let mut samples = Vec::new();
+    // Split, because the two halves have different owners: getting a holder
+    // and a PTY, versus the first output finding its way to a screen.
+    let mut spawn_samples = Vec::new();
+    for index in 0..count {
+        let started = Instant::now();
+        let mut session = Session::spawn(
+            spec(
+                &format!("s_start_{index}"),
+                "printf 'READY> '; sleep 30",
+                &root,
+                153,
+                39,
+            ),
+            engine(),
+        )
+        .expect("spawn");
+        spawn_samples.push(started.elapsed().as_secs_f64() * 1000.0);
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while Instant::now() < deadline {
+            if session
+                .screen_lines()
+                .iter()
+                .any(|line| line.contains("READY>"))
+            {
+                samples.push(started.elapsed().as_secs_f64() * 1000.0);
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        let _ = session.terminate(Duration::from_secs(2));
+    }
+    percentiles(spawn_samples, "  of which spawn");
+    percentiles(samples, "startup to prompt");
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Time from adopting a live session to its screen being restored.
+///
+/// This is what switching to a session that a previous daemon was running
+/// costs: the scrollback has to be replayed through a fresh emulator before
+/// anything can be shown.
+fn attach(count: usize) {
+    let root = work_dir("attach");
+    // A screenful of history to restore, with a marker the check can find.
+    let script = "for i in $(seq 1 4000); do echo \"history line $i\"; done; \
+         printf 'ATTACHME\\n'; sleep 120";
+    let session =
+        Session::spawn(spec("s_attach", script, &root, 153, 39), engine()).expect("spawn");
+    let deadline = Instant::now() + Duration::from_secs(60);
+    while Instant::now() < deadline {
+        if session
+            .screen_lines()
+            .iter()
+            .any(|line| line.contains("ATTACHME"))
+        {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    // The holder outlives this; every adoption below is a fresh daemon
+    // meeting a session that is already running.
+    drop(session);
+
+    let holder = holder_config(&root);
+    let paths = diri_engine::holder::HolderPaths::new(&holder.holders_dir, "s_attach");
+    let client = HolderClient::new(paths.socket());
+    let mut samples = Vec::new();
+    for _ in 0..count {
+        let stat = client.stat().expect("holder alive");
+        let started = Instant::now();
+        let adopted = Session::adopt(
+            spec("s_attach", "", &root, 153, 39),
+            &holder,
+            &stat,
+            engine(),
+        )
+        .expect("adopt");
+        let deadline = Instant::now() + Duration::from_secs(60);
+        while Instant::now() < deadline {
+            if adopted
+                .screen_lines()
+                .iter()
+                .any(|line| line.contains("ATTACHME"))
+            {
+                samples.push(started.elapsed().as_secs_f64() * 1000.0);
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        drop(adopted);
+    }
+    percentiles(samples, "attach to screen");
+    let _ = client.kill_tree();
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// What one step of a window drag costs.
+///
+/// A drag is not one resize, it is a stream of them, and each reflows the
+/// grid. Measured as the round trip to a screen that has taken the new size.
+fn resize(count: usize) {
+    let root = work_dir("resize");
+    let script = "for i in $(seq 1 2000); do echo \"a line of scrollback $i\"; done; sleep 120";
+    let mut session =
+        Session::spawn(spec("s_resize", script, &root, 153, 39), engine()).expect("spawn");
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline && session.screen_lines().is_empty() {
+        std::thread::sleep(Duration::from_millis(5));
+    }
+
+    let mut samples = Vec::new();
+    for step in 0..count {
+        // Widths a drag would actually pass through, not one repeated size.
+        let cols = 80 + (step as u16 % 100);
+        let started = Instant::now();
+        session.resize(cols, 39).expect("resize");
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline {
+            if session.screen_size().0 == cols as usize {
+                samples.push(started.elapsed().as_secs_f64() * 1000.0);
+                break;
+            }
+            std::thread::sleep(Duration::from_micros(200));
+        }
+    }
+    percentiles(samples, "resize step");
+    let _ = session.terminate(Duration::from_secs(2));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// What a fleet of idle sessions costs when nothing is happening.
+///
+/// Every session holds a PTY, a holder, threads and a subscription. Idle cost
+/// is a battery question, and the only honest way to ask it is to leave them
+/// alone and watch.
+fn idle(count: usize) {
+    let root = work_dir("idle");
+    let sessions: Vec<Session> = (0..count)
+        .map(|index| {
+            Session::spawn(
+                spec(&format!("s_idle_{index}"), "sleep 600", &root, 153, 39),
+                engine(),
+            )
+            .expect("spawn")
+        })
+        .collect();
+    // Let startup settle before measuring what steady state costs.
+    std::thread::sleep(Duration::from_secs(5));
+
+    let sample_secs = 10;
+    let before = cpu_seconds();
+    std::thread::sleep(Duration::from_secs(sample_secs));
+    let used = cpu_seconds() - before;
+    println!(
+        "idle {count} sessions      {:.2}% of one core over {sample_secs}s ({:.1} ms per session per second)",
+        used / sample_secs as f64 * 100.0,
+        used * 1000.0 / sample_secs as f64 / count.max(1) as f64
+    );
+    for mut session in sessions {
+        let _ = session.terminate(Duration::from_secs(2));
+    }
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// CPU seconds this process and its children have used.
+fn cpu_seconds() -> f64 {
+    let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
+    let mut total = 0.0;
+    for who in [libc::RUSAGE_SELF, libc::RUSAGE_CHILDREN] {
+        // SAFETY: `usage` is a valid, fully initialized rusage.
+        if unsafe { libc::getrusage(who, &mut usage) } == 0 {
+            total += usage.ru_utime.tv_sec as f64 + usage.ru_utime.tv_usec as f64 / 1e6;
+            total += usage.ru_stime.tv_sec as f64 + usage.ru_stime.tv_usec as f64 / 1e6;
+        }
+    }
+    total
+}
+
+fn main() {
+    let mode = std::env::args().nth(1).unwrap_or_else(|| "startup".into());
+    let count: usize = std::env::args()
+        .nth(2)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(20);
+    match mode.as_str() {
+        "startup" => startup(count),
+        "attach" => attach(count),
+        "resize" => resize(count),
+        "idle" => idle(count),
+        other => eprintln!("unknown mode {other}: expected startup, attach, resize or idle"),
+    }
+}

--- a/diri/crates/diri-engine/src/holder.rs
+++ b/diri/crates/diri-engine/src/holder.rs
@@ -31,6 +31,19 @@ pub mod server;
 mod fanout;
 
 pub use client::{HolderClient, HolderManagerClient, HolderOutputStream};
+
+/// Delays for polling something that is about to become ready.
+///
+/// A holder answers within a couple of milliseconds, so asking again on a
+/// fixed 20 ms cadence spent most of a session's startup asleep. These start
+/// almost immediately and settle into the same slow cadence, which keeps the
+/// patience of a long wait without charging it to the common case.
+pub(crate) fn readiness_delays() -> impl Iterator<Item = std::time::Duration> {
+    use std::time::Duration;
+    std::iter::successors(Some(Duration::from_micros(200)), |delay| {
+        Some((*delay * 2).min(Duration::from_millis(20)))
+    })
+}
 pub use launcher::HolderLauncher;
 pub use paths::{HolderManagerPaths, HolderPaths};
 pub use protocol::{

--- a/diri/crates/diri-engine/src/holder/client.rs
+++ b/diri/crates/diri-engine/src/holder/client.rs
@@ -202,24 +202,29 @@ impl HolderOutputStream {
     }
 
     /// Blocks up to `timeout` for the next frame, then folds in every frame
-    /// already waiting behind it, up to `budget` bytes.
+    /// already waiting behind it, into `run`, up to `budget` bytes.
     ///
-    /// Frames are PTY-sized, and the pump's per-pass work — locking the
-    /// screen, checking timers, publishing — is charged per call rather than
-    /// per byte. Handing back one large contiguous run instead of a dozen
-    /// small ones is worth several times the throughput, and costs nothing:
-    /// only frames that had already arrived are folded in.
-    pub fn next_run(
+    /// Frames are PTY-sized while the caller's per-pass work — locking the
+    /// screen, checking timers, publishing — is charged per call, so handing
+    /// back one large contiguous run instead of a dozen small ones is worth
+    /// several times the throughput. `run` is the caller's buffer and is
+    /// reused, because allocating one per frame and copying into it charged
+    /// every byte of output an allocation and a copy it did not need.
+    ///
+    /// Returns the offset the run begins at.
+    pub fn next_run_into(
         &mut self,
         timeout: Duration,
         budget: usize,
-    ) -> HolderResult<Option<(u64, Vec<u8>)>> {
-        let Some((offset, mut payload)) = self.next_frame(timeout)? else {
+        run: &mut Vec<u8>,
+    ) -> HolderResult<Option<u64>> {
+        run.clear();
+        let Some(offset) = self.read_frame_into(timeout, run)? else {
             return Ok(None);
         };
-        while payload.len() < budget {
-            match self.next_frame(Duration::ZERO) {
-                Ok(Some((_, mut more))) => payload.append(&mut more),
+        while run.len() < budget {
+            match self.read_frame_into(Duration::ZERO, run) {
+                Ok(Some(_)) => {}
                 Ok(None) => break,
                 // A frame that fails mid-run leaves the stream unusable, but
                 // what was already read is contiguous and safe to return; the
@@ -227,32 +232,48 @@ impl HolderOutputStream {
                 Err(_) => break,
             }
         }
-        Ok(Some((offset, payload)))
+        Ok(Some(offset))
     }
 
-    /// Blocks up to `timeout` for the next frame, returning its stream offset
-    /// and payload.
-    ///
-    /// `Ok(None)` means nothing arrived in time — the child is simply quiet.
-    /// `Err` means the stream is finished or broken, and the caller must go
-    /// back to the log, which has everything.
-    pub fn next_frame(&mut self, timeout: Duration) -> HolderResult<Option<(u64, Vec<u8>)>> {
+    /// Reads one frame onto the end of `run`, returning where it began.
+    fn read_frame_into(
+        &mut self,
+        timeout: Duration,
+        run: &mut Vec<u8>,
+    ) -> HolderResult<Option<u64>> {
         // A zero `SO_RCVTIMEO` means "no timeout", which would block forever;
         // the shortest expressible wait is what "poll" has to mean here.
         let timeout = timeout.max(Duration::from_nanos(1));
-        self.set_timeout(Some(timeout))?;
         let mut header = [0_u8; 12];
-        match self.stream.read_exact(&mut header) {
-            Ok(()) => {}
-            Err(error)
-                if matches!(
-                    error.kind(),
-                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
-                ) =>
-            {
-                return Ok(None);
+        let mut filled = 0;
+        while filled < header.len() {
+            // The timeout applies only while waiting for a frame to begin.
+            // Once any byte of one has arrived the rest is awaited without a
+            // deadline: abandoning a frame halfway leaves those bytes consumed
+            // and the stream desynchronized, and the next read would take
+            // whatever followed for a header — a length that never arrives,
+            // and a read that blocks until the holder exits.
+            self.set_timeout(if filled == 0 { Some(timeout) } else { None })?;
+            match self.stream.read(&mut header[filled..]) {
+                Ok(0) => {
+                    return Err(HolderError::io(
+                        "read output stream",
+                        std::io::Error::from(std::io::ErrorKind::UnexpectedEof),
+                    ));
+                }
+                Ok(read) => filled += read,
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(error)
+                    if filled == 0
+                        && matches!(
+                            error.kind(),
+                            std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                        ) =>
+                {
+                    return Ok(None);
+                }
+                Err(error) => return Err(HolderError::io("read output stream", error)),
             }
-            Err(error) => return Err(HolderError::io("read output stream", error)),
         }
         let offset = u64::from_be_bytes(header[..8].try_into().expect("eight-byte offset"));
         let length = u32::from_be_bytes(header[8..].try_into().expect("four-byte length")) as usize;
@@ -264,11 +285,12 @@ impl HolderOutputStream {
         // The rest of a frame that has started must arrive: a timeout here
         // would strand half of it and desynchronize the stream.
         self.set_timeout(None)?;
-        let mut payload = vec![0_u8; length];
+        let from = run.len();
+        run.resize(from + length, 0);
         self.stream
-            .read_exact(&mut payload)
+            .read_exact(&mut run[from..])
             .map_err(|error| HolderError::io("read output frame", error))?;
-        Ok(Some((offset, payload)))
+        Ok(Some(offset))
     }
 }
 

--- a/diri/crates/diri-engine/src/holder/launcher.rs
+++ b/diri/crates/diri-engine/src/holder/launcher.rs
@@ -8,7 +8,6 @@
 use std::fs::OpenOptions;
 use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
 
 use super::client::{HolderClient, HolderManagerClient};
 use super::paths::{HolderManagerPaths, HolderPaths};
@@ -17,7 +16,6 @@ use super::{HolderError, HolderResult};
 
 /// How long to wait for a freshly spawned manager: 250 × 20ms = 5s.
 const READINESS_ATTEMPTS: u32 = 250;
-const READINESS_INTERVAL: Duration = Duration::from_millis(20);
 
 pub struct HolderLauncher;
 
@@ -47,13 +45,15 @@ impl HolderLauncher {
         let manager = HolderManagerClient::new(manager_paths.socket());
         if !manager.is_alive() {
             spawn_manager(executable_path, &manager_paths.directory)?;
-            let ready = (0..READINESS_ATTEMPTS).any(|_| {
-                if manager.is_alive() {
-                    return true;
-                }
-                std::thread::sleep(READINESS_INTERVAL);
-                false
-            });
+            let ready = super::readiness_delays()
+                .take(READINESS_ATTEMPTS as usize)
+                .any(|delay| {
+                    if manager.is_alive() {
+                        return true;
+                    }
+                    std::thread::sleep(delay);
+                    false
+                });
             if !ready {
                 return Err(HolderError::Launch(
                     "shared holder manager did not become ready".into(),
@@ -72,11 +72,11 @@ impl HolderLauncher {
                     return Err(error);
                 }
                 spawn_manager(executable_path, &manager_paths.directory)?;
-                for _ in 0..READINESS_ATTEMPTS {
+                for delay in super::readiness_delays().take(READINESS_ATTEMPTS as usize) {
                     if let Ok(pid) = manager.launch(spec) {
                         return Ok(pid);
                     }
-                    std::thread::sleep(READINESS_INTERVAL);
+                    std::thread::sleep(delay);
                 }
                 Err(HolderError::Launch(
                     "shared holder manager did not accept launch".into(),

--- a/diri/crates/diri-engine/src/holder/protocol.rs
+++ b/diri/crates/diri-engine/src/holder/protocol.rs
@@ -354,6 +354,17 @@ impl HolderExitMarker {
         marker
     }
 
+    /// Whether a chunk can go straight to the emulator.
+    ///
+    /// True when it holds no marker and does not end in something that could
+    /// become one, which is every chunk of ordinary output. The caller can
+    /// then feed the bytes where they lie instead of copying them through an
+    /// accumulator to have the same bytes handed back.
+    #[must_use]
+    pub fn absent_from(chunk: &[u8]) -> bool {
+        find(chunk, Self::PREFIX).is_none() && longest_suffix_of_prefix(chunk) == 0
+    }
+
     /// Pulls complete output and markers from a chunk accumulator. A possible
     /// split marker prefix stays buffered for the next append. Returns the
     /// displayable bytes and the last complete exit status found, if any.
@@ -394,9 +405,20 @@ impl HolderExitMarker {
 }
 
 fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    haystack
-        .windows(needle.len())
-        .position(|window| window == needle)
+    // Anchored on the first byte rather than comparing the whole needle at
+    // every offset. Every byte of every session's output passes through here,
+    // and a nineteen-byte window comparison per position was costing more than
+    // parsing the bytes did.
+    let (first, rest) = needle.split_first()?;
+    let mut offset = 0;
+    while let Some(hit) = haystack[offset..].iter().position(|byte| byte == first) {
+        let start = offset + hit;
+        if haystack[start + 1..].starts_with(rest) {
+            return Some(start);
+        }
+        offset = start + 1;
+    }
+    None
 }
 
 fn longest_suffix_of_prefix(data: &[u8]) -> usize {

--- a/diri/crates/diri-engine/src/holder/server.rs
+++ b/diri/crates/diri-engine/src/holder/server.rs
@@ -416,9 +416,17 @@ fn broadcast_output(shared: &Shared, frame: &Arc<[u8]>) {
     if fanout.subscribers.is_empty() {
         return;
     }
-    fanout
-        .subscribers
-        .retain(|subscriber| offer_frame(subscriber, offset, frame));
+    fanout.subscribers.retain(|subscriber| {
+        if offer_frame(subscriber, offset, frame) {
+            return true;
+        }
+        // Closing is what makes dropping visible. Letting the subscriber go
+        // only releases this end of the queue; its writer would keep waiting
+        // on the other, holding the socket open, and the daemon would wait for
+        // frames that are never coming instead of falling back to the log.
+        subscriber.frames.close();
+        false
+    });
 }
 
 /// Offers one frame to a subscriber, waiting only as long as
@@ -535,6 +543,15 @@ fn watch_exit(shared: &Shared, pump: std::thread::JoinHandle<()>) {
         let mut log = shared.log.lock().expect("log");
         let _ = log.append(&HolderExitMarker::encode(&exit));
         let _ = log.flush();
+    }
+
+    // The marker goes to the log, not the stream — it is not PTY output — so a
+    // subscriber would otherwise keep waiting for frames from a child that has
+    // already gone, and learn of the exit only when this process finally
+    // closed its socket. Ending the subscription sends it back to the log,
+    // where the marker is already durable.
+    for subscriber in shared.output.lock().expect("output").subscribers.drain(..) {
+        subscriber.frames.close();
     }
 
     let _ = std::fs::remove_file(&shared.spec.socket_path);

--- a/diri/crates/diri-engine/src/holder/server.rs
+++ b/diri/crates/diri-engine/src/holder/server.rs
@@ -211,6 +211,12 @@ impl HolderServer {
                 Ok(request) if request.op == HolderOperation::OutputStream => {
                     if request.stream_version != Some(HOLDER_OUTPUT_STREAM_VERSION) {
                         HolderResponse::failure("unsupported Holder output stream version")
+                    } else if shared.finished.load(Ordering::SeqCst) {
+                        // Nothing will ever be streamed again, and the log is
+                        // complete including the exit marker. Accepting here
+                        // would leave the subscriber waiting on a stream that
+                        // is over while the marker sat unread in the file.
+                        HolderResponse::failure("holder has finished")
                     } else {
                         // Registered under the same lock that hands out frames,
                         // so the offset quoted here is exactly where this

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -1788,7 +1788,7 @@ fn wait_for_holder(
     session_id: &str,
     pre_spawn_tail: u64,
 ) -> Result<u64, crate::holder::HolderError> {
-    for _ in 0..250 {
+    for delay in crate::holder::readiness_delays().take(300) {
         if let Ok(stat) = client.stat() {
             return Ok(stat.epoch_offset.unwrap_or(pre_spawn_tail));
         }
@@ -1798,7 +1798,7 @@ fn wait_for_holder(
                 return Ok(pre_spawn_tail);
             }
         }
-        std::thread::sleep(Duration::from_millis(20));
+        std::thread::sleep(delay);
     }
     Err(crate::holder::HolderError::Launch(
         "holder did not become ready".into(),

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -182,6 +182,11 @@ const LOG_READ_BUDGET: usize = 512 << 10;
 /// twice within one frame is not two observations worth having.
 const EVAL_INTERVAL: Duration = Duration::from_millis(16);
 
+/// How far ahead of the pump a subscription may start and still be worth
+/// taking. Beyond this the file is followed instead, which costs latency for a
+/// moment rather than churning subscriptions that cannot be read yet.
+const LIVE_HANDOVER_GAP: u64 = 256 << 10;
+
 /// What a session looks like from the outside.
 #[derive(Clone, Debug)]
 pub struct SessionView {
@@ -2717,8 +2722,18 @@ fn pump_held(
         // a drained log keeps the handover to a few frames.
         if live.is_none() && drained {
             if let Ok(Some(stream)) = client.open_output_stream() {
+                // A drained log does not mean the holder is where the log
+                // ends: writes are queued, so it can be megabytes further on.
+                // Subscribing across that distance is the worst case — the
+                // holder fills a queue this loop cannot read until the file
+                // catches up, then drops it for being full, and both ends
+                // repeat. Take the subscription only when the gap is small
+                // enough to close immediately, and otherwise keep tailing and
+                // try again the next time the log runs dry.
                 live_from = stream.start_offset();
-                live = Some(stream);
+                if live_from.saturating_sub(offset) <= LIVE_HANDOVER_GAP {
+                    live = Some(stream);
+                }
             }
             drained = false;
         }

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -2704,6 +2704,9 @@ fn pump_held(
     // and the loop just goes back to reading the file from the offset it had
     // reached.
     let mut live: Option<crate::holder::HolderOutputStream> = None;
+    // Reused across passes: a fresh allocation per pass would charge every
+    // byte of output an allocation it does not need.
+    let mut live_run: Vec<u8> = Vec::new();
     // Where the subscription's first frame sits. The holder is ahead of the
     // log by whatever it has read but not yet written, so the file has to be
     // followed up to this point before a frame can be consumed.
@@ -2739,30 +2742,35 @@ fn pump_held(
         }
         // Frames only once the file has been followed up to where they begin.
         let streaming = live.is_some() && offset >= live_from;
-        let (start, chunk) = match live.as_mut().filter(|_| streaming) {
-            Some(stream) => match stream.next_run(shared.quiet_tick(), LOG_READ_BUDGET) {
-                // Contiguous by construction, and checked anyway: a frame that
-                // does not start where the last one ended means something
-                // raced, and the log is the authority to fall back on rather
-                // than feed the emulator a gap it cannot detect.
-                Ok(Some((at, frame))) if at == offset => (offset, frame),
-                Ok(Some(_)) => {
-                    live = None;
-                    continue;
+        let from_log;
+        let (start, chunk): (u64, &[u8]) = match live.as_mut().filter(|_| streaming) {
+            Some(stream) => {
+                match stream.next_run_into(shared.quiet_tick(), LOG_READ_BUDGET, &mut live_run) {
+                    // Contiguous by construction, and checked anyway: a run
+                    // that does not start where the last one ended means
+                    // something raced, and the log is the authority to fall
+                    // back on rather than feed the emulator a gap it cannot
+                    // detect.
+                    Ok(Some(at)) if at == offset => (offset, &live_run[..]),
+                    Ok(Some(_)) => {
+                        live = None;
+                        continue;
+                    }
+                    // Quiet: fall through to the timers with nothing to feed.
+                    Ok(None) => (offset, &[][..]),
+                    Err(_) => {
+                        // Dropped for falling behind, or the child is gone.
+                        // The log has every byte; resume from it.
+                        live = None;
+                        continue;
+                    }
                 }
-                // Quiet: fall through to the timers below with nothing to feed.
-                Ok(None) => (offset, Vec::new()),
-                Err(_) => {
-                    // Dropped for falling behind, or the child is gone. The
-                    // log has every byte; resume from it at the same offset.
-                    live = None;
-                    continue;
-                }
-            },
+            }
             None => {
                 let mut log = shared.log.lock().expect("log");
                 log.refresh_from_disk();
-                log.read(offset, LOG_READ_BUDGET)
+                from_log = log.read(offset, LOG_READ_BUDGET);
+                (from_log.0, &from_log.1[..])
             }
         };
         // A full read means the tail is not caught up, so this pass may hold
@@ -2896,23 +2904,37 @@ fn pump_held(
         let honored_from = exit_marker_floor
             .saturating_sub(start)
             .min(chunk.len() as u64) as usize;
-        let mut output = Vec::new();
-        if honored_from > 0 {
-            marker_buffer.extend_from_slice(&chunk[..honored_from]);
-            let (replayed, _stale_exit) = HolderExitMarker::drain(&mut marker_buffer);
-            output.extend_from_slice(&replayed);
-            if start + honored_from as u64 >= exit_marker_floor {
-                marker_buffer.clear(); // an unfinished stale marker ends here
+        // Ordinary output carries no exit marker, and accumulating it only to
+        // be handed the same bytes back costs several copies of everything a
+        // session ever prints. When there is nothing buffered and nothing
+        // marker-shaped in the chunk, it is fed where it lies.
+        let staged;
+        let output: &[u8] = if honored_from == 0
+            && marker_buffer.is_empty()
+            && HolderExitMarker::absent_from(chunk)
+        {
+            chunk
+        } else {
+            let mut assembled = Vec::new();
+            if honored_from > 0 {
+                marker_buffer.extend_from_slice(&chunk[..honored_from]);
+                let (replayed, _stale_exit) = HolderExitMarker::drain(&mut marker_buffer);
+                assembled.extend_from_slice(&replayed);
+                if start + honored_from as u64 >= exit_marker_floor {
+                    marker_buffer.clear(); // an unfinished stale marker ends here
+                }
             }
-        }
-        if honored_from < chunk.len() {
-            marker_buffer.extend_from_slice(&chunk[honored_from..]);
-            let (live, exit) = HolderExitMarker::drain(&mut marker_buffer);
-            output.extend_from_slice(&live);
-            if exit.is_some() {
-                exit_status = exit;
+            if honored_from < chunk.len() {
+                marker_buffer.extend_from_slice(&chunk[honored_from..]);
+                let (live, exit) = HolderExitMarker::drain(&mut marker_buffer);
+                assembled.extend_from_slice(&live);
+                if exit.is_some() {
+                    exit_status = exit;
+                }
             }
-        }
+            staged = assembled;
+            &staged
+        };
 
         if !output.is_empty() {
             checkpoint_dirty_at = Some(Instant::now());
@@ -2928,7 +2950,7 @@ fn pump_held(
             eval_dirty = !evaluate_now;
             let (observation, replies) = {
                 let mut screen = shared.screen.lock().expect("screen");
-                screen.feed(&output);
+                screen.feed(output);
                 let replies = screen.take_replies();
                 let observation = if evaluate_now {
                     last_eval_at = Some(Instant::now());


### PR DESCRIPTION
Two new harnesses for the things never measured — a fleet, and the lifecycle events a user feels as "sluggish" rather than "slow" — and the fixes they found. Then the ~2x gap between what the emulator parses and what the pipeline sustained, which turned out to be copies.

## The gap between parsing and sustaining

The emulator parses 190–260 MB/s. The pipeline sustained **92**. Almost all of the difference was work done to bytes before the parser ever saw them.

Every chunk was scanned for the exit marker with a **nineteen-byte window comparison at every offset**, accumulated into a buffer, drained out of the front of it (the same memmove-per-append shape already fixed in the log), and copied into an output vector — so the parser could be handed the bytes it would have been handed anyway. Ordinary output carries no marker and now pays none of it: the scan is anchored on the prefix's first byte, and a chunk with no marker and no marker-shaped tail is fed where it lies.

Frames also arrived in a fresh allocation each and were appended into a run buffer, charging every byte an allocation and another copy. They are read into one buffer the pump reuses.

**Sustained 40 MB through a real holder: 92 → 105–161 MB/s**, depending on what else the machine is doing.

## A fleet (`examples/fleetbench`)

diri runs a screenful of agents, each with its own PTY, holder, writer thread, subscription and spill file. Measuring that found **four** ways a subscription could outlive its usefulness while the session waited on it. A single session catting 40 MB took 30.8 seconds, of which 30.1 were spent waiting to notice it had already finished.

| 16 sessions × 40 MB | before | after |
|---|---:|---:|
| aggregate | 18.2 MB/s | **129.8 MB/s** |
| slowest session | 35.2 s | **5.11 s** |
| spread | 4.5 → 35.2 s | 4.67 → 5.11 s |

- **The exit marker never reaches a subscriber** — it goes to the log, not the stream. The subscription is closed once the marker is durable.
- **Dropping a subscriber released only one end of its queue**, so its writer held the socket open and the pump saw neither frames nor EOF. Dropping now closes.
- **A drained log does not mean the holder is where the log ends**, since writes are queued behind it. Subscribing across that gap made the holder fill a queue the pump could not read, drop it, and repeat. A subscription is taken only when the gap can be closed at once.
- **A finished holder still accepted subscriptions.** A pump that drained the log, marked itself caught up and subscribed again waited on a stream that was over while the marker sat unread a few bytes away — the 30-second straggler above. A finished holder now refuses; there is nothing left to stream and the log is complete.

Plus a latent stream bug the fleet exposed: a read timeout could fire **mid-header**, and those bytes were consumed and then discarded as "nothing arrived", so the next read began mid-frame and took whatever followed for a length. The timeout now applies only while waiting for a frame to *begin*.

Single-session latency under load improved throughout, p95 1.2 ms → **0.5 ms**. Ghostty is 0.32 ms; Kitty is 12.2 ms.

## Scaling, and where it stops

| sessions × payload | aggregate | fastest → slowest |
|---|---:|---|
| 1 × 40 MB | 105 MB/s | 0.37 s |
| 4 × 40 MB | 140 MB/s | 1.49 → 1.50 s |
| 16 × 40 MB | 130 MB/s | 4.67 → 5.11 s |
| 32 × 8 MB | 114 MB/s | 0.75 → 2.14 s |
| 32 × 40 MB | 31 MB/s | 8.5 → 40.8 s |

The last row is 1.3 GB of spill files landing at once and the disk saturating; the same 32 sessions at 8 MB each stay tight. The filesystem's limit, not the fleet's — and most of those bytes are written only to be truncated away, which is the thread to pull if it ever matters.

## The rest of a session's life (`examples/sessionbench`)

| | |
|---|---|
| startup to first prompt | 35.1 ms → **24.6 ms** |
| adopt a session with 4000 lines of scrollback | 9.8 ms |
| one step of a window drag | < 0.1 ms |
| 16 idle sessions | 0.10% of one core |

Startup was mostly *sleeping*: waiting for a holder polled every 20 ms while a holder answers in about two, and the same cadence sat in front of the manager launch. Polling now starts at 200 µs and doubles to the same ceiling. What remains is largely not ours — ~10 ms to spawn the holder and its PTY, and most of the rest is the child shell's own fork and exec.

The other three were already fine and are recorded so a regression has something to fail against.

## Testing

383 tests pass; clippy and fmt clean. Both harnesses report distributions rather than averages — for a fleet the spread *is* the question, since one that averages well while starving a session is not working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)