### PR TITLE
fix: keep the daemon serving when it runs out of file descriptors

### DIFF
--- a/diri/crates/diri-client/examples/attach_probe.rs
+++ b/diri/crates/diri-client/examples/attach_probe.rs
@@ -1,0 +1,138 @@
+//! Attach to a live session the way the desktop pane does and log every grid
+//! frame, so the seed/resize sequence can be inspected outside the GUI.
+//! Usage: attach_probe <session-id> <cols> <rows>
+use std::time::{Duration, Instant};
+
+use diri_client::{SessionAttachment, TerminalChunk};
+use diri_proto::SessionId;
+use diri_proto::grid::GridCell;
+use diri_proto::paths::DirijorPaths;
+
+fn non_blank_rows(cells: &[GridCell], cols: usize) -> usize {
+    if cols == 0 {
+        return 0;
+    }
+    cells
+        .chunks(cols)
+        .filter(|row| {
+            row.iter()
+                .any(|cell| cell.scalar != 0 && cell.scalar != u32::from(b' '))
+        })
+        .count()
+}
+
+fn style_summary(cells: &[GridCell], cols: usize, rows_to_show: &[usize]) -> String {
+    use diri_proto::grid::TermStyle;
+    let mut invisible = 0usize;
+    let mut dim = 0usize;
+    let mut inverse = 0usize;
+    let mut printable = 0usize;
+    let mut fgs = std::collections::HashSet::new();
+    for cell in cells {
+        if cell.scalar != 0 && cell.scalar != 32 {
+            printable += 1;
+            fgs.insert(format!("{:?}", cell.fg));
+            if cell.style.contains(TermStyle::INVISIBLE) {
+                invisible += 1;
+            }
+            if cell.style.contains(TermStyle::DIM) {
+                dim += 1;
+            }
+            if cell.style.contains(TermStyle::INVERSE) {
+                inverse += 1;
+            }
+        }
+    }
+    let mut out = format!(
+        "printable={printable} invisible={invisible} dim={dim} inverse={inverse} fgs={fgs:?}"
+    );
+    for row in rows_to_show {
+        if let Some(cells) = cells.get(row * cols..(row + 1) * cols) {
+            let text: String = cells
+                .iter()
+                .map(|c| char::from_u32(c.scalar).unwrap_or(' '))
+                .collect();
+            out.push_str(&format!("\n    row {row}: {:?}", text.trim_end()));
+        }
+    }
+    out
+}
+
+#[tokio::main]
+async fn main() {
+    let mut args = std::env::args().skip(1);
+    let id = SessionId(args.next().expect("session id"));
+    let cols: u16 = args.next().and_then(|v| v.parse().ok()).unwrap_or(0);
+    let rows: u16 = args.next().and_then(|v| v.parse().ok()).unwrap_or(0);
+    let socket = DirijorPaths::socket(std::env::var("HOME").unwrap());
+    let start = Instant::now();
+    let mut attachment = SessionAttachment::connect(&socket, id)
+        .await
+        .expect("connect");
+    eprintln!("[{:>7.1?}] connected", start.elapsed());
+    let mut cells = Vec::new();
+    let mut resized = false;
+    let deadline = Instant::now() + Duration::from_secs(4);
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let chunk = tokio::select! {
+            chunk = attachment.chunks.recv() => chunk,
+            _ = tokio::time::sleep(remaining.min(Duration::from_millis(300))) => {
+                if !resized && cols > 0 && rows > 0 {
+                    resized = true;
+                    attachment.resize(cols, rows).expect("resize");
+                    eprintln!("[{:>7.1?}] sent resize {cols}x{rows}", start.elapsed());
+                }
+                continue;
+            }
+        };
+        let Some(chunk) = chunk else {
+            eprintln!("closed");
+            break;
+        };
+        match chunk {
+            TerminalChunk::Grid(update) => {
+                update.apply(&mut cells);
+                eprintln!(
+                    "[{:>7.1?}] grid full={} {}x{} changed_rows={} cursor=({},{}) vis={} -> composed non-blank rows={}",
+                    start.elapsed(),
+                    update.is_full_snapshot,
+                    update.cols,
+                    update.rows,
+                    update.changed_rows.len(),
+                    update.cursor_col,
+                    update.cursor_row,
+                    update.cursor_visible,
+                    non_blank_rows(&cells, usize::from(update.cols)),
+                );
+                if update.is_full_snapshot {
+                    let cursor_row = usize::from(update.cursor_row);
+                    let rows = [
+                        cursor_row.saturating_sub(2),
+                        cursor_row.saturating_sub(1),
+                        cursor_row,
+                    ];
+                    eprintln!(
+                        "    {}",
+                        style_summary(&cells, usize::from(update.cols), &rows)
+                    );
+                }
+            }
+            TerminalChunk::Modes {
+                alt_screen,
+                bracketed_paste,
+                mouse,
+            } => {
+                eprintln!(
+                    "[{:>7.1?}] modes alt={alt_screen} bp={bracketed_paste} mouse={mouse:?}",
+                    start.elapsed()
+                );
+            }
+            TerminalChunk::Pong => {}
+        }
+    }
+    attachment.close().await;
+}

