### PR TITLE
fix: keep standalone session spawning outside MCP policy

### DIFF
--- a/diri/crates/dirijor-mcp/src/bin/dirijor.rs
+++ b/diri/crates/dirijor-mcp/src/bin/dirijor.rs
@@ -528,18 +528,15 @@ fn session_spawn(arguments: &[String]) -> Result<(), CliError> {
         })
         .ok_or_else(|| CliError::failure("could not determine the working directory"))?;
     let result = bridge()
-        .call(
-            "spawn_agent",
-            &json!({
-                "kind": kind,
-                "cwd": cwd,
-                "worktree": has_flag(arguments, "--worktree"),
-                "branch": option_value(arguments, "--branch"),
-                "prompt": option_value(arguments, "--prompt"),
-                "name": option_value(arguments, "--title").or_else(|| option_value(arguments, "--name")),
-                "host": option_value(arguments, "--host"),
-            }),
-        )
+        .spawn_user_session(&json!({
+            "kind": kind,
+            "cwd": cwd,
+            "worktree": has_flag(arguments, "--worktree"),
+            "branch": option_value(arguments, "--branch"),
+            "prompt": option_value(arguments, "--prompt"),
+            "name": option_value(arguments, "--title").or_else(|| option_value(arguments, "--name")),
+            "host": option_value(arguments, "--host"),
+        }))
         .map_err(map_bridge_error)?;
     if has_flag(arguments, "--json") {
         print_json(&result);

--- a/diri/crates/dirijor-mcp/src/bridge.rs
+++ b/diri/crates/dirijor-mcp/src/bridge.rs
@@ -122,6 +122,19 @@ impl Bridge {
             self.caller.as_deref(),
         )?
         .authorize(WriteAction::Spawn)?;
+        self.spawn_session(arguments, self.caller.clone().map(SessionId))
+    }
+
+    /// Spawn a top-level session for the regular user-facing CLI.
+    ///
+    /// MCP writes remain policy-gated through [`Self::spawn_agent`]. The
+    /// standalone `dirijor session spawn` command is a direct user automation
+    /// surface and intentionally creates a root session without an MCP caller.
+    pub fn spawn_user_session(&self, arguments: &Value) -> Result<Value, String> {
+        self.spawn_session(arguments, None)
+    }
+
+    fn spawn_session(&self, arguments: &Value, parent: Option<SessionId>) -> Result<Value, String> {
         let requested = required_string(arguments, "kind")?;
         let readiness: AgentReadinessResult =
             self.request_typed(Method::AGENT_READINESS, json!({}), DEFAULT_TIMEOUT)?;
@@ -134,7 +147,7 @@ impl Bridge {
             worktree_branch: optional_string(arguments, "branch"),
             title: optional_string(arguments, "name"),
             initial_prompt: optional_string(arguments, "prompt"),
-            parent: self.caller.clone().map(SessionId),
+            parent,
             initial_cols: None,
             initial_rows: None,
             host: optional_string(arguments, "host"),

--- a/diri/crates/dirijor-mcp/tests/spawn_prompt.rs
+++ b/diri/crates/dirijor-mcp/tests/spawn_prompt.rs
@@ -11,7 +11,7 @@ use diri_engine::control::ControlServer;
 use diri_engine::detect::ManifestEngine;
 use diri_engine::registry::Registry;
 use diri_proto::{
-    AgentKind, DateMillis, Project, Resumability, SessionId, SessionRecord, SessionStatus,
+    AgentKind, DateMillis, Method, Project, Resumability, SessionId, SessionRecord, SessionStatus,
     TitleSource,
 };
 use dirijor_mcp::Bridge;
@@ -188,6 +188,46 @@ fn call_spawn_agent_through_mcp(socket: &Path, arguments: serde_json::Value) -> 
             .expect("MCP text content"),
     )
     .expect("decode spawn result")
+}
+
+#[test]
+fn standalone_cli_spawn_creates_a_root_session_without_an_mcp_caller() {
+    let temp = tempfile::tempdir().expect("temp");
+    let repo = temp.path().join("repo");
+    let fixture = temp.path().join("prompt-fixture");
+    std::fs::create_dir_all(&repo).expect("create repository directory");
+    std::fs::write(&fixture, "#!/bin/sh\nsleep 30\n").expect("write fixture");
+    std::fs::set_permissions(&fixture, std::fs::Permissions::from_mode(0o700))
+        .expect("make fixture executable");
+
+    let server = start_server(temp.path(), &fixture, &repo);
+    let bridge = Bridge::new(server.socket_path().to_path_buf(), None);
+    let spawned = bridge
+        .spawn_user_session(&json!({
+            "kind": "prompt-fixture",
+            "cwd": repo,
+            "name": "standalone CLI regression",
+        }))
+        .expect("standalone spawn");
+    let id = spawned["id"].as_str().expect("session id");
+    let sessions = bridge
+        .request(Method::SESSION_LIST, json!({}), Duration::from_secs(3))
+        .expect("list sessions");
+    let record = sessions["sessions"]
+        .as_array()
+        .expect("session array")
+        .iter()
+        .find(|record| record["id"] == id)
+        .expect("spawned session record");
+
+    assert!(record["parent"].is_null(), "standalone sessions are roots");
+    bridge
+        .request(
+            Method::SESSION_KILL,
+            json!({"sessionID": id}),
+            Duration::from_secs(3),
+        )
+        .expect("release standalone session");
 }
 
 #[test]


### PR DESCRIPTION
The MCP authorization hardening correctly gates agent-initiated writes, but the regular user-facing dirijor session spawn command shared that path and could no longer create a root session outside an existing Diri session. Route standalone CLI spawning through a direct root-session entry point while keeping MCP spawn_agent policy-gated. Adds an integration regression test proving an unhosted CLI spawn creates a root session.