### PR TITLE
feat: paste dropped files into the terminal

### DIFF
--- a/diri/crates/diri-app/src/clipboard_transfer.rs
+++ b/diri/crates/diri-app/src/clipboard_transfer.rs
@@ -38,25 +38,65 @@ impl StagedClipboardImage {
             .path()
             .file_name()
             .ok_or_else(|| "clipboard image has no file name".to_owned())?
-            .to_string_lossy();
-        let remote_path = format!("{REMOTE_TEMP_DIRECTORY}/{file_name}");
-        let output = Command::new(SCP)
-            .args(scp_arguments(self.local_file.path(), ssh, &remote_path))
-            .output()
-            .map_err(|error| format!("could not start scp: {error}"))?;
-
-        if output.status.success() {
-            return Ok(remote_path);
-        }
-
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let detail = stderr.trim();
-        Err(if detail.is_empty() {
-            format!("scp exited with {}", output.status)
-        } else {
-            format!("scp failed: {detail}")
-        })
+            .to_string_lossy()
+            .into_owned();
+        upload_to_remote_temp(self.local_file.path(), ssh, &file_name)
     }
+}
+
+/// Copies a file dropped on a remote session into that host's temp directory
+/// and returns the path valid there. The remote name keeps the original file
+/// name (so an Agent still sees `shot.png`, not an opaque id) under a unique
+/// prefix, reduced to characters that are inert in the remote shell scp uses.
+pub(crate) fn upload_dropped_file(local_path: &Path, ssh: &str) -> Result<String, String> {
+    let file_name = local_path
+        .file_name()
+        .ok_or_else(|| format!("{} has no file name", local_path.display()))?
+        .to_string_lossy();
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_nanos())
+        .unwrap_or(0);
+    let remote_name = format!("dirijor-drop-{unique}-{}", remote_safe_name(&file_name));
+    upload_to_remote_temp(local_path, ssh, &remote_name)
+}
+
+fn remote_safe_name(name: &str) -> String {
+    let safe: String = name
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    safe.trim_start_matches(['.', '-']).to_owned()
+}
+
+fn upload_to_remote_temp(
+    local_path: &Path,
+    ssh: &str,
+    remote_name: &str,
+) -> Result<String, String> {
+    let remote_path = format!("{REMOTE_TEMP_DIRECTORY}/{remote_name}");
+    let output = Command::new(SCP)
+        .args(scp_arguments(local_path, ssh, &remote_path))
+        .output()
+        .map_err(|error| format!("could not start scp: {error}"))?;
+
+    if output.status.success() {
+        return Ok(remote_path);
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let detail = stderr.trim();
+    Err(if detail.is_empty() {
+        format!("scp exited with {}", output.status)
+    } else {
+        format!("scp failed: {detail}")
+    })
 }
 
 fn scp_arguments(local_path: &Path, ssh: &str, remote_path: &str) -> Vec<OsString> {
@@ -94,6 +134,16 @@ mod tests {
         assert_eq!(args[3], "--");
         assert_eq!(args[4], PathBuf::from("/tmp/local image.png"));
         assert_eq!(args[5], "cristi@forge:/tmp/dirijor-clipboard-a1.png");
+    }
+
+    #[test]
+    fn dropped_file_names_are_reduced_to_shell_inert_characters() {
+        assert_eq!(
+            remote_safe_name("Screen Shot 2026 (1).png"),
+            "Screen_Shot_2026__1_.png"
+        );
+        assert_eq!(remote_safe_name("$(rm -rf ~)`x`;y"), "__rm_-rf____x__y");
+        assert_eq!(remote_safe_name(".hidden"), "hidden");
     }
 
     #[test]

--- a/diri/crates/diri-app/src/external_drop.rs
+++ b/diri/crates/diri-app/src/external_drop.rs
@@ -41,6 +41,7 @@ pub(crate) enum ExternalPathRejection {
     RequiresDirectory,
     AdditionalPath,
     RemoteTarget,
+    RemoteDirectory,
 }
 
 impl ExternalPathRejection {
@@ -54,6 +55,7 @@ impl ExternalPathRejection {
             Self::RequiresDirectory => "is not a directory",
             Self::AdditionalPath => "only the first directory starts the session",
             Self::RemoteTarget => "is local, but the target runs on another host",
+            Self::RemoteDirectory => "is a folder, and only files can be sent to another host",
         }
     }
 }
@@ -95,34 +97,134 @@ impl ExternalDropPlan {
 
     /// Short, visible copy for the inline sidebar/composer feedback surface.
     pub fn feedback(&self) -> Option<String> {
-        if self.rejected.is_empty() {
-            return None;
-        }
-        let prefix = if self.action.is_some() {
-            "Ignored"
-        } else {
-            "Couldn't use"
-        };
-        let details = self
-            .rejected
-            .iter()
-            .take(3)
-            .map(|rejection| {
-                format!(
-                    "“{}” {}",
-                    rejection.path.to_string_lossy(),
-                    rejection.reason.explanation()
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("; ");
-        let remaining = self.rejected.len().saturating_sub(3);
-        Some(if remaining == 0 {
-            format!("{prefix}: {details}.")
-        } else {
-            format!("{prefix}: {details}; and {remaining} more.")
-        })
+        describe_rejections(self.action.is_some(), &self.rejected)
     }
+}
+
+/// One line naming up to three rejected paths and why, or `None` when every
+/// path was accepted. `partial` picks the softer prefix used when the drop
+/// still did something with the other paths.
+fn describe_rejections(partial: bool, rejected: &[RejectedExternalPath]) -> Option<String> {
+    if rejected.is_empty() {
+        return None;
+    }
+    let prefix = if partial { "Ignored" } else { "Couldn't use" };
+    let details = rejected
+        .iter()
+        .take(3)
+        .map(|rejection| {
+            format!(
+                "“{}” {}",
+                rejection.path.to_string_lossy(),
+                rejection.reason.explanation()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+    let remaining = rejected.len().saturating_sub(3);
+    Some(if remaining == 0 {
+        format!("{prefix}: {details}.")
+    } else {
+        format!("{prefix}: {details}; and {remaining} more.")
+    })
+}
+
+/// What a drop released directly on a terminal grid should do.
+///
+/// A terminal drop behaves like Terminal.app or iTerm2: the paths are typed
+/// into the foreground program as one paste, which is how Claude Code, Codex
+/// and Cursor pick up dropped images and attach them. Local sessions paste
+/// immediately; sessions on another host first copy each file over so the
+/// pasted path exists where the Agent runs.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum TerminalDropAction {
+    /// Paste this text into the PTY as one paste.
+    Paste(String),
+    /// Copy these files to the session's host, then paste the remote paths.
+    Upload(Vec<PathBuf>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct TerminalDropPlan {
+    pub action: Option<TerminalDropAction>,
+    pub rejected: Vec<RejectedExternalPath>,
+}
+
+impl TerminalDropPlan {
+    pub fn feedback(&self) -> Option<String> {
+        describe_rejections(self.action.is_some(), &self.rejected)
+    }
+}
+
+pub(crate) fn plan_terminal_drop(paths: &[PathBuf], remote: bool) -> TerminalDropPlan {
+    plan_terminal_drop_with(paths, remote, &FileSystemProbe)
+}
+
+fn plan_terminal_drop_with(
+    paths: &[PathBuf],
+    remote: bool,
+    probe: &impl PathProbe,
+) -> TerminalDropPlan {
+    let mut accepted = Vec::new();
+    let mut rejected = Vec::new();
+    for result in stage_external_paths_with(paths, probe) {
+        match result {
+            Ok(path) if remote && path.kind == ExternalPathKind::Directory => {
+                rejected.push(RejectedExternalPath {
+                    path: path.path,
+                    reason: ExternalPathRejection::RemoteDirectory,
+                });
+            }
+            Ok(path) => accepted.push(path),
+            Err(error) => rejected.push(error),
+        }
+    }
+    let action = if accepted.is_empty() {
+        None
+    } else if remote {
+        Some(TerminalDropAction::Upload(
+            accepted.into_iter().map(|path| path.path).collect(),
+        ))
+    } else {
+        Some(TerminalDropAction::Paste(terminal_drop_text(
+            accepted
+                .iter()
+                .map(|path| path.path.to_str().expect("staged paths are unicode")),
+        )))
+    };
+    TerminalDropPlan { action, rejected }
+}
+
+/// The text a desktop terminal pastes when files land on it: every path
+/// backslash-escaped and followed by a space, matching Terminal.app and iTerm2.
+/// Agents that attach dropped images (Claude Code, Codex) recognise exactly
+/// this shape and strip the escapes themselves; the trailing space keeps a
+/// second drop or typed text from fusing with the path.
+pub(crate) fn terminal_drop_text<'a>(paths: impl IntoIterator<Item = &'a str>) -> String {
+    let mut text = String::new();
+    for path in paths {
+        text.push_str(&escape_path_for_terminal(path));
+        text.push(' ');
+    }
+    text
+}
+
+/// Backslash-escape a path the way macOS terminals do on drop. Alphanumerics,
+/// non-ASCII text and the safe punctuation common in paths pass through;
+/// everything a shell could interpret is escaped so the path survives even if
+/// the foreground program is a plain shell.
+pub(crate) fn escape_path_for_terminal(path: &str) -> String {
+    let mut escaped = String::with_capacity(path.len());
+    for ch in path.chars() {
+        let plain = ch.is_alphanumeric()
+            || !ch.is_ascii()
+            || matches!(ch, '/' | '.' | '_' | '-' | '+' | ',' | ':' | '@');
+        if !plain {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped
 }
 
 /// Validate and route a Finder payload for one sidebar target.
@@ -537,6 +639,67 @@ mod tests {
         assert!(plan.action.is_none());
         assert_eq!(plan.rejected[0].reason, ExternalPathRejection::RemoteTarget);
         assert!(plan.feedback().unwrap().contains("another host"));
+    }
+
+    #[test]
+    fn a_terminal_drop_pastes_escaped_paths_in_order_with_trailing_spaces() {
+        let probe = FakeProbe::default()
+            .file("/tmp/Screen Shot 2026.png")
+            .directory("/tmp/a folder")
+            .dataless("/tmp/cloud.png");
+        let plan = plan_terminal_drop_with(
+            &paths(&[
+                "/tmp/Screen Shot 2026.png",
+                "/tmp/a folder",
+                "/tmp/cloud.png",
+            ]),
+            false,
+            &probe,
+        );
+        assert_eq!(
+            plan.action,
+            Some(TerminalDropAction::Paste(
+                "/tmp/Screen\\ Shot\\ 2026.png /tmp/a\\ folder ".into()
+            ))
+        );
+        assert_eq!(plan.rejected.len(), 1);
+        assert!(plan.feedback().unwrap().starts_with("Ignored:"));
+    }
+
+    #[test]
+    fn a_terminal_drop_on_a_remote_session_uploads_files_and_refuses_folders() {
+        let probe = FakeProbe::default()
+            .file("/tmp/shot.png")
+            .directory("/tmp/a folder");
+        let plan =
+            plan_terminal_drop_with(&paths(&["/tmp/shot.png", "/tmp/a folder"]), true, &probe);
+        assert_eq!(
+            plan.action,
+            Some(TerminalDropAction::Upload(vec![PathBuf::from(
+                "/tmp/shot.png"
+            )]))
+        );
+        assert_eq!(
+            plan.rejected[0].reason,
+            ExternalPathRejection::RemoteDirectory
+        );
+
+        let nothing = plan_terminal_drop_with(&paths(&["/tmp/missing"]), true, &probe);
+        assert!(nothing.action.is_none());
+        assert!(nothing.feedback().unwrap().starts_with("Couldn't use:"));
+    }
+
+    #[test]
+    fn terminal_escaping_matches_what_macos_terminals_paste_on_drop() {
+        assert_eq!(
+            escape_path_for_terminal("/tmp/a b/$HOME;$(touch nope)'\"`x"),
+            "/tmp/a\\ b/\\$HOME\\;\\$\\(touch\\ nope\\)\\'\\\"\\`x"
+        );
+        assert_eq!(
+            escape_path_for_terminal("/Users/giga/Desktop/Ștampilă-2026_v1.png"),
+            "/Users/giga/Desktop/Ștampilă-2026_v1.png"
+        );
+        assert_eq!(terminal_drop_text(["/a", "/b c"]), "/a /b\\ c ");
     }
 
     #[test]

--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -283,14 +283,18 @@ impl RootView {
             });
         }
         if let Some(terminal) = &terminal {
-            cx.subscribe(terminal, |this, _, event, cx| {
-                let TerminalPaneEvent::OpenFileReference { reference, cwd, .. } = event;
-                let inspector = this.inspector.clone();
-                this.reveal_inspector(cx);
-                if let Some(inspector) = inspector {
-                    inspector.update(cx, |inspector, cx| {
-                        inspector.open_file_reference(cwd.clone(), reference.clone(), cx);
-                    });
+            cx.subscribe(terminal, |this, _, event, cx| match event {
+                TerminalPaneEvent::OpenFileReference { reference, cwd, .. } => {
+                    let inspector = this.inspector.clone();
+                    this.reveal_inspector(cx);
+                    if let Some(inspector) = inspector {
+                        inspector.update(cx, |inspector, cx| {
+                            inspector.open_file_reference(cwd.clone(), reference.clone(), cx);
+                        });
+                    }
+                }
+                TerminalPaneEvent::ExternalDropFeedback { message } => {
+                    this.show_quote_feedback("Dropped files", message.clone(), cx);
                 }
             })
             .detach();

--- a/diri/crates/diri-app/src/terminal_pane.rs
+++ b/diri/crates/diri-app/src/terminal_pane.rs
@@ -35,18 +35,19 @@ use diri_ui::{
 };
 use gpui::{
     AnyElement, ClickEvent, ClipboardEntry, ClipboardItem, Context, Entity, EventEmitter,
-    FocusHandle, KeyDownEvent, KeyUpEvent, ModifiersChangedEvent, MouseButton, Render, Role,
-    ScrollDelta, ScrollWheelEvent, SharedString, StatefulInteractiveElement, Task, Window, div,
-    font, prelude::*, px, rgba,
+    ExternalPaths, FocusHandle, KeyDownEvent, KeyUpEvent, ModifiersChangedEvent, MouseButton,
+    Render, Role, ScrollDelta, ScrollWheelEvent, SharedString, StatefulInteractiveElement, Task,
+    Window, div, font, prelude::*, px, rgba,
 };
 use tokio::runtime::Handle;
 use tokio::sync::mpsc;
 
-use crate::clipboard_transfer::StagedClipboardImage;
+use crate::clipboard_transfer::{StagedClipboardImage, upload_dropped_file};
 use crate::commands::{
     CloseFind, CopySelection, FindNext, FindPrevious, OpenFind, Paste, ResetZoom, TERMINAL_CONTEXT,
     ToggleInspector, ToggleSidebar, ZoomIn, ZoomOut,
 };
+use crate::external_drop::{TerminalDropAction, plan_terminal_drop, terminal_drop_text};
 use crate::icons::{SymbolWeight, sf_symbol, sf_symbol_weighted};
 use crate::navigation::{NavigationOverlay, query_label};
 use crate::query_editor::{self, ClipboardEdit, Edit, QueryEditor};
@@ -109,6 +110,8 @@ pub enum TerminalPaneEvent {
         cwd: String,
         session_id: SessionId,
     },
+    /// Files were dropped on the grid and some (or all) could not be used.
+    ExternalDropFeedback { message: String },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -529,6 +532,9 @@ enum PaneEvent {
     ScrollbackCells(SessionId, diri_proto::ReadScrollbackCellsResult, usize),
     ScrollbackFailed(SessionId),
     ClipboardUploadFinished(SessionId, Result<String, String>),
+    /// Files dropped on a remote session finished copying; on success the
+    /// remote paths are ready to paste in drop order.
+    DroppedFilesUploaded(SessionId, Result<Vec<String>, String>),
 }
 
 /// Identifies one attachment task, not the durable session it reads. A session
@@ -1381,7 +1387,116 @@ impl TerminalPane {
                 }
                 Err(error) => eprintln!("diri: clipboard image upload failed: {error}"),
             },
+            PaneEvent::DroppedFilesUploaded(id, result) => match result {
+                Ok(remote_paths) => {
+                    let text = terminal_drop_text(remote_paths.iter().map(String::as_str));
+                    self.paste_into_session(&id, &text);
+                }
+                Err(error) => {
+                    eprintln!("diri: dropped file upload failed: {error}");
+                    cx.emit(TerminalPaneEvent::ExternalDropFeedback {
+                        message: format!(
+                            "Couldn't copy the dropped files to the session's host: {error}"
+                        ),
+                    });
+                }
+            },
         }
+    }
+
+    /// Writes `text` to a resident session as one paste, honouring the
+    /// child's bracketed-paste mode exactly like Command-V does.
+    fn paste_into_session(&self, id: &SessionId, text: &str) {
+        if let Some(resident) = self.residents.get(id) {
+            resident
+                .attachment
+                .input(terminal_paste(text, resident.bracketed_paste));
+        }
+    }
+
+    /// Finder released files over the grid. Behaves like a desktop terminal:
+    /// the paths are pasted into the foreground program, which is how Claude
+    /// Code, Codex and Cursor attach dropped images. Sessions on another host
+    /// get the files copied over first so the pasted path exists there.
+    fn external_drop(
+        &mut self,
+        paths: &ExternalPaths,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(id) = self.selected_id() else {
+            return;
+        };
+        if !self.residents.contains_key(&id) {
+            return;
+        }
+        let ssh = {
+            let store = self
+                .runtime
+                .store
+                .read()
+                .expect("session store lock poisoned");
+            store
+                .sessions()
+                .get(&id)
+                .and_then(|session| session.host.as_deref())
+                .and_then(|host_id| store.host(host_id))
+                .map(|host| host.ssh.clone())
+        };
+
+        let plan = plan_terminal_drop(paths.paths(), ssh.is_some());
+        if let Some(message) = plan.feedback() {
+            cx.emit(TerminalPaneEvent::ExternalDropFeedback { message });
+        }
+        match plan.action {
+            None => {}
+            Some(TerminalDropAction::Paste(text)) => {
+                self.paste_into_session(&id, &text);
+            }
+            Some(TerminalDropAction::Upload(files)) => {
+                let Some(ssh) = ssh else {
+                    return;
+                };
+                let pane_tx = self.pane_tx.clone();
+                let upload_id = id.clone();
+                self.tokio.spawn(async move {
+                    let result = tokio::task::spawn_blocking(move || {
+                        files
+                            .iter()
+                            .map(|file| upload_dropped_file(file, &ssh))
+                            .collect::<Result<Vec<_>, _>>()
+                    })
+                    .await
+                    .unwrap_or_else(|error| Err(format!("upload task failed: {error}")));
+                    let _ = pane_tx.send(PaneEvent::DroppedFilesUploaded(upload_id, result));
+                });
+            }
+        }
+        // The drop lands where the caret is, so the next keystroke should too.
+        window.focus(&self.focus, cx);
+        cx.notify();
+    }
+
+    /// Present only while a drag is in flight, so it never sits between the
+    /// pointer and the grid during normal use. Styled only when what is being
+    /// dragged is a set of desktop files: other in-app drags pass through it.
+    fn external_drop_overlay(&self, cx: &mut Context<Self>) -> AnyElement {
+        div()
+            .id("diri-terminal-external-drop")
+            .absolute()
+            .inset_0()
+            .rounded(px(Radius::PANEL))
+            .drag_over::<ExternalPaths>(|overlay, _, _, _| {
+                overlay
+                    .bg(Ink::FRESH.alpha(0.07))
+                    .border_2()
+                    .border_color(Ink::FRESH.alpha(0.5))
+            })
+            .on_drop(cx.listener(|this, paths: &ExternalPaths, window, cx| {
+                cx.stop_propagation();
+                this.external_drop(paths, window, cx);
+            }))
+            .into_any_element()
     }
 
     fn attachment_is_current(&self, id: &SessionId, generation: AttachmentGeneration) -> bool {
@@ -3442,10 +3557,16 @@ impl Render for TerminalPane {
             SessionSource::FollowSelection => SharedString::from("diri-terminal-root"),
             SessionSource::Fixed(id) => SharedString::from(format!("diri-terminal-root-{}", id.0)),
         };
+        let has_resident = self
+            .selected_id()
+            .is_some_and(|id| self.residents.contains_key(&id));
+        let drop_overlay =
+            (has_resident && cx.has_active_drag()).then(|| self.external_drop_overlay(cx));
         div()
             .id(root_id)
             .key_context(TERMINAL_CONTEXT)
             .track_focus(&self.focus)
+            .relative()
             .flex()
             .size_full()
             .text_color(colors.primary)
@@ -3462,6 +3583,7 @@ impl Render for TerminalPane {
             .on_key_up(cx.listener(Self::handle_key_up))
             .on_modifiers_changed(cx.listener(Self::handle_modifiers_changed))
             .child(content)
+            .children(drop_overlay)
     }
 }
 


### PR DESCRIPTION
## Why

Dropping an image (or any file) from Finder onto the terminal did nothing. Only the sidebar accepted external paths, and it routed them into the launcher composer. Claude Code, Codex and Cursor attach dropped images the way real terminals deliver them: the path pasted into the foreground program, backslash-escaped, followed by a space. herdr gets this for free because it lives inside a host terminal; diri owns the surface, so it has to do the paste itself.

## What

- **Terminal pane drop target.** While a drag is in flight the pane mounts an overlay that accepts `ExternalPaths`, highlights on hover, and pastes the escaped paths in drop order through the same bracketed-paste path Command-V uses. The overlay only exists during a drag, so it never sits between the pointer and the grid otherwise.
- **`plan_terminal_drop` / `escape_path_for_terminal`** in `external_drop.rs`: reuses the existing staging gate (missing, unreadable, cloud-dataless, non-unicode paths are rejected) and produces Terminal.app-shaped text.
- **Remote sessions.** Files are copied to the host with the existing scp transfer (`upload_dropped_file`, original file name kept under a unique, shell-inert prefix), then the remote paths are pasted. Folders are refused with a message.
- **Feedback.** Rejections and upload failures show in the root status banner via a new `TerminalPaneEvent::ExternalDropFeedback`.

## Verification

- `cargo test -p diri-app`: 475 passed. New tests cover escaping, ordering, trailing space, remote folder refusal, and remote-name sanitizing.
- `cargo clippy -p diri-app --all-targets -- -D warnings` and `cargo fmt --check` are clean.
- The exact paste text (`/…/drop\ test/Screen\ Shot\ 2026.png `) was written into real `claude` (2.1.260) and `codex` (0.153.0) processes in a PTY. Both attached it as `[Image #1]`. `cursor-agent` could not be checked here (not signed in on this machine).
- Not exercised: an actual Finder drag in the GUI. The overlay relies on GPUI redrawing on drag-move and clearing the drag on mouse-up, which I confirmed in the vendored GPUI source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vsh7uzn1VYCyyNJWGHJqNX