--- a/diri/crates/diri-engine/src/bin/dirijord-rs.rs
+++ b/diri/crates/diri-engine/src/bin/dirijord-rs.rs
@@ -41,6 +41,19 @@ fn main() {
         env!("CARGO_PKG_VERSION")
     );
 
+    // The app also launches us with launchd's 256-descriptor soft limit. One
+    // PTY holder, one ssh child, and one client each cost several, so a
+    // working fleet blows through that within a few dozen sessions and every
+    // attach after that fails before its first frame.
+    match diri_engine::limits::raise_fd_limit() {
+        Some(limit) => eprintln!(
+            "dirijord-rs: file descriptor limit soft={} hard={}",
+            limit.soft,
+            limit.hard_label()
+        ),
+        None => eprintln!("dirijord-rs: file descriptor limit could not be read"),
+    }
+
     // The app launches us with launchd's generic SHELL and minimal PATH.
     // Normalize both from the user's account before any session snapshots the
     // inherited environment: wrapped agents must return to the user's actual
@@ -213,9 +226,13 @@ fn main() {
                     });
             }
             Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            // Never leave the accept loop: exiting here strands every
+            // attached terminal, and the usual cause (descriptor exhaustion)
+            // clears the moment a session or client goes away.
             Err(error) => {
-                eprintln!("dirijord-rs: accept: {error}");
-                break;
+                let delay = diri_engine::limits::accept_retry_delay(&error);
+                eprintln!("dirijord-rs: accept: {error}; retrying in {delay:?}");
+                std::thread::sleep(delay);
             }
         }
     }

--- a/diri/crates/diri-engine/src/control.rs
+++ b/diri/crates/diri-engine/src/control.rs
@@ -303,15 +303,27 @@ impl ControlServer {
             return Vec::new();
         };
         let hosts = diri_proto::HostsConfig::load(self.hosts_file());
