### PR TITLE
fix: name Cursor chats from the first prompt and mark them idle when a turn ends

### DIFF
--- a/diri/crates/diri-engine/manifests/cursor.json
+++ b/diri/crates/diri-engine/manifests/cursor.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "id": "cursor",
-  "version": "2026.07.10",
+  "version": "2026.08.31",
   "statusModel": "full",
   "agent": {
     "id": "cursor",
@@ -38,6 +38,59 @@
     }
   },
   "rules": [
+    {
+      "id": "blocked-osc-confirmation",
+      "state": "blockedPermission",
+      "priority": 1300,
+      "region": "osc_title",
+      "when": {
+        "contains": "waiting for confirmation"
+      },
+      "flags": [
+        "visible_blocker"
+      ],
+      "capture": {
+        "region": "bottom_non_empty_lines",
+        "regionLines": 12,
+        "maxChars": 400
+      }
+    },
+    {
+      "id": "blocked-osc-waiting-for-you",
+      "state": "blockedQuestion",
+      "priority": 1250,
+      "region": "osc_title",
+      "when": {
+        "contains": "waiting for you"
+      },
+      "flags": [
+        "visible_blocker"
+      ],
+      "capture": {
+        "region": "bottom_non_empty_lines",
+        "regionLines": 12,
+        "maxChars": 400
+      }
+    },
+    {
+      "id": "working-osc-title",
+      "state": "working",
+      "priority": 1200,
+      "region": "osc_title",
+      "_notice": "cursor-agent writes OSC 0 as '{name} - {emoji} {stamp}'. The stamp stays Working/Planning/Running shell for the whole turn, including Grep/Read, so this outranks leftover idle chrome in the TUI.",
+      "when": {
+        "regex": " - [^A-Za-z]*(Working|Planning|Queued|Loading conversation|Reconnecting|Running shell command|Moving to cloud|Reviewing changes)"
+      }
+    },
+    {
+      "id": "idle-osc-title",
+      "state": "idle",
+      "priority": 1150,
+      "region": "osc_title",
+      "when": {
+        "regex": " - [^A-Za-z]*Ready\\s*$"
+      }
+    },
     {
       "id": "confirm-dialog",
       "state": "blockedPermission",
@@ -98,16 +151,17 @@
       "region": "bottom_non_empty_lines",
       "regionLines": 4,
       "when": {
-        "lineRegex": "^\\s*(Generating|Thinking)"
+        "lineRegex": "^\\s*(Generating|Thinking|Responding|Working|Grep|Read |Read file|Edit |Delete |List |Glob |Search |Web search|Fetch |Web fetch|Subagent|Running |Shell command|Codebase search)"
       }
     },
     {
       "id": "idle-prompt-arrow",
       "state": "idle",
       "priority": 500,
-      "region": "prompt_box_body",
+      "region": "bottom_non_empty_lines",
+      "regionLines": 8,
       "when": {
-        "lineRegex": "^\\s*\u2192"
+        "lineRegex": "^\\s*\u2192\\s*Add a follow-up"
       }
     },
     {

--- a/diri/crates/diri-engine/src/detect/mod.rs
+++ b/diri/crates/diri-engine/src/detect/mod.rs
@@ -300,7 +300,7 @@ mod tests {
             .into_iter()
             .map(|id| engine.manifest(id).expect("manifest").rules.len())
             .sum();
-        assert_eq!(rules, 85, "the shipped ruleset lost rules");
+        assert_eq!(rules, 89, "the shipped ruleset lost rules");
 
         for id in engine.ids() {
             let expected_empty = matches!(id, "shell" | "generic" | "pi");
@@ -399,6 +399,53 @@ mod tests {
             observation.is_none() || observation.unwrap().state != ManifestState::BlockedPermission,
             "ordinary output must not read as a blocker"
         );
+    }
+
+    fn cursor_snapshot(lines: &[&str], osc_title: Option<&str>) -> ScreenSnapshot {
+        ScreenSnapshot {
+            lines: lines.iter().map(|line| (*line).to_owned()).collect(),
+            osc_title: osc_title.map(str::to_owned),
+            ..ScreenSnapshot::default()
+        }
+    }
+
+    #[test]
+    fn cursor_osc_title_keeps_tool_turns_working_until_ready() {
+        let engine = engine();
+        let grep = cursor_snapshot(
+            &["Add a follow-up", "Grep AgentKind", "→"],
+            Some("Cursor Integration Fix - \u{23f3} Working ..."),
+        );
+        let observation = engine.evaluate(&grep, "cursor").expect("match");
+        assert_eq!(observation.state, ManifestState::Working);
+        assert_eq!(observation.matched_rule_id, "working-osc-title");
+
+        let ready = cursor_snapshot(
+            &["Add a follow-up"],
+            Some("Cursor Integration Fix - \u{2705} Ready"),
+        );
+        let observation = engine.evaluate(&ready, "cursor").expect("match");
+        assert_eq!(observation.state, ManifestState::Idle);
+        assert_eq!(observation.matched_rule_id, "idle-osc-title");
+
+        let grep_without_osc = cursor_snapshot(&["Grep AgentKind", "Add a follow-up"], None);
+        let observation = engine.evaluate(&grep_without_osc, "cursor").expect("match");
+        assert_eq!(observation.state, ManifestState::Working);
+        assert_eq!(observation.matched_rule_id, "working-status-line");
+
+        let leftover_follow_up = cursor_snapshot(
+            &["Grep AgentKind already finished", "Add a follow-up"],
+            None,
+        );
+        let observation = engine
+            .evaluate(&leftover_follow_up, "cursor")
+            .expect("grep outranks leftover follow-up chrome");
+        assert_eq!(observation.state, ManifestState::Working);
+
+        let idle_prompt = cursor_snapshot(&["\u{2192} Add a follow-up"], None);
+        let observation = engine.evaluate(&idle_prompt, "cursor").expect("match");
+        assert_eq!(observation.state, ManifestState::Idle);
+        assert_eq!(observation.matched_rule_id, "idle-prompt-arrow");
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/events.rs
+++ b/diri/crates/diri-engine/src/events.rs
@@ -394,7 +394,9 @@ pub fn spawn_registry_watcher(
                     let Ok(mut registry) = registry.lock() else {
                         break;
                     };
-                    registry.changed_since(&mut published)
+                    let mut changed = registry.changed_since(&mut published);
+                    changed.extend(registry.refresh_cursor_generated_titles());
+                    changed
                 };
                 for (id, record) in changed {
                     events.publish_encoded(

--- a/diri/crates/diri-engine/src/history.rs
+++ b/diri/crates/diri-engine/src/history.rs
@@ -16,6 +16,7 @@
 //!
 //! Ported from the Swift `HistoryScanner`.
 
+use std::collections::HashSet;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
@@ -29,6 +30,8 @@ const MAX_ENTRIES: usize = 500;
 const CLAUDE_HEAD_CAP: usize = 8 << 20;
 /// Tail window scanned for the newest Claude `ai-title`.
 const CLAUDE_TAIL_BYTES: usize = 16 << 10;
+/// Tail window for Cursor's last jsonl object (turn working/idle).
+const CURSOR_TAIL_BYTES: usize = 64 << 10;
 /// Cap on a Codex `session_meta` first line.
 const CODEX_FIRST_LINE_CAP: usize = 512 << 10;
 const CHUNK: usize = 64 << 10;
@@ -238,6 +241,232 @@ pub(crate) fn latest_claude_ai_title(path: &Path) -> Option<String> {
         }
     }
     newest
+}
+
+/// Cursor conversation identity plus the generated title Cursor writes to
+/// `~/.cursor/chats/<workspace>/<id>/meta.json`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CursorConversation {
+    pub id: String,
+    pub title: Option<String>,
+    pub transcript_path: Option<String>,
+}
+
+/// Last complete jsonl object in a Cursor transcript: in-flight or done.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CursorTranscriptTurn {
+    Working,
+    Idle,
+}
+
+/// Cursor writes `tool_use` while a turn is in flight and a text-only
+/// assistant line (or `turn_ended`) when it is done. `turn_ended` is the
+/// whole conversation, not each turn, so the last object is the signal.
+pub(crate) fn cursor_transcript_turn(path: &Path) -> Option<CursorTranscriptTurn> {
+    classify_cursor_transcript_object(&last_jsonl_object(path)?)
+}
+
+fn classify_cursor_transcript_object(object: &Value) -> Option<CursorTranscriptTurn> {
+    if object.get("type").and_then(Value::as_str) == Some("turn_ended") {
+        return Some(CursorTranscriptTurn::Idle);
+    }
+    match object.get("role").and_then(Value::as_str) {
+        Some("user") => Some(CursorTranscriptTurn::Working),
+        Some("assistant") => Some(if assistant_uses_tool(object) {
+            CursorTranscriptTurn::Working
+        } else {
+            CursorTranscriptTurn::Idle
+        }),
+        _ => None,
+    }
+}
+
+fn assistant_uses_tool(object: &Value) -> bool {
+    object
+        .get("message")
+        .and_then(|message| message.get("content"))
+        .and_then(Value::as_array)
+        .is_some_and(|content| {
+            content
+                .iter()
+                .any(|part| part.get("type").and_then(Value::as_str) == Some("tool_use"))
+        })
+}
+
+fn last_jsonl_object(path: &Path) -> Option<Value> {
+    let mut handle = std::fs::File::open(path).ok()?;
+    let end = handle.seek(SeekFrom::End(0)).ok()?;
+    if end == 0 {
+        return None;
+    }
+    let start = end.saturating_sub(CURSOR_TAIL_BYTES as u64);
+    handle.seek(SeekFrom::Start(start)).ok()?;
+    let mut data = Vec::new();
+    handle
+        .take((CURSOR_TAIL_BYTES + (4 << 10)) as u64)
+        .read_to_end(&mut data)
+        .ok()?;
+    let text = String::from_utf8_lossy(&data);
+    let mut lines = text.split('\n').filter(|line| !line.is_empty());
+    if start > 0 {
+        lines.next();
+    }
+    let mut newest = None;
+    for line in lines {
+        if let Ok(value) = serde_json::from_str::<Value>(line) {
+            newest = Some(value);
+        }
+    }
+    newest
+}
+
+/// `~/.cursor/projects/<slug>/` slug for a working directory: leading slash
+/// stripped, remaining `/` replaced by `-`.
+pub(crate) fn cursor_project_slug(cwd: &str) -> String {
+    cwd.trim_end_matches('/')
+        .trim_start_matches('/')
+        .replace('/', "-")
+}
+
+/// Resolve a Cursor conversation and its generated title.
+///
+/// `conversation_id` wins when the caller already knows it (hook payload).
+/// Otherwise the newest unclaimed transcript under the cwd's project whose
+/// `createdAtMs` is at or after `created_after_ms` is chosen.
+pub(crate) fn cursor_conversation(
+    home: &Path,
+    cwd: &str,
+    conversation_id: Option<&str>,
+    created_after_ms: f64,
+    claimed: &HashSet<String>,
+) -> Option<CursorConversation> {
+    if let Some(id) = conversation_id.filter(|id| is_cursor_conversation_id(id)) {
+        return Some(read_cursor_conversation(home, cwd, id));
+    }
+    discover_cursor_conversation(home, cwd, created_after_ms, claimed)
+}
+
+fn is_cursor_conversation_id(id: &str) -> bool {
+    (32..80).contains(&id.len())
+        && id
+            .chars()
+            .all(|character| character.is_ascii_hexdigit() || character == '-')
+}
+
+fn read_cursor_conversation(home: &Path, cwd: &str, id: &str) -> CursorConversation {
+    let transcript = cursor_transcript_path(home, cwd, id).filter(|path| path.is_file());
+    CursorConversation {
+        title: cursor_meta_title(home, id),
+        transcript_path: transcript.map(|path| path.to_string_lossy().into_owned()),
+        id: id.to_owned(),
+    }
+}
+
+fn discover_cursor_conversation(
+    home: &Path,
+    cwd: &str,
+    created_after_ms: f64,
+    claimed: &HashSet<String>,
+) -> Option<CursorConversation> {
+    let transcripts = cursor_transcripts_dir(home, cwd)?;
+    let Ok(entries) = std::fs::read_dir(&transcripts) else {
+        return None;
+    };
+    let floor = created_after_ms - 2_000.0;
+    let mut best: Option<(f64, CursorConversation)> = None;
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let id = entry.file_name().to_string_lossy().into_owned();
+        if claimed.contains(&id) || !is_cursor_conversation_id(&id) {
+            continue;
+        }
+        let conversation = read_cursor_conversation(home, cwd, &id);
+        let created = cursor_meta_created_ms(home, &id).unwrap_or_else(|| {
+            std::fs::metadata(&path)
+                .and_then(|meta| meta.created().or_else(|_| meta.modified()))
+                .ok()
+                .map(system_time_ms)
+                .unwrap_or(0.0)
+        });
+        if created < floor {
+            continue;
+        }
+        let better = best.as_ref().is_none_or(|(best_created, _)| {
+            (created - created_after_ms).abs() < (best_created - created_after_ms).abs()
+        });
+        if better {
+            best = Some((created, conversation));
+        }
+    }
+    best.map(|(_, conversation)| conversation)
+}
+
+fn cursor_transcripts_dir(home: &Path, cwd: &str) -> Option<PathBuf> {
+    let dir = home
+        .join(".cursor/projects")
+        .join(cursor_project_slug(cwd))
+        .join("agent-transcripts");
+    confined_dir(home.join(".cursor"), &dir)
+}
+
+fn cursor_transcript_path(home: &Path, cwd: &str, id: &str) -> Option<PathBuf> {
+    let path = cursor_transcripts_dir(home, cwd)?
+        .join(id)
+        .join(format!("{id}.jsonl"));
+    confined_file(home.join(".cursor"), &path)
+}
+
+fn cursor_meta_title(home: &Path, id: &str) -> Option<String> {
+    cursor_meta(home, id)?
+        .get("title")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .map(str::to_owned)
+}
+
+fn cursor_meta_created_ms(home: &Path, id: &str) -> Option<f64> {
+    cursor_meta(home, id)?
+        .get("createdAtMs")
+        .and_then(Value::as_f64)
+}
+
+fn cursor_meta(home: &Path, id: &str) -> Option<Value> {
+    let chats = home.join(".cursor/chats");
+    let Ok(workspaces) = std::fs::read_dir(&chats) else {
+        return None;
+    };
+    for workspace in workspaces.filter_map(Result::ok) {
+        let meta = workspace.path().join(id).join("meta.json");
+        let Some(meta) = confined_file(&chats, &meta) else {
+            continue;
+        };
+        let bytes = std::fs::read(&meta).ok()?;
+        return serde_json::from_slice(&bytes).ok();
+    }
+    None
+}
+
+fn confined_dir(root: impl AsRef<Path>, path: &Path) -> Option<PathBuf> {
+    let root = root.as_ref().canonicalize().ok()?;
+    let canonical = path.canonicalize().ok()?;
+    canonical.starts_with(&root).then_some(canonical)
+}
+
+fn confined_file(root: impl AsRef<Path>, path: &Path) -> Option<PathBuf> {
+    if !path.is_file() {
+        return None;
+    }
+    confined_dir(root, path)
+}
+
+fn system_time_ms(time: SystemTime) -> f64 {
+    time.duration_since(SystemTime::UNIX_EPOCH)
+        .map(|since| since.as_secs_f64() * 1000.0)
+        .unwrap_or(0.0)
 }
 
 // MARK: Codex
@@ -611,5 +840,114 @@ mod tests {
         );
         let entries = scan_roots(&claude, &temp.path().join("codex"), &[]);
         assert_eq!(entries[0].cwd, "/tmp");
+    }
+
+    #[test]
+    fn a_cursor_meta_title_is_the_generated_conversation_name() {
+        let temp = tempfile::tempdir().expect("temp");
+        let home = temp.path();
+        let id = "11111fcb-7655-4342-8b2f-88068c650200";
+        let cwd = "/Users/alex/GitHub/diri";
+        write_cursor_chat(home, cwd, id, "Cursor Integration Fix", 1_788_110_437_802.0);
+
+        let conversation =
+            cursor_conversation(home, cwd, Some(id), 0.0, &HashSet::new()).expect("found");
+        assert_eq!(conversation.id, id);
+        assert_eq!(
+            conversation.title.as_deref(),
+            Some("Cursor Integration Fix")
+        );
+    }
+
+    #[test]
+    fn an_unclaimed_cursor_transcript_is_matched_to_the_session_cwd() {
+        let temp = tempfile::tempdir().expect("temp");
+        let home = temp.path();
+        let cwd = "/Users/alex/GitHub/diri";
+        let claimed = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa".to_owned();
+        write_cursor_chat(home, cwd, &claimed, "Old chat", 1_000.0);
+        write_cursor_chat(
+            home,
+            cwd,
+            "bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb",
+            "Cursor Integration Fix",
+            5_000.0,
+        );
+
+        let conversation = cursor_conversation(home, cwd, None, 4_500.0, &HashSet::from([claimed]))
+            .expect("found");
+        assert_eq!(conversation.id, "bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb");
+        assert_eq!(
+            conversation.title.as_deref(),
+            Some("Cursor Integration Fix")
+        );
+    }
+
+    #[test]
+    fn cursor_transcript_last_object_is_working_or_idle() {
+        let temp = tempfile::tempdir().expect("temp");
+        let path = temp.path().join("chat.jsonl");
+
+        write(
+            &path,
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"hi"}]}}
+"#,
+        );
+        assert_eq!(
+            cursor_transcript_turn(&path),
+            Some(CursorTranscriptTurn::Working)
+        );
+
+        write(
+            &path,
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"hi"}]}}
+{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Grep"}]}}
+"#,
+        );
+        assert_eq!(
+            cursor_transcript_turn(&path),
+            Some(CursorTranscriptTurn::Working)
+        );
+
+        write(
+            &path,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Grep"}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"done"}]}}
+"#,
+        );
+        assert_eq!(
+            cursor_transcript_turn(&path),
+            Some(CursorTranscriptTurn::Idle)
+        );
+
+        write(
+            &path,
+            r#"{"role":"assistant","message":{"content":[{"type":"text","text":"done"}]}}
+{"type":"turn_ended","status":"success"}
+"#,
+        );
+        assert_eq!(
+            cursor_transcript_turn(&path),
+            Some(CursorTranscriptTurn::Idle)
+        );
+    }
+
+    fn write_cursor_chat(home: &Path, cwd: &str, id: &str, title: &str, created_at_ms: f64) {
+        let transcripts = home
+            .join(".cursor/projects")
+            .join(cursor_project_slug(cwd))
+            .join("agent-transcripts")
+            .join(id);
+        std::fs::create_dir_all(&transcripts).expect("transcripts");
+        std::fs::write(transcripts.join(format!("{id}.jsonl")), "{}\n").expect("jsonl");
+        let meta_dir = home.join(".cursor/chats/workspace").join(id);
+        std::fs::create_dir_all(&meta_dir).expect("meta");
+        std::fs::write(
+            meta_dir.join("meta.json"),
+            format!(
+                r#"{{"schemaVersion":1,"createdAtMs":{created_at_ms},"title":"{title}","cwd":"{cwd}"}}"#
+            ),
+        )
+        .expect("meta");
     }
 }

