### PR TITLE
ci: pass session context to installed MCP smoke

### DIFF
--- a/diri/scripts/smoke-installed-linux.sh
+++ b/diri/scripts/smoke-installed-linux.sh
@@ -105,7 +105,7 @@ printf '%s\n' '{"prompt":"package smoke"}' \
     | DIRIJOR_APP_SUPPORT="${smoke_root}/support" DIRIJOR_SESSION_ID="${session_id}" \
         dirijor hook UserPromptSubmit >/dev/null
 printf '%s\n' '{}' \
-    | DIRIJOR_APP_SUPPORT="${smoke_root}/support" \
+    | DIRIJOR_APP_SUPPORT="${smoke_root}/support" DIRIJOR_SESSION_ID="${session_id}" \
         dirijor mcp-call --tool list_agents \
     | jq -e --arg id "${session_id}" '.ok.agents[] | select(.id == $id)' >/dev/null
 


### PR DESCRIPTION
The installed Linux smoke invokes list_agents after spawning a live session but omitted DIRIJOR_SESSION_ID. Current MCP policy correctly requires live-session context. Propagate the session ID so the packaging smoke validates the installed CLI inside the session it created.