-        let mut registry = match self.registry.lock() {
-            Ok(registry) => registry,
-            Err(_) => return Vec::new(),
+        // Snapshot under the lock, then let it go. Every step below is an SSH
+        // round trip, and a delegated fleet is dozens of bindings on one host:
+        // holding the Registry across all of them blocked attaches, hook
+        // reports, and readiness probes for minutes after boot, which the app
+        // showed as a blank pane for every session, local ones included.
+        let (records, engine) = {
+            let Ok(registry) = self.registry.lock() else {
+                return Vec::new();
+            };
+            let records = registry
+                .records()
+                .into_iter()
+                .map(|record| (record.id.0.clone(), record))
+                .collect::<std::collections::HashMap<_, _>>();
+            (records, registry.engine())
         };
-        let records = registry
-            .records()
-            .into_iter()
-            .map(|record| (record.id.0.clone(), record))
-            .collect::<std::collections::HashMap<_, _>>();
+        // One Helper probe per host and build rather than one per session.
+        let mut helpers = std::collections::HashMap::<
+            (String, String, u16),
+            Option<crate::remote::manager::InstalledHelper>,
+        >::new();
         let mut adopted = Vec::new();
         for binding in bindings {
             let Some(record) = records.get(&binding.session_id) else {
@@ -323,9 +335,17 @@ impl ControlServer {
             let Some(host) = hosts.host(&binding.host_id) else {
                 continue;
             };
-            let Ok(helper) =
-                manager.existing_helper(host, &binding.helper_build_id, binding.protocol)
-            else {
+            let helper_key = (
+                binding.host_id.clone(),
+                binding.helper_build_id.clone(),
+                binding.protocol.major,
+            );
+            let helper = helpers.entry(helper_key).or_insert_with(|| {
+                manager
+                    .existing_helper(host, &binding.helper_build_id, binding.protocol)
+                    .ok()
+            });
+            let Some(helper) = helper.clone() else {
                 continue;
             };
             let selector = diri_proto::remote_pty::SessionSelector {
@@ -358,7 +378,7 @@ impl ControlServer {
                 pty: crate::pty::PtySpec::new(Vec::new(), &record.cwd)
                     .size(inspection.cols, inspection.rows),
                 manifest_id: manifest_id.clone(),
-                authority: crate::session::authority_for(&manifest_id, &registry.engine()),
+                authority: crate::session::authority_for(&manifest_id, &engine),
                 logs_dir: self.logs_dir.clone(),
                 holder: None,
                 remote: None,
@@ -371,6 +391,13 @@ impl ControlServer {
                 incarnation: binding.session_incarnation,
                 binding_store: store.clone(),
                 output_offset: binding.last_output_offset,
+            };
+            // Adoption itself is local (the attach channel opens on the
+            // session's own pump thread), so the lock is held only here.
+            // `adopt_remote` re-checks the record, which covers a session
+            // removed while its inspection was in flight.
+            let Ok(mut registry) = self.registry.lock() else {
+                break;
             };
             if registry.adopt_remote(spec, remote).is_ok() {
                 adopted.push(binding.session_id);

--- a/diri/crates/diri-engine/src/lib.rs
+++ b/diri/crates/diri-engine/src/lib.rs
@@ -39,6 +39,7 @@ pub mod hosts;
 pub mod inject;
 pub mod legacy_remote;
 mod lifecycle;
+pub mod limits;
 pub mod log;
 pub mod migrate;
 pub mod pr_monitor;

--- a/diri/crates/diri-engine/src/limits.rs
+++ b/diri/crates/diri-engine/src/limits.rs
@@ -1,0 +1,204 @@
+//! Process-level resource hygiene for the daemon.
+//!
+//! The Engine multiplexes every session a user has: one PTY holder socket and
+//! output log per local session, one long-lived `ssh` child (three pipes) per
+//! remote session, a control connection per app, MCP bridge, and hook, plus
+//! logs and checkpoints. macOS launches GUI apps with a 256-descriptor soft
+//! limit and the daemon inherits it, so a few dozen sessions exhaust it while
+//! the hard limit sits orders of magnitude higher. Once `EMFILE` hits,
+//! attaches close before their first frame, resizes never reach the PTY, and
+//! the app's terminal goes blank until something happens to free a
+//! descriptor — and the moment `accept` itself fails the daemon used to exit
+//! outright, taking every session's terminal with it.
+
+use std::io;
+use std::time::Duration;
+
+/// Where the descriptor limit ended up after [`raise_fd_limit`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FdLimit {
+    pub soft: u64,
+    pub hard: u64,
+}
+
+impl FdLimit {
+    /// The hard limit as a log-friendly word: Darwin's `RLIM_INFINITY` is
+    /// `i64::MAX`, which reads as noise in a boot log.
+    #[must_use]
+    pub fn hard_label(&self) -> String {
+        if self.hard >= i64::MAX as u64 {
+            "unlimited".to_owned()
+        } else {
+            self.hard.to_string()
+        }
+    }
+}
+
+/// Raises the soft `RLIMIT_NOFILE` to the hard limit (or the highest value
+/// the kernel accepts below it), never lowering it. Returns the resulting
+/// limits, or `None` when the platform refused to report them.
+#[cfg(unix)]
+pub fn raise_fd_limit() -> Option<FdLimit> {
+    let mut limit = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    // SAFETY: `limit` is a valid, writable rlimit and RLIMIT_NOFILE is a
+    // documented resource.
+    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limit) } != 0 {
+        return None;
+    }
+    // `rlim_t` is platform-sized (u64 here, narrower on some 32-bit libcs).
+    #[allow(clippy::unnecessary_cast)]
+    let current = FdLimit {
+        soft: limit.rlim_cur as u64,
+        hard: limit.rlim_max as u64,
+    };
+    let target = raise_target(current, platform_fd_ceiling());
+    if target <= current.soft {
+        return Some(current);
+    }
+    // macOS rejects a soft limit above `kern.maxfilesperproc` even when the
+    // hard limit is unlimited, so step down from the target until the kernel
+    // accepts a value; the last candidate is the OPEN_MAX every Darwin honors.
+    for candidate in fallback_candidates(target, current.soft) {
+        let request = libc::rlimit {
+            rlim_cur: candidate as libc::rlim_t,
+            rlim_max: limit.rlim_max,
+        };
+        // SAFETY: `request` is a fully initialised rlimit.
+        if unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &request) } == 0 {
+            return Some(FdLimit {
+                soft: candidate,
+                hard: current.hard,
+            });
+        }
+    }
+    Some(current)
+}
+
+#[cfg(not(unix))]
+pub fn raise_fd_limit() -> Option<FdLimit> {
+    None
+}
+
+/// The soft limit to ask for: the hard limit, capped by the kernel's
+/// per-process ceiling when one is advertised. Pure so the arithmetic is
+/// testable without touching the real process limits.
+fn raise_target(current: FdLimit, ceiling: Option<u64>) -> u64 {
+    let mut target = current.hard;
+    if let Some(ceiling) = ceiling {
+        target = target.min(ceiling);
+    }
+    target.max(current.soft)
+}
+
+/// Values to try, highest first. Each is strictly above the soft limit we
+/// already hold, so a successful call always improves matters.
+fn fallback_candidates(target: u64, soft: u64) -> Vec<u64> {
+    let mut candidates = vec![target, 65_536, 10_240, 4_096, 1_024];
+    candidates.sort_unstable_by(|a, b| b.cmp(a));
+    candidates.dedup();
+    candidates.retain(|candidate| *candidate > soft && *candidate <= target);
+    candidates
+}
+
+#[cfg(target_os = "macos")]
+fn platform_fd_ceiling() -> Option<u64> {
+    let mut value: libc::c_int = 0;
+    let mut size = std::mem::size_of::<libc::c_int>();
+    let name = c"kern.maxfilesperproc";
+    // SAFETY: the buffer and its size describe a valid c_int; sysctlbyname
+    // writes at most `size` bytes.
+    let status = unsafe {
+        libc::sysctlbyname(
+            name.as_ptr(),
+            (&raw mut value).cast(),
+            &raw mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    (status == 0 && value > 0).then_some(value as u64)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn platform_fd_ceiling() -> Option<u64> {
+    None
+}
+
+/// How long the accept loop should pause after `accept` fails before trying
+/// again. Descriptor exhaustion and aborted handshakes are transient: the
+/// right response is to wait for a descriptor to free up, not to stop
+/// serving. Anything else still gets retried — a daemon that exits strands
+/// every attached terminal — just at a pace that keeps the log readable.
+pub fn accept_retry_delay(error: &io::Error) -> Duration {
+    match error.raw_os_error() {
+        Some(libc::EMFILE | libc::ENFILE | libc::ENOBUFS | libc::ENOMEM) => {
+            Duration::from_millis(100)
+        }
+        Some(libc::ECONNABORTED | libc::EAGAIN) => Duration::from_millis(10),
+        _ => Duration::from_secs(1),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_target_is_the_hard_limit_capped_by_the_kernel_ceiling() {
+        let current = FdLimit {
+            soft: 256,
+            hard: u64::MAX,
+        };
+        assert_eq!(raise_target(current, Some(138_240)), 138_240);
+        assert_eq!(
+            raise_target(
+                FdLimit {
+                    soft: 1_024,
+                    hard: 524_288
+                },
+                None
+            ),
+            524_288
+        );
+    }
+
+    #[test]
+    fn the_target_never_drops_below_the_soft_limit_already_held() {
+        let generous = FdLimit {
+            soft: 1_048_576,
+            hard: u64::MAX,
+        };
+        assert_eq!(raise_target(generous, Some(138_240)), 1_048_576);
+    }
+
+    #[test]
+    fn fallbacks_only_ever_improve_on_the_current_soft_limit() {
+        let candidates = fallback_candidates(138_240, 256);
+        assert_eq!(candidates, vec![138_240, 65_536, 10_240, 4_096, 1_024]);
+        assert!(fallback_candidates(10_240, 10_240).is_empty());
+        assert_eq!(fallback_candidates(2_048, 1_024), vec![2_048]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn raising_the_limit_is_monotonic_and_stays_within_the_hard_limit() {
+        let before = raise_fd_limit().expect("rlimit readable");
+        let after = raise_fd_limit().expect("rlimit readable");
+        assert!(after.soft >= before.soft);
+        assert!(after.soft <= after.hard);
+        assert_eq!(after.hard, before.hard);
+    }
+
+    #[test]
+    fn descriptor_exhaustion_pauses_briefly_instead_of_ending_the_daemon() {
+        let emfile = io::Error::from_raw_os_error(libc::EMFILE);
+        assert_eq!(accept_retry_delay(&emfile), Duration::from_millis(100));
+        let aborted = io::Error::from_raw_os_error(libc::ECONNABORTED);
+        assert_eq!(accept_retry_delay(&aborted), Duration::from_millis(10));
+        let unknown = io::Error::other("listener vanished");
+        assert_eq!(accept_retry_delay(&unknown), Duration::from_secs(1));
+    }
+}


### PR DESCRIPTION
## Why

Switching to a session showed a blank pane with only the cursor block; a window resize brought the text back. It looked like a renderer bug. It was the daemon out of file descriptors.

`dirijord-rs` is launched by the app with launchd's 256-descriptor soft limit and never raised it. Every forge session costs one long-lived `ssh -T … diri-remote attach` child (three pipes), every local session a holder socket and output log, and every app, MCP bridge, and hook a control connection. With ~50 remote sessions the daemon crossed the limit. Its boot log from today:

```
diri-engine: activity log append failed: Too many open files (os error 24)
dirijord-rs: accept: Too many open files (os error 24)
```

Past the limit, attaches closed before their seed frame and resizes never reached the PTY, which is what the app rendered as a blank grid until a resize happened to get through. When `accept` itself failed, the loop `break`s, so the daemon exited at 13:53 and the app sat with no daemon.

A second problem surfaced while diagnosing the restarted daemon: `restore_remote_bindings` held the Registry lock across one ssh RPC per binding. A `sample` of the process showed every `dirijord-connection` thread, the attach pump, `hook_report`, and `agent_readiness` waiting on that mutex while `diri-remote-restore` ran `ProcessExecutor::run`. For minutes after each daemon start, every attach blocked, local sessions included.

## What changed

- `diri_engine::limits::raise_fd_limit()` runs first thing in `dirijord-rs`: soft `RLIMIT_NOFILE` goes to the hard limit, capped by `kern.maxfilesperproc` on macOS, stepping down if the kernel refuses. The result is logged to the boot log. Under launchd's limits (soft 256, hard unlimited) it lands at 138240.
- The accept loop never exits. `accept_retry_delay()` pauses 100 ms on `EMFILE`/`ENFILE`, 10 ms on aborted handshakes, and 1 s otherwise, then keeps serving. A daemon that exits strands every attached terminal; descriptor exhaustion clears the moment a session or client closes.
- `restore_remote_bindings` snapshots records and the engine under the lock, releases it, probes the Helper once per host and build instead of once per session, inspects each binding unlocked, and retakes the lock only to `adopt_remote` (which re-checks the record). The attach channel already opened on the session's own pump thread, so adoption itself stays cheap.
- New `crates/diri-client/examples/attach_probe.rs`: attaches to a session exactly like the desktop pane and prints every grid frame (full/diff, size, cursor, non-blank rows, cell styles), optionally sending a resize. This is how the daemon side was proven clean and the stall was found.

## Verification

- [x] `./scripts/check.sh` passes, or I explained why a check is not applicable. Ran `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p diri-engine` (all targets, 311 unit + integration suites green). Did not run the full workspace test suite or the shell/license guards.
- [x] Existing sessions still survive app and daemon restarts, or the migration is documented. Restarted the installed daemon by hand today; it adopted 17 live holders and 4 remote sessions and the app reconnected.
- [x] I considered security and privacy impact (processes, IPC, logs, updates, remote hosts). No new IPC or process; the boot log gains one line with the descriptor limits.
- [x] User-visible behavior or setup changes are documented. None beyond the fix.
- [ ] UI changes include a screenshot or short recording. No UI change.

Live checks:

- `dirijord-rs` built from this branch under `ulimit -S -n 256` (hard unlimited) logs `file descriptor limit soft=138240 hard=unlimited`.
- `attach_probe s_6a9d64a10164` against the healthy daemon: full 168x61 seed with 40 non-blank rows in 25 ms; same styles before and after a resize. Against the exhausted daemon the same call got `connected` then `closed` with no frame.
- Unit tests cover the limit arithmetic (never lowers, respects the kernel ceiling, fallbacks only improve) and the accept retry policy.

Not in this PR: the app does not respawn a daemon that dies after startup; with the accept loop no longer exiting that path matters less, but it is still a gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011En2AXyr6jisiBfQ3HfjmB