--- a/diri/crates/diri-engine/src/hooks.rs
+++ b/diri/crates/diri-engine/src/hooks.rs
@@ -36,7 +36,8 @@ pub fn parse_claude_hook(
     // moves to a different project directory when an agent enters a worktree
     // mid-session, and capturing it once would leave the record pointing at the
     // pre-worktree path forever.
-    meta.agent_session_id = string(payload, "session_id");
+    meta.agent_session_id =
+        string(payload, "session_id").or_else(|| string(payload, "conversation_id"));
     meta.transcript_path = string(payload, "transcript_path");
 
     let hook = match event {
@@ -230,6 +231,23 @@ mod tests {
         assert_eq!(
             meta.transcript_path.as_deref(),
             Some("/new/project/dir/abc-123.jsonl")
+        );
+    }
+
+    #[test]
+    fn cursor_conversation_id_is_accepted_as_session_identity() {
+        let payload = json!({
+            "conversation_id": "11111fcb-7655-4342-8b2f-88068c650200",
+            "prompt": "Fix the cursor session title",
+        });
+        let (_, meta) = parse_claude_hook("UserPromptSubmit", &payload, now()).expect("parsed");
+        assert_eq!(
+            meta.agent_session_id.as_deref(),
+            Some("11111fcb-7655-4342-8b2f-88068c650200")
+        );
+        assert_eq!(
+            meta.first_prompt_title.as_deref(),
+            Some("Fix the cursor session title")
         );
     }
 

--- a/diri/crates/diri-engine/src/registry.rs
+++ b/diri/crates/diri-engine/src/registry.rs
@@ -4,7 +4,7 @@
 //! It also owns the additive `{ version, projects, sessions }` persistence
 //! envelope. Unknown project fields survive a read/write cycle.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -12,8 +12,10 @@ use diri_proto::{DateMillis, ExitInfo, ExitReason, SessionRecord, SessionStatus,
 use serde::{Deserialize, Serialize};
 
 use crate::detect::ManifestEngine;
+use crate::history::CursorTranscriptTurn;
 use crate::holder::{HolderClient, HolderManagerPaths, HolderPaths};
 use crate::session::{HolderConfig, RemoteAdoptSpec, Session, SessionSpec, SessionView};
+use crate::status::StatusSignal;
 
 /// The versioned on-disk snapshot.
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -51,6 +53,7 @@ pub struct Registry {
     /// tab switch), and the flusher or the next persist call writes it out.
     dirty: bool,
     last_persist: Option<std::time::Instant>,
+    cursor_title_refresh_at: Option<std::time::Instant>,
 }
 
 /// How long consecutive persists coalesce. Matches the Swift daemon's
@@ -96,6 +99,7 @@ impl Registry {
             state_file: state_file.into(),
             dirty: false,
             last_persist: None,
+            cursor_title_refresh_at: None,
         }
     }
 
@@ -484,6 +488,77 @@ impl Registry {
         changed
     }
 
+    /// Pulls Cursor's generated `meta.json` title and jsonl turn state into
+    /// live Cursor sessions. Cheap when none are running: one kind check per
+    /// live session, then at most one bounded directory walk per second.
+    pub fn refresh_cursor_generated_titles(&mut self) -> Vec<(String, SessionRecord)> {
+        let Some(home) = user_home() else {
+            return Vec::new();
+        };
+        let now = std::time::Instant::now();
+        if self.cursor_title_refresh_at.is_some_and(|previous| {
+            now.duration_since(previous) < std::time::Duration::from_secs(1)
+        }) {
+            return Vec::new();
+        }
+        self.cursor_title_refresh_at = Some(now);
+        let live: Vec<String> = self
+            .sessions
+            .keys()
+            .filter(|id| {
+                self.records
+                    .get(*id)
+                    .is_some_and(|record| record.kind == diri_proto::AgentKind::CURSOR)
+            })
+            .cloned()
+            .collect();
+        if live.is_empty() {
+            return Vec::new();
+        }
+        let mut changed = Vec::new();
+        for id in live {
+            let claimed = self.claimed_agent_ids(Some(&id));
+            let mut record_changed = false;
+            let transcript = {
+                let Some(record) = self.records.get_mut(&id) else {
+                    continue;
+                };
+                if apply_cursor_store_title(record, &home, &claimed) {
+                    record.updated_at = DateMillis::from(std::time::SystemTime::now());
+                    self.dirty = true;
+                    record_changed = true;
+                }
+                record.transcript_path.clone()
+            };
+            let mut status_changed = false;
+            if let (Some(path), Some(session)) = (transcript, self.sessions.get(&id))
+                && let Some(turn) = crate::history::cursor_transcript_turn(Path::new(&path))
+            {
+                let outcome = match turn {
+                    CursorTranscriptTurn::Working => {
+                        session.feed_signal(StatusSignal::CursorTranscriptWorking)
+                    }
+                    CursorTranscriptTurn::Idle => {
+                        session.feed_signal(StatusSignal::CursorTranscriptIdle);
+                        session.feed_signal(StatusSignal::Tick)
+                    }
+                };
+                status_changed = outcome.status_change.is_some() || outcome.turn_completed;
+            }
+            if !(record_changed || status_changed) {
+                continue;
+            }
+            let Some(record) = self.records.get_mut(&id) else {
+                continue;
+            };
+            if let Some(session) = self.sessions.get(&id) {
+                fold_session_view(record, &session.view());
+            }
+            changed.push((id, record.clone()));
+        }
+        changed
+    }
+
     /// Ends a session but keeps its record, which is what archiving means here.
     pub fn terminate(
         &mut self,
@@ -610,21 +685,39 @@ impl Registry {
     /// and Claude's generated `ai-title` when it becomes available. Returns
     /// whether anything changed.
     pub fn apply_hook_metadata(&mut self, id: &str, meta: &crate::hooks::HookMetadata) -> bool {
+        let home = user_home();
+        let claimed = self.claimed_agent_ids(Some(id));
         let generated_title = self.records.get(id).and_then(|record| {
-            let accepts_generated_title = record.kind == diri_proto::AgentKind::CLAUDE_CODE
-                && matches!(
-                    record.title_source,
-                    TitleSource::Placeholder | TitleSource::FirstPrompt | TitleSource::Unknown
-                );
-            accepts_generated_title
-                .then(|| {
-                    meta.transcript_path
-                        .as_deref()
-                        .or(record.transcript_path.as_deref())
-                })
-                .flatten()
-                .and_then(|path| crate::history::latest_claude_ai_title(Path::new(path)))
-                .and_then(|title| normalize_agent_title(&title))
+            let accepts_generated_title = matches!(
+                record.title_source,
+                TitleSource::Placeholder | TitleSource::FirstPrompt | TitleSource::Unknown
+            );
+            if !accepts_generated_title {
+                return None;
+            }
+            if record.kind == diri_proto::AgentKind::CLAUDE_CODE {
+                return meta
+                    .transcript_path
+                    .as_deref()
+                    .or(record.transcript_path.as_deref())
+                    .and_then(|path| crate::history::latest_claude_ai_title(Path::new(path)))
+                    .and_then(|title| normalize_agent_title(&title));
+            }
+            None
+        });
+        let cursor = self.records.get(id).and_then(|record| {
+            if record.kind != diri_proto::AgentKind::CURSOR {
+                return None;
+            }
+            crate::history::cursor_conversation(
+                home.as_deref()?,
+                &record.cwd,
+                meta.agent_session_id
+                    .as_deref()
+                    .or(record.agent_session_id.as_deref()),
+                record.created_at.0,
+                &claimed,
+            )
         });
         let Some(record) = self.records.get_mut(id) else {
             return false;
@@ -642,6 +735,9 @@ impl Registry {
         {
             record.transcript_path = Some(transcript.clone());
             changed = true;
+        }
+        if let Some(conversation) = cursor {
+            changed |= apply_cursor_conversation(record, conversation);
         }
         if repair_persisted_agent_title(record) {
             changed = true;
@@ -880,6 +976,69 @@ impl Registry {
     pub fn state_file(&self) -> &Path {
         &self.state_file
     }
+
+    fn claimed_agent_ids(&self, except: Option<&str>) -> HashSet<String> {
+        self.records
+            .iter()
+            .filter(|(id, _)| except != Some(id.as_str()))
+            .filter_map(|(_, record)| record.agent_session_id.clone())
+            .collect()
+    }
+}
+
+fn user_home() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
+fn apply_cursor_store_title(
+    record: &mut SessionRecord,
+    home: &Path,
+    claimed: &HashSet<String>,
+) -> bool {
+    let Some(conversation) = crate::history::cursor_conversation(
+        home,
+        &record.cwd,
+        record.agent_session_id.as_deref(),
+        record.created_at.0,
+        claimed,
+    ) else {
+        return false;
+    };
+    apply_cursor_conversation(record, conversation)
+}
+
+fn apply_cursor_conversation(
+    record: &mut SessionRecord,
+    conversation: crate::history::CursorConversation,
+) -> bool {
+    let mut changed = false;
+    if record.agent_session_id.as_deref() != Some(conversation.id.as_str()) {
+        record.agent_session_id = Some(conversation.id);
+        record.resumability = diri_proto::Resumability::Live;
+        changed = true;
+    }
+    if let Some(path) = conversation.transcript_path
+        && record.transcript_path.as_ref() != Some(&path)
+    {
+        record.transcript_path = Some(path);
+        changed = true;
+    }
+    let accepts_generated_title = matches!(
+        record.title_source,
+        TitleSource::Placeholder | TitleSource::FirstPrompt | TitleSource::Unknown
+    );
+    if accepts_generated_title
+        && let Some(title) = conversation
+            .title
+            .and_then(|title| normalize_agent_title(&title))
+            .filter(|title| !is_generic_terminal_title(title, record))
+        && (record.title != title || record.title_source != TitleSource::AgentProvided)
+    {
+        record.title = title;
+        record.title_source = TitleSource::AgentProvided;
+        changed = true;
+    }
+    changed
 }
 
 fn fold_session_view(record: &mut SessionRecord, view: &SessionView) {
@@ -934,6 +1093,9 @@ fn repair_persisted_agent_title(record: &mut SessionRecord) -> bool {
 fn fold_session_status(record: &mut SessionRecord, view: &SessionView) {
     record.status.clone_from(&view.status);
     record.needs_input.clone_from(&view.needs_input);
+    if view.last_turn_completed_at > record.last_turn_completed_at {
+        record.last_turn_completed_at = view.last_turn_completed_at;
+    }
 }
 
 fn normalize_agent_title(title: &str) -> Option<String> {
@@ -978,17 +1140,45 @@ fn is_cursor_status_title(title: &str) -> bool {
     let rest = title
         .strip_prefix("cursor agent")
         .or_else(|| title.strip_prefix("cursor-agent"));
-    let Some(rest) = rest else {
-        return false;
-    };
-    let compact: String = rest
+    if let Some(rest) = rest {
+        let compact: String = rest
+            .chars()
+            .filter(|character| character.is_alphanumeric())
+            .collect();
+        if compact.is_empty() || is_cursor_status_stamp(&compact) {
+            return true;
+        }
+    }
+    title
+        .rsplit_once(" - ")
+        .is_some_and(|(_, stamp)| is_cursor_status_stamp(&compact_alnum(stamp)))
+}
+
+fn compact_alnum(value: &str) -> String {
+    value
         .chars()
         .filter(|character| character.is_alphanumeric())
-        .collect();
-    compact.is_empty()
+        .collect()
+}
+
+fn is_cursor_status_stamp(compact: &str) -> bool {
+    compact.starts_with("working")
         || matches!(
-            compact.as_str(),
-            "ready" | "working" | "thinking" | "generating" | "idle" | "newchat"
+            compact,
+            "ready"
+                | "thinking"
+                | "generating"
+                | "idle"
+                | "newchat"
+                | "planning"
+                | "queued"
+                | "runningshellcommand"
+                | "loadingconversation"
+                | "reconnecting"
+                | "movingtocloud"
+                | "reviewingchanges"
+                | "waitingforyou"
+                | "waitingforconfirmation"
         )
 }
 
@@ -1445,6 +1635,7 @@ mod tests {
             needs_input: None,
             title: Some("Repair remote attach".to_owned()),
             title_source: Some(TitleSource::AgentProvided),
+            last_turn_completed_at: None,
             tail_offset: 0,
             exited: false,
         };
@@ -1520,9 +1711,20 @@ mod tests {
         let cursor_prompt = SessionView {
             title: Some("Fix the cursor session title".to_owned()),
             title_source: Some(TitleSource::FirstPrompt),
-            ..cursor_ready
+            ..cursor_ready.clone()
         };
         fold_session_view(&mut cursor, &cursor_prompt);
+        assert_eq!(cursor.title, "Fix the cursor session title");
+        assert_eq!(cursor.title_source, TitleSource::FirstPrompt);
+
+        cursor.title = "Fix the cursor session title".to_owned();
+        cursor.title_source = TitleSource::FirstPrompt;
+        let named_working = SessionView {
+            title: Some("Cursor Integration Fix - \u{23f3} Working ...".to_owned()),
+            title_source: Some(TitleSource::AgentProvided),
+            ..cursor_ready
+        };
+        fold_session_view(&mut cursor, &named_working);
         assert_eq!(cursor.title, "Fix the cursor session title");
         assert_eq!(cursor.title_source, TitleSource::FirstPrompt);
     }
@@ -1548,5 +1750,40 @@ mod tests {
         let updated = registry.record("cursor").expect("record");
         assert_eq!(updated.title, "Rename cursor chats from the first prompt");
         assert_eq!(updated.title_source, TitleSource::FirstPrompt);
+    }
+
+    #[test]
+    fn a_cursor_generated_meta_title_promotes_over_the_first_prompt() {
+        let temp = tempfile::tempdir().expect("temp");
+        let home = temp.path();
+        let cwd = "/Users/alex/GitHub/diri";
+        let id = "11111fcb-7655-4342-8b2f-88068c650200";
+        let transcripts = home
+            .join(".cursor/projects")
+            .join("Users-alex-GitHub-diri")
+            .join("agent-transcripts")
+            .join(id);
+        std::fs::create_dir_all(&transcripts).expect("transcripts");
+        std::fs::write(transcripts.join(format!("{id}.jsonl")), "{}\n").expect("jsonl");
+        let meta_dir = home.join(".cursor/chats/workspace").join(id);
+        std::fs::create_dir_all(&meta_dir).expect("meta");
+        std::fs::write(
+            meta_dir.join("meta.json"),
+            format!(
+                r#"{{"schemaVersion":1,"createdAtMs":5000,"title":"Cursor Integration Fix","cwd":"{cwd}"}}"#
+            ),
+        )
+        .expect("meta");
+
+        let mut session = record("cursor");
+        session.kind = AgentKind::CURSOR;
+        session.cwd = cwd.into();
+        session.title = "on another pr created from main".into();
+        session.title_source = TitleSource::FirstPrompt;
+        session.created_at = DateMillis(4_000.0);
+        apply_cursor_store_title(&mut session, home, &HashSet::new());
+        assert_eq!(session.title, "Cursor Integration Fix");
+        assert_eq!(session.title_source, TitleSource::AgentProvided);
+        assert_eq!(session.agent_session_id.as_deref(), Some(id));
     }
 }

--- a/diri/crates/diri-engine/src/registry.rs
+++ b/diri/crates/diri-engine/src/registry.rs
@@ -643,6 +643,9 @@ impl Registry {
             record.transcript_path = Some(transcript.clone());
             changed = true;
         }
+        if repair_persisted_agent_title(record) {
+            changed = true;
+        }
         if let Some(title) = &meta.first_prompt_title
             && record.title_source == TitleSource::Placeholder
         {
@@ -881,6 +884,10 @@ impl Registry {
 
 fn fold_session_view(record: &mut SessionRecord, view: &SessionView) {
     fold_session_status(record, view);
+    // cursor-agent (and similar) stamp a brand/status OSC title as soon as
+    // they are idle. That must not freeze the record as AgentProvided, or
+    // the first real prompt can never name the session.
+    repair_persisted_agent_title(record);
     if record.kind == diri_proto::AgentKind::SHELL
         || matches!(
             record.title_source,
@@ -955,7 +962,33 @@ fn is_generic_terminal_title(title: &str, record: &SessionRecord) -> bool {
         || title == directory
         || matches!(
             compact_title.as_str(),
-            "claude" | "claudecode" | "codex" | "cursor" | "gemini" | "terminal" | "shell"
+            "claude"
+                | "claudecode"
+                | "codex"
+                | "cursor"
+                | "cursoragent"
+                | "gemini"
+                | "terminal"
+                | "shell"
+        )
+        || is_cursor_status_title(&title)
+}
+
+fn is_cursor_status_title(title: &str) -> bool {
+    let rest = title
+        .strip_prefix("cursor agent")
+        .or_else(|| title.strip_prefix("cursor-agent"));
+    let Some(rest) = rest else {
+        return false;
+    };
+    let compact: String = rest
+        .chars()
+        .filter(|character| character.is_alphanumeric())
+        .collect();
+    compact.is_empty()
+        || matches!(
+            compact.as_str(),
+            "ready" | "working" | "thinking" | "generating" | "idle" | "newchat"
         )
 }
 
@@ -1461,7 +1494,7 @@ mod tests {
         decorated.kind = AgentKind::CLAUDE_CODE;
         let decorated_view = SessionView {
             title: Some("✳ Claude Code".to_owned()),
-            ..generic_view
+            ..generic_view.clone()
         };
         fold_session_view(&mut decorated, &decorated_view);
         assert_eq!(decorated.title_source, TitleSource::Placeholder);
@@ -1471,5 +1504,49 @@ mod tests {
         assert!(repair_persisted_agent_title(&mut decorated));
         assert_eq!(decorated.title, AgentKind::CLAUDE_CODE_ID);
         assert_eq!(decorated.title_source, TitleSource::Placeholder);
+
+        let mut cursor = record("cursor");
+        cursor.kind = AgentKind::CURSOR;
+        let cursor_ready = SessionView {
+            title: Some("Cursor Agent - \u{2705} Ready".to_owned()),
+            title_source: Some(TitleSource::AgentProvided),
+            ..generic_view
+        };
+        fold_session_view(&mut cursor, &cursor_ready);
+        assert_eq!(cursor.title_source, TitleSource::Placeholder);
+
+        cursor.title = "Cursor Agent - \u{2705} Ready".to_owned();
+        cursor.title_source = TitleSource::AgentProvided;
+        let cursor_prompt = SessionView {
+            title: Some("Fix the cursor session title".to_owned()),
+            title_source: Some(TitleSource::FirstPrompt),
+            ..cursor_ready
+        };
+        fold_session_view(&mut cursor, &cursor_prompt);
+        assert_eq!(cursor.title, "Fix the cursor session title");
+        assert_eq!(cursor.title_source, TitleSource::FirstPrompt);
+    }
+
+    #[test]
+    fn a_cursor_status_title_does_not_block_the_first_prompt_hook() {
+        let temp = tempfile::tempdir().expect("temp");
+        let mut registry = Registry::new(engine(), temp.path().join("state.json"));
+        let mut session = record("cursor");
+        session.kind = AgentKind::CURSOR;
+        session.title = "Cursor Agent - \u{2705} Ready".to_owned();
+        session.title_source = TitleSource::AgentProvided;
+        registry.insert_record(session);
+
+        assert!(registry.apply_hook_metadata(
+            "cursor",
+            &crate::hooks::HookMetadata {
+                first_prompt_title: Some("Rename cursor chats from the first prompt".into()),
+                ..crate::hooks::HookMetadata::default()
+            }
+        ));
+
+        let updated = registry.record("cursor").expect("record");
+        assert_eq!(updated.title, "Rename cursor chats from the first prompt");
+        assert_eq!(updated.title_source, TitleSource::FirstPrompt);
     }
 }

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -105,6 +105,7 @@ pub struct SessionView {
     pub needs_input: Option<NeedsInputDetail>,
     pub title: Option<String>,
     pub title_source: Option<diri_proto::TitleSource>,
+    pub last_turn_completed_at: Option<diri_proto::DateMillis>,
     pub tail_offset: u64,
     pub exited: bool,
 }
@@ -167,6 +168,7 @@ struct Shared {
     id: String,
     status: Mutex<SessionStatus>,
     needs_input: Mutex<Option<NeedsInputDetail>>,
+    last_turn_completed_at: Mutex<Option<diri_proto::DateMillis>>,
     title: Mutex<Option<String>>,
     prompt_title: Mutex<Option<String>>,
     prompt_input: Mutex<PromptInputState>,
@@ -1001,6 +1003,11 @@ impl Session {
             needs_input: self.shared.needs_input.lock().expect("needs input").clone(),
             title,
             title_source,
+            last_turn_completed_at: *self
+                .shared
+                .last_turn_completed_at
+                .lock()
+                .expect("last turn completed"),
             tail_offset: self.shared.log.lock().expect("log").tail_offset(),
             exited: self.shared.exited.load(Ordering::SeqCst),
         }
@@ -1598,6 +1605,7 @@ fn new_shared(spec: &SessionSpec, log: OutputLog) -> Arc<Shared> {
         id: spec.id.clone(),
         status: Mutex::new(SessionStatus::Starting),
         needs_input: Mutex::new(None),
+        last_turn_completed_at: Mutex::new(None),
         title: Mutex::new(None),
         prompt_title: Mutex::new(None),
         prompt_input: Mutex::new(PromptInputState::default()),
@@ -1680,6 +1688,13 @@ fn apply(shared: &Shared, outcome: &ReducerOutcome) {
             *current = Some(detail.clone());
             changed = true;
         }
+    }
+    if outcome.turn_completed {
+        *shared
+            .last_turn_completed_at
+            .lock()
+            .expect("last turn completed") = Some(diri_proto::DateMillis::from(SystemTime::now()));
+        changed = true;
     }
     // Leaving a needs-input state clears the pending detail, so the UI does not
     // keep showing a prompt that has been answered.

--- a/diri/crates/diri-engine/src/status/mod.rs
+++ b/diri/crates/diri-engine/src/status/mod.rs
@@ -92,6 +92,10 @@ pub enum StatusSignal {
         is_subagent: bool,
     },
     CodexTurnComplete,
+    /// Cursor jsonl tail: last object is a user prompt or `tool_use`.
+    CursorTranscriptWorking,
+    /// Cursor jsonl tail: last object is assistant text or `turn_ended`.
+    CursorTranscriptIdle,
     Screen(ScreenObservation),
     PtyOutputActivity,
     UserKeystroke,
@@ -149,6 +153,10 @@ struct InternalState {
     responding_since: Option<SystemTime>,
     /// Last needs-input detail produced, for dedupe upstream.
     pending_needs_input: Option<NeedsInputDetail>,
+    /// Cursor jsonl said the turn ended. Ignore leftover Working OSC until
+    /// the transcript shows work again — cursor-agent does not update the
+    /// title to Ready at end of turn.
+    hold_idle_against_screen: bool,
 }
 
 impl InternalState {
@@ -169,6 +177,7 @@ impl InternalState {
             skip_active: false,
             responding_since: None,
             pending_needs_input: None,
+            hold_idle_against_screen: false,
         }
     }
 }
@@ -275,6 +284,19 @@ impl StatusReducer {
                 self.state.last_signal_at = now;
                 self.handle_strong_idle(now, &mut outcome);
             }
+            StatusSignal::CursorTranscriptWorking => {
+                if matches!(self.status, SessionStatus::NeedsInput(_)) {
+                    return outcome;
+                }
+                self.go_working(now, false, &mut outcome);
+            }
+            StatusSignal::CursorTranscriptIdle => {
+                self.state.last_signal_at = now;
+                if self.status == SessionStatus::Working {
+                    self.state.hold_idle_against_screen = true;
+                    self.handle_strong_idle(now, &mut outcome);
+                }
+            }
             StatusSignal::Screen(observation) => self.handle_screen(observation, now, &mut outcome),
             StatusSignal::Tick => self.handle_tick(now, &mut outcome),
         }
@@ -306,6 +328,7 @@ impl StatusReducer {
         clear_screen_blocker: bool,
         outcome: &mut ReducerOutcome,
     ) {
+        self.state.hold_idle_against_screen = false;
         self.cancel_idle_candidacy();
         if clear_screen_blocker {
             self.state.screen_blocker_active = false;
@@ -523,6 +546,7 @@ impl StatusReducer {
             let detail = screen_detail(kind, &observation, now);
             self.state.pending_needs_input = Some(detail.clone());
             outcome.needs_input = Some(detail);
+            self.state.hold_idle_against_screen = false;
             self.cancel_idle_candidacy();
             self.set_status(SessionStatus::NeedsInput(kind), outcome);
             return;
@@ -567,7 +591,12 @@ impl StatusReducer {
         outcome: &mut ReducerOutcome,
     ) {
         match observation.state {
-            ManifestState::Working => self.go_working(now, false, outcome),
+            ManifestState::Working => {
+                if self.state.hold_idle_against_screen {
+                    return;
+                }
+                self.go_working(now, false, outcome);
+            }
             ManifestState::Idle => {
                 if self.status == SessionStatus::Working {
                     self.confirm_idle(now, outcome);

--- a/diri/crates/diri-engine/src/status/tests.rs
+++ b/diri/crates/diri-engine/src/status/tests.rs
@@ -493,3 +493,40 @@ fn a_repeated_screen_sequence_is_not_reprocessed() {
     assert_eq!(outcome.status_change, None);
     assert_eq!(*reducer.status(), SessionStatus::Working);
 }
+
+#[test]
+fn cursor_transcript_idle_commits_even_when_the_osc_still_says_working() {
+    let mut reducer = StatusReducer::new(Authority::ScreenPrimary, t0());
+    let mut now = settled(&mut reducer, t0());
+
+    reducer.reduce(
+        StatusSignal::Screen(observation(ManifestState::Working, 1)),
+        now,
+    );
+    now += Duration::from_millis(100);
+    reducer.reduce(StatusSignal::CursorTranscriptIdle, now);
+    now += Duration::from_millis(100);
+    let still_working = reducer.reduce(
+        StatusSignal::Screen(observation(ManifestState::Working, 2)),
+        now,
+    );
+    assert_eq!(still_working.status_change, None);
+    assert_eq!(*reducer.status(), SessionStatus::Working);
+
+    now += Duration::from_millis(100);
+    let outcome = reducer.reduce(StatusSignal::Tick, now);
+    assert_eq!(outcome.status_change, Some(SessionStatus::Idle));
+    assert!(outcome.turn_completed);
+
+    now += Duration::from_millis(100);
+    let stale_osc = reducer.reduce(
+        StatusSignal::Screen(observation(ManifestState::Working, 3)),
+        now,
+    );
+    assert_eq!(stale_osc.status_change, None);
+    assert_eq!(*reducer.status(), SessionStatus::Idle);
+
+    now += Duration::from_millis(100);
+    reducer.reduce(StatusSignal::CursorTranscriptWorking, now);
+    assert_eq!(*reducer.status(), SessionStatus::Working);
+}


### PR DESCRIPTION
## Why

Two Cursor bugs in Diri:

1. Every new Cursor chat was stuck as `Cursor Agent - ✅ Ready`. cursor-agent stamps that brand/status string as the OSC title as soon as it is idle, and Diri treated it as an agent-provided conversation name. After that, the first prompt could never rename the session.

2. After a turn finished, Diri often stayed `working` and then fell to `unknown`. cursor-agent does not write Ready on the OSC title at end of turn, leftover Working OSC outranked idle chrome (`→ Add a follow-up`), and leftover follow-up text mid-Grep used to look like idle (false "finished" banners).

## What changed

- Treat Cursor brand/status OSC titles (`Cursor Agent - ✅ Ready`, `- ⏳ Working`, and the other idle/working stamps) as generic. Demote ones already persisted as agent-provided so a later first prompt, hook, or generated `meta.json` title can name the chat.
- Read Cursor's generated conversation name from `~/.cursor/chats/.../meta.json`.
- Drive turn working/idle from the transcript jsonl tail (user / `tool_use` = working; assistant text / `turn_ended` = idle). After jsonl idle, ignore stale Working OSC so it cannot flip the session back. Stamp `lastTurnCompletedAt` so the done/green pulse can fire.

## Verification

- [x] `cargo test -p diri-engine --lib cursor_`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `./scripts/check.sh` passes, or I explained why a check is not applicable.
- [x] Existing sessions still survive app and daemon restarts, or the migration is documented.
- [x] I considered security and privacy impact (processes, IPC, logs, updates, remote hosts).
- [x] User-visible behavior or setup changes are documented.
- [ ] UI changes include a screenshot or short recording.

Live on a rebuilt diri-dev: a no-tools turn went idle; a Grep turn stayed `working` while leftover `→ Add a follow-up` was still on screen, then went idle with `lastTurnCompletedAt`; a Grep follow-up did the same. Full `./scripts/check.sh` was not run; fmt and workspace clippy were.

Transcript paths stay under `~/.cursor`. Status logs still do not dump jsonl payloads.
