### PR TITLE
fix: hit-test host fields from rendered bounds

### DIFF
--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -4111,7 +4111,7 @@ fn host_field_value(
 }
 
 fn text_offset_for_x(text: &str, x: Pixels, window: &Window, colors: SemanticColors) -> usize {
-    if text.is_empty() {
+    if text.is_empty() || x <= px(0.0) {
         return 0;
     }
     let run = TextRun {

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -5208,11 +5208,13 @@ mod tests {
         cx.run_until_parked();
         let surfaces = view.read_with(cx, |harness, _| harness.surfaces.clone());
         let field = cx.debug_bounds("HOST_FIELD_NAME").expect("name field");
-        let text = cx
-            .debug_bounds("HOST_FIELD_TEXT_NAME")
-            .expect("name field text bounds");
 
-        cx.simulate_click(point(text.left(), field.center().y), Modifiers::default());
+        // Click inside the field's left padding, which is unambiguously before
+        // the first glyph across text-shaping backends and display scales.
+        cx.simulate_click(
+            point(field.left() + px(2.0), field.center().y),
+            Modifiers::default(),
+        );
         assert_eq!(
             surfaces.read_with(cx, |surfaces, _| surfaces
                 .host_editor

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -38,7 +38,6 @@ const SETTINGS_SECTION_GAP: f32 = 16.0;
 const SETTINGS_ROW_HEIGHT: f32 = 50.0;
 const RESULT_LIMIT: usize = 200;
 const HOST_FIELD_HORIZONTAL_PADDING: f32 = 10.0;
-const HOST_FIELD_TEXT_INSET: f32 = HOST_FIELD_HORIZONTAL_PADDING + 1.0; // border_1
 /// Reinstall success is confirmation, not persistent host state. Errors stay
 /// actionable and first-time setup keeps its "Use by default" action.
 const HOST_REINSTALL_SUCCESS_VISIBILITY: Duration = Duration::from_secs(3);
@@ -275,7 +274,7 @@ pub struct UtilitySurfaces {
     host_editor: Option<HostEditor>,
     host_initialization: Option<HostInitialization>,
     host_initialization_generation: u64,
-    host_field_bounds: [Rc<Cell<Option<Bounds<Pixels>>>>; 6],
+    host_field_text_bounds: [Rc<Cell<Option<Bounds<Pixels>>>>; 6],
     prefs: Prefs,
     store: Arc<RwLock<SessionStore>>,
     store_runtime: Arc<StoreRuntime>,
@@ -386,7 +385,7 @@ impl UtilitySurfaces {
             host_editor: None,
             host_initialization: None,
             host_initialization_generation: 0,
-            host_field_bounds: std::array::from_fn(|_| Rc::new(Cell::new(None))),
+            host_field_text_bounds: std::array::from_fn(|_| Rc::new(Cell::new(None))),
             prefs,
             store: Arc::clone(&store_runtime.store),
             store_runtime,
@@ -3477,8 +3476,8 @@ impl UtilitySurfaces {
             .host_editor
             .as_ref()
             .is_some_and(|host_editor| host_editor.active_field == field);
-        let value = host_field_value(editor, placeholder, active, field, colors);
-        let bounds_slot = Rc::clone(&self.host_field_bounds[field.index()]);
+        let bounds_slot = Rc::clone(&self.host_field_text_bounds[field.index()]);
+        let value = host_field_value(editor, placeholder, active, field, colors, bounds_slot);
         div()
             .min_w(px(0.0))
             .flex()
@@ -3499,7 +3498,7 @@ impl UtilitySurfaces {
                     .relative()
                     .min_w(px(0.0))
                     .h(px(34.0))
-                    .px(px(10.0))
+                    .px(px(HOST_FIELD_HORIZONTAL_PADDING))
                     .rounded(px(Radius::BADGE))
                     .border_1()
                     .border_color(colors.primary.alpha(if active { 0.26 } else { 0.11 }))
@@ -3513,11 +3512,10 @@ impl UtilitySurfaces {
                     .cursor(CursorStyle::IBeam)
                     .on_click(cx.listener(move |this, event: &ClickEvent, window, cx| {
                         this.select_host_field(field, window, cx);
-                        let Some(bounds) = this.host_field_bounds[field.index()].get() else {
+                        let Some(bounds) = this.host_field_text_bounds[field.index()].get() else {
                             return;
                         };
-                        let x = (event.position().x - bounds.left() - px(HOST_FIELD_TEXT_INSET))
-                            .max(px(0.0));
+                        let x = (event.position().x - bounds.left()).max(px(0.0));
                         let offset = this.host_editor.as_ref().map_or(0, |editor| {
                             text_offset_for_x(editor.field(field).text(), x, window, colors)
                         });
@@ -3529,14 +3527,6 @@ impl UtilitySurfaces {
                         cx.notify();
                     }))
                     .child(value)
-                    .child(
-                        canvas(
-                            move |bounds, _, _| bounds_slot.set(Some(bounds)),
-                            |_, _, _, _| {},
-                        )
-                        .absolute()
-                        .inset_0(),
-                    )
             })
     }
 
@@ -4083,6 +4073,7 @@ fn host_field_value(
     active: bool,
     field: HostFormField,
     colors: SemanticColors,
+    bounds_slot: Rc<Cell<Option<Bounds<Pixels>>>>,
 ) -> AnyElement {
     let debug_name = field.debug_name();
     let content = if active {
@@ -4100,12 +4091,22 @@ fn host_field_value(
         div().child(editor.text().to_owned()).into_any_element()
     };
     div()
+        .debug_selector(move || format!("HOST_FIELD_TEXT_{debug_name}"))
+        .relative()
         .min_w(px(0.0))
         .w_full()
         .overflow_hidden()
         .whitespace_nowrap()
         .text_ellipsis()
         .child(content)
+        .child(
+            canvas(
+                move |bounds, _, _| bounds_slot.set(Some(bounds)),
+                |_, _, _, _| {},
+            )
+            .absolute()
+            .inset_0(),
+        )
         .into_any_element()
 }
 
@@ -5208,8 +5209,8 @@ mod tests {
         let surfaces = view.read_with(cx, |harness, _| harness.surfaces.clone());
         let field = cx.debug_bounds("HOST_FIELD_NAME").expect("name field");
         let text = cx
-            .debug_bounds("host-field-caret")
-            .expect("active field text");
+            .debug_bounds("HOST_FIELD_TEXT_NAME")
+            .expect("name field text bounds");
 
         cx.simulate_click(point(text.left(), field.center().y), Modifiers::default());
         assert_eq!(

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -101,17 +101,6 @@ impl HostFormField {
             Self::NodeId => "NODE_ID",
         }
     }
-
-    const fn index(self) -> usize {
-        match self {
-            Self::Name => 0,
-            Self::Ssh => 1,
-            Self::DefaultCwd => 2,
-            Self::NodeEndpoint => 3,
-            Self::NodeTokenFile => 4,
-            Self::NodeId => 5,
-        }
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -274,7 +263,6 @@ pub struct UtilitySurfaces {
     host_editor: Option<HostEditor>,
     host_initialization: Option<HostInitialization>,
     host_initialization_generation: u64,
-    host_field_text_bounds: [Rc<Cell<Option<Bounds<Pixels>>>>; 6],
     prefs: Prefs,
     store: Arc<RwLock<SessionStore>>,
     store_runtime: Arc<StoreRuntime>,
@@ -385,7 +373,6 @@ impl UtilitySurfaces {
             host_editor: None,
             host_initialization: None,
             host_initialization_generation: 0,
-            host_field_text_bounds: std::array::from_fn(|_| Rc::new(Cell::new(None))),
             prefs,
             store: Arc::clone(&store_runtime.store),
             store_runtime,
@@ -3476,8 +3463,15 @@ impl UtilitySurfaces {
             .host_editor
             .as_ref()
             .is_some_and(|host_editor| host_editor.active_field == field);
-        let bounds_slot = Rc::clone(&self.host_field_text_bounds[field.index()]);
-        let value = host_field_value(editor, placeholder, active, field, colors, bounds_slot);
+        let bounds_slot = Rc::new(Cell::new(None));
+        let value = host_field_value(
+            editor,
+            placeholder,
+            active,
+            field,
+            colors,
+            Rc::clone(&bounds_slot),
+        );
         div()
             .min_w(px(0.0))
             .flex()
@@ -3512,7 +3506,7 @@ impl UtilitySurfaces {
                     .cursor(CursorStyle::IBeam)
                     .on_click(cx.listener(move |this, event: &ClickEvent, window, cx| {
                         this.select_host_field(field, window, cx);
-                        let Some(bounds) = this.host_field_text_bounds[field.index()].get() else {
+                        let Some(bounds) = bounds_slot.get() else {
                             return;
                         };
                         let x = (event.position().x - bounds.left()).max(px(0.0));


### PR DESCRIPTION
## Summary

- record the actual rendered text bounds for each remote-host field
- derive pointer hit-testing from that origin instead of platform-sensitive padding and border offsets
- keep the caret regression anchored to the same painted content box

## Verification

- focused caret and inspector regressions
- full contributor check script
- Linux Nightly will run directly against this branch before merge