### PR TITLE
fix: give sidebar drag and drop outline-view drop zones

### DIFF
--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -997,6 +997,16 @@ impl RootView {
     }
 
     fn on_key_down(&mut self, event: &KeyDownEvent, window: &mut Window, cx: &mut Context<Self>) {
+        // A sidebar drag rarely has sidebar focus (the press left it in the
+        // terminal), so Escape is caught here, on the window's capture path.
+        if event.keystroke.key == "escape"
+            && self
+                .sidebar
+                .update(cx, |sidebar, cx| sidebar.cancel_active_drag(cx))
+        {
+            cx.stop_propagation();
+            return;
+        }
         if self.quote_target_picker.is_some() {
             let target_count = self
                 .quote_target_picker

--- a/diri/crates/diri-app/src/sidebar/mod.rs
+++ b/diri/crates/diri-app/src/sidebar/mod.rs
@@ -5,7 +5,10 @@ mod state;
 mod view;
 
 pub use fixture::{PreviewScenario, SidebarPreviewFixture};
-pub use state::{CursorMove, DragItem, Popover, SidebarUiState, move_before, move_to_end};
+pub use state::{
+    CursorMove, DragItem, DropZone, Popover, SidebarUiState, drop_zone, move_before, move_past,
+    move_to_end,
+};
 pub(crate) use view::DraggedSidebarItem;
 pub use view::Sidebar;
 pub(crate) use view::SidebarEvent;

--- a/diri/crates/diri-app/src/sidebar/state.rs
+++ b/diri/crates/diri-app/src/sidebar/state.rs
@@ -1,5 +1,5 @@
 use diri_proto::{ProjectId, SessionId};
-use gpui::{Pixels, Point};
+use gpui::{Bounds, Pixels, Point};
 
 use crate::delegation::SiblingProposal;
 use crate::query_editor::QueryEditor;
@@ -29,6 +29,37 @@ pub enum DragItem {
         archived: bool,
     },
     Sessions(Vec<SessionId>),
+}
+
+/// Where the pointer sits inside a row during a drag. Outline views split a
+/// row into two insertion bands and a core: the bands mean "put the dragged
+/// row beside this one", the core means "drop it onto this one". Reordering
+/// and delegation share the same rows, and this is what keeps them apart.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DropZone {
+    Before,
+    Onto,
+    After,
+}
+
+/// Classifies `position` against a row's bounds. `band` is the height of each
+/// insertion band; `None` when the pointer is not over the row at all.
+pub fn drop_zone(
+    bounds: Bounds<Pixels>,
+    position: Point<Pixels>,
+    band: Pixels,
+) -> Option<DropZone> {
+    if !bounds.contains(&position) {
+        return None;
+    }
+    let offset = position.y - bounds.origin.y;
+    if offset < band {
+        Some(DropZone::Before)
+    } else if offset > bounds.size.height - band {
+        Some(DropZone::After)
+    } else {
+        Some(DropZone::Onto)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -66,6 +97,9 @@ pub struct SidebarUiState {
     pub hover_card: Option<(SessionId, f32)>,
     pub drag: Option<DragItem>,
     pub drag_target: Option<String>,
+    /// Project order when a header drag began. Headers reorder live under the
+    /// pointer, so cancelling the gesture has to put them back.
+    pub project_order_at_drag_start: Option<Vec<ProjectId>>,
     /// Keyboard source for the two-step mark-then-delegate equivalent.
     pub delegation_mark: Option<SessionId>,
     /// Empty-space drops stop here until the user confirms the sibling spawn.
@@ -98,6 +132,7 @@ impl SidebarUiState {
             hover_card: None,
             drag: None,
             drag_target: None,
+            project_order_at_drag_start: None,
             delegation_mark: None,
             pending_sibling: None,
             delegation_notice: None,
@@ -223,6 +258,22 @@ pub fn move_before<T: Clone + PartialEq>(order: &mut Vec<T>, moved: &T, target: 
     order.insert(target_index, item);
 }
 
+/// Moves `moved` to the far side of `target`: below it when it came from
+/// above, above it when it came from below. Live reordering under a pointer
+/// needs this rather than [`move_before`]: a row already sits before its
+/// lower neighbour, so "move before it" could never move anything down.
+pub fn move_past<T: Clone + PartialEq>(order: &mut Vec<T>, moved: &T, target: &T) {
+    let position = |item: &T| order.iter().position(|candidate| candidate == item);
+    let (Some(from), Some(to)) = (position(moved), position(target)) else {
+        return;
+    };
+    if from == to {
+        return;
+    }
+    let item = order.remove(from);
+    order.insert(to, item);
+}
+
 pub fn move_to_end<T: Clone + PartialEq>(order: &mut Vec<T>, moved: &T) {
     let Some(index) = order.iter().position(|item| item == moved) else {
         return;
@@ -252,6 +303,44 @@ mod tests {
         assert_eq!(values, [1, 4, 2, 3]);
         move_to_end(&mut values, &1);
         assert_eq!(values, [4, 2, 3, 1]);
+    }
+
+    #[test]
+    fn move_past_crosses_the_target_in_either_direction() {
+        let mut values = vec![1, 2, 3];
+        move_past(&mut values, &1, &2);
+        assert_eq!(
+            values,
+            [2, 1, 3],
+            "dragging down by one lands below the neighbour"
+        );
+        move_past(&mut values, &3, &2);
+        assert_eq!(
+            values,
+            [3, 2, 1],
+            "dragging up by one lands above the neighbour"
+        );
+        move_past(&mut values, &3, &1);
+        assert_eq!(values, [2, 1, 3]);
+        move_past(&mut values, &2, &2);
+        assert_eq!(values, [2, 1, 3], "a row over itself stays put");
+    }
+
+    #[test]
+    fn drop_zone_splits_a_row_into_bands_and_a_core() {
+        use gpui::{px, size};
+        let bounds = Bounds::new(gpui::point(px(0.0), px(100.0)), size(px(200.0), px(28.0)));
+        let band = px(7.0);
+        let at = |y: f32| drop_zone(bounds, gpui::point(px(20.0), px(y)), band);
+        assert_eq!(at(99.0), None);
+        assert_eq!(at(100.0), Some(DropZone::Before));
+        assert_eq!(at(106.0), Some(DropZone::Before));
+        assert_eq!(at(107.0), Some(DropZone::Onto));
+        assert_eq!(at(114.0), Some(DropZone::Onto));
+        assert_eq!(at(121.0), Some(DropZone::Onto));
+        assert_eq!(at(122.0), Some(DropZone::After));
+        assert_eq!(at(127.9), Some(DropZone::After));
+        assert_eq!(at(128.0), None);
     }
 
     #[test]

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -38,9 +38,13 @@ use crate::updates::{UpdateCommand, UpdatePhase, UpdateState};
 use crate::usage::{UsageFormat, UsageSnapshot};
 
 use super::{
-    CursorMove, DragItem, Popover, PreviewScenario, SidebarPreviewFixture, SidebarUiState,
-    move_before, move_to_end,
+    CursorMove, DragItem, DropZone, Popover, PreviewScenario, SidebarPreviewFixture,
+    SidebarUiState, drop_zone, move_before, move_past, move_to_end,
 };
+
+/// Height of each insertion band at the top and bottom of a session row. A
+/// quarter of the row on each side leaves half the row as the drop-onto core.
+const INSERT_BAND: f32 = Metrics::ROW_HEIGHT / 4.0;
 
 const PREVIEW_USAGE: f64 = 4.82;
 
@@ -159,13 +163,33 @@ impl DraggedSidebarItem {
     }
 }
 
+/// What releasing a dragged session over a given row would do, decided once
+/// per frame from the pointer position so the row's highlight, the insertion
+/// marker and the drop itself all agree.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum RowDrop {
+    /// The row the drag started from. A release here is the click the press
+    /// was about to be before it wandered past GPUI's drag threshold.
+    Origin,
+    /// Reorder among siblings; the zone is never `Onto`.
+    Insert(DropZone),
+    Handoff,
+    Refused(String),
+}
+
 struct DragPreview {
     label: SharedString,
     colors: SemanticColors,
+    /// Escape cancelled the gesture. GPUI keeps the drag alive until the
+    /// button comes up, so the ghost hides itself instead.
+    hidden: bool,
 }
 
 impl Render for DragPreview {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        if self.hidden {
+            return div();
+        }
         div()
             .px(px(10.0))
             .h(px(28.0))
@@ -193,6 +217,9 @@ pub struct Sidebar {
     /// Window-space row bounds from the latest prepaint. Keyboard navigation
     /// uses these to reveal only rows that actually crossed the viewport edge.
     row_bounds: Rc<RefCell<HashMap<SessionId, Bounds<Pixels>>>>,
+    /// The ghost following the pointer during a drag, kept so a cancel can
+    /// hide it before GPUI lets go of the gesture.
+    drag_preview: Option<Entity<DragPreview>>,
     directory_scroll: ScrollHandle,
     glyphs: HashMap<SessionId, Entity<StatusGlyph>>,
     /// Rebuilt once per projection render. Looking up ⌘1…⌘9 inside every row
@@ -295,6 +322,7 @@ impl Sidebar {
             ui,
             list_scroll: ScrollHandle::new(),
             row_bounds: Rc::new(RefCell::new(HashMap::new())),
+            drag_preview: None,
             directory_scroll: ScrollHandle::new(),
             glyphs: HashMap::new(),
             shortcut_ranks: HashMap::new(),
@@ -1381,12 +1409,55 @@ impl Sidebar {
         )
     }
 
-    fn empty_space_drop_target(&self, cx: &mut Context<Self>) -> AnyElement {
+    /// The strip below the last project. Finder drops open the launcher
+    /// here, and a dragged session can be fanned out into a sibling -- but
+    /// only here, and only while the zone says so. It used to be the whole
+    /// list, which turned every release between two rows into a proposal.
+    fn empty_space_drop_target(
+        &self,
+        colors: SemanticColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let fan_out_offered = matches!(
+            self.ui.drag,
+            Some(DragItem::Session {
+                archived: false,
+                ..
+            })
+        ) && cx.has_active_drag();
         div()
             .id("sidebar-empty-space-drop-target")
             .flex_1()
             .min_h(px(52.0))
             .rounded(px(Radius::ROW))
+            .when(fan_out_offered, |element| {
+                element
+                    .debug_selector(|| "sidebar-fan-out-zone".to_owned())
+                    .mt(px(6.0))
+                    .border_1()
+                    .border_dashed()
+                    .border_color(Palette::CLAY.alpha(0.42))
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .text_size(px(Typo::META.size))
+                    .text_color(colors.secondary)
+                    .child("Drop to fan out a sibling")
+            })
+            .drag_over::<DraggedSidebarItem>(move |element, dragged, _, _| {
+                if fan_out_offered && dragged.session_id().is_some() {
+                    element
+                        .bg(Palette::CLAY.alpha(0.14))
+                        .border_color(Palette::CLAY.alpha(0.86))
+                        .text_color(colors.primary)
+                } else {
+                    element
+                }
+            })
+            .on_drop(cx.listener(|this, dragged: &DraggedSidebarItem, _, cx| {
+                cx.stop_propagation();
+                this.finish_fan_out_drop(dragged, cx);
+            }))
             .drag_over::<ExternalPaths>(move |element, paths, _, _| {
                 if Self::can_accept_external_drop(paths, ExternalDropTarget::EmptySpace) {
                     element
@@ -1556,23 +1627,35 @@ impl Sidebar {
                         }
                     }),
                 )
-                .on_drag(
-                    DraggedSidebarItem(DragItem::Project(id.clone())),
-                    move |_, _, _, cx| {
-                        cx.new(|_| DragPreview {
+                .on_drag(DraggedSidebarItem(DragItem::Project(id.clone())), {
+                    let drag_entity = entity.clone();
+                    move |dragged, _, _, cx| {
+                        let dragged = dragged.0.clone();
+                        let preview = cx.new(|_| DragPreview {
                             label: drag_label.clone(),
                             colors,
-                        })
-                    },
-                )
+                            hidden: false,
+                        });
+                        drag_entity.update(cx, |this, cx| {
+                            this.begin_drag(dragged, preview.clone(), cx);
+                        });
+                        preview
+                    }
+                })
+                // Headers reorder live under the pointer: the dragged
+                // project crosses to the far side of whichever header it is
+                // over, so one step down works as well as one step up.
                 .drag_over::<DraggedSidebarItem>({
                     let id = id.clone();
                     move |element, dragged, _, cx| {
                         if let DragItem::Project(moved) = &dragged.0 {
                             entity.update(cx, |this, cx| {
-                                this.reorder_project(moved, &id);
-                                this.ui.drag_target = Some(format!("project:{}", id.0));
-                                cx.notify();
+                                let target = format!("project:{}", id.0);
+                                let moved_now = this.reorder_project(moved, &id);
+                                if moved_now || this.ui.drag_target.as_deref() != Some(&target) {
+                                    this.ui.drag_target = Some(target);
+                                    cx.notify();
+                                }
                             });
                             element.bg(colors.primary.alpha(0.08))
                         } else {
@@ -1725,8 +1808,13 @@ impl Sidebar {
         for row in &group.sessions {
             let shortcut = self.shortcut_for(row.id());
             let id = row.id().clone();
-            let rendered = self.session_row(row, shortcut, colors, window, cx);
-            section = section.child(self.track_row_bounds(id, rendered));
+            let drop = self.row_drop_feedback(row, window, cx);
+            let marker = match drop {
+                Some(RowDrop::Insert(zone)) => Some((zone, row.depth)),
+                _ => None,
+            };
+            let rendered = self.session_row(row, shortcut, drop, colors, window, cx);
+            section = section.child(self.track_row_bounds(id, rendered, marker));
         }
         if !collapsed && !group.archived.is_empty() {
             section = section.child(self.archived_bucket(group, colors, window, cx));
@@ -1734,24 +1822,81 @@ impl Sidebar {
         section.into_any_element()
     }
 
-    fn track_row_bounds(&self, id: SessionId, row: AnyElement) -> AnyElement {
+    fn track_row_bounds(
+        &self,
+        id: SessionId,
+        row: AnyElement,
+        insertion: Option<(DropZone, u16)>,
+    ) -> AnyElement {
         let bounds = Rc::clone(&self.row_bounds);
         div()
             .w_full()
             .flex_none()
+            .relative()
             .on_children_prepainted(move |children, _, _| {
                 if let Some(row) = children.first().copied() {
                     bounds.borrow_mut().insert(id.clone(), row);
                 }
             })
             .child(row)
+            .when_some(insertion, |element, (zone, depth)| {
+                element.child(insertion_marker(zone, depth))
+            })
             .into_any_element()
+    }
+
+    /// Decides what a release over `row` would do right now. Only the row
+    /// under the pointer pays for the store lookup; every other row gets
+    /// `None` from the bounds check.
+    fn row_drop_feedback(
+        &self,
+        row: &crate::store::SidebarRow,
+        window: &Window,
+        cx: &App,
+    ) -> Option<RowDrop> {
+        let Some(DragItem::Session {
+            id: source,
+            project,
+            parent,
+            archived,
+        }) = self.ui.drag.as_ref()
+        else {
+            return None;
+        };
+        if !cx.has_active_drag() {
+            return None;
+        }
+        let bounds = *self.row_bounds.borrow().get(row.id())?;
+        let zone = drop_zone(bounds, window.mouse_position(), px(INSERT_BAND))?;
+        let target = &row.session;
+        if source == &target.id {
+            return Some(RowDrop::Origin);
+        }
+        // Reordering only ever moves a row inside its own sibling run, and
+        // pinned rows sort ahead of the manual order, so a pin boundary is a
+        // run boundary too. Anywhere else the bands fall back to the handoff
+        // the core offers rather than drawing a marker the drop cannot honour.
+        let store = self.store.read().expect("session store lock poisoned");
+        let sibling = !archived
+            && project == &target.project_id
+            && parent == &target.parent
+            && store.preferences().sidebar_pinned_sessions.contains(source) == row.pinned;
+        if sibling && zone != DropZone::Onto {
+            return Some(RowDrop::Insert(zone));
+        }
+        Some(
+            match validate_handoff(store.sessions(), source, &target.id) {
+                Ok(()) => RowDrop::Handoff,
+                Err(refusal) => RowDrop::Refused(refusal.0),
+            },
+        )
     }
 
     fn session_row(
         &mut self,
         row: &crate::store::SidebarRow,
         shortcut: Option<usize>,
+        drop: Option<RowDrop>,
         colors: SemanticColors,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -1895,10 +2040,12 @@ impl Sidebar {
                 archived,
             }
         };
+        let drag_label: SharedString = match &drag_item {
+            DragItem::Sessions(ids) => format!("{} sessions", ids.len()).into(),
+            _ => title.clone().into(),
+        };
         let drag_payload = DraggedSidebarItem(drag_item);
-        let drag_label: SharedString = title.clone().into();
-        let entity = cx.entity();
-        let drag_entity = entity.clone();
+        let drag_entity = cx.entity();
         let row = div()
             .id(format!("session:{}", id.0))
             .pl(px(Space::ROW_H))
@@ -1983,62 +2130,40 @@ impl Sidebar {
             )
             .on_drag(drag_payload, move |dragged, _, _, cx| {
                 let dragged = dragged.0.clone();
-                drag_entity.update(cx, |this, cx| {
-                    this.ui.drag = Some(dragged);
-                    this.ui.delegation_notice = None;
-                    cx.notify();
-                });
-                cx.new(|_| DragPreview {
+                let preview = cx.new(|_| DragPreview {
                     label: drag_label.clone(),
                     colors,
-                })
+                    hidden: false,
+                });
+                drag_entity.update(cx, |this, cx| {
+                    this.begin_drag(dragged, preview.clone(), cx);
+                });
+                preview
             })
+            // Only a drop-onto highlights the row. Insertion bands draw
+            // their marker from the wrapper, the origin row stays quiet, and
+            // a target that would refuse shows nothing rather than shouting
+            // red at every row the pointer crosses; the refusal is explained
+            // on release instead.
             .drag_over::<DraggedSidebarItem>({
-                let target = id.clone();
-                move |element, dragged, _, _cx| {
-                    let valid = dragged.session_id().is_some_and(|source| {
-                        let store = entity
-                            .read(_cx)
-                            .store
-                            .read()
-                            .expect("session store lock poisoned");
-                        validate_handoff(store.sessions(), source, &target).is_ok()
-                    });
-                    if valid {
+                let handoff = drop == Some(RowDrop::Handoff);
+                move |element, _, _, _| {
+                    if handoff {
                         element
                             .bg(Palette::CLAY.alpha(0.18))
                             .border_1()
                             .border_color(Palette::CLAY.alpha(0.72))
-                            .cursor(CursorStyle::DragCopy)
                     } else {
                         element
-                            .bg(Ink::DANGER.alpha(0.10))
-                            .border_1()
-                            .border_color(Ink::DANGER.alpha(0.56))
-                            .cursor(CursorStyle::OperationNotAllowed)
                     }
                 }
             })
             .on_drop(cx.listener({
                 let target = id.clone();
-                move |this, dragged: &DraggedSidebarItem, _, cx| {
-                    if let Some(source) = dragged.session_id() {
-                        let proposal = {
-                            let store = this.store.read().expect("session store lock poisoned");
-                            handoff_proposal(store.sessions(), source, &target)
-                        };
-                        match proposal {
-                            Ok(proposal) => {
-                                this.ui.delegation_mark = None;
-                                this.ui.delegation_notice = None;
-                                cx.emit(SidebarEvent::HandoffProposed(proposal));
-                            }
-                            Err(refusal) => this.ui.delegation_notice = Some(refusal.0),
-                        }
-                    }
-                    this.finish_drag();
+                let drop = drop.clone();
+                move |this, dragged: &DraggedSidebarItem, window, cx| {
                     cx.stop_propagation();
-                    cx.notify();
+                    this.finish_row_drop(dragged, &target, drop.clone(), window, cx);
                 }
             }))
             .drag_over::<ExternalPaths>({
@@ -2280,18 +2405,16 @@ impl Sidebar {
                 let entity = cx.entity();
                 let project_id = project_id.clone();
                 move |element, dragged, _, cx| {
-                    let valid = match &dragged.0 {
-                        DragItem::Session {
-                            project, archived, ..
-                        } => project == &project_id && !archived,
-                        DragItem::Sessions(_) => true,
-                        DragItem::Project(_) => false,
-                    };
-                    if valid {
-                        entity.update(cx, |this, cx| {
-                            this.ui.drag_target = Some(format!("archive:{}", project_id.0));
+                    let valid = entity.update(cx, |this, cx| {
+                        let valid = !this.archivable_drop(dragged, &project_id).is_empty();
+                        let target = format!("archive:{}", project_id.0);
+                        if valid && this.ui.drag_target.as_deref() != Some(&target) {
+                            this.ui.drag_target = Some(target);
                             cx.notify();
-                        });
+                        }
+                        valid
+                    });
+                    if valid {
                         element.bg(colors.primary.alpha(0.08))
                     } else {
                         element
@@ -2301,19 +2424,12 @@ impl Sidebar {
             .on_drop(cx.listener({
                 let project_id = project_id.clone();
                 move |this, dragged: &DraggedSidebarItem, _, cx| {
-                    let ids = match &dragged.0 {
-                        DragItem::Session {
-                            id,
-                            project,
-                            archived: false,
-                            ..
-                        } if project == &project_id => vec![id.clone()],
-                        DragItem::Sessions(ids) => ids.clone(),
-                        _ => Vec::new(),
-                    };
-                    this.archive_sessions(ids);
-                    this.finish_drag();
                     cx.stop_propagation();
+                    if this.ui.drag.is_some() {
+                        let ids = this.archivable_drop(dragged, &project_id);
+                        this.archive_sessions(ids);
+                    }
+                    this.finish_drag();
                     cx.notify();
                 }
             }))
@@ -2371,7 +2487,7 @@ impl Sidebar {
             for session in &group.archived {
                 let id = session.id.clone();
                 let rendered = self.archived_row(session, colors, window, cx);
-                bucket = bucket.child(self.track_row_bounds(id, rendered));
+                bucket = bucket.child(self.track_row_bounds(id, rendered, None));
             }
         }
         bucket.into_any_element()
@@ -2399,6 +2515,7 @@ impl Sidebar {
         let revive_id = id.clone();
         let title = display_title(session);
         let drag_label: SharedString = title.clone().into();
+        let drag_entity = cx.entity();
         div()
             .id(format!("archived-session:{}", id.0))
             .pl(px(Space::ROW_H + Space::INDENT))
@@ -2456,11 +2573,17 @@ impl Sidebar {
                     parent: session.parent.clone(),
                     archived: true,
                 }),
-                move |_, _, _, cx| {
-                    cx.new(|_| DragPreview {
+                move |dragged, _, _, cx| {
+                    let dragged = dragged.0.clone();
+                    let preview = cx.new(|_| DragPreview {
                         label: drag_label.clone(),
                         colors,
-                    })
+                        hidden: false,
+                    });
+                    drag_entity.update(cx, |this, cx| {
+                        this.begin_drag(dragged, preview.clone(), cx);
+                    });
+                    preview
                 },
             )
             .child(
@@ -4463,7 +4586,8 @@ impl Sidebar {
     }
 
     pub fn cancel_delegation(&mut self, cx: &mut Context<Self>) -> bool {
-        if self.ui.drag.is_none()
+        let cancelled_drag = self.cancel_active_drag(cx);
+        if !cancelled_drag
             && self.ui.delegation_mark.is_none()
             && self.ui.pending_sibling.is_none()
             && self.ui.delegation_notice.is_none()
@@ -4473,6 +4597,197 @@ impl Sidebar {
         self.ui.cancel_delegation();
         cx.notify();
         true
+    }
+
+    /// Escape during a drag. GPUI only ends a drag on mouse-up, so this
+    /// hides the ghost, restores any live header reorder, and forgets the
+    /// gesture; the eventual release then lands as a no-op everywhere.
+    pub fn cancel_active_drag(&mut self, cx: &mut Context<Self>) -> bool {
+        if self.ui.drag.is_none() {
+            return false;
+        }
+        if let Some(order) = self.ui.project_order_at_drag_start.take() {
+            self.store
+                .write()
+                .expect("session store lock poisoned")
+                .stage_project_order(order);
+        }
+        self.ui.order_dirty = false;
+        self.ui.drag = None;
+        self.ui.drag_target = None;
+        if let Some(preview) = self.drag_preview.take() {
+            preview.update(cx, |preview, cx| {
+                preview.hidden = true;
+                cx.notify();
+            });
+        }
+        cx.notify();
+        true
+    }
+
+    fn begin_drag(&mut self, item: DragItem, preview: Entity<DragPreview>, cx: &mut Context<Self>) {
+        if matches!(item, DragItem::Project(_)) {
+            let order = self
+                .store
+                .write()
+                .expect("session store lock poisoned")
+                .sidebar_project_order();
+            self.ui.project_order_at_drag_start = Some(order);
+        }
+        self.ui.drag = Some(item);
+        self.ui.drag_target = None;
+        self.ui.delegation_notice = None;
+        self.drag_preview = Some(preview);
+        cx.notify();
+    }
+
+    /// Release of a dragged session over a live row. `drop` is what the last
+    /// frame promised for this row; a release GPUI delivers without a frame's
+    /// worth of feedback falls back to the row's core action.
+    fn finish_row_drop(
+        &mut self,
+        dragged: &DraggedSidebarItem,
+        target: &SessionId,
+        drop: Option<RowDrop>,
+        window: &Window,
+        cx: &mut Context<Self>,
+    ) {
+        let live = self.ui.drag.is_some();
+        if let Some(source) = dragged.session_id().cloned()
+            && live
+        {
+            let drop = drop.unwrap_or(if &source == target {
+                RowDrop::Origin
+            } else {
+                RowDrop::Handoff
+            });
+            match drop {
+                RowDrop::Origin => {
+                    // The press was a click until the pointer wandered past
+                    // the threshold. Finish it as one: select, activate.
+                    let modifiers = window.modifiers();
+                    if !modifiers.platform && !modifiers.shift {
+                        self.ui.focus_cursor = Some(target.clone());
+                        self.store
+                            .write()
+                            .expect("session store lock poisoned")
+                            .sidebar_click(target.clone(), ClickModifiers::default());
+                        cx.emit(SidebarEvent::SessionActivated);
+                    }
+                }
+                RowDrop::Insert(zone) => self.reorder_session_beside(&source, target, zone),
+                RowDrop::Handoff => {
+                    let proposal = {
+                        let store = self.store.read().expect("session store lock poisoned");
+                        handoff_proposal(store.sessions(), &source, target)
+                    };
+                    match proposal {
+                        Ok(proposal) => {
+                            self.ui.delegation_mark = None;
+                            self.ui.delegation_notice = None;
+                            cx.emit(SidebarEvent::HandoffProposed(proposal));
+                        }
+                        Err(refusal) => self.ui.delegation_notice = Some(refusal.0),
+                    }
+                }
+                RowDrop::Refused(reason) => self.ui.delegation_notice = Some(reason),
+            }
+        }
+        self.finish_drag();
+        cx.notify();
+    }
+
+    /// Release of a dragged session on the fan-out zone below the projects.
+    fn finish_fan_out_drop(&mut self, dragged: &DraggedSidebarItem, cx: &mut Context<Self>) {
+        if let Some(source_id) = dragged.session_id()
+            && self.ui.drag.is_some()
+        {
+            let proposal = {
+                let store = self.store.read().expect("session store lock poisoned");
+                store.sessions().get(source_id).map_or_else(
+                    || {
+                        Err(crate::delegation::DelegationRefusal(
+                            "The dragged session no longer exists.".to_owned(),
+                        ))
+                    },
+                    |source| {
+                        store.projects().get(&source.project_id).map_or_else(
+                            || {
+                                Err(crate::delegation::DelegationRefusal(
+                                    "The session's project no longer exists.".to_owned(),
+                                ))
+                            },
+                            |project| sibling_proposal(source, project),
+                        )
+                    },
+                )
+            };
+            match proposal {
+                Ok(proposal) => {
+                    self.ui.pending_sibling = Some(proposal);
+                    self.ui.delegation_notice = None;
+                }
+                Err(refusal) => self.ui.delegation_notice = Some(refusal.0),
+            }
+        }
+        self.finish_drag();
+        cx.notify();
+    }
+
+    /// The sessions a drop on `project_id`'s archive bucket would archive:
+    /// live rows of that project only. A multi-selection spanning projects
+    /// contributes just the rows that belong here.
+    fn archivable_drop(
+        &self,
+        dragged: &DraggedSidebarItem,
+        project_id: &ProjectId,
+    ) -> Vec<SessionId> {
+        match &dragged.0 {
+            DragItem::Session {
+                id,
+                project,
+                archived: false,
+                ..
+            } if project == project_id => vec![id.clone()],
+            DragItem::Session { .. } | DragItem::Project(_) => Vec::new(),
+            DragItem::Sessions(ids) => {
+                let store = self.store.read().expect("session store lock poisoned");
+                ids.iter()
+                    .filter(|id| {
+                        store.sessions().get(*id).is_some_and(|session| {
+                            &session.project_id == project_id && !session.is_archived()
+                        })
+                    })
+                    .cloned()
+                    .collect()
+            }
+        }
+    }
+
+    /// Puts `moved` directly before or after `target` inside their shared
+    /// sibling run. "After" means before the next sibling, or at the end of
+    /// the manual order when `target` is last -- the projection sorts each
+    /// run among itself, so the tail of the whole order is the tail of the
+    /// run.
+    fn reorder_session_beside(&mut self, moved: &SessionId, target: &SessionId, zone: DropZone) {
+        let mut store = self.store.write().expect("session store lock poisoned");
+        let anchor = match zone {
+            DropZone::Before | DropZone::Onto => Some(target.clone()),
+            DropZone::After => {
+                let projection = store.sidebar_projection();
+                let run = sibling_run(&projection, target);
+                run.iter()
+                    .position(|id| id == target)
+                    .and_then(|index| run.get(index + 1))
+                    .cloned()
+            }
+        };
+        let mut order = store.sidebar_session_order();
+        match anchor {
+            Some(anchor) => move_before(&mut order, moved, &anchor),
+            None => move_to_end(&mut order, moved),
+        }
+        self.ui.order_dirty |= store.stage_session_order(order);
     }
 
     /// Keyboard equivalent for row-to-row drag: first invocation marks the
@@ -4516,11 +4831,14 @@ impl Sidebar {
         }
     }
 
-    fn reorder_project(&mut self, moved: &ProjectId, target: &ProjectId) {
+    /// Live header reorder; returns whether the order changed.
+    fn reorder_project(&mut self, moved: &ProjectId, target: &ProjectId) -> bool {
         let mut store = self.store.write().expect("session store lock poisoned");
         let mut order = store.sidebar_project_order();
-        move_before(&mut order, moved, target);
-        self.ui.order_dirty |= store.stage_project_order(order);
+        move_past(&mut order, moved, target);
+        let changed = store.stage_project_order(order);
+        self.ui.order_dirty |= changed;
+        changed
     }
 
     fn reorder_session(&mut self, moved: &SessionId, target: &SessionId) {
@@ -4535,6 +4853,8 @@ impl Sidebar {
     fn finish_drag(&mut self) {
         self.ui.drag = None;
         self.ui.drag_target = None;
+        self.ui.project_order_at_drag_start = None;
+        self.drag_preview = None;
         if self.ui.order_dirty {
             self.ui.order_dirty = false;
             let _ = self
@@ -4954,55 +5274,11 @@ impl Render for Sidebar {
                 .pb(px(Metrics::ROW_HEIGHT + 17.0))
                 .flex()
                 .flex_col()
-                .gap(px(2.0))
-                .drag_over::<DraggedSidebarItem>(|element, dragged, _, _| {
-                    if dragged.session_id().is_some() {
-                        element
-                            .bg(Palette::CLAY.alpha(0.055))
-                            .cursor(CursorStyle::DragCopy)
-                    } else {
-                        element
-                    }
-                })
-                .on_drop(cx.listener(|this, dragged: &DraggedSidebarItem, _, cx| {
-                    if let Some(source_id) = dragged.session_id() {
-                        let proposal = {
-                            let store = this.store.read().expect("session store lock poisoned");
-                            store.sessions().get(source_id).map_or_else(
-                                || {
-                                    Err(crate::delegation::DelegationRefusal(
-                                        "The dragged session no longer exists.".to_owned(),
-                                    ))
-                                },
-                                |source| {
-                                    store.projects().get(&source.project_id).map_or_else(
-                                        || {
-                                            Err(crate::delegation::DelegationRefusal(
-                                                "The session's project no longer exists."
-                                                    .to_owned(),
-                                            ))
-                                        },
-                                        |project| sibling_proposal(source, project),
-                                    )
-                                },
-                            )
-                        };
-                        match proposal {
-                            Ok(proposal) => {
-                                this.ui.pending_sibling = Some(proposal);
-                                this.ui.delegation_notice = None;
-                            }
-                            Err(refusal) => this.ui.delegation_notice = Some(refusal.0),
-                        }
-                    }
-                    this.finish_drag();
-                    cx.stop_propagation();
-                    cx.notify();
-                }));
+                .gap(px(2.0));
             for group in &projection.projects {
                 list = list.child(self.project_section(group, colors, window, cx));
             }
-            list = list.child(self.empty_space_drop_target(cx));
+            list = list.child(self.empty_space_drop_target(colors, cx));
             list
         });
 
@@ -5026,6 +5302,14 @@ impl Render for Sidebar {
                     }
                 }),
             )
+            // A release over chrome that accepts nothing (the top bar, the
+            // footer, a header) is a cancel, not a gesture left half-open.
+            .on_drop(cx.listener(|this, _: &DraggedSidebarItem, _, cx| {
+                if this.ui.drag.is_some() {
+                    this.finish_drag();
+                    cx.notify();
+                }
+            }))
             .child(self.top_bar(colors, cx));
         if let Some(nav) = self.settings_nav.clone() {
             root = root.child(self.settings_body(&nav, colors, cx));
@@ -5114,6 +5398,58 @@ const ENDED_TITLE: &str = "Ended";
 /// One leading column per ancestor level. A column is drawn full height while
 /// that ancestor still has siblings below, and stops halfway on the last child
 /// so a subtree visibly closes instead of trailing a rail into the next row.
+/// The rows sharing `id`'s parent inside its project, in display order.
+fn sibling_run(projection: &crate::store::SidebarProjection, id: &SessionId) -> Vec<SessionId> {
+    let Some(group) = projection
+        .projects
+        .iter()
+        .find(|group| group.sessions.iter().any(|row| row.id() == id))
+    else {
+        return Vec::new();
+    };
+    let parent = group
+        .sessions
+        .iter()
+        .find(|row| row.id() == id)
+        .and_then(|row| row.session.parent.clone());
+    group
+        .sessions
+        .iter()
+        .filter(|row| row.session.parent == parent)
+        .map(|row| row.id().clone())
+        .collect()
+}
+
+/// The insertion line an outline view draws between rows: a hollow dot at
+/// the indent of the dragged row's run and a rule to the trailing edge. It
+/// straddles the gap above or below the row instead of pushing anything.
+fn insertion_marker(zone: DropZone, depth: u16) -> AnyElement {
+    const HEIGHT: f32 = 6.0;
+    let inset = Space::ROW_H + f32::from(depth) * Space::INDENT;
+    let marker = div()
+        .debug_selector(move || format!("insertion-marker:{zone:?}"))
+        .absolute()
+        .left(px(inset - HEIGHT / 2.0))
+        .right(px(Space::ROW_H))
+        .h(px(HEIGHT))
+        .flex()
+        .items_center()
+        .child(
+            div()
+                .size(px(HEIGHT))
+                .flex_none()
+                .rounded_full()
+                .border_2()
+                .border_color(Palette::CLAY),
+        )
+        .child(div().flex_1().h(px(2.0)).rounded(px(1.0)).bg(Palette::CLAY));
+    match zone {
+        DropZone::Before => marker.top(px(-(HEIGHT / 2.0 + 0.5))),
+        DropZone::Onto | DropZone::After => marker.bottom(px(-(HEIGHT / 2.0 + 0.5))),
+    }
+    .into_any_element()
+}
+
 fn indent_rails(row: &crate::store::SidebarRow, colors: SemanticColors) -> Vec<AnyElement> {
     (0..row.depth)
         .map(|column| {
@@ -5999,6 +6335,300 @@ mod tests {
             cx.debug_bounds("selected-session-shortcut").is_some(),
             "keyboard navigation should reveal the focused row shortcut cue"
         );
+    }
+
+    struct SidebarDragHarness {
+        sidebar: Entity<Sidebar>,
+    }
+
+    impl Render for SidebarDragHarness {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .size_full()
+                .child(div().h_full().w(px(248.0)).child(self.sidebar.clone()))
+        }
+    }
+
+    /// A sidebar over the typical preview data plus the handoffs it emits.
+    fn drag_harness(
+        cx: &mut TestAppContext,
+    ) -> (
+        Entity<Sidebar>,
+        Rc<RefCell<Vec<HandoffProposal>>>,
+        &mut VisualTestContext,
+    ) {
+        let handoffs: Rc<RefCell<Vec<HandoffProposal>>> = Rc::default();
+        let (view, cx) = cx.add_window_view({
+            let handoffs = Rc::clone(&handoffs);
+            move |_, cx| {
+                let sidebar = cx.new(|cx| Sidebar::new(None, true, PreviewScenario::Typical, cx));
+                cx.subscribe(&sidebar, move |_, _, event: &SidebarEvent, _| {
+                    if let SidebarEvent::HandoffProposed(proposal) = event {
+                        handoffs.borrow_mut().push(proposal.clone());
+                    }
+                })
+                .detach();
+                SidebarDragHarness { sidebar }
+            }
+        });
+        let sidebar = view.read_with(cx, |harness, _| harness.sidebar.clone());
+        (sidebar, handoffs, cx)
+    }
+
+    fn row_bounds(sidebar: &Entity<Sidebar>, cx: &VisualTestContext, id: &str) -> Bounds<Pixels> {
+        sidebar
+            .read_with(cx, |sidebar, _| {
+                sidebar
+                    .row_bounds
+                    .borrow()
+                    .get(&SessionId::new(id))
+                    .copied()
+            })
+            .unwrap_or_else(|| panic!("{id} should render a row"))
+    }
+
+    /// Press, cross GPUI's drag threshold, travel to `to`.
+    fn drag_to(cx: &mut VisualTestContext, from: Point<Pixels>, to: Point<Pixels>) {
+        cx.simulate_mouse_down(from, MouseButton::Left, Modifiers::default());
+        cx.simulate_mouse_move(
+            from + point(px(0.0), px(6.0)),
+            MouseButton::Left,
+            Modifiers::default(),
+        );
+        cx.simulate_mouse_move(to, MouseButton::Left, Modifiers::default());
+    }
+
+    fn drag_and_release(cx: &mut VisualTestContext, from: Point<Pixels>, to: Point<Pixels>) {
+        drag_to(cx, from, to);
+        cx.simulate_mouse_up(to, MouseButton::Left, Modifiers::default());
+    }
+
+    fn top_level_run(sidebar: &Entity<Sidebar>, cx: &VisualTestContext) -> Vec<String> {
+        sidebar.read_with(cx, |sidebar, _| {
+            let mut store = sidebar.store.write().expect("session store lock poisoned");
+            let projection = store.sidebar_projection();
+            sibling_run(&projection, &SessionId::new("preview-claude"))
+                .into_iter()
+                .map(|id| id.0.to_string())
+                .collect()
+        })
+    }
+
+    fn drag_state(
+        sidebar: &Entity<Sidebar>,
+        cx: &VisualTestContext,
+    ) -> (bool, Option<String>, bool) {
+        sidebar.read_with(cx, |sidebar, _| {
+            (
+                sidebar.ui.drag.is_some(),
+                sidebar.ui.delegation_notice.clone(),
+                sidebar.ui.pending_sibling.is_some(),
+            )
+        })
+    }
+
+    #[gpui::test]
+    fn a_press_that_wanders_and_returns_is_a_click_not_a_self_handoff(cx: &mut TestAppContext) {
+        let (sidebar, handoffs, cx) = drag_harness(cx);
+        let claude = row_bounds(&sidebar, cx, "preview-claude");
+        let wobble = claude.center() + point(px(3.0), px(3.0));
+
+        cx.simulate_mouse_down(claude.center(), MouseButton::Left, Modifiers::default());
+        cx.simulate_mouse_move(wobble, MouseButton::Left, Modifiers::default());
+        cx.simulate_mouse_up(wobble, MouseButton::Left, Modifiers::default());
+
+        assert_eq!(drag_state(&sidebar, cx), (false, None, false));
+        assert!(handoffs.borrow().is_empty());
+        sidebar.read_with(cx, |sidebar, _| {
+            assert_eq!(
+                sidebar
+                    .store
+                    .read()
+                    .expect("session store lock poisoned")
+                    .selected_session_id(),
+                Some(&SessionId::new("preview-claude")),
+                "the release on the origin row must finish the click it started as"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn dropping_onto_a_row_proposes_a_handoff(cx: &mut TestAppContext) {
+        let (sidebar, handoffs, cx) = drag_harness(cx);
+        let claude = row_bounds(&sidebar, cx, "preview-claude");
+        let codex = row_bounds(&sidebar, cx, "preview-codex");
+
+        drag_and_release(cx, claude.center(), codex.center());
+
+        let handoffs = handoffs.borrow();
+        assert_eq!(handoffs.len(), 1);
+        assert_eq!(handoffs[0].source_id, SessionId::new("preview-claude"));
+        assert_eq!(handoffs[0].target_id, SessionId::new("preview-codex"));
+        assert_eq!(drag_state(&sidebar, cx), (false, None, false));
+        assert_eq!(
+            top_level_run(&sidebar, cx),
+            ["preview-claude", "preview-codex", "preview-shell"],
+            "a drop onto the core never reorders"
+        );
+    }
+
+    #[gpui::test]
+    fn dropping_below_a_sibling_reorders_after_it(cx: &mut TestAppContext) {
+        let (sidebar, handoffs, cx) = drag_harness(cx);
+        let codex = row_bounds(&sidebar, cx, "preview-codex");
+        let shell = row_bounds(&sidebar, cx, "preview-shell");
+        let below = point(shell.center().x, shell.bottom() - px(2.0));
+
+        drag_to(cx, codex.center(), below);
+        assert!(
+            cx.debug_bounds("insertion-marker:After").is_some(),
+            "the lower band shows an insertion marker under the target"
+        );
+        assert!(cx.debug_bounds("insertion-marker:Before").is_none());
+        cx.simulate_mouse_up(below, MouseButton::Left, Modifiers::default());
+
+        assert_eq!(
+            top_level_run(&sidebar, cx),
+            ["preview-claude", "preview-shell", "preview-codex"]
+        );
+        assert!(handoffs.borrow().is_empty());
+        assert_eq!(drag_state(&sidebar, cx), (false, None, false));
+        assert!(cx.debug_bounds("insertion-marker:After").is_none());
+    }
+
+    #[gpui::test]
+    fn dropping_above_a_sibling_reorders_before_it(cx: &mut TestAppContext) {
+        let (sidebar, handoffs, cx) = drag_harness(cx);
+        let codex = row_bounds(&sidebar, cx, "preview-codex");
+        let shell = row_bounds(&sidebar, cx, "preview-shell");
+        let above = point(codex.center().x, codex.top() + px(2.0));
+
+        drag_to(cx, shell.center(), above);
+        assert!(cx.debug_bounds("insertion-marker:Before").is_some());
+        cx.simulate_mouse_up(above, MouseButton::Left, Modifiers::default());
+
+        assert_eq!(
+            top_level_run(&sidebar, cx),
+            ["preview-claude", "preview-shell", "preview-codex"]
+        );
+        assert!(handoffs.borrow().is_empty());
+    }
+
+    #[gpui::test]
+    fn a_pinned_row_never_offers_to_reorder_across_the_pin_boundary(cx: &mut TestAppContext) {
+        // preview-claude is pinned, so the projection keeps it above every
+        // unpinned sibling; a marker there would promise a move that never
+        // lands. Its bands offer the handoff instead, like a cousin's.
+        let (sidebar, handoffs, cx) = drag_harness(cx);
+        let claude = row_bounds(&sidebar, cx, "preview-claude");
+        let shell = row_bounds(&sidebar, cx, "preview-shell");
+        let below = point(shell.center().x, shell.bottom() - px(2.0));
+
+        drag_to(cx, claude.center(), below);
+        assert!(cx.debug_bounds("insertion-marker:After").is_none());
+        cx.simulate_mouse_up(below, MouseButton::Left, Modifiers::default());
+
+        assert_eq!(handoffs.borrow().len(), 1);
+        assert_eq!(
+            top_level_run(&sidebar, cx),
+            ["preview-claude", "preview-codex", "preview-shell"]
+        );
+    }
+
+    #[gpui::test]
+    fn a_cousin_row_offers_a_handoff_from_every_band(cx: &mut TestAppContext) {
+        // preview-cursor is codex's child: not a sibling of claude, so its
+        // bands cannot mean "reorder" and fall back to the drop-onto action.
+        let (sidebar, handoffs, cx) = drag_harness(cx);
+        let claude = row_bounds(&sidebar, cx, "preview-claude");
+        let cursor = row_bounds(&sidebar, cx, "preview-cursor");
+        let edge = point(cursor.center().x, cursor.top() + px(2.0));
+
+        drag_to(cx, claude.center(), edge);
+        assert!(cx.debug_bounds("insertion-marker:Before").is_none());
+        cx.simulate_mouse_up(edge, MouseButton::Left, Modifiers::default());
+
+        assert_eq!(handoffs.borrow().len(), 1);
+        assert_eq!(
+            top_level_run(&sidebar, cx),
+            ["preview-claude", "preview-codex", "preview-shell"]
+        );
+    }
+
+    #[gpui::test]
+    fn escape_cancels_a_drag_so_the_release_does_nothing(cx: &mut TestAppContext) {
+        let (sidebar, handoffs, cx) = drag_harness(cx);
+        let claude = row_bounds(&sidebar, cx, "preview-claude");
+        let codex = row_bounds(&sidebar, cx, "preview-codex");
+
+        drag_to(cx, claude.center(), codex.center());
+        assert!(drag_state(&sidebar, cx).0);
+        let cancelled = sidebar.update(cx, |sidebar, cx| sidebar.cancel_active_drag(cx));
+        assert!(cancelled);
+        assert!(
+            !sidebar.update(cx, |sidebar, cx| sidebar.cancel_active_drag(cx)),
+            "a second Escape has nothing left to cancel"
+        );
+        cx.simulate_mouse_up(codex.center(), MouseButton::Left, Modifiers::default());
+
+        assert!(handoffs.borrow().is_empty());
+        assert_eq!(drag_state(&sidebar, cx), (false, None, false));
+    }
+
+    #[gpui::test]
+    fn releasing_over_chrome_or_between_rows_is_a_plain_cancel(cx: &mut TestAppContext) {
+        let (sidebar, handoffs, cx) = drag_harness(cx);
+        let claude = row_bounds(&sidebar, cx, "preview-claude");
+
+        // The gap between two rows used to be the whole-list sibling target.
+        let gap = point(claude.center().x, claude.bottom() + px(0.5));
+        drag_and_release(cx, claude.center(), gap);
+        assert_eq!(drag_state(&sidebar, cx), (false, None, false));
+
+        // Chrome that accepts nothing: the top bar.
+        drag_and_release(cx, claude.center(), point(px(100.0), px(8.0)));
+        assert_eq!(drag_state(&sidebar, cx), (false, None, false));
+
+        assert!(handoffs.borrow().is_empty());
+        assert_eq!(
+            top_level_run(&sidebar, cx),
+            ["preview-claude", "preview-codex", "preview-shell"]
+        );
+    }
+
+    #[gpui::test]
+    fn the_fan_out_zone_appears_during_a_drag_and_proposes_a_sibling(cx: &mut TestAppContext) {
+        let (sidebar, handoffs, cx) = drag_harness(cx);
+        sidebar.update(cx, |sidebar, _| {
+            let mut store = sidebar.store.write().expect("session store lock poisoned");
+            let mut record = (**store
+                .sessions()
+                .get(&SessionId::new("preview-codex"))
+                .expect("fixture session"))
+            .clone();
+            record.originating_prompt = Some("Ship the parser".to_owned());
+            store.upsert_session(record);
+        });
+        let codex = row_bounds(&sidebar, cx, "preview-codex");
+        assert!(
+            cx.debug_bounds("sidebar-fan-out-zone").is_none(),
+            "the zone only exists while a session is being dragged"
+        );
+
+        drag_to(cx, codex.center(), codex.center() + point(px(0.0), px(6.0)));
+        let zone = cx
+            .debug_bounds("sidebar-fan-out-zone")
+            .expect("a live session drag offers the fan-out zone");
+        cx.simulate_mouse_move(zone.center(), MouseButton::Left, Modifiers::default());
+        cx.simulate_mouse_up(zone.center(), MouseButton::Left, Modifiers::default());
+
+        let proposal = sidebar
+            .read_with(cx, |sidebar, _| sidebar.ui.pending_sibling.clone())
+            .expect("the zone proposes a sibling for confirmation");
+        assert_eq!(proposal.source_id, SessionId::new("preview-codex"));
+        assert_eq!(proposal.prompt, "Ship the parser");
+        assert!(handoffs.borrow().is_empty());
+        assert!(cx.debug_bounds("sidebar-fan-out-zone").is_none());
     }
 
     #[gpui::test]

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -26,6 +26,15 @@ Claude Code and Codex have first-class status detection and resume support.
 Other agents may offer partial detection; every agent can still run as a normal
 terminal.
 
+## Drag and drop in the sidebar
+
+Drag a session between two rows to reorder it among its siblings; an insertion
+line shows where it will land. Drop it onto another session's row to review a
+handoff of its work to that session, or onto the zone that appears below the
+last project to fan out a sibling with the same prompt. Project headers reorder
+the same way. Escape cancels a drag, and releasing where nothing accepts the
+drop does nothing.
+
 ## Working from the keyboard
 
 ⌘N opens the launcher, ⌘T starts a session with the default agent, ⌘K is the


### PR DESCRIPTION
## Problem

Dragging in the sidebar was unpredictable, and most attempts ended in the toast **"A session cannot delegate work to itself."**

- GPUI starts a drag after 2px of movement. A trackpad press that wobbles and releases on the same row was delivered as a drop onto itself, refused by the handoff validator, and the click was swallowed.
- The whole session list was a drop target that proposed a sibling fan-out, so releasing in the 1px gap between two rows opened a confirmation panel.
- Every row the pointer crossed that would refuse a handoff painted red.
- Project headers could not be dragged down by one place (`move_before` on the row below is a no-op).
- The drag-over cursor styles (`DragCopy`, `OperationNotAllowed`) were dead code: GPUI pins the cursor to the source element's style for the whole drag.
- Escape did not cancel a drag unless the sidebar itself had focus.

## Design

Rows now follow the outline-view convention (NSOutlineView drop-on vs drop-above):

- **Outer quarter of a row, top and bottom**: insertion band. Reorders among siblings and draws a marker (dot + rule) between the rows. Only offered when source and target share project, parent, and pin state, since pinned rows sort ahead of the manual order and a marker there would promise a move that never lands.
- **Middle half**: drop-onto core. Proposes the handoff, highlighted in clay as before.
- **Origin row**: a release there finishes the click it started as (select + activate).
- **Refusing targets** (descendants, ended sessions): quiet during the drag, refusal explained on release.
- **Sibling fan-out**: a labelled dashed zone below the last project that only exists while a session is being dragged.
- **Escape** cancels from anywhere in the window (caught on the root's capture path), hides the ghost, and restores a live project reorder. The eventual release is then a no-op everywhere.
- **Release over chrome** that accepts nothing is a plain cancel.
- Project headers use `move_past` so one step down works like one step up. Multi-selection drags label the ghost with a count and archive only the bucket's own project rows.

## Tests

Nine new GPUI tests drive real mouse-down / move / up sequences through the preview fixture: wobbly click selects instead of refusing, drop-onto proposes a handoff, insert above/below reorders, cousin and pinned rows fall back to handoff without a marker, Escape cancels, gap and chrome releases are no-ops, and the fan-out zone appears only mid-drag and proposes a sibling. Plus unit tests for `drop_zone` and `move_past`.

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, and `cargo test -p diri-app` (482 passed) are clean.

## Not verified

I did not run the change in a live window; the running Diri instance hosts this session, so installing over it was not an option. The marker geometry (2px rule straddling the 1px row gap, 6px hollow dot at the run's indent) and the fan-out zone styling deserve a quick look in a dev build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUxkjpEZq5J5KG9ArAmJGB
