### PR TITLE
fix: stabilize Linux app tests

### DIFF
--- a/diri/crates/diri-app/src/inspector.rs
+++ b/diri/crates/diri-app/src/inspector.rs
@@ -627,11 +627,9 @@ impl WorkbenchInspector {
                     .map(snapshot_from_read_diff)
                     .map(Arc::new)
             } else {
-                tokio
-                    .spawn_blocking(move || load_local_diff(&cwd, layer))
+                cx.background_spawn(async move { load_local_diff(&cwd, layer) })
                     .await
-                    .map_err(|error| format!("Diff worker stopped: {error}"))
-                    .and_then(|result| result.map_err(|error| error.to_string()))
+                    .map_err(|error| error.to_string())
                     .map(Arc::new)
             };
             let _ = this.update(cx, |this, cx| {
@@ -733,16 +731,14 @@ impl WorkbenchInspector {
         if !matches!(self.review_state, ReviewLoadState::Ready(_)) {
             self.review_state = ReviewLoadState::Loading;
         }
-        let tokio = self.tokio.clone();
         self.review_task = Some(cx.spawn(async move |this, cx| {
-            let result = tokio
-                .spawn_blocking(move || {
+            let result = cx
+                .background_spawn(async move {
                     let repository = GitRepository::discover(&cwd)?;
                     repository.status()
                 })
                 .await
-                .map_err(|error| format!("Git status worker stopped: {error}"))
-                .and_then(|result| result.map_err(|error| error.to_string()));
+                .map_err(|error: GitReviewError| error.to_string());
             let _ = this.update(cx, |this, cx| {
                 if this.review_generation != generation {
                     return;
@@ -768,10 +764,9 @@ impl WorkbenchInspector {
         self.discard_armed = false;
         self.armed_hunk = None;
         cx.notify();
-        let tokio = self.tokio.clone();
         self.review_action_task = Some(cx.spawn(async move |this, cx| {
-            let result = tokio
-                .spawn_blocking(move || -> Result<String, GitReviewError> {
+            let result = cx
+                .background_spawn(async move {
                     let repository = GitRepository::discover(&context.cwd)?;
                     match action {
                         ReviewAction::Stage(paths) => {
@@ -802,8 +797,7 @@ impl WorkbenchInspector {
                     }
                 })
                 .await
-                .map_err(|error| format!("Git action worker stopped: {error}"))
-                .and_then(|result| result.map_err(|error| error.to_string()));
+                .map_err(|error: GitReviewError| error.to_string());
             let _ = this.update(cx, |this, cx| {
                 this.review_action_busy = false;
                 match result {
@@ -5216,10 +5210,8 @@ mod tests {
             InspectorTab::Info
         );
         inspector.update(cx, |inspector, cx| inspector.set_visible(true, cx));
-        // Drain the Info refresh before asserts/teardown. Leaving a live
-        // `cx.spawn` + `tokio.spawn_blocking` task lets GPUI's test scheduler
-        // abort it on a worker thread ("local task dropped by a thread that
-        // didn't spawn it") after the test already reported ok.
+        // Drain the Info refresh before asserts/teardown so no background Git
+        // work outlives the deterministic GPUI test scheduler.
         cx.run_until_parked();
 
         let (generation, context, polling) = inspector.read_with(cx, |inspector, _| {

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -5204,11 +5204,11 @@ mod tests {
         cx.run_until_parked();
         let surfaces = view.read_with(cx, |harness, _| harness.surfaces.clone());
         let field = cx.debug_bounds("HOST_FIELD_NAME").expect("name field");
+        let text = cx
+            .debug_bounds("host-field-caret")
+            .expect("active field text");
 
-        cx.simulate_click(
-            point(field.left() + px(11.0), field.center().y),
-            Modifiers::default(),
-        );
+        cx.simulate_click(point(text.left(), field.center().y), Modifiers::default());
         assert_eq!(
             surfaces.read_with(cx, |surfaces, _| surfaces
                 .host_editor

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -37,6 +37,8 @@ const SETTINGS_TRANSITION_DURATION: Duration = Duration::from_millis(190);
 const SETTINGS_SECTION_GAP: f32 = 16.0;
 const SETTINGS_ROW_HEIGHT: f32 = 50.0;
 const RESULT_LIMIT: usize = 200;
+const HOST_FIELD_HORIZONTAL_PADDING: f32 = 10.0;
+const HOST_FIELD_TEXT_INSET: f32 = HOST_FIELD_HORIZONTAL_PADDING + 1.0; // border_1
 /// Reinstall success is confirmation, not persistent host state. Errors stay
 /// actionable and first-time setup keeps its "Use by default" action.
 const HOST_REINSTALL_SUCCESS_VISIBILITY: Duration = Duration::from_secs(3);
@@ -3330,7 +3332,7 @@ impl UtilitySurfaces {
         if let Some(error) = &editor.error {
             form = form.child(
                 div()
-                    .px(px(10.0))
+                    .px(px(HOST_FIELD_HORIZONTAL_PADDING))
                     .py(px(8.0))
                     .rounded(px(Radius::BADGE))
                     .bg(Ink::DANGER.alpha(0.08))
@@ -3514,7 +3516,8 @@ impl UtilitySurfaces {
                         let Some(bounds) = this.host_field_bounds[field.index()].get() else {
                             return;
                         };
-                        let x = (event.position().x - bounds.left() - px(10.0)).max(px(0.0));
+                        let x = (event.position().x - bounds.left() - px(HOST_FIELD_TEXT_INSET))
+                            .max(px(0.0));
                         let offset = this.host_editor.as_ref().map_or(0, |editor| {
                             text_offset_for_x(editor.field(field).text(), x, window, colors)
                         });


### PR DESCRIPTION
## Summary

- run local inspector Git work on GPUI's background executor so Tokio workers cannot wake the deterministic test scheduler
- anchor the host-field caret test to rendered text geometry instead of platform-dependent font offsets

## Verification

- focused inspector and caret regressions
- full contributor check script
- cargo build --workspace --release