### PR TITLE
remote: frame output in batches rather than one frame per PTY read

### DIFF
--- a/diri/crates/diri-remote/src/holder.rs
+++ b/diri/crates/diri-remote/src/holder.rs
@@ -34,6 +34,8 @@ const DIFF_COALESCE: Duration = Duration::from_millis(8);
 const INTERACTIVE_GRID_BUDGET: u8 = 2;
 const MAX_OUTBOUND_BYTES: usize = 20 << 20;
 const MAX_PENDING_INPUT_BYTES: usize = 1 << 20;
+/// How much raw output may accumulate before it is framed for the client.
+const OUTPUT_FRAME_BYTES: usize = 64 << 10;
 const REPLAY_BUDGET_BYTES: usize = 4 << 20;
 const PERSIST_OFFSET_INTERVAL: u64 = 1 << 20;
 
@@ -408,6 +410,9 @@ struct Holder {
     pending_connection: Option<Connection>,
     pending_input: PendingBytes,
     dirty_since: Option<Instant>,
+    /// Raw output waiting to be framed, and the offset it starts at.
+    pending_output: Vec<u8>,
+    pending_output_offset: u64,
     interactive_grid_budget: u8,
     last_persisted_offset: u64,
 }
@@ -481,6 +486,8 @@ impl Holder {
             pending_connection: None,
             pending_input: PendingBytes::default(),
             dirty_since: None,
+            pending_output: Vec::with_capacity(OUTPUT_FRAME_BYTES),
+            pending_output_offset: 0,
             interactive_grid_budget: 0,
             last_persisted_offset: 0,
         })
@@ -613,6 +620,8 @@ impl Holder {
             if self.dirty_since.is_some_and(|since| {
                 self.interactive_grid_budget > 0 || since.elapsed() >= DIFF_COALESCE
             }) {
+                // Held output goes out with the diff it belongs to.
+                self.flush_output()?;
                 self.emit_grid_delta()?;
             }
         }
@@ -629,6 +638,25 @@ impl Holder {
                 Err(error) => return Err(error),
             }
         }
+    }
+
+    /// Frames whatever output has accumulated.
+    ///
+    /// Called when it reaches a frame's worth and when the coalescing interval
+    /// expires, so held bytes are never delayed longer than a grid diff would
+    /// have been. The buffer's allocation is kept for the next batch.
+    fn flush_output(&mut self) -> io::Result<()> {
+        if self.pending_output.is_empty() {
+            return Ok(());
+        }
+        let pending = std::mem::take(&mut self.pending_output);
+        let result = self.queue(RemoteMessage::Terminal(Frame::output(
+            self.pending_output_offset,
+            &pending,
+        )));
+        self.pending_output = pending;
+        self.pending_output.clear();
+        result
     }
 
     fn drain_pty(&mut self) -> io::Result<()> {
@@ -660,7 +688,20 @@ impl Holder {
                         .as_ref()
                         .is_some_and(|connection| connection.epoch.is_some())
                     {
-                        self.queue(RemoteMessage::Terminal(Frame::output(offset, bytes)))?;
+                        // Held rather than framed here. A PTY hands over about
+                        // a kilobyte per read, and a frame each meant ten
+                        // thousand of them for eleven megabytes — a header, a
+                        // queue entry and a share of a write syscall apiece, on
+                        // both ends. The loop flushes these on the same
+                        // interval it already paces grid diffs by, so nothing
+                        // waits longer than a frame.
+                        if self.pending_output.is_empty() {
+                            self.pending_output_offset = offset;
+                        }
+                        self.pending_output.extend_from_slice(bytes);
+                        if self.pending_output.len() >= OUTPUT_FRAME_BYTES {
+                            self.flush_output()?;
+                        }
                     }
                     if self
                         .state


### PR DESCRIPTION
Follow-up to #142, which measured the remote path for the first time. This is the first thing in it worth fixing.

## What was wrong

Eleven megabytes through a remote session became **10,083 protocol frames** — about a kilobyte each, because the Holder framed whatever a single PTY read returned. Each frame costs a header, a queue entry and a share of a write syscall on the sending side, and a decode plus a full pass through the log and emulator on the receiving one.

Output now accumulates and is framed at 64 KiB, or when the coalescing interval expires, whichever comes first. It rides the same interval that already paces grid diffs — held bytes wait no longer than a frame would have — and the flush sits with the diff publication so the two travel together.

| 11.4 MB remote session | before | after |
|---|---:|---:|
| protocol frames | 10,083 | **191** |
| wall clock | 587 ms | **~485 ms** |
| engine's share | 148 ms | 73 ms |
| — of which emulator | 105 ms | 59 ms |
| — of which log append | 43 ms | 13 ms |

Most of the engine-side saving is the emulator working on chunks instead of kilobytes.

## How it was found, including what it wasn't

Two hypotheses missed before this one, and neither is in this commit:

**The Holder's own log was not the bottleneck.** It has the same shape the engine's log had before it was fixed — a synchronous disk write on the drain thread, a truncation that keeps half, and a `File::open` per replay read. I implemented all three fixes and measured **30.8 → 30.6 MB/s**. Nothing. Discarded.

**Detection per frame was not the bottleneck either.** The remote path runs `evaluate_if_screen_changed` on every frame with none of the throttling the local pump got in #132. Adding it changed nothing measurable. Also discarded.

What settled it was instrumenting the phases and counting: the engine was doing 148 ms of work in a 587 ms run, across ten thousand frames. The frame count was the thing.

## A caveat on the headline number from #142

That PR reported remote sustaining "21–31 MB/s" against local's 105–161. The instrumentation shows that comparison is not apples to apples: on a 23.8 MB payload the engine received only **5 MB** — the Holder hit its 20 MiB outbound cap and reseeded, discarding the backlog by design. Past that cap the benchmark measures skipped work, not throughput. Under the cap, delivery is complete and the figures above are real.

## Testing

40 tests pass in `diri-remote`; clippy and fmt clean. `examples/remotebench` (from #142) reproduces all of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)