### PR TITLE
test: refresh focused host field bounds

### DIFF
--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -5219,6 +5219,10 @@ mod tests {
             0
         );
 
+        cx.run_until_parked();
+        let field = cx
+            .debug_bounds("HOST_FIELD_NAME")
+            .expect("focused name field");
         cx.simulate_click(
             point(field.right() - px(11.0), field.center().y),
             Modifiers::default(),


### PR DESCRIPTION
The host-field caret regression focused and re-rendered the field after its first click, but sent the second click using the pre-focus rectangle. Linux moves that layout enough for the stale right-edge point to miss the current field. Settle the render and query the focused field bounds before the second assertion.\n\nVerified locally with the focused GPUI caret test and cargo fmt --check.