### PR TITLE
Add resilient session recovery, forks, and activity history

### DIFF
--- a/diri/README.md
+++ b/diri/README.md
@@ -23,6 +23,27 @@ adopted by whatever daemon starts next.
 on-disk state, while `diri-holder` owns local PTYs across Engine restarts.
 [`PORT.md`](PORT.md) records the completed migration layer by layer.
 
+Holder recovery does not depend solely on the daemon's global registry. Before
+a local Holder starts, the Engine writes a small per-session recovery capsule
+beside its provider storage. Hooks and notifications update a separate,
+privacy-minimized activity seed before attempting the control socket. A new
+daemon can therefore adopt a surviving Holder, reconstruct its identity, and
+replay its last lifecycle signal even when the registry write was interrupted.
+
+Authoritative lifecycle transitions are also appended to
+`activity-log.jsonl`. Entries contain status and session metadata, not terminal
+output, prompts, or tool input. The automation CLI exposes the recent history
+and manifest-supported native forks:
+
+```sh
+dirijor activity --limit 25
+dirijor activity --json
+dirijor session fork <session-id-or-title>
+```
+
+Fork support is capability-driven: it is offered only when the selected agent
+manifest declares a native fork command.
+
 ## Install
 
 ```sh

--- a/diri/crates/diri-client/src/client.rs
+++ b/diri/crates/diri-client/src/client.rs
@@ -477,6 +477,13 @@ impl DaemonClient {
         Ok(record.id)
     }
 
+    pub async fn fork(&self, session_id: &SessionId) -> Result<SessionId, ClientError> {
+        let record: SessionForkResult = self
+            .typed(Method::SESSION_FORK, &session_params(session_id))
+            .await?;
+        Ok(record.id)
+    }
+
     /// `session.migrate`: git shuttling + respawn can take a while, so this
     /// carries its own generous timeout instead of waiting forever.
     pub async fn migrate(
@@ -752,6 +759,11 @@ impl DaemonClient {
 
     pub async fn history(&self) -> Result<SessionHistoryResult, ClientError> {
         self.no_params(Method::SESSION_HISTORY).await
+    }
+
+    pub async fn activity(&self, limit: Option<u16>) -> Result<ActivityListResult, ClientError> {
+        self.typed(Method::ACTIVITY_LIST, &ActivityListParams { limit })
+            .await
     }
 
     pub async fn resume_from_history(

--- a/diri/crates/diri-engine/manifests/claude-code.json
+++ b/diri/crates/diri-engine/manifests/claude-code.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "id": "claude-code",
-  "version": "2026.07.07.1",
+  "version": "2026.08.15.1",
   "statusModel": "full",
   "agent": {
     "id": "claude-code",
@@ -27,6 +27,23 @@
     "resume": {
       "style": "flag",
       "token": "--resume"
+    },
+    "conversation": {
+      "freshArgs": ["--session-id", "{newId}"],
+      "resume": {
+        "exactArgs": ["--resume", "{id}"],
+        "latestArgs": ["--continue"]
+      },
+      "fork": {
+        "exactArgs": ["--resume", "{id}", "--fork-session"],
+        "latestArgs": ["--continue", "--fork-session"]
+      },
+      "stripArgs": [
+        {"token": "--resume", "value": "nonoption"},
+        {"token": "--continue"},
+        {"token": "--session-id", "value": "any"},
+        {"token": "--fork-session"}
+      ]
     },
     "env": {
       "CLAUDE_CODE_NO_FLICKER": "1"

--- a/diri/crates/diri-engine/manifests/codex.json
+++ b/diri/crates/diri-engine/manifests/codex.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "id": "codex",
-  "version": "2026.07.07",
+  "version": "2026.08.15.1",
   "statusModel": "full",
   "agent": {
     "id": "codex",
@@ -26,6 +26,20 @@
       "style": "flag",
       "token": "resume"
     },
+    "conversation": {
+      "resume": {
+        "exactArgs": ["resume", "{id}"],
+        "latestArgs": ["resume", "--last"]
+      },
+      "fork": {
+        "exactArgs": ["fork", "{id}"],
+        "latestArgs": ["fork", "--last"]
+      },
+      "stripArgs": [
+        {"token": "resume", "value": "any"},
+        {"token": "fork", "value": "any"}
+      ]
+    },
     "envScrubPrefixes": [
       "CODEX",
       "DIRI_",
@@ -42,7 +56,7 @@
       "text": "",
       "submit": true
     },
-    "_resumeStyleNotice": "Swift's \"subcommand\" style has no implementation in Rust's AgentDescriptor::resume_args. Declared as \"flag\": with no id it emits `codex resume`, and once a notify payload supplies a thread-id it emits `codex resume <thread-id>` \u2014 both are valid codex invocations.",
+    "_resumeStyleNotice": "The structured conversation grammar keeps Codex's resume/fork subcommands after global Diri config overrides and strips stale conversation subcommands before selecting one canonical launch mode.",
     "deny": {
       "text": "\u001b",
       "submit": false

--- a/diri/crates/diri-engine/manifests/gemini.json
+++ b/diri/crates/diri-engine/manifests/gemini.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "id": "gemini",
-  "version": "2026.07.10",
+  "version": "2026.08.15.1",
   "statusModel": "full",
   "agent": {
     "id": "gemini",
@@ -25,6 +25,17 @@
     "resume": {
       "style": "flag",
       "token": "--resume"
+    },
+    "conversation": {
+      "freshArgs": ["--session-id", "{newId}"],
+      "resume": {
+        "exactArgs": ["--resume", "{id}"],
+        "latestArgs": ["--resume", "latest"]
+      },
+      "stripArgs": [
+        {"token": "--resume", "value": "any"},
+        {"token": "--session-id", "value": "any"}
+      ]
     },
     "envScrubPrefixes": [
       "GEMINI_CLI",

--- a/diri/crates/diri-engine/manifests/pi.json
+++ b/diri/crates/diri-engine/manifests/pi.json
@@ -2,7 +2,7 @@
   "_notice": "Screen-detection predicates adapted from the herdr project (https://github.com/herdrdev/herdr, src/detect/manifests/*.toml), licensed Apache-2.0. Translated from herdr's TOML rule schema into Dirijor's JSON predicate schema and re-prioritised for this engine; the agent capability block is Dirijor's own.",
   "schemaVersion": 2,
   "id": "pi",
-  "version": "2026.07.31.1",
+  "version": "2026.08.15.1",
   "statusModel": "processOnly",
   "agent": {
     "id": "pi",
@@ -23,12 +23,25 @@
       "style": "flag",
       "token": "-c"
     },
+    "conversation": {
+      "freshArgs": ["--session-dir", "{sessionDir}"],
+      "resume": {
+        "latestArgs": ["--session-dir", "{sessionDir}", "-c"]
+      },
+      "stripArgs": [
+        {"token": "-c"},
+        {"token": "--continue"},
+        {"token": "--session", "value": "any"},
+        {"token": "--session-dir", "value": "any"},
+        {"token": "--fork"}
+      ]
+    },
     "returnToLoginShell": true,
     "foregroundExecNames": [
       "pi"
     ],
     "_resumeNotice": "Verified against Pi's official README: 'pi -c                  # Continue most recent session'. https://github.com/earendil-works/pi/blob/main/packages/coding-agent/README.md. --session requires a path or id.",
-    "_resumeStyleNotice": "Rust's AgentDescriptor::resume_args implements only \"flag\" and \"sessionIDFlag\"; Swift's \"latest\" has no implementation there and would silently resume nothing. Declared as \"flag\": this agent has no sessionIDFlag, so it never carries a caller-minted id and resume_args emits the bare token \u2014 exactly the semantics the token was chosen for.",
+    "_resumeStyleNotice": "Diri pins Pi's fresh and continue commands to a per-session provider directory, so `-c` cannot accidentally select another Diri session's latest conversation.",
     "envScrubPrefixes": [
       "DIRI_",
       "DIRIJOR_"

--- a/diri/crates/diri-engine/src/activity.rs
+++ b/diri/crates/diri-engine/src/activity.rs
@@ -1,0 +1,293 @@
+//! Bounded durable history of authoritative Session lifecycle outcomes.
+//!
+//! Callers present complete `SessionRecord`s at the existing event-publication
+//! seam. This module alone maps statuses to activity vocabulary, collapses
+//! repeats, snapshots display identity, and maintains the JSONL file.
+
+use std::fs::OpenOptions;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use diri_proto::{ActivityEntry, ActivityKind, DateMillis, SessionRecord, SessionStatus};
+
+const MAX_ENTRIES: usize = 300;
+const COMPACT_AT_PHYSICAL_LINES: usize = MAX_ENTRIES * 2;
+
+pub struct ActivityLog {
+    path: PathBuf,
+    entries: Vec<ActivityEntry>,
+    physical_lines: usize,
+}
+
+impl ActivityLog {
+    pub fn load(path: impl Into<PathBuf>) -> io::Result<Self> {
+        let path = path.into();
+        let bytes = match std::fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Vec::new(),
+            Err(error) => return Err(error),
+        };
+        let physical_lines = bytes
+            .split(|byte| *byte == b'\n')
+            .filter(|line| !line.is_empty())
+            .count();
+        let mut entries = Vec::new();
+        for line in bytes
+            .split(|byte| *byte == b'\n')
+            .filter(|line| !line.is_empty())
+        {
+            let Ok(entry) = serde_json::from_slice::<ActivityEntry>(line) else {
+                continue;
+            };
+            append_collapsing(&mut entries, entry);
+            trim(&mut entries);
+        }
+        Ok(Self {
+            path,
+            entries,
+            physical_lines,
+        })
+    }
+
+    pub fn recent(&self, limit: usize) -> Vec<ActivityEntry> {
+        self.entries.iter().rev().take(limit).cloned().collect()
+    }
+
+    pub fn observe(&mut self, record: &SessionRecord) -> io::Result<bool> {
+        let kind = match record.status {
+            SessionStatus::Starting | SessionStatus::Working => ActivityKind::Started,
+            SessionStatus::NeedsInput(_) => ActivityKind::NeedsInput,
+            SessionStatus::Idle => ActivityKind::Finished,
+            SessionStatus::Exited(_) => ActivityKind::Exited,
+            SessionStatus::Unknown => return Ok(false),
+        };
+        self.append(record, kind)
+    }
+
+    pub fn observe_removed(&mut self, record: &SessionRecord) -> io::Result<bool> {
+        self.append(record, ActivityKind::Exited)
+    }
+
+    fn append(&mut self, record: &SessionRecord, kind: ActivityKind) -> io::Result<bool> {
+        if self
+            .entries
+            .iter()
+            .rev()
+            .find(|entry| entry.session_id == record.id)
+            .is_some_and(|entry| {
+                entry.kind == kind
+                    && entry.title == record.title
+                    && entry.agent_id == record.effective_kind().id()
+                    && entry.project_id == record.project_id
+                    && entry.cwd == record.cwd
+                    && entry.host == record.host
+            })
+        {
+            return Ok(false);
+        }
+        let entry = ActivityEntry {
+            id: activity_id(),
+            session_id: record.id.clone(),
+            kind,
+            at: DateMillis::from(std::time::SystemTime::now()),
+            title: record.title.clone(),
+            agent_id: record.effective_kind().id().to_owned(),
+            project_id: record.project_id.clone(),
+            cwd: record.cwd.clone(),
+            host: record.host.clone(),
+        };
+        append_line(&self.path, &entry)?;
+        self.physical_lines += 1;
+        append_collapsing(&mut self.entries, entry);
+        trim(&mut self.entries);
+        if self.physical_lines >= COMPACT_AT_PHYSICAL_LINES {
+            compact(&self.path, &self.entries)?;
+            self.physical_lines = self.entries.len();
+        }
+        Ok(true)
+    }
+}
+
+fn append_collapsing(entries: &mut Vec<ActivityEntry>, entry: ActivityEntry) {
+    if let Some(previous) = entries
+        .iter()
+        .rposition(|candidate| candidate.session_id == entry.session_id)
+        && entries[previous].kind == entry.kind
+    {
+        entries.remove(previous);
+    }
+    entries.push(entry);
+}
+
+fn trim(entries: &mut Vec<ActivityEntry>) {
+    if entries.len() > MAX_ENTRIES {
+        entries.drain(..entries.len() - MAX_ENTRIES);
+    }
+}
+
+fn append_line(path: &Path, entry: &ActivityEntry) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path)?;
+    serde_json::to_writer(&mut file, entry)?;
+    file.write_all(b"\n")?;
+    file.sync_data()
+}
+
+fn compact(path: &Path, entries: &[ActivityEntry]) -> io::Result<()> {
+    static NEXT_TEMPORARY: AtomicU64 = AtomicU64::new(0);
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("activity-log.jsonl");
+    let temporary = path.with_file_name(format!(
+        ".{file_name}.tmp-{}-{}",
+        std::process::id(),
+        NEXT_TEMPORARY.fetch_add(1, Ordering::Relaxed)
+    ));
+    let mut options = OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(&temporary)?;
+    for entry in entries {
+        serde_json::to_writer(&mut file, entry)?;
+        file.write_all(b"\n")?;
+    }
+    file.sync_all()?;
+    drop(file);
+    if let Err(error) = std::fs::rename(&temporary, path) {
+        let _ = std::fs::remove_file(temporary);
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn activity_id() -> String {
+    let mut bytes = [0_u8; 8];
+    if getrandom::fill(&mut bytes).is_err() {
+        let fallback = DateMillis::from(std::time::SystemTime::now()).0.to_bits();
+        bytes = fallback.to_be_bytes();
+    }
+    format!(
+        "a_{}",
+        bytes
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use diri_proto::{AgentKind, ProjectId, Resumability, SessionId, TitleSource};
+
+    fn record(id: &str, status: SessionStatus) -> SessionRecord {
+        SessionRecord {
+            id: SessionId::new(id),
+            kind: AgentKind::CODEX,
+            cwd: "/tmp/project".into(),
+            project_id: ProjectId::new("p_project"),
+            worktree_path: None,
+            git_branch: None,
+            title: format!("Session {id}"),
+            title_source: TitleSource::Placeholder,
+            originating_prompt: None,
+            agent_session_id: None,
+            transcript_path: None,
+            status,
+            status_evidence: None,
+            needs_input: None,
+            resumability: Resumability::Live,
+            capabilities: None,
+            parent: None,
+            created_at: DateMillis(1.0),
+            updated_at: DateMillis(1.0),
+            last_turn_completed_at: None,
+            last_seen_at: None,
+            pinned: false,
+            archived_at: None,
+            host: None,
+            remote_persistence: None,
+            hibernation: None,
+            memory_bytes: None,
+            artifacts: None,
+            pull_requests: None,
+            listening_ports: None,
+            foreground_agent: None,
+        }
+    }
+
+    #[test]
+    fn lifecycle_outcomes_are_durable_and_repeat_collapsed() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let path = directory.path().join("activity.jsonl");
+        let mut log = ActivityLog::load(&path).expect("load");
+        let working = record("s_one", SessionStatus::Working);
+        assert!(log.observe(&working).expect("started"));
+        assert!(!log.observe(&working).expect("duplicate"));
+        let idle = record("s_one", SessionStatus::Idle);
+        assert!(log.observe(&idle).expect("finished"));
+
+        let reloaded = ActivityLog::load(&path).expect("reload");
+        assert_eq!(
+            reloaded
+                .recent(10)
+                .into_iter()
+                .map(|entry| entry.kind)
+                .collect::<Vec<_>>(),
+            [ActivityKind::Finished, ActivityKind::Started]
+        );
+    }
+
+    #[test]
+    fn snapshots_survive_a_removed_record() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let path = directory.path().join("activity.jsonl");
+        let mut log = ActivityLog::load(&path).expect("load");
+        let record = record("s_removed", SessionStatus::Working);
+        log.observe(&record).expect("started");
+        log.observe_removed(&record).expect("removed");
+
+        let entries = ActivityLog::load(path).expect("reload").recent(1);
+        assert_eq!(entries[0].kind, ActivityKind::Exited);
+        assert_eq!(entries[0].title, "Session s_removed");
+        assert_eq!(entries[0].cwd, "/tmp/project");
+    }
+
+    #[test]
+    fn malformed_lines_do_not_hide_later_history() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let path = directory.path().join("activity.jsonl");
+        let valid = ActivityEntry {
+            id: "a_valid".into(),
+            session_id: SessionId::new("s_valid"),
+            kind: ActivityKind::Finished,
+            at: DateMillis(1.0),
+            title: "Valid".into(),
+            agent_id: "codex".into(),
+            project_id: ProjectId::new("p"),
+            cwd: "/tmp".into(),
+            host: None,
+        };
+        let mut bytes = b"not json\n".to_vec();
+        bytes.extend(serde_json::to_vec(&valid).expect("encode"));
+        bytes.push(b'\n');
+        std::fs::write(&path, bytes).expect("fixture");
+
+        assert_eq!(ActivityLog::load(path).expect("load").recent(10), [valid]);
+    }
+}

--- a/diri/crates/diri-engine/src/agent.rs
+++ b/diri/crates/diri-engine/src/agent.rs
@@ -38,6 +38,73 @@ pub struct ResumeSpec {
     pub token: Option<String>,
 }
 
+/// Manifest-owned grammar for one conversation verb.
+///
+/// Tokens are argv, not a shell fragment. `{id}`, `{newId}`, and
+/// `{sessionDir}` are the only substitutions, keeping launch construction
+/// structured all the way into local and remote Holders.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConversationCommandSpec {
+    #[serde(default)]
+    pub exact_args: Vec<String>,
+    #[serde(default)]
+    pub latest_args: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum StripValue {
+    #[default]
+    None,
+    Any,
+    Nonoption,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConversationStripSpec {
+    pub token: String,
+    #[serde(default)]
+    pub value: StripValue,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConversationSpec {
+    #[serde(default)]
+    pub fresh_args: Vec<String>,
+    #[serde(default)]
+    pub resume: Option<ConversationCommandSpec>,
+    #[serde(default)]
+    pub fork: Option<ConversationCommandSpec>,
+    #[serde(default)]
+    pub strip_args: Vec<ConversationStripSpec>,
+}
+
+pub enum ConversationLaunch<'a> {
+    Fresh {
+        new_id: Option<&'a str>,
+        session_dir: Option<&'a std::path::Path>,
+    },
+    Resume {
+        source_id: Option<&'a str>,
+        session_dir: Option<&'a std::path::Path>,
+    },
+    Fork {
+        source_id: Option<&'a str>,
+        session_dir: Option<&'a std::path::Path>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConversationLaunchPlan {
+    pub args: Vec<String>,
+    /// Provider-side identity known at launch. Forks intentionally clear it:
+    /// the provider will report the newly created conversation.
+    pub agent_session_id: Option<String>,
+}
+
 /// The config-injection mechanisms a manifest can opt into. Each is a
 /// Dirijor-implemented shim (hooks file, MCP config, notify callback): the
 /// manifest names the mechanism, the daemon owns the file it points at.
@@ -119,6 +186,10 @@ pub struct AgentDescriptor {
     pub injection: InjectionSpec,
     #[serde(default)]
     pub resume: Option<ResumeSpec>,
+    /// Structured fresh/resume/fork grammar. `resume` above remains the
+    /// additive compatibility path for older user manifests.
+    #[serde(default)]
+    pub conversation: Option<ConversationSpec>,
     /// Environment the agent needs.
     #[serde(default)]
     pub env: std::collections::BTreeMap<String, String>,
@@ -143,10 +214,12 @@ impl AgentDescriptor {
         resumability: diri_proto::Resumability,
         status: &diri_proto::SessionStatus,
         archived: bool,
+        agent_session_id: Option<&str>,
     ) -> diri_proto::SessionCapabilities {
         let live = !archived && !matches!(status, diri_proto::SessionStatus::Exited(_));
         diri_proto::SessionCapabilities {
             resume: resumability == diri_proto::Resumability::Resumable,
+            fork: self.can_fork(agent_session_id),
             archive: !archived,
             send_text: live,
             quick_approve: self.approve.is_some(),
@@ -159,6 +232,154 @@ impl AgentDescriptor {
     pub fn authority(&self) -> Authority {
         self.status_authority
             .map_or(Authority::ProcessOnly, Authority::from)
+    }
+
+    pub fn supports_resume(&self) -> bool {
+        self.conversation
+            .as_ref()
+            .is_some_and(|conversation| conversation.resume.is_some())
+            || self.resume.is_some()
+    }
+
+    /// Whether the manifest intentionally resumes from session-scoped storage
+    /// without requiring a provider conversation identifier.
+    pub fn supports_id_free_resume(&self) -> bool {
+        self.conversation
+            .as_ref()
+            .and_then(|conversation| conversation.resume.as_ref())
+            .is_some_and(|resume| resume.exact_args.is_empty() && !resume.latest_args.is_empty())
+    }
+
+    pub fn supports_fork(&self) -> bool {
+        self.conversation
+            .as_ref()
+            .is_some_and(|conversation| conversation.fork.is_some())
+    }
+
+    pub fn can_fork(&self, agent_session_id: Option<&str>) -> bool {
+        self.conversation
+            .as_ref()
+            .and_then(|conversation| conversation.fork.as_ref())
+            .is_some_and(|fork| {
+                (agent_session_id.is_some() && !fork.exact_args.is_empty())
+                    || !fork.latest_args.is_empty()
+            })
+    }
+
+    pub fn mints_conversation_id(&self) -> bool {
+        self.session_id_flag.is_some()
+            || self.conversation.as_ref().is_some_and(|conversation| {
+                conversation
+                    .fresh_args
+                    .iter()
+                    .any(|token| token == "{newId}")
+            })
+    }
+
+    /// Canonicalizes caller/manifest args and applies exactly one
+    /// conversation mode. Every launch path uses this interface, preventing a
+    /// stale resume marker from being stacked with a new identity.
+    pub fn conversation_plan(
+        &self,
+        base_args: &[String],
+        launch: ConversationLaunch<'_>,
+    ) -> Option<ConversationLaunchPlan> {
+        let mut args = self.strip_conversation_args(base_args);
+        if let Some(conversation) = &self.conversation {
+            let (tokens, agent_session_id) = match launch {
+                ConversationLaunch::Fresh {
+                    new_id,
+                    session_dir,
+                } => (
+                    render_tokens(&conversation.fresh_args, new_id, new_id, session_dir)?,
+                    new_id.map(str::to_owned),
+                ),
+                ConversationLaunch::Resume {
+                    source_id,
+                    session_dir,
+                } => (
+                    render_command(conversation.resume.as_ref()?, source_id, session_dir)?,
+                    source_id.map(str::to_owned),
+                ),
+                ConversationLaunch::Fork {
+                    source_id,
+                    session_dir,
+                } => (
+                    render_command(conversation.fork.as_ref()?, source_id, session_dir)?,
+                    None,
+                ),
+            };
+            args.extend(tokens);
+            return Some(ConversationLaunchPlan {
+                args,
+                agent_session_id,
+            });
+        }
+
+        match launch {
+            ConversationLaunch::Fresh { new_id, .. } => {
+                if let (Some(flag), Some(id)) = (&self.session_id_flag, new_id) {
+                    args.extend([flag.clone(), id.to_owned()]);
+                }
+                Some(ConversationLaunchPlan {
+                    args,
+                    agent_session_id: new_id.map(str::to_owned),
+                })
+            }
+            ConversationLaunch::Resume { source_id, .. } => {
+                args.extend(self.legacy_resume_args(source_id)?);
+                Some(ConversationLaunchPlan {
+                    args,
+                    agent_session_id: source_id.map(str::to_owned),
+                })
+            }
+            ConversationLaunch::Fork { .. } => None,
+        }
+    }
+
+    fn strip_conversation_args(&self, base_args: &[String]) -> Vec<String> {
+        let mut markers: Vec<(&str, StripValue)> = self
+            .conversation
+            .as_ref()
+            .into_iter()
+            .flat_map(|conversation| conversation.strip_args.iter())
+            .map(|marker| (marker.token.as_str(), marker.value))
+            .collect();
+        if let Some(flag) = self.session_id_flag.as_deref()
+            && !markers.iter().any(|(token, _)| *token == flag)
+        {
+            markers.push((flag, StripValue::Any));
+        }
+        if self.conversation.is_none()
+            && let Some(resume) = &self.resume
+            && let Some(token) = resume.token.as_deref()
+            && !markers.iter().any(|(candidate, _)| *candidate == token)
+        {
+            markers.push((token, StripValue::Nonoption));
+        }
+
+        let mut stripped = Vec::with_capacity(base_args.len());
+        let mut index = 0;
+        while index < base_args.len() {
+            let token = &base_args[index];
+            if let Some((_, value)) = markers.iter().find(|(marker, _)| *marker == token) {
+                index += 1;
+                let consumes = match value {
+                    StripValue::None => false,
+                    StripValue::Any => index < base_args.len(),
+                    StripValue::Nonoption => base_args
+                        .get(index)
+                        .is_some_and(|candidate| !candidate.starts_with('-')),
+                };
+                if consumes {
+                    index += 1;
+                }
+            } else {
+                stripped.push(token.clone());
+                index += 1;
+            }
+        }
+        stripped
     }
 
     /// Builds the launch spec for this agent in `cwd`.
@@ -321,6 +542,18 @@ pub(crate) fn resolve_on_path(binary: &str, path: &str) -> Option<String> {
 impl AgentDescriptor {
     /// The argv tail that resumes an existing conversation, if the agent can.
     pub fn resume_args(&self, agent_session_id: Option<&str>) -> Option<Vec<String>> {
+        self.conversation_plan(
+            &[],
+            ConversationLaunch::Resume {
+                source_id: agent_session_id,
+                session_dir: None,
+            },
+        )
+        .map(|plan| plan.args)
+        .or_else(|| self.legacy_resume_args(agent_session_id))
+    }
+
+    fn legacy_resume_args(&self, agent_session_id: Option<&str>) -> Option<Vec<String>> {
         let resume = self.resume.as_ref()?;
         let token = resume.token.clone()?;
         match resume.style.as_str() {
@@ -338,6 +571,37 @@ impl AgentDescriptor {
             _ => None,
         }
     }
+}
+
+fn render_command(
+    command: &ConversationCommandSpec,
+    id: Option<&str>,
+    session_dir: Option<&std::path::Path>,
+) -> Option<Vec<String>> {
+    if let Some(id) = id
+        && !command.exact_args.is_empty()
+    {
+        return render_tokens(&command.exact_args, Some(id), None, session_dir);
+    }
+    (!command.latest_args.is_empty())
+        .then(|| render_tokens(&command.latest_args, id, None, session_dir))?
+}
+
+fn render_tokens(
+    tokens: &[String],
+    id: Option<&str>,
+    new_id: Option<&str>,
+    session_dir: Option<&std::path::Path>,
+) -> Option<Vec<String>> {
+    tokens
+        .iter()
+        .map(|token| match token.as_str() {
+            "{id}" => id.map(str::to_owned),
+            "{newId}" => new_id.map(str::to_owned),
+            "{sessionDir}" => session_dir.map(|path| path.to_string_lossy().into_owned()),
+            _ => Some(token.clone()),
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -638,7 +902,7 @@ mod tests {
         );
         assert_eq!(
             claude.resume_args(None),
-            Some(vec!["--resume".to_string()]),
+            Some(vec!["--continue".to_string()]),
             "claude can resume the latest session without an id"
         );
 
@@ -657,7 +921,6 @@ mod tests {
         for (id, token) in [
             ("opencode", "--continue"),
             ("aider", "--restore-chat-history"),
-            ("codex", "resume"),
             ("cursor", "resume"),
             ("pi", "-c"),
         ] {
@@ -667,6 +930,101 @@ mod tests {
                 "{id} must resume"
             );
         }
+        assert_eq!(
+            descriptor("codex").resume_args(None),
+            Some(vec!["resume".into(), "--last".into()])
+        );
+    }
+
+    #[test]
+    fn conversation_plans_replace_stale_markers_and_support_native_forks() {
+        let claude = descriptor("claude-code");
+        let base = vec![
+            "--resume".into(),
+            "stale".into(),
+            "--fork-session".into(),
+            "--settings".into(),
+            "hooks.json".into(),
+        ];
+        let resumed = claude
+            .conversation_plan(
+                &base,
+                ConversationLaunch::Resume {
+                    source_id: Some("current"),
+                    session_dir: None,
+                },
+            )
+            .expect("resume");
+        assert_eq!(
+            resumed.args,
+            ["--settings", "hooks.json", "--resume", "current"]
+        );
+        let forked = claude
+            .conversation_plan(
+                &resumed.args,
+                ConversationLaunch::Fork {
+                    source_id: Some("current"),
+                    session_dir: None,
+                },
+            )
+            .expect("fork");
+        assert_eq!(
+            forked.args,
+            [
+                "--settings",
+                "hooks.json",
+                "--resume",
+                "current",
+                "--fork-session"
+            ]
+        );
+        assert!(forked.agent_session_id.is_none());
+
+        let codex = descriptor("codex");
+        let codex_fork = codex
+            .conversation_plan(
+                &[
+                    "-c".into(),
+                    "notify=[]".into(),
+                    "resume".into(),
+                    "old".into(),
+                ],
+                ConversationLaunch::Fork {
+                    source_id: Some("thread-9"),
+                    session_dir: None,
+                },
+            )
+            .expect("codex fork");
+        assert_eq!(codex_fork.args, ["-c", "notify=[]", "fork", "thread-9"]);
+    }
+
+    #[test]
+    fn pi_storage_pinning_makes_continue_session_specific() {
+        let pi = descriptor("pi");
+        let directory = Path::new("/tmp/diri/s_pi/provider");
+        let fresh = pi
+            .conversation_plan(
+                &[],
+                ConversationLaunch::Fresh {
+                    new_id: None,
+                    session_dir: Some(directory),
+                },
+            )
+            .expect("fresh");
+        assert_eq!(fresh.args, ["--session-dir", "/tmp/diri/s_pi/provider"]);
+        let resumed = pi
+            .conversation_plan(
+                &fresh.args,
+                ConversationLaunch::Resume {
+                    source_id: None,
+                    session_dir: Some(directory),
+                },
+            )
+            .expect("resume");
+        assert_eq!(
+            resumed.args,
+            ["--session-dir", "/tmp/diri/s_pi/provider", "-c"]
+        );
     }
 
     #[test]
@@ -677,16 +1035,25 @@ mod tests {
             code: Some(0),
             signal: None,
         });
-        let capabilities =
-            codex.session_capabilities(diri_proto::Resumability::Resumable, &exited, false);
+        let capabilities = codex.session_capabilities(
+            diri_proto::Resumability::Resumable,
+            &exited,
+            false,
+            Some("thread-1"),
+        );
         assert!(capabilities.resume);
+        assert!(capabilities.fork);
         assert!(capabilities.archive);
         assert!(!capabilities.send_text);
         assert!(capabilities.quick_approve);
         assert!(capabilities.reliable_completion);
 
-        let archived =
-            codex.session_capabilities(diri_proto::Resumability::Resumable, &exited, true);
+        let archived = codex.session_capabilities(
+            diri_proto::Resumability::Resumable,
+            &exited,
+            true,
+            Some("thread-1"),
+        );
         assert!(archived.resume, "restore can re-enter the conversation");
         assert!(!archived.archive);
     }

--- a/diri/crates/diri-engine/src/control.rs
+++ b/diri/crates/diri-engine/src/control.rs
@@ -70,6 +70,12 @@ pub struct InjectionConfig {
     pub cli_path: PathBuf,
 }
 
+#[derive(Clone, Copy)]
+enum ConversationAction {
+    Resume,
+    Fork,
+}
+
 /// Whether a local session's execution directory is inside `target`.
 ///
 /// Session cwd values intentionally preserve the spelling supplied at spawn,
@@ -118,6 +124,14 @@ impl ControlServer {
                 eprintln!("diri-engine: Agent configuration unavailable: {error}");
                 crate::agent_catalog::AgentCatalogStore::empty(agent_config_path)
             });
+        let events = crate::events::EventBus::new();
+        let activity_path = logs_dir
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(diri_proto::paths::ACTIVITY_LOG_FILE_NAME);
+        if let Err(error) = events.enable_activity_log(activity_path) {
+            eprintln!("diri-engine: activity history unavailable: {error}");
+        }
         Self {
             registry,
             socket_path,
@@ -125,7 +139,7 @@ impl ControlServer {
             holder: None,
             remote: None,
             remote_bindings,
-            events: crate::events::EventBus::new(),
+            events,
             attach: crate::attach::AttachHub::new(),
             pr_monitor_wake: crate::pr_monitor::PrMonitorWake::default(),
             injection: None,
@@ -173,6 +187,14 @@ impl ControlServer {
     /// socket, matching the Swift daemon's layout.
     pub fn with_logs_dir(mut self, logs_dir: impl Into<PathBuf>) -> Self {
         self.logs_dir = logs_dir.into();
+        let activity_path = self
+            .logs_dir
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(diri_proto::paths::ACTIVITY_LOG_FILE_NAME);
+        if let Err(error) = self.events.enable_activity_log(activity_path) {
+            eprintln!("diri-engine: activity history unavailable: {error}");
+        }
         self
     }
 
@@ -668,6 +690,7 @@ impl ControlServer {
             Method::SESSION_ARCHIVE => self.session_archive(params),
             Method::SESSION_UNARCHIVE => self.session_unarchive(params),
             Method::SESSION_HISTORY => self.session_history(),
+            Method::ACTIVITY_LIST => self.activity_list(params),
             Method::WORKTREE_CREATE => self.worktree_create(params),
             Method::WORKTREE_LIST => self.worktree_list(params),
             Method::WORKTREE_REMOVE => self.worktree_remove(params),
@@ -683,6 +706,7 @@ impl ControlServer {
             Method::HOST_LOCATE_REPO => self.host_locate_repo(params),
             Method::HOOK_REPORT => self.hook_report(params),
             Method::SESSION_RESUME => self.session_resume(params),
+            Method::SESSION_FORK => self.session_fork(params),
             Method::SESSION_RESUME_FROM_HISTORY => self.session_resume_from_history(params),
             Method::SESSION_REOPEN_LAST => self.session_reopen_last(),
             Method::AGENT_READINESS => self.agent_readiness(params),
@@ -805,12 +829,6 @@ impl ControlServer {
         let mut agent_session_id = None;
         if descriptor.binary.is_some() {
             launch_args.extend(descriptor.spawn_args.iter().cloned());
-            agent_session_id = descriptor.session_id_flag.as_ref().map(|flag| {
-                let uuid = crate::inject::uuid_v4();
-                launch_args.push(flag.clone());
-                launch_args.push(uuid.clone());
-                uuid
-            });
             if let Some(injection) = &self.injection {
                 launch_args.extend(crate::inject::injection_args_with_cursor(
                     &descriptor.injection,
@@ -822,6 +840,25 @@ impl ControlServer {
                     }),
                 ));
             }
+            let minted = descriptor
+                .mints_conversation_id()
+                .then(crate::inject::uuid_v4);
+            let provider_dir = registry.recovery_directory(&id).join("provider");
+            let plan = descriptor
+                .conversation_plan(
+                    &launch_args,
+                    crate::agent::ConversationLaunch::Fresh {
+                        new_id: minted.as_deref(),
+                        session_dir: Some(&provider_dir),
+                    },
+                )
+                .ok_or_else(|| {
+                    ControlError::bad_request(format!(
+                        "agent {kind:?} has an incomplete fresh conversation grammar"
+                    ))
+                })?;
+            launch_args = plan.args;
+            agent_session_id = plan.agent_session_id;
         }
 
         let inherited: Vec<(String, String)> = std::env::vars().collect();
@@ -882,6 +919,13 @@ impl ControlServer {
                 pty.env.push((
                     crate::inject::CLI_ENV.into(),
                     injection.cli_path.to_string_lossy().into_owned(),
+                ));
+                pty.env.push((
+                    diri_proto::paths::ENV_SESSION_RECOVERY_DIR.into(),
+                    registry
+                        .recovery_directory(&id)
+                        .to_string_lossy()
+                        .into_owned(),
                 ));
             }
             if let Some(uuid) = &agent_session_id {
@@ -1034,12 +1078,29 @@ impl ControlServer {
         let mut launch_args = caller_argv.clone();
         if descriptor.binary.is_some() {
             launch_args.extend(descriptor.spawn_args.iter().cloned());
-            agent_session_id = descriptor.session_id_flag.as_ref().map(|flag| {
-                let uuid = crate::inject::uuid_v4();
-                launch_args.push(flag.clone());
-                launch_args.push(uuid.clone());
-                uuid
-            });
+            let minted = descriptor
+                .mints_conversation_id()
+                .then(crate::inject::uuid_v4);
+            let provider_dir = inherited
+                .iter()
+                .rev()
+                .find(|(name, value)| name == "HOME" && !value.is_empty())
+                .map(|(_, home)| Path::new(home).join(".diri/session-storage").join(&id));
+            let plan = descriptor
+                .conversation_plan(
+                    &launch_args,
+                    crate::agent::ConversationLaunch::Fresh {
+                        new_id: minted.as_deref(),
+                        session_dir: provider_dir.as_deref(),
+                    },
+                )
+                .ok_or_else(|| {
+                    ControlError::bad_request(format!(
+                        "agent {kind:?} has an incomplete fresh conversation grammar"
+                    ))
+                })?;
+            launch_args = plan.args;
+            agent_session_id = plan.agent_session_id;
         }
 
         let argv = if descriptor.binary.is_some() {
@@ -1781,18 +1842,30 @@ impl ControlServer {
     fn session_remove(&self, params: Option<JsonValue>) -> Result<JsonValue, ControlError> {
         let p: diri_proto::SessionIdParams = decode(params)?;
         let mut registry = self.registry.lock().map_err(poisoned)?;
+        let removed = registry
+            .record(&p.session_id.0)
+            .ok_or_else(|| ControlError::not_found(p.session_id.0.clone()))?;
         registry
             .remove(&p.session_id.0, &self.logs_dir)
             .map_err(io_control_error)?;
         if let Some(store) = &self.remote_bindings {
             let _ = store.remove(&p.session_id.0);
         }
+        self.events.record_removed(&removed);
         self.events.publish(
             diri_proto::EventName::SESSION_REMOVED,
             json!({ "id": p.session_id.0, "reason": "released" }),
             Some(&p.session_id.0),
         );
         Ok(json!({}))
+    }
+
+    fn activity_list(&self, params: Option<JsonValue>) -> Result<JsonValue, ControlError> {
+        let p: diri_proto::ActivityListParams = decode(params)?;
+        let limit = usize::from(p.limit.unwrap_or(100).clamp(1, 300));
+        encode(&diri_proto::ActivityListResult {
+            entries: self.events.recent_activity(limit),
+        })
     }
 
     fn session_rename(&self, params: Option<JsonValue>) -> Result<JsonValue, ControlError> {
@@ -1950,9 +2023,77 @@ impl ControlServer {
         serde_json::to_value(&record).map_err(|error| ControlError::internal(error.to_string()))
     }
 
+    /// Starts a new Session whose provider conversation is a native fork of
+    /// `source`. The Diri record and provider identity are both new; lineage
+    /// points at the source and the source remains untouched.
+    fn session_fork(&self, params: Option<JsonValue>) -> Result<JsonValue, ControlError> {
+        let p: diri_proto::SessionForkParams = decode(params)?;
+        let source = {
+            let registry = self.registry.lock().map_err(poisoned)?;
+            registry
+                .records()
+                .into_iter()
+                .find(|record| record.id == p.session_id)
+                .ok_or_else(|| ControlError::not_found(p.session_id.0.clone()))?
+        };
+        let kind = source.effective_kind().clone();
+        let id = next_session_id();
+        let spec = if source.host.is_some() {
+            self.remote_conversation_spec(&source, &id, &kind, ConversationAction::Fork)?
+        } else {
+            let registry = self.registry.lock().map_err(poisoned)?;
+            self.local_conversation_spec(
+                &registry,
+                &id,
+                kind.id(),
+                &source.cwd,
+                source.agent_session_id.as_deref(),
+                ConversationAction::Fork,
+            )?
+        };
+        let remote_persistence = spec.remote.as_ref().map(|remote| remote.launch.persistence);
+        let mut record = new_record(&id, kind.id(), &source.cwd);
+        record.kind = kind;
+        record.project_id = source.project_id.clone();
+        record.worktree_path = source.worktree_path.clone();
+        record.git_branch = source.git_branch.clone();
+        record.parent = Some(source.id.clone());
+        record.host = source.host.clone();
+        record.remote_persistence = remote_persistence;
+        record.title = format!("Fork of {}", source.title);
+        record.title_source = diri_proto::TitleSource::DirijorAssigned;
+
+        let mut registry = self.registry.lock().map_err(poisoned)?;
+        registry.ensure_session_project(&source.cwd, source.host.as_deref());
+        registry
+            .spawn(spec, record)
+            .map_err(|error| ControlError::internal(error.to_string()))?;
+        let _ = registry.persist();
+        self.publish_updated(&registry, &id);
+        let record = registry
+            .record(&id)
+            .ok_or_else(|| ControlError::internal("the forked session vanished"))?;
+        encode(&record)
+    }
+
     fn remote_resume_spec(
         &self,
         record: &diri_proto::SessionRecord,
+    ) -> Result<crate::session::SessionSpec, ControlError> {
+        self.remote_conversation_spec(
+            record,
+            &record.id.0,
+            &record.kind,
+            ConversationAction::Resume,
+        )
+    }
+
+    fn remote_conversation_spec(
+        &self,
+        record: &diri_proto::SessionRecord,
+        target_id: &str,
+        kind: &diri_proto::AgentKind,
+        action: ConversationAction,
     ) -> Result<crate::session::SessionSpec, ControlError> {
         let manager = self
             .remote
@@ -1974,8 +2115,8 @@ impl ControlServer {
         let (mut descriptor, authority) = {
             let registry = self.registry.lock().map_err(poisoned)?;
             let engine = registry.engine();
-            let manifest = engine.manifest(record.kind.id()).ok_or_else(|| {
-                ControlError::not_found(format!("no manifest for agent {}", record.kind.id()))
+            let manifest = engine.manifest(kind.id()).ok_or_else(|| {
+                ControlError::not_found(format!("no manifest for agent {}", kind.id()))
             })?;
             let descriptor = manifest.agent.clone().unwrap_or_default();
             let authority = descriptor.authority();
@@ -1985,7 +2126,7 @@ impl ControlServer {
             let (executable, captured) = self.discover_remote_agent_for_launch(
                 manager.as_ref(),
                 &host,
-                record.kind.id(),
+                kind.id(),
                 binary,
                 record.cwd.clone(),
             )?;
@@ -2009,16 +2150,39 @@ impl ControlServer {
             ));
         }
         let mut launch_args = descriptor.spawn_args.clone();
-        launch_args.extend(
-            descriptor
-                .resume_args(record.agent_session_id.as_deref())
-                .ok_or_else(|| {
-                    ControlError::bad_request(format!(
-                        "agent {} does not support resume",
-                        record.kind.id()
-                    ))
-                })?,
-        );
+        let provider_dir = captured
+            .environment
+            .iter()
+            .rev()
+            .find(|variable| variable.name == "HOME" && !variable.value.is_empty())
+            .map(|variable| {
+                Path::new(&variable.value)
+                    .join(".diri/session-storage")
+                    .join(target_id)
+            });
+        let launch = match action {
+            ConversationAction::Resume => crate::agent::ConversationLaunch::Resume {
+                source_id: record.agent_session_id.as_deref(),
+                session_dir: provider_dir.as_deref(),
+            },
+            ConversationAction::Fork => crate::agent::ConversationLaunch::Fork {
+                source_id: record.agent_session_id.as_deref(),
+                session_dir: provider_dir.as_deref(),
+            },
+        };
+        launch_args = descriptor
+            .conversation_plan(&launch_args, launch)
+            .ok_or_else(|| {
+                ControlError::bad_request(format!(
+                    "agent {} does not support {}",
+                    kind.id(),
+                    match action {
+                        ConversationAction::Resume => "resume",
+                        ConversationAction::Fork => "fork",
+                    }
+                ))
+            })?
+            .args;
         let inherited = captured
             .environment
             .into_iter()
@@ -2026,10 +2190,10 @@ impl ControlServer {
         let pty = descriptor
             .remote_spawn_spec(&cwd, inherited, &launch_args)
             .ok_or_else(|| {
-                ControlError::bad_request(format!("agent {} declares no binary", record.kind.id()))
+                ControlError::bad_request(format!("agent {} declares no binary", kind.id()))
             })?;
         let launch = diri_proto::remote_pty::LaunchRequest {
-            session_id: record.id.0.clone(),
+            session_id: target_id.to_owned(),
             session_token: random_session_token()?,
             argv: pty.argv.clone(),
             cwd: captured.cwd,
@@ -2048,9 +2212,9 @@ impl ControlServer {
             persistence,
         };
         Ok(crate::session::SessionSpec {
-            id: record.id.0.clone(),
+            id: target_id.to_owned(),
             pty,
-            manifest_id: record.kind.id().to_string(),
+            manifest_id: kind.id().to_string(),
             authority,
             logs_dir: self.logs_dir.clone(),
             holder: None,
@@ -2121,6 +2285,25 @@ impl ControlServer {
         cwd: &str,
         agent_session_id: Option<&str>,
     ) -> Result<crate::session::SessionSpec, ControlError> {
+        self.local_conversation_spec(
+            registry,
+            id,
+            kind,
+            cwd,
+            agent_session_id,
+            ConversationAction::Resume,
+        )
+    }
+
+    fn local_conversation_spec(
+        &self,
+        registry: &Registry,
+        id: &str,
+        kind: &str,
+        cwd: &str,
+        agent_session_id: Option<&str>,
+        action: ConversationAction,
+    ) -> Result<crate::session::SessionSpec, ControlError> {
         let engine = registry.engine();
         let manifest = engine
             .manifest(kind)
@@ -2132,25 +2315,10 @@ impl ControlServer {
             .ok_or_else(|| ControlError::bad_request(format!("agent {kind} declares no binary")))?;
         let binary = descriptor.binary.clone().expect("checked above");
         descriptor.binary = Some(self.resolve_local_agent_executable(kind, &binary)?);
-        let tail = descriptor.resume_args(agent_session_id).ok_or_else(|| {
-            ControlError::bad_request(format!("agent {kind} does not support resume"))
-        })?;
-
         let mut launch_args = descriptor.spawn_args.clone();
-        launch_args.extend(tail);
         if let Some(injection) = &self.injection {
-            // Only the appendable flag mechanisms replay on resume, exactly
-            // as in Swift: Codex's global `-c` overrides must precede the
-            // resume SUBCOMMAND and are deliberately not replayed.
-            let replay = crate::agent::InjectionSpec {
-                claude_hooks: descriptor.injection.claude_hooks,
-                claude_mcp: descriptor.injection.claude_mcp,
-                cursor_mcp: descriptor.injection.cursor_mcp,
-                cursor_hooks: descriptor.injection.cursor_hooks,
-                ..Default::default()
-            };
             launch_args.extend(crate::inject::injection_args_with_cursor(
-                &replay,
+                &descriptor.injection,
                 &injection.inject_dir,
                 &injection.cli_path,
                 Some(crate::inject::CursorInject {
@@ -2159,6 +2327,29 @@ impl ControlServer {
                 }),
             ));
         }
+        let provider_dir = registry.recovery_directory(id).join("provider");
+        let launch = match action {
+            ConversationAction::Resume => crate::agent::ConversationLaunch::Resume {
+                source_id: agent_session_id,
+                session_dir: Some(&provider_dir),
+            },
+            ConversationAction::Fork => crate::agent::ConversationLaunch::Fork {
+                source_id: agent_session_id,
+                session_dir: Some(&provider_dir),
+            },
+        };
+        launch_args = descriptor
+            .conversation_plan(&launch_args, launch)
+            .ok_or_else(|| {
+                ControlError::bad_request(format!(
+                    "agent {kind} does not support {}",
+                    match action {
+                        ConversationAction::Resume => "resume",
+                        ConversationAction::Fork => "fork",
+                    }
+                ))
+            })?
+            .args;
 
         let inherited: Vec<(String, String)> = std::env::vars().collect();
         let mut pty = descriptor
@@ -2174,6 +2365,13 @@ impl ControlServer {
             pty.env.push((
                 crate::inject::CLI_ENV.into(),
                 injection.cli_path.to_string_lossy().into_owned(),
+            ));
+            pty.env.push((
+                diri_proto::paths::ENV_SESSION_RECOVERY_DIR.into(),
+                registry
+                    .recovery_directory(id)
+                    .to_string_lossy()
+                    .into_owned(),
             ));
         }
         Ok(crate::session::SessionSpec {
@@ -3585,6 +3783,38 @@ mod tests {
     }
 
     #[test]
+    fn activity_list_reads_the_durable_publication_history() {
+        let temp = tempfile::tempdir().expect("temp");
+        let server = server(temp.path());
+        {
+            let mut registry = server.registry.lock().expect("registry");
+            let mut record = test_record("s_activity");
+            record.kind = diri_proto::AgentKind::CODEX;
+            record.status = diri_proto::SessionStatus::Working;
+            registry.insert_record(record);
+            server.publish_updated(&registry, "s_activity");
+            registry.update_record("s_activity", |record| {
+                record.status = diri_proto::SessionStatus::Idle;
+            });
+            server.publish_updated(&registry, "s_activity");
+        }
+
+        let result = ok_of(call(
+            &server,
+            diri_proto::Method::ACTIVITY_LIST,
+            Some(json!({"limit": 10})),
+        ));
+        assert_eq!(result["entries"][0]["kind"], "finished");
+        assert_eq!(result["entries"][1]["kind"], "started");
+        assert_eq!(result["entries"][0]["sessionID"], "s_activity");
+        assert!(
+            temp.path()
+                .join(diri_proto::paths::ACTIVITY_LOG_FILE_NAME)
+                .is_file()
+        );
+    }
+
+    #[test]
     fn a_client_on_another_protocol_is_told_so() {
         let temp = tempfile::tempdir().expect("temp");
         let server = server(temp.path());
@@ -3662,6 +3892,22 @@ mod tests {
             command.contains(&format!("{}'", executable.display()))
                 && command.contains("'--resume' 'uuid-1'"),
             "resume flags must reach the agent: {command:?}"
+        );
+
+        let fork = server
+            .local_conversation_spec(
+                &registry,
+                "s_fork",
+                "claude-code",
+                "/tmp",
+                Some("uuid-1"),
+                ConversationAction::Fork,
+            )
+            .expect("fork spec");
+        let command = fork.pty.argv.last().expect("fork argv");
+        assert!(
+            command.contains("'--resume' 'uuid-1' '--fork-session'"),
+            "fork grammar must reach the agent: {command:?}"
         );
     }
 

--- a/diri/crates/diri-engine/src/detect/mod.rs
+++ b/diri/crates/diri-engine/src/detect/mod.rs
@@ -151,6 +151,7 @@ impl ManifestEngine {
             .map_or_else(
                 || diri_proto::SessionCapabilities {
                     resume: false,
+                    fork: false,
                     archive: !record.is_archived(),
                     send_text: !record.is_archived()
                         && !matches!(record.status, diri_proto::SessionStatus::Exited(_)),
@@ -162,6 +163,7 @@ impl ManifestEngine {
                         record.resumability,
                         &record.status,
                         record.is_archived(),
+                        record.agent_session_id.as_deref(),
                     )
                 },
             )

--- a/diri/crates/diri-engine/src/events.rs
+++ b/diri/crates/diri-engine/src/events.rs
@@ -174,6 +174,7 @@ struct BusInner {
 #[derive(Clone)]
 pub struct EventBus {
     inner: Arc<Mutex<BusInner>>,
+    activity: Arc<Mutex<Option<crate::activity::ActivityLog>>>,
     ring_capacity: usize,
     ring_byte_capacity: usize,
     subscriber_capacity: usize,
@@ -206,6 +207,7 @@ impl EventBus {
                 subscribers: HashMap::new(),
                 next_subscriber: 0,
             })),
+            activity: Arc::new(Mutex::new(None)),
             ring_capacity,
             ring_byte_capacity,
             subscriber_capacity: subscriber_capacity
@@ -263,7 +265,44 @@ impl EventBus {
         session_id: Option<&str>,
     ) {
         if let Ok(params) = serde_json::to_value(value) {
+            if name == diri_proto::EventName::SESSION_UPDATED
+                && let Ok(record) =
+                    serde_json::from_value::<diri_proto::SessionRecord>(params.clone())
+                && let Ok(mut activity) = self.activity.lock()
+                && let Some(activity) = activity.as_mut()
+                && let Err(error) = activity.observe(&record)
+            {
+                eprintln!("diri-engine: activity log append failed: {error}");
+            }
             self.publish(name, params, session_id);
+        }
+    }
+
+    /// Enables durable history at the same publication seam used by every
+    /// live-status producer. Reconfiguration is used only during daemon/test
+    /// construction, before publishers start.
+    pub fn enable_activity_log(&self, path: impl Into<std::path::PathBuf>) -> std::io::Result<()> {
+        let log = crate::activity::ActivityLog::load(path)?;
+        *self.activity.lock().expect("activity log") = Some(log);
+        Ok(())
+    }
+
+    pub fn recent_activity(&self, limit: usize) -> Vec<diri_proto::ActivityEntry> {
+        self.activity
+            .lock()
+            .ok()
+            .and_then(|activity| activity.as_ref().map(|activity| activity.recent(limit)))
+            .unwrap_or_default()
+    }
+
+    /// Records a final snapshot before `session.remove` makes the Registry
+    /// record unavailable, while keeping the existing wire event unchanged.
+    pub fn record_removed(&self, record: &diri_proto::SessionRecord) {
+        if let Ok(mut activity) = self.activity.lock()
+            && let Some(activity) = activity.as_mut()
+            && let Err(error) = activity.observe_removed(record)
+        {
+            eprintln!("diri-engine: activity log append failed: {error}");
         }
     }
 

--- a/diri/crates/diri-engine/src/hooks.rs
+++ b/diri/crates/diri-engine/src/hooks.rs
@@ -127,6 +127,52 @@ pub fn parse_codex_notify(payload: &Value) -> Option<(StatusSignal, HookMetadata
     Some((StatusSignal::CodexTurnComplete, meta))
 }
 
+/// Rehydrates the privacy-filtered activity written by the hook CLI while the
+/// Engine was unavailable. The seed deliberately contains too little data to
+/// recreate prompt titles or command summaries; lifecycle and conversation
+/// identity are the durable contract.
+pub fn parse_activity_seed(
+    seed: &diri_proto::recovery::HookActivitySeed,
+) -> Option<(StatusSignal, HookMetadata)> {
+    if seed.version != diri_proto::recovery::HookActivitySeed::VERSION {
+        return None;
+    }
+    let now = std::time::UNIX_EPOCH
+        .checked_add(std::time::Duration::from_millis(seed.occurred_at_ms))
+        .unwrap_or(std::time::SystemTime::now());
+    let mut payload = serde_json::Map::new();
+    if let Some(value) = &seed.agent_session_id {
+        payload.insert(
+            if seed.kind == "codex-notify" {
+                "thread-id"
+            } else {
+                "session_id"
+            }
+            .into(),
+            Value::String(value.clone()),
+        );
+    }
+    for (key, value) in [
+        ("transcript_path", seed.transcript_path.as_ref()),
+        ("notification_type", seed.notification_type.as_ref()),
+        ("tool_name", seed.tool_name.as_ref()),
+    ] {
+        if let Some(value) = value {
+            payload.insert(key.into(), Value::String(value.clone()));
+        }
+    }
+    let payload = Value::Object(payload);
+    match seed.kind.as_str() {
+        "claude-hook" => parse_claude_hook(seed.event.as_deref()?, &payload, now),
+        "codex-notify" => {
+            let mut payload = payload.as_object().cloned().unwrap_or_default();
+            payload.insert("type".into(), Value::String("agent-turn-complete".into()));
+            parse_codex_notify(&Value::Object(payload))
+        }
+        _ => None,
+    }
+}
+
 fn needs_input_kind(notification_type: Option<&str>) -> Option<NeedsInputKind> {
     match notification_type {
         Some("permission_prompt") => Some(NeedsInputKind::Permission),
@@ -350,5 +396,30 @@ mod tests {
     fn other_codex_notifications_are_not_turn_completions() {
         let payload = json!({ "type": "something-else", "thread-id": "t-1" });
         assert!(parse_codex_notify(&payload).is_none());
+    }
+
+    #[test]
+    fn a_durable_seed_rehydrates_lifecycle_and_safe_identity() {
+        let seed = diri_proto::recovery::HookActivitySeed {
+            version: diri_proto::recovery::HookActivitySeed::VERSION,
+            kind: "claude-hook".into(),
+            event: Some("PermissionRequest".into()),
+            occurred_at_ms: 42,
+            agent_session_id: Some("conversation".into()),
+            transcript_path: Some("/tmp/transcript.jsonl".into()),
+            notification_type: None,
+            tool_name: Some("Bash".into()),
+        };
+        let (signal, metadata) = parse_activity_seed(&seed).expect("seed");
+        assert!(matches!(
+            signal,
+            StatusSignal::ClaudeHook {
+                hook: ClaudeHook::PermissionRequest { .. },
+                ..
+            }
+        ));
+        assert_eq!(metadata.agent_session_id.as_deref(), Some("conversation"));
+        let detail = metadata.needs_input.expect("generic permission detail");
+        assert_eq!(detail.summary, "wants to run `a command`");
     }
 }

--- a/diri/crates/diri-engine/src/lib.rs
+++ b/diri/crates/diri-engine/src/lib.rs
@@ -18,6 +18,7 @@
 //!   it can be built and tested while the existing daemon keeps serving live
 //!   sessions.
 
+pub mod activity;
 pub mod agent;
 pub mod agent_catalog;
 pub mod artifacts;

--- a/diri/crates/diri-engine/src/registry.rs
+++ b/diri/crates/diri-engine/src/registry.rs
@@ -8,7 +8,10 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use diri_proto::{DateMillis, ExitInfo, ExitReason, SessionRecord, SessionStatus, TitleSource};
+use diri_proto::{
+    AgentKind, DateMillis, ExitInfo, ExitReason, Resumability, SessionRecord, SessionStatus,
+    TitleSource,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::detect::ManifestEngine;
@@ -48,6 +51,9 @@ pub struct Registry {
     /// Sessions the user closed, newest last — the "reopen closed tab" stack.
     recently_closed: Vec<SessionRecord>,
     state_file: JsonStateFile,
+    /// Minimal per-session state used only to rediscover surviving local
+    /// Holders when the global Registry file is unavailable.
+    recovery_root: PathBuf,
     /// Trailing-edge persistence: a mutation inside the debounce window marks
     /// dirty instead of rewriting the whole file (mark-seen fires on every
     /// tab switch), and the flusher or the next persist call writes it out.
@@ -89,13 +95,19 @@ pub fn spawn_persist_flusher(
 
 impl Registry {
     pub fn new(engine: Arc<ManifestEngine>, state_file: impl Into<PathBuf>) -> Self {
+        let state_path = state_file.into();
+        let recovery_root = state_path
+            .parent()
+            .map(|parent| parent.join(diri_proto::paths::SESSION_RECOVERY_DIR_NAME))
+            .unwrap_or_else(|| PathBuf::from(diri_proto::paths::SESSION_RECOVERY_DIR_NAME));
         Self {
             engine,
             sessions: HashMap::new(),
             records: HashMap::new(),
             projects: Vec::new(),
             recently_closed: Vec::new(),
-            state_file: JsonStateFile::new(state_file),
+            state_file: JsonStateFile::new(state_path),
+            recovery_root,
             dirty: false,
             last_persist: None,
         }
@@ -241,10 +253,48 @@ impl Registry {
         self.records.insert(record.id.0.clone(), record);
     }
 
+    /// Exact directory exported to this session's hook/notify process.
+    pub fn recovery_directory(&self, id: &str) -> PathBuf {
+        self.recovery_root.join(id)
+    }
+
+    fn recovery_store(&self, id: &str) -> diri_proto::recovery::SessionRecoveryStore {
+        diri_proto::recovery::SessionRecoveryStore::new(self.recovery_directory(id))
+    }
+
+    fn write_recovery_capsule(&self, record: &SessionRecord) -> std::io::Result<()> {
+        if record.host.is_some() {
+            return Ok(());
+        }
+        self.recovery_store(&record.id.0).write_capsule(
+            &diri_proto::recovery::SessionRecoveryCapsule {
+                version: diri_proto::recovery::SessionRecoveryCapsule::VERSION,
+                session_id: record.id.clone(),
+                manifest_id: record.kind.id().to_owned(),
+                cwd: record.cwd.clone(),
+                created_at: record.created_at,
+                agent_session_id: record.agent_session_id.clone(),
+                transcript_path: record.transcript_path.clone(),
+            },
+        )
+    }
+
     /// Starts a session and takes ownership of it.
     pub fn spawn(&mut self, spec: SessionSpec, record: SessionRecord) -> std::io::Result<String> {
         let id = spec.id.clone();
-        let session = Session::spawn(spec, Arc::clone(&self.engine))?;
+        let recoverable = spec.holder.is_some() && record.host.is_none();
+        if recoverable {
+            self.write_recovery_capsule(&record)?;
+        }
+        let session = match Session::spawn(spec, Arc::clone(&self.engine)) {
+            Ok(session) => session,
+            Err(error) => {
+                if recoverable {
+                    let _ = self.recovery_store(&id).remove_owned_files();
+                }
+                return Err(error);
+            }
+        };
         self.records.insert(id.clone(), record);
         self.sessions.insert(id.clone(), session);
         Ok(id)
@@ -286,8 +336,12 @@ impl Registry {
     /// [`load`]: Registry::load
     /// [`reap_orphans`]: Registry::reap_orphans
     pub fn restore(&mut self, holder: &HolderConfig, logs_dir: &Path) -> Vec<String> {
+        let records_before = self.records.len();
         let adopted = self.adopt_live_holders(holder, logs_dir);
         self.reap_orphans();
+        if self.records.len() > records_before {
+            let _ = self.persist_now();
+        }
         adopted
     }
 
@@ -354,9 +408,6 @@ impl Registry {
 
         let mut adopted = Vec::new();
         for session_id in holder_session_ids {
-            let Some(record) = self.records.get(&session_id) else {
-                continue; // a holder without a record is not ours to run
-            };
             if self.sessions.contains_key(&session_id) {
                 continue;
             }
@@ -366,10 +417,32 @@ impl Registry {
             if !stat.alive {
                 continue;
             }
+            let recovered_from_capsule = if !self.records.contains_key(&session_id) {
+                let Ok(Some(capsule)) = self.recovery_store(&session_id).read_capsule() else {
+                    continue;
+                };
+                if capsule.version != diri_proto::recovery::SessionRecoveryCapsule::VERSION
+                    || capsule.session_id.0 != session_id
+                    || !Path::new(&capsule.cwd).is_absolute()
+                    || self.engine.manifest(&capsule.manifest_id).is_none()
+                {
+                    continue;
+                }
+                let recovered = recovered_record(capsule);
+                self.ensure_session_project(&recovered.cwd, None);
+                self.records.insert(session_id.clone(), recovered);
+                true
+            } else {
+                false
+            };
+            let Some(record) = self.records.get(&session_id) else {
+                continue;
+            };
             let manifest_id = record.kind.id().to_string();
             let record_status = record.status.clone();
             let record_needs_input = record.needs_input.clone();
             let record_hibernated = record.hibernation.is_some();
+            let record_updated_at = record.updated_at.0;
             let spec = SessionSpec {
                 id: session_id.clone(),
                 // The holder owns the real spec; this one only shapes the
@@ -392,6 +465,16 @@ impl Registry {
                         let _ = session.set_hibernated(true);
                     }
                     self.sessions.insert(session_id.clone(), session);
+                    if let Ok(Some(seed)) = self.recovery_store(&session_id).read_activity()
+                        && (recovered_from_capsule
+                            || seed.occurred_at_ms as f64 >= record_updated_at)
+                        && let Some((signal, metadata)) = crate::hooks::parse_activity_seed(&seed)
+                    {
+                        let _ = self.apply_hook_metadata(&session_id, &metadata);
+                        if let Some(session) = self.sessions.get(&session_id) {
+                            session.feed_signal(signal);
+                        }
+                    }
                     adopted.push(session_id);
                 }
                 Err(_) => continue,
@@ -556,6 +639,7 @@ impl Registry {
         if plan.delete_output_log {
             let _ = std::fs::remove_file(logs_dir.join(format!("{id}.bin")));
         }
+        let _ = self.recovery_store(id).remove_owned_files();
         Ok(())
     }
 
@@ -578,6 +662,11 @@ impl Registry {
         let id = spec.id.clone();
         if !self.records.contains_key(&id) {
             return Err(not_found(&id));
+        }
+        let record = self.records.get(&id).expect("checked above");
+        let recoverable = spec.holder.is_some() && record.host.is_none();
+        if recoverable {
+            self.write_recovery_capsule(record)?;
         }
         let session = Session::spawn(spec, Arc::clone(&self.engine))?;
         self.sessions.insert(id.clone(), session);
@@ -721,6 +810,10 @@ impl Registry {
         }
         if changed {
             record.updated_at = DateMillis::from(std::time::SystemTime::now());
+        }
+        let recovery_snapshot = changed.then(|| record.clone());
+        if let Some(record) = recovery_snapshot.as_ref() {
+            let _ = self.write_recovery_capsule(record);
         }
         changed
     }
@@ -1098,14 +1191,13 @@ fn fold_record_lifecycle(engine: &ManifestEngine, record: &mut SessionRecord) {
 }
 
 fn can_reenter(engine: &ManifestEngine, record: &SessionRecord) -> bool {
-    let Some(agent_session_id) = record.agent_session_id.as_deref() else {
-        return false;
-    };
     engine
         .manifest(record.kind.id())
         .and_then(|manifest| manifest.agent.as_ref())
-        .and_then(|agent| agent.resume_args(Some(agent_session_id)))
-        .is_some()
+        .is_some_and(|agent| {
+            agent.supports_resume()
+                && (record.agent_session_id.is_some() || agent.supports_id_free_resume())
+        })
 }
 
 fn normalize_agent_title(title: &str) -> Option<String> {
@@ -1136,6 +1228,44 @@ fn is_generic_terminal_title(title: &str, record: &SessionRecord) -> bool {
             compact_title.as_str(),
             "claude" | "claudecode" | "codex" | "cursor" | "gemini" | "terminal" | "shell"
         )
+}
+
+fn recovered_record(capsule: diri_proto::recovery::SessionRecoveryCapsule) -> SessionRecord {
+    let now = DateMillis::from(std::time::SystemTime::now());
+    let project_id = session_project_id(&capsule.cwd, None);
+    SessionRecord {
+        id: capsule.session_id,
+        kind: AgentKind::new(capsule.manifest_id),
+        cwd: capsule.cwd,
+        project_id,
+        worktree_path: None,
+        git_branch: None,
+        title: "Recovered session".into(),
+        title_source: TitleSource::Placeholder,
+        originating_prompt: None,
+        agent_session_id: capsule.agent_session_id,
+        transcript_path: capsule.transcript_path,
+        status: SessionStatus::Starting,
+        status_evidence: None,
+        needs_input: None,
+        resumability: Resumability::Live,
+        capabilities: None,
+        parent: None,
+        created_at: capsule.created_at,
+        updated_at: now,
+        last_turn_completed_at: None,
+        last_seen_at: None,
+        pinned: false,
+        archived_at: None,
+        host: None,
+        remote_persistence: None,
+        hibernation: None,
+        memory_bytes: None,
+        artifacts: None,
+        pull_requests: None,
+        listening_ports: None,
+        foreground_agent: None,
+    }
 }
 
 fn not_found(id: &str) -> std::io::Error {

--- a/diri/crates/diri-engine/tests/holder_session.rs
+++ b/diri/crates/diri-engine/tests/holder_session.rs
@@ -8,14 +8,15 @@
 
 #![cfg(unix)]
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use diri_engine::holder::{HolderClient, HolderPaths};
+use diri_engine::holder::{HolderClient, HolderLaunchSpec, HolderPaths, HolderServer};
 use diri_engine::session::{HolderConfig, Session, SessionSpec};
 use diri_engine::{Authority, ManifestEngine, OutputLog, PtySpec, Registry};
-use diri_proto::SessionStatus;
+use diri_proto::{AgentKind, SessionStatus};
 
 fn engine() -> Arc<ManifestEngine> {
     let dir = diri_engine::detect::bundled_manifest_dir()
@@ -173,6 +174,89 @@ fn a_registry_restore_adopts_live_holders_from_a_previous_life() {
     registry
         .terminate("s_live", Duration::from_secs(2))
         .expect("terminate");
+}
+
+#[test]
+fn a_capsule_and_hook_seed_recover_a_holder_when_global_state_is_gone() {
+    let root = holders_dir("capsule");
+    let logs = root.join("logs");
+    let holder = holder_config(&root);
+    let state_file = root.join("state.json");
+
+    let paths = HolderPaths::new(&holder.holders_dir, "s_recover");
+    let launch = HolderLaunchSpec {
+        session_id: "s_recover".into(),
+        socket_path: paths.socket().to_string_lossy().into_owned(),
+        pid_file_path: paths.pid_file().to_string_lossy().into_owned(),
+        log_file_path: logs.join("s_recover.bin").to_string_lossy().into_owned(),
+        argv: vec!["/bin/cat".into()],
+        cwd: "/tmp".into(),
+        environment: HashMap::from([
+            ("PATH".into(), "/usr/bin:/bin".into()),
+            ("TERM".into(), "xterm-256color".into()),
+        ]),
+        cols: 80,
+        rows: 24,
+        disk_capacity: diri_engine::holder::protocol::DEFAULT_DISK_CAPACITY,
+    };
+    let holder_thread = std::thread::spawn(move || HolderServer::run(launch));
+    let client = HolderClient::new(paths.socket());
+    wait_until("holder ready", Duration::from_secs(5), || client.is_alive());
+
+    let recovery_dir = root.join("sessions/s_recover");
+    let store = diri_proto::recovery::SessionRecoveryStore::new(&recovery_dir);
+    store
+        .write_capsule(&diri_proto::recovery::SessionRecoveryCapsule {
+            version: diri_proto::recovery::SessionRecoveryCapsule::VERSION,
+            session_id: diri_proto::SessionId::new("s_recover"),
+            manifest_id: AgentKind::CLAUDE_CODE_ID.into(),
+            cwd: "/tmp/recovered-project".into(),
+            created_at: diri_proto::DateMillis(10.0),
+            agent_session_id: None,
+            transcript_path: None,
+        })
+        .expect("capsule");
+    store
+        .write_activity(&diri_proto::recovery::HookActivitySeed {
+            version: diri_proto::recovery::HookActivitySeed::VERSION,
+            kind: "claude-hook".into(),
+            event: Some("Stop".into()),
+            occurred_at_ms: 100,
+            agent_session_id: Some("conversation-recovered".into()),
+            transcript_path: None,
+            notification_type: None,
+            tool_name: None,
+        })
+        .expect("seed");
+
+    let mut registry = Registry::new(engine(), &state_file);
+    let adopted = registry.restore(&holder, &logs);
+    assert_eq!(adopted, ["s_recover"]);
+    let recovered = registry.record("s_recover").expect("recovered record");
+    assert_eq!(recovered.kind, AgentKind::CLAUDE_CODE);
+    assert_eq!(recovered.cwd, "/tmp/recovered-project");
+    assert_eq!(
+        recovered.agent_session_id.as_deref(),
+        Some("conversation-recovered")
+    );
+    wait_until("hook seed restores idle", Duration::from_secs(3), || {
+        matches!(
+            registry.record("s_recover").map(|record| record.status),
+            Some(SessionStatus::Idle)
+        )
+    });
+    assert!(
+        state_file.is_file(),
+        "the reconstructed record is persisted"
+    );
+
+    registry
+        .terminate("s_recover", Duration::from_secs(2))
+        .expect("terminate");
+    holder_thread
+        .join()
+        .expect("holder thread")
+        .expect("holder exits cleanly");
 }
 
 #[test]

--- a/diri/crates/diri-proto/src/lib.rs
+++ b/diri/crates/diri-proto/src/lib.rs
@@ -8,6 +8,7 @@ pub mod methods;
 pub mod model;
 pub mod node;
 pub mod paths;
+pub mod recovery;
 pub mod remote_pty;
 pub mod terminal;
 

--- a/diri/crates/diri-proto/src/methods.rs
+++ b/diri/crates/diri-proto/src/methods.rs
@@ -23,6 +23,7 @@ impl Method {
     pub const SESSION_REMOVE: &'static str = "session.remove";
     pub const SESSION_RENAME: &'static str = "session.rename";
     pub const SESSION_RESUME: &'static str = "session.resume";
+    pub const SESSION_FORK: &'static str = "session.fork";
     pub const SESSION_SEND_TEXT: &'static str = "session.send_text";
     pub const SESSION_RESIZE: &'static str = "session.resize";
     pub const SESSION_READ_SCREEN: &'static str = "session.read_screen";
@@ -42,6 +43,7 @@ impl Method {
     pub const HOST_INITIALIZE: &'static str = "host.initialize";
     pub const HOST_LIST_DIRECTORIES: &'static str = "host.list_directories";
     pub const SESSION_HISTORY: &'static str = "session.history";
+    pub const ACTIVITY_LIST: &'static str = "activity.list";
     pub const SESSION_RESUME_FROM_HISTORY: &'static str = "session.resume_from_history";
     pub const WORKTREE_CREATE: &'static str = "worktree.create";
     pub const WORKTREE_LIST: &'static str = "worktree.list";
@@ -88,6 +90,21 @@ pub struct SessionResourcesEvent {
 pub struct EmptyParams {}
 
 pub type EmptyResult = EmptyParams;
+pub type SessionForkParams = SessionIdParams;
+pub type SessionForkResult = SessionRecord;
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityListParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u16>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ActivityListResult {
+    /// Newest first.
+    pub entries: Vec<crate::model::ActivityEntry>,
+}
 
 /// Result of a best-effort desktop ownership release. The Engine remains
 /// alive whenever it still owns a live session or another control client is

--- a/diri/crates/diri-proto/src/model.rs
+++ b/diri/crates/diri-proto/src/model.rs
@@ -702,10 +702,40 @@ pub struct PortInfo {
 #[serde(rename_all = "camelCase")]
 pub struct SessionCapabilities {
     pub resume: bool,
+    #[serde(default)]
+    pub fork: bool,
     pub archive: bool,
     pub send_text: bool,
     pub quick_approve: bool,
     pub reliable_completion: bool,
+}
+
+string_enum! {
+    pub enum ActivityKind {
+        Started => "started",
+        NeedsInput => "needsInput",
+        Finished => "finished",
+        Exited => "exited",
+    }
+}
+
+/// One durable lifecycle transition with enough display identity to remain
+/// useful after its SessionRecord has been removed.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityEntry {
+    pub id: String,
+    #[serde(rename = "sessionID")]
+    pub session_id: SessionId,
+    pub kind: ActivityKind,
+    pub at: DateMillis,
+    pub title: String,
+    pub agent_id: String,
+    #[serde(rename = "projectID")]
+    pub project_id: ProjectId,
+    pub cwd: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/diri/crates/diri-proto/src/paths.rs
+++ b/diri/crates/diri-proto/src/paths.rs
@@ -22,11 +22,18 @@ pub const HOSTS_CONFIG_FILE_NAME: &str = "hosts.json";
 pub const PREFS_FILE_NAME: &str = "prefs.json";
 pub const QUICK_OPEN_CACHE_FILE_NAME: &str = "quick-open-index.json";
 pub const USAGE_CACHE_FILE_NAME: &str = "usage-cache.json";
+pub const ACTIVITY_LOG_FILE_NAME: &str = "activity-log.jsonl";
+pub const SESSION_RECOVERY_DIR_NAME: &str = "sessions";
 
 pub const ENV_SESSION_ID: &str = "DIRIJOR_SESSION_ID";
 pub const ENV_SOCKET: &str = "DIRIJOR_SOCKET";
 pub const ENV_CLI: &str = "DIRIJOR_CLI";
 pub const ENV_APP_SUPPORT: &str = "DIRIJOR_APP_SUPPORT";
+/// Exact per-session recovery directory exported to hook/notify shims.
+///
+/// The directory is chosen by the Engine rather than reconstructed by the CLI,
+/// so macOS and XDG layouts share one contract and tests never need HOME.
+pub const ENV_SESSION_RECOVERY_DIR: &str = "DIRIJOR_SESSION_RECOVERY_DIR";
 
 pub struct DirijorPaths;
 
@@ -93,6 +100,10 @@ impl DirijorPaths {
 
     pub fn logs_dir(home: impl AsRef<Path>) -> PathBuf {
         Self::state_dir(home).join(LOGS_DIR_NAME)
+    }
+
+    pub fn session_recovery_root(home: impl AsRef<Path>) -> PathBuf {
+        Self::state_dir(home).join(SESSION_RECOVERY_DIR_NAME)
     }
 
     pub fn inject_dir(home: impl AsRef<Path>) -> PathBuf {

--- a/diri/crates/diri-proto/src/recovery.rs
+++ b/diri/crates/diri-proto/src/recovery.rs
@@ -1,0 +1,240 @@
+//! Minimal durable facts shared by the Engine and hook CLI.
+//!
+//! Each local session owns a directory containing two independently written
+//! files:
+//!
+//! - `recovery.json` is an Engine snapshot with only the identity required to
+//!   rediscover a live Holder when the global Registry is unavailable.
+//! - `last-activity.json` is written by the hook/notify CLI before it attempts
+//!   daemon delivery, so a daemon outage cannot erase the latest lifecycle
+//!   signal.
+//!
+//! The files are deliberately not a second SessionRecord. UI state, project
+//! ordering, pins, prompts, and other mutable product metadata remain owned by
+//! the Registry.
+
+use std::fs::{DirBuilder, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{DateMillis, SessionId};
+
+pub const RECOVERY_CAPSULE_FILE: &str = "recovery.json";
+pub const LAST_ACTIVITY_FILE: &str = "last-activity.json";
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionRecoveryCapsule {
+    pub version: u32,
+    pub session_id: SessionId,
+    pub manifest_id: String,
+    pub cwd: String,
+    pub created_at: DateMillis,
+    #[serde(
+        rename = "agentSessionID",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub agent_session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transcript_path: Option<String>,
+}
+
+impl SessionRecoveryCapsule {
+    pub const VERSION: u32 = 1;
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HookActivitySeed {
+    pub version: u32,
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event: Option<String>,
+    pub occurred_at_ms: u64,
+    #[serde(
+        rename = "agentSessionID",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub agent_session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transcript_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notification_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+}
+
+impl HookActivitySeed {
+    pub const VERSION: u32 = 1;
+}
+
+/// Filesystem adapter for one session's recovery directory.
+#[derive(Clone, Debug)]
+pub struct SessionRecoveryStore {
+    directory: PathBuf,
+}
+
+impl SessionRecoveryStore {
+    pub fn new(directory: impl Into<PathBuf>) -> Self {
+        Self {
+            directory: directory.into(),
+        }
+    }
+
+    pub fn directory(&self) -> &Path {
+        &self.directory
+    }
+
+    pub fn write_capsule(&self, capsule: &SessionRecoveryCapsule) -> io::Result<()> {
+        write_json_atomic(&self.directory, RECOVERY_CAPSULE_FILE, capsule)
+    }
+
+    pub fn read_capsule(&self) -> io::Result<Option<SessionRecoveryCapsule>> {
+        read_json(&self.directory.join(RECOVERY_CAPSULE_FILE))
+    }
+
+    pub fn write_activity(&self, seed: &HookActivitySeed) -> io::Result<()> {
+        write_json_atomic(&self.directory, LAST_ACTIVITY_FILE, seed)
+    }
+
+    pub fn read_activity(&self) -> io::Result<Option<HookActivitySeed>> {
+        read_json(&self.directory.join(LAST_ACTIVITY_FILE))
+    }
+
+    /// Removes only the two files this module owns, then the directory if it
+    /// became empty. Provider-specific durable storage may live beside them.
+    pub fn remove_owned_files(&self) -> io::Result<()> {
+        for name in [RECOVERY_CAPSULE_FILE, LAST_ACTIVITY_FILE] {
+            match std::fs::remove_file(self.directory.join(name)) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
+        }
+        match std::fs::remove_dir(&self.directory) {
+            Ok(()) => Ok(()),
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::NotFound | io::ErrorKind::DirectoryNotEmpty
+                ) =>
+            {
+                Ok(())
+            }
+            Err(error) => Err(error),
+        }
+    }
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> io::Result<Option<T>> {
+    let bytes = match std::fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    serde_json::from_slice(&bytes)
+        .map(Some)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+}
+
+fn write_json_atomic<T: Serialize>(directory: &Path, name: &str, value: &T) -> io::Result<()> {
+    create_private_directory(directory)?;
+    static NEXT_TEMPORARY: AtomicU64 = AtomicU64::new(0);
+    let temporary = directory.join(format!(
+        ".{name}.tmp-{}-{}",
+        std::process::id(),
+        NEXT_TEMPORARY.fetch_add(1, Ordering::Relaxed)
+    ));
+    let body = serde_json::to_vec(value)?;
+    let mut options = OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(&temporary)?;
+    if let Err(error) = file.write_all(&body).and_then(|()| file.sync_all()) {
+        drop(file);
+        let _ = std::fs::remove_file(&temporary);
+        return Err(error);
+    }
+    drop(file);
+    if let Err(error) = std::fs::rename(&temporary, directory.join(name)) {
+        let _ = std::fs::remove_file(temporary);
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn create_private_directory(path: &Path) -> io::Result<()> {
+    let mut builder = DirBuilder::new();
+    builder.recursive(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        builder.mode(0o700);
+    }
+    builder.create(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn capsule() -> SessionRecoveryCapsule {
+        SessionRecoveryCapsule {
+            version: SessionRecoveryCapsule::VERSION,
+            session_id: SessionId::new("s_one"),
+            manifest_id: "claude-code".into(),
+            cwd: "/tmp/project".into(),
+            created_at: DateMillis(42.0),
+            agent_session_id: Some("conversation".into()),
+            transcript_path: None,
+        }
+    }
+
+    #[test]
+    fn independently_owned_files_survive_each_others_updates() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let store = SessionRecoveryStore::new(directory.path().join("s_one"));
+        let seed = HookActivitySeed {
+            version: HookActivitySeed::VERSION,
+            kind: "claude-hook".into(),
+            event: Some("Stop".into()),
+            occurred_at_ms: 99,
+            agent_session_id: Some("conversation".into()),
+            transcript_path: None,
+            notification_type: None,
+            tool_name: None,
+        };
+
+        store.write_capsule(&capsule()).expect("capsule");
+        store.write_activity(&seed).expect("activity");
+        let mut updated = capsule();
+        updated.transcript_path = Some("/tmp/transcript.jsonl".into());
+        store.write_capsule(&updated).expect("capsule update");
+
+        assert_eq!(store.read_capsule().expect("read"), Some(updated));
+        assert_eq!(store.read_activity().expect("read"), Some(seed));
+    }
+
+    #[test]
+    fn cleanup_does_not_remove_provider_storage() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let session = directory.path().join("s_one");
+        let store = SessionRecoveryStore::new(&session);
+        store.write_capsule(&capsule()).expect("capsule");
+        std::fs::create_dir_all(session.join("provider")).expect("provider directory");
+
+        store.remove_owned_files().expect("cleanup");
+
+        assert!(session.join("provider").is_dir());
+        assert!(!session.join(RECOVERY_CAPSULE_FILE).exists());
+    }
+}

--- a/diri/crates/dirijor-mcp/src/bin/dirijor.rs
+++ b/diri/crates/dirijor-mcp/src/bin/dirijor.rs
@@ -66,6 +66,7 @@ fn run(arguments: &[String]) -> Result<(), CliError> {
         "mcp-tools" => mcp_tools(),
         "mcp-call" => mcp_call(arguments.get(1..).unwrap_or_default()),
         "status" => session_list(arguments.get(1..).unwrap_or_default(), true),
+        "activity" => activity(arguments.get(1..).unwrap_or_default()),
         "session" => session(arguments.get(1..).unwrap_or_default()),
         "worktree" => worktree(arguments.get(1..).unwrap_or_default()),
         "artifacts" => artifacts(arguments.get(1..).unwrap_or_default()),
@@ -82,7 +83,7 @@ fn run(arguments: &[String]) -> Result<(), CliError> {
 fn print_help() {
     println!(
         "dirijor — Diri automation CLI\n\n\
-         Usage:\n  dirijor status [--json]\n  dirijor session <list|get|read|send|wait|spawn|release|archive> ...\n  \
+         Usage:\n  dirijor status [--json]\n  dirijor activity [--limit N] [--json]\n  dirijor session <list|get|read|send|wait|spawn|fork|release|archive> ...\n  \
          dirijor worktree <list|create|remove> ...\n  dirijor artifacts <session> [--json]\n  \
          dirijor events <subscribe|wait> ...\n  dirijor ports [--json]\n  dirijor doctor\n  \
          dirijor hook <event>\n  dirijor notify <json>\n  dirijor mcp-tools\n  \
@@ -118,6 +119,7 @@ fn map_bridge_error(message: String) -> CliError {
 fn hook(event: Option<&str>) -> Result<(), CliError> {
     let event = event.unwrap_or_default();
     let payload = stdin_json(1 << 20, Duration::from_millis(500));
+    persist_hook_activity("claude-hook", Some(event), &payload);
     let result = bridge().request(
         Method::HOOK_REPORT,
         json!({
@@ -154,6 +156,9 @@ fn notify(arguments: &[String]) -> Result<(), CliError> {
         return Ok(());
     };
     let payload = serde_json::from_str(raw).unwrap_or_else(|_| json!({"raw": raw}));
+    if payload.get("type").and_then(Value::as_str) == Some("agent-turn-complete") {
+        persist_hook_activity("codex-notify", None, &payload);
+    }
     let _ = bridge().request(
         Method::HOOK_REPORT,
         json!({
@@ -165,6 +170,47 @@ fn notify(arguments: &[String]) -> Result<(), CliError> {
         Duration::from_secs(3),
     );
     Ok(())
+}
+
+/// Records only lifecycle and identity fields before attempting delivery.
+/// Raw prompts, tool inputs, and notification messages never enter this file.
+fn persist_hook_activity(kind: &str, event: Option<&str>, payload: &Value) {
+    let Some(directory) = std::env::var_os(diri_proto::paths::ENV_SESSION_RECOVERY_DIR)
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+    else {
+        return;
+    };
+    let occurred_at_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX);
+    let string = |key: &str| {
+        payload
+            .get(key)
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned)
+    };
+    let seed = diri_proto::recovery::HookActivitySeed {
+        version: diri_proto::recovery::HookActivitySeed::VERSION,
+        kind: kind.to_owned(),
+        event: event.filter(|value| !value.is_empty()).map(str::to_owned),
+        occurred_at_ms,
+        agent_session_id: string(if kind == "codex-notify" {
+            "thread-id"
+        } else {
+            "session_id"
+        }),
+        transcript_path: string("transcript_path"),
+        notification_type: string("notification_type"),
+        tool_name: string("tool_name"),
+    };
+    // Hook contracts are fail-open. A read-only disk or interrupted rename
+    // must not prevent the provider from completing its own callback.
+    let _ = diri_proto::recovery::SessionRecoveryStore::new(directory).write_activity(&seed);
 }
 
 fn mcp_stdio() -> Result<(), CliError> {
@@ -242,6 +288,7 @@ fn session(arguments: &[String]) -> Result<(), CliError> {
         "send" => session_send(rest),
         "wait" => session_wait(rest),
         "spawn" => session_spawn(rest),
+        "fork" => session_fork(rest),
         "release" => session_release(rest),
         "archive" => session_archive(rest),
         other => Err(CliError::failure(format!(
@@ -262,6 +309,40 @@ fn session_list(arguments: &[String], include_archived_by_default: bool) -> Resu
         print_json(&json!({"sessions": sessions}));
     } else {
         print_session_table(&sessions);
+    }
+    Ok(())
+}
+
+fn activity(arguments: &[String]) -> Result<(), CliError> {
+    let limit = option_value(arguments, "--limit")
+        .and_then(|value| value.parse::<u16>().ok())
+        .unwrap_or(50)
+        .clamp(1, 300);
+    let result = request(
+        Method::ACTIVITY_LIST,
+        json!({"limit": limit}),
+        Duration::from_secs(10),
+    )?;
+    if has_flag(arguments, "--json") {
+        print_json(&result);
+        return Ok(());
+    }
+    let entries = result
+        .get("entries")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    for entry in entries {
+        let kind = entry
+            .get("kind")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let session = entry
+            .get("sessionID")
+            .and_then(Value::as_str)
+            .unwrap_or("?");
+        let title = entry.get("title").and_then(Value::as_str).unwrap_or("");
+        println!("{kind:<10}  {session:<16}  {title}");
     }
     Ok(())
 }
@@ -464,6 +545,26 @@ fn session_spawn(arguments: &[String]) -> Result<(), CliError> {
         print_json(&result);
     } else if let Some(id) = result.get("id").and_then(Value::as_str) {
         println!("spawned {id}");
+    } else {
+        print_json(&result);
+    }
+    Ok(())
+}
+
+fn session_fork(arguments: &[String]) -> Result<(), CliError> {
+    let target = positional(arguments, 0)
+        .ok_or_else(|| CliError::failure("session fork requires a target"))?;
+    let sessions = sessions()?;
+    let source = resolve_session(&target, &sessions)?;
+    let result = request(
+        Method::SESSION_FORK,
+        json!({"sessionID": source.id.0}),
+        Duration::from_secs(30),
+    )?;
+    if has_flag(arguments, "--json") {
+        print_json(&result);
+    } else if let Some(id) = result.get("id").and_then(Value::as_str) {
+        println!("forked {} from {}", id, source.id.0);
     } else {
         print_json(&result);
     }

--- a/diri/crates/dirijor-mcp/tests/hook_recovery.rs
+++ b/diri/crates/dirijor-mcp/tests/hook_recovery.rs
@@ -1,0 +1,54 @@
+#![cfg(unix)]
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use diri_proto::recovery::{HookActivitySeed, SessionRecoveryStore};
+
+#[test]
+fn a_hook_records_its_safe_seed_before_unreachable_daemon_delivery() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let session_dir = directory.path().join("s_hook");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_dirijor"))
+        .args(["hook", "PermissionRequest"])
+        .env("DIRIJOR_SESSION_ID", "s_hook")
+        .env("DIRIJOR_SESSION_RECOVERY_DIR", &session_dir)
+        .env("DIRIJOR_SOCKET", directory.path().join("missing.sock"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn hook CLI");
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(
+            br#"{"session_id":"conversation-7","transcript_path":"/tmp/t.jsonl","tool_name":"Bash","tool_input":{"command":"secret command"},"prompt":"secret prompt"}"#,
+        )
+        .expect("payload");
+    let output = child.wait_with_output().expect("wait");
+    assert!(output.status.success(), "hooks fail open: {output:?}");
+
+    let seed = SessionRecoveryStore::new(session_dir)
+        .read_activity()
+        .expect("read seed")
+        .expect("seed exists");
+    assert_eq!(
+        seed,
+        HookActivitySeed {
+            version: HookActivitySeed::VERSION,
+            kind: "claude-hook".into(),
+            event: Some("PermissionRequest".into()),
+            occurred_at_ms: seed.occurred_at_ms,
+            agent_session_id: Some("conversation-7".into()),
+            transcript_path: Some("/tmp/t.jsonl".into()),
+            notification_type: None,
+            tool_name: Some("Bash".into()),
+        }
+    );
+    let bytes =
+        std::fs::read(directory.path().join("s_hook/last-activity.json")).expect("activity bytes");
+    let text = String::from_utf8(bytes).expect("utf8");
+    assert!(!text.contains("secret command"));
+    assert!(!text.contains("secret prompt"));
+}

--- a/docs/AGENT-MANIFESTS.md
+++ b/docs/AGENT-MANIFESTS.md
@@ -129,10 +129,47 @@ an unavailable-agent row, and use `signInHint` only for the documented next
 step after installation. Setup metadata is guidance: Diri does not run either
 hint or open its URL without an explicit user action.
 
-### Resume behavior
+### Conversation behavior
 
-`sessionIDFlag` tells Diri that it may mint an id at launch, for example
-`"--session-id"`. `resume` declares how that id is passed later:
+`conversation` is the preferred launch grammar for fresh, resumed, and forked
+conversations. Its values are argv arrays, never shell fragments:
+
+```jsonc
+"conversation": {
+  "freshArgs": ["--session-id", "{newId}"],
+  "resume": {
+    "exactArgs": ["--resume", "{id}"],
+    "latestArgs": ["--continue"]
+  },
+  "fork": {
+    "exactArgs": ["--fork-session", "{id}"]
+  },
+  "stripArgs": [
+    { "token": "--resume", "value": "any" },
+    { "token": "--continue" },
+    { "token": "--fork-session", "value": "any" }
+  ]
+}
+```
+
+| Field | Meaning |
+| --- | --- |
+| `freshArgs` | Args applied to a new conversation. Use `{newId}` when Diri should mint and retain the provider id. |
+| `resume.exactArgs` | Resume a known provider conversation. `{id}` is the source provider id. |
+| `resume.latestArgs` | Resume from intentionally session-scoped storage when no provider id is required. |
+| `fork.exactArgs` | Fork a known provider conversation. A fork starts with no known provider id; hooks or notifications can report its new identity later. |
+| `fork.latestArgs` | Provider-native fork of its latest conversation when that is a documented operation. |
+| `stripArgs` | Remove stale conversation markers before applying one canonical mode. `value` is `none` (default), `any`, or `nonoption`. |
+
+The supported placeholders are `{id}`, `{newId}`, and `{sessionDir}`. The last
+one points at Diri's per-session provider-storage directory and is useful for
+agents whose “continue latest” behavior can otherwise select a different
+session. Every placeholder used by the selected command must have a value or
+the launch is rejected.
+
+`sessionIDFlag` and `resume` are the legacy additive form retained for existing
+user manifests. `sessionIDFlag` tells Diri that it may mint an id at launch, for
+example `"--session-id"`. Legacy `resume` declares how that id is passed later:
 
 | `resume.style` | Result |
 | --- | --- |
@@ -143,9 +180,10 @@ hint or open its URL without an explicit user action.
 
 Declare resume only when the CLI documents it and Diri can obtain the required
 id. A flag that accepts an id is not useful if the CLI never reports that id.
-The engine's current built-in representation uses `flag` without an id for bare
-latest-session tokens; follow the closest manifest and verify the actual argv in
-tests rather than guessing.
+Use `latestArgs` without `exactArgs` only when storage is pinned with
+`{sessionDir}`; otherwise an exited record with no provider id remains
+non-resumable. Follow the closest manifest and verify fresh, resume, and fork
+argv in tests rather than guessing.
 
 ### Injection mechanisms
 


### PR DESCRIPTION
## Summary

- persist a minimal per-session recovery capsule plus a privacy-filtered hook activity seed, allowing a fresh daemon to rediscover and rehydrate a surviving local Holder when global registry state is unavailable
- make fresh, resume, and native fork argv a manifest-owned conversation grammar; add exact Claude and Codex forks, canonical stale-argument stripping, and per-session Pi storage pinning for deterministic continue behavior
- expose session.fork through the protocol, Rust client, capabilities, and dirijor CLI
- append bounded, repeat-collapsed lifecycle outcomes to a durable JSONL activity log and expose activity.list plus dirijor activity
- document the new manifest contract and recovery/privacy boundaries

## Design notes

- recovery.json and last-activity.json have independent ownership and atomic writes; hooks record only lifecycle and safe identity fields before attempting daemon delivery
- Holder adoption validates a live socket, capsule version, session identity, absolute cwd, and known manifest before reconstructing a conservative record
- stale activity seeds are ignored when registry state is newer
- activity history snapshots status and display metadata only; terminal output, prompts, tool inputs, and notification messages are excluded

## Verification

- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p diri-engine --test holder_session a_capsule_and_hook_seed_recover_a_holder_when_global_state_is_gone
- cargo test -p diri-remote --quiet
- cargo test --workspace --no-fail-fast --quiet completed all changed targets successfully; one timing-sensitive remote Holder lifecycle test failed once and then passed both focused and in the full package rerun
