### PR TITLE
fix: only hibernate sessions the governor has watched go quiet

### DIFF
--- a/diri/crates/diri-app/src/store/prefs.rs
+++ b/diri/crates/diri-app/src/store/prefs.rs
@@ -93,6 +93,15 @@ pub struct Prefs {
     pub skipped_update_version: String,
     pub hibernate_after_minutes: u32,
     pub memory_hard_limit_gb: u64,
+    /// Which generation of hibernation defaults this file was last brought
+    /// up to. Prefs are written wholesale, so an old default is
+    /// indistinguishable from a choice; this lets a raised default reach
+    /// users who never touched the setting, once, without ever moving a
+    /// value that differs from the old default. Field-level default so a
+    /// file written before the field existed reads as revision 0, not as
+    /// whatever `Prefs::default()` currently carries.
+    #[serde(default)]
+    pub hibernation_defaults_revision: u32,
     pub terminal_theme: String,
     pub terminal_font_size: f32,
     /// Last size, position, and presentation mode of the main window.
@@ -136,8 +145,9 @@ impl Default for Prefs {
             status_sounds: true,
             automatic_updates: true,
             skipped_update_version: String::new(),
-            hibernate_after_minutes: 15,
-            memory_hard_limit_gb: 6,
+            hibernate_after_minutes: 60,
+            memory_hard_limit_gb: 16,
+            hibernation_defaults_revision: Self::HIBERNATION_DEFAULTS_REVISION,
             terminal_theme: DEFAULT_THEME.to_owned(),
             terminal_font_size: 13.0,
             window_placement: None,
@@ -176,11 +186,16 @@ impl Prefs {
         DirijorPaths::prefs_file(home)
     }
 
+    /// Bump when a hibernation default changes, and teach
+    /// [`Self::migrate_hibernation_defaults`] the old value to move.
+    pub const HIBERNATION_DEFAULTS_REVISION: u32 = 1;
+
     pub fn load(path: &Path) -> io::Result<Self> {
         match fs::read(path) {
             Ok(bytes) => {
                 let mut prefs: Self = serde_json::from_slice(&bytes)
                     .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+                prefs.migrate_hibernation_defaults();
                 prefs.normalize();
                 Ok(prefs)
             }
@@ -210,6 +225,22 @@ impl Prefs {
 
     pub fn reset_terminal_zoom(&mut self) {
         self.terminal_font_size = 13.0;
+    }
+
+    /// Moves values still sitting on a superseded default onto the current
+    /// one. Anything the user changed from the old default is left alone.
+    pub fn migrate_hibernation_defaults(&mut self) {
+        if self.hibernation_defaults_revision < 1 {
+            // Revision 1 (2026-09): 15 min → 1 h, 6 GB → 16 GB. Sessions
+            // were being frozen mid-work far too readily.
+            if self.hibernate_after_minutes == 15 {
+                self.hibernate_after_minutes = 60;
+            }
+            if self.memory_hard_limit_gb == 6 {
+                self.memory_hard_limit_gb = 16;
+            }
+        }
+        self.hibernation_defaults_revision = Self::HIBERNATION_DEFAULTS_REVISION;
     }
 
     pub fn normalize(&mut self) {
@@ -256,6 +287,45 @@ impl Prefs {
 mod tests {
     use super::*;
     use crate::launch_recipe::{LaunchRecipe, RecipeProject};
+
+    fn prefs_with_hibernation(minutes: u32, gb: u64, revision: Option<u32>) -> Prefs {
+        let mut value = serde_json::to_value(Prefs::default()).expect("serialize prefs");
+        value["hibernateAfterMinutes"] = serde_json::json!(minutes);
+        value["memoryHardLimitGb"] = serde_json::json!(gb);
+        match revision {
+            Some(revision) => value["hibernationDefaultsRevision"] = serde_json::json!(revision),
+            None => {
+                value
+                    .as_object_mut()
+                    .expect("prefs object")
+                    .remove("hibernationDefaultsRevision");
+            }
+        }
+        let mut prefs: Prefs = serde_json::from_value(value).expect("readable");
+        prefs.migrate_hibernation_defaults();
+        prefs
+    }
+
+    #[test]
+    fn stale_hibernation_defaults_move_to_the_current_ones_once() {
+        // A file written before the revision field existed, still on the
+        // old defaults: both move.
+        let migrated = prefs_with_hibernation(15, 6, None);
+        assert_eq!(migrated.hibernate_after_minutes, 60);
+        assert_eq!(migrated.memory_hard_limit_gb, 16);
+        assert_eq!(
+            migrated.hibernation_defaults_revision,
+            Prefs::HIBERNATION_DEFAULTS_REVISION
+        );
+        // A deliberate choice away from the old defaults is untouched.
+        let chosen = prefs_with_hibernation(30, 8, None);
+        assert_eq!(chosen.hibernate_after_minutes, 30);
+        assert_eq!(chosen.memory_hard_limit_gb, 8);
+        // Choosing the old default AFTER the migration ran sticks.
+        let rechosen = prefs_with_hibernation(15, 6, Some(1));
+        assert_eq!(rechosen.hibernate_after_minutes, 15);
+        assert_eq!(rechosen.memory_hard_limit_gb, 6);
+    }
 
     #[test]
     fn older_preferences_migrate_to_an_empty_recipe_book() {

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -2744,14 +2744,14 @@ impl UtilitySurfaces {
                         .flex_col()
                         .child(setting_row(
                             "Hibernate idle sessions",
-                            "Freeze inactive sessions after this amount of time.",
+                            "Freeze a session once it has sat idle, with no output or CPU activity, for this long.",
                             self.hibernate_dropdown(cx),
                             colors,
                         ))
                         .child(setting_divider(colors))
                         .child(setting_row(
                             "Memory limit",
-                            "Freeze an individual session when it reaches this size.",
+                            "Freeze an idle session when its process tree reaches this size.",
                             self.memory_dropdown(cx),
                             colors,
                         )),
@@ -3624,12 +3624,13 @@ impl UtilitySurfaces {
     }
 
     fn hibernate_dropdown(&self, cx: &mut Context<Self>) -> AnyElement {
-        const OPTIONS: [(u32, &str); 5] = [
+        const OPTIONS: [(u32, &str); 6] = [
             (0, "Off"),
-            (5, "5 minutes"),
             (15, "15 minutes"),
             (30, "30 minutes"),
             (60, "1 hour"),
+            (120, "2 hours"),
+            (240, "4 hours"),
         ];
         let colors = self.settings_colors();
         let selected_label = OPTIONS
@@ -3674,7 +3675,7 @@ impl UtilitySurfaces {
     }
 
     fn memory_dropdown(&self, cx: &mut Context<Self>) -> AnyElement {
-        const OPTIONS: [u64; 4] = [2, 4, 6, 8];
+        const OPTIONS: [u64; 6] = [4, 8, 16, 32, 64, 128];
         let colors = self.settings_colors();
         let open = self.settings_menu == Some(SettingsMenu::MemoryLimit);
         let mut control = div()

--- a/diri/crates/diri-engine/src/governor.rs
+++ b/diri/crates/diri-engine/src/governor.rs
@@ -36,8 +36,9 @@ use crate::events::EventBus;
 use crate::holder::process_tree;
 use crate::registry::Registry;
 
-/// Tunables, defaulting to the Swift daemon's values. `governor.configure`
-/// overrides the two the app exposes.
+/// Tunables. `governor.configure` overrides the two the app exposes; the
+/// rest are the daemon's own, and err towards leaving sessions alone: a
+/// freeze the user did not ask for costs far more than the memory it saves.
 #[derive(Clone, Debug)]
 pub struct GovernorConfig {
     pub idle_threshold_seconds: f64,
@@ -62,10 +63,10 @@ pub struct GovernorConfig {
 impl Default for GovernorConfig {
     fn default() -> Self {
         Self {
-            idle_threshold_seconds: 900.0,
-            hard_memory_bytes: 6 << 30,
-            global_budget_fraction: 0.75,
-            budget_min_idle_seconds: 300.0,
+            idle_threshold_seconds: 3600.0,
+            hard_memory_bytes: 16 << 30,
+            global_budget_fraction: 0.9,
+            budget_min_idle_seconds: 1800.0,
             hibernated_sample_every: 5,
             port_scan_enabled: true,
             scan_interval: Duration::from_secs(30),

--- a/diri/crates/diri-engine/src/governor.rs
+++ b/diri/crates/diri-engine/src/governor.rs
@@ -8,7 +8,22 @@
 //! Three policies then reclaim memory — always only from idle, unattended
 //! sessions: a hard per-session limit, a sustained-idle freeze, and a global
 //! budget that freezes idle sessions oldest-first until under.
+//!
+//! "Idle" is not taken on the status machine's word alone. Status is a
+//! heuristic read off the screen, hooks, and transcripts, and it has been
+//! wrong in every way that matters here: a shell whose dev server is
+//! serving, an agent inside a long silent tool call, a Cursor turn the
+//! transcript closed early. Freezing any of those is indistinguishable from
+//! killing them — connections drop, servers stop answering, parents waiting
+//! on a child hang. So the governor keeps its own evidence, independent of
+//! status: how much CPU the tree burned since the last sweep, how much it
+//! wrote to the PTY, whether its process set changed, and — right before a
+//! freeze — whether anything in it is listening on a port. A session is
+//! only frozen after a whole idle-threshold's worth of consecutive quiet
+//! sweeps on top of reading idle, and the quiet clock restarts at daemon
+//! boot, so stale record timestamps never freeze anything on their own.
 
+use std::collections::HashMap;
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -32,6 +47,16 @@ pub struct GovernorConfig {
     pub hibernated_sample_every: u64,
     pub port_scan_enabled: bool,
     pub scan_interval: Duration,
+    /// A tree that burned more than this fraction of the wall time between
+    /// two sweeps is working. Measured over 20 s on a Mac with 14 live
+    /// sessions: idle Claude Code trees of 5–23 processes (shell, agent,
+    /// MCP servers) sat at 0.4–1.0%; the trees with a turn in flight read
+    /// 3.7% and 8.7%. A build or test run is far above any of these.
+    pub busy_cpu_fraction: f64,
+    /// A tree that wrote at least this many bytes to its PTY between two
+    /// sweeps is working. A spinner frame alone is tens of bytes at ~10 fps,
+    /// so any in-flight turn clears this by orders of magnitude.
+    pub busy_output_bytes: u64,
 }
 
 impl Default for GovernorConfig {
@@ -44,8 +69,110 @@ impl Default for GovernorConfig {
             hibernated_sample_every: 5,
             port_scan_enabled: true,
             scan_interval: Duration::from_secs(30),
+            busy_cpu_fraction: 0.03,
+            busy_output_bytes: 1024,
         }
     }
+}
+
+// MARK: Liveness
+
+/// What one sweep saw of a session's tree, in the terms the quiet check
+/// compares.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Observation {
+    pub at_ms: f64,
+    /// Summed user+system CPU time of every process in the tree.
+    pub cpu_nanos: u64,
+    /// The session's output-log tail offset.
+    pub output_tail: u64,
+    /// The tree's pids, sorted, so membership changes are visible.
+    pub pids: Vec<i32>,
+}
+
+struct Tracked {
+    last: Observation,
+    quiet_since_ms: f64,
+}
+
+/// The governor's own, status-independent record of which sessions have
+/// been doing nothing, and for how long. Lives on the governor thread; a
+/// fresh daemon starts with no evidence at all.
+#[derive(Default)]
+pub struct Liveness {
+    seen: HashMap<String, Tracked>,
+}
+
+impl Liveness {
+    /// Folds one sweep's observation. Returns when the session's current
+    /// quiet stretch began, or `None` when there is no quiet stretch — the
+    /// tree was busy since the last sweep, or this is its first sighting and
+    /// there is nothing yet to compare against.
+    pub fn observe(&mut self, id: &str, now: Observation, config: &GovernorConfig) -> Option<f64> {
+        let Some(tracked) = self.seen.get_mut(id) else {
+            let quiet_since_ms = now.at_ms;
+            self.seen.insert(
+                id.to_owned(),
+                Tracked {
+                    last: now,
+                    quiet_since_ms,
+                },
+            );
+            return None;
+        };
+        let busy = is_busy(&tracked.last, &now, config);
+        if busy {
+            tracked.quiet_since_ms = now.at_ms;
+        }
+        tracked.last = now;
+        (!busy).then_some(tracked.quiet_since_ms)
+    }
+
+    /// Drops what was known about `id`. Called when a session is frozen, so
+    /// that after it wakes the quiet clock starts over rather than resuming
+    /// a stretch measured before the freeze.
+    pub fn forget(&mut self, id: &str) {
+        self.seen.remove(id);
+    }
+
+    /// Keeps only the sessions still on the books.
+    pub fn retain<'a>(&mut self, live: impl IntoIterator<Item = &'a str>) {
+        let live: std::collections::HashSet<&str> = live.into_iter().collect();
+        self.seen.retain(|id, _| live.contains(id.as_str()));
+    }
+}
+
+/// Whether the tree did anything between `prev` and `now`. Every comparison
+/// fails towards busy: a clock that did not advance, a CPU total that went
+/// backwards (a member exited), a process set that changed.
+pub fn is_busy(prev: &Observation, now: &Observation, config: &GovernorConfig) -> bool {
+    let elapsed_ms = now.at_ms - prev.at_ms;
+    if elapsed_ms.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
+        return true;
+    }
+    if now.pids != prev.pids {
+        return true;
+    }
+    let Some(cpu_delta) = now.cpu_nanos.checked_sub(prev.cpu_nanos) else {
+        return true;
+    };
+    if cpu_delta as f64 > elapsed_ms * 1_000_000.0 * config.busy_cpu_fraction {
+        return true;
+    }
+    match now.output_tail.checked_sub(prev.output_tail) {
+        Some(written) => written >= config.busy_output_bytes,
+        None => true,
+    }
+}
+
+/// An idle, unattended, quiet session the policies may freeze.
+struct Candidate {
+    id: String,
+    /// When the session's idle stretch began: the later of what the record
+    /// says and what the governor has itself observed.
+    idle_since_ms: f64,
+    footprint: u64,
+    pids: Vec<i32>,
 }
 
 pub fn should_scan_ports(enabled: bool, attached: bool, tick: u64) -> bool {
@@ -66,6 +193,7 @@ pub fn spawn_governor(
         .name("diri-governor".into())
         .spawn(move || {
             let mut tick: u64 = 0;
+            let mut liveness = Liveness::default();
             while !stop.load(Ordering::SeqCst) {
                 // Sleep first: a fresh daemon's startup work should settle
                 // before the first sweep.
@@ -78,7 +206,15 @@ pub fn spawn_governor(
                     std::thread::sleep(Duration::from_millis(250));
                 }
                 tick += 1;
-                sweep(&registry, &events, &attach, &pr_monitor_wake, &config, tick);
+                sweep(
+                    &registry,
+                    &events,
+                    &attach,
+                    &pr_monitor_wake,
+                    &config,
+                    &mut liveness,
+                    tick,
+                );
             }
         })
         .expect("spawn governor")
@@ -90,6 +226,7 @@ fn sweep(
     attach: &AttachHub,
     pr_monitor_wake: &crate::pr_monitor::PrMonitorWake,
     config: &Arc<Mutex<GovernorConfig>>,
+    liveness: &mut Liveness,
     tick: u64,
 ) {
     let config = config.lock().expect("config").clone();
@@ -97,13 +234,15 @@ fn sweep(
         let Ok(guard) = registry.lock() else { return };
         guard.records()
     };
+    liveness.retain(records.iter().map(|record| record.id.0.as_str()));
 
     let mut total_footprint: u64 = 0;
-    let mut idle_candidates: Vec<(String, f64, u64)> = Vec::new(); // (id, idle_since_ms, footprint)
+    let mut idle_candidates: Vec<Candidate> = Vec::new();
 
     for record in &records {
         let id = record.id.0.clone();
         if let Some(hibernation) = &record.hibernation {
+            liveness.forget(&id);
             // Frozen trees barely change; sample occasionally so the badge
             // stays honest.
             if tick.is_multiple_of(config.hibernated_sample_every) {
@@ -124,11 +263,16 @@ fn sweep(
             continue;
         }
 
-        let (child_pid, artifacts, live) = {
+        let (child_pid, artifacts, output_tail, live) = {
             let Ok(guard) = registry.lock() else { return };
             match guard.get(&id) {
-                Some(session) => (session.child_pid(), session.artifacts(), true),
-                None => (0, Vec::new(), false),
+                Some(session) => (
+                    session.child_pid(),
+                    session.artifacts(),
+                    session.output_tail(),
+                    true,
+                ),
+                None => (0, Vec::new(), 0, false),
             }
         };
         if !live || child_pid <= 1 {
@@ -136,7 +280,8 @@ fn sweep(
         }
 
         let tree = process_tree::enumerate(child_pid);
-        let pids: Vec<i32> = tree.iter().map(|sample| sample.pid).collect();
+        let mut pids: Vec<i32> = tree.iter().map(|sample| sample.pid).collect();
+        pids.sort_unstable();
         let footprint = footprint_of(&pids);
         total_footprint = total_footprint.wrapping_add(footprint);
 
@@ -155,32 +300,77 @@ fn sweep(
             (!artifacts.is_empty()).then_some(artifacts),
         );
 
-        // Eligibility for ANY auto-hibernation: idle and unattended. A
-        // working / needs-input session, or one a client is viewing, is never
-        // frozen out from under the user.
-        if let Some(idle_since) = idle_since(record, attached) {
-            if footprint > config.hard_memory_bytes {
-                let _ = hibernate(
-                    registry,
-                    events,
-                    &id,
-                    diri_proto::HibernationReason::MemoryPressure,
-                );
-                continue;
-            }
-            idle_candidates.push((id, idle_since, footprint));
+        // What the tree actually did since the last sweep, independent of
+        // what the status machine believes about it. Observed for every
+        // live session so the quiet clock is running by the time the record
+        // reads idle.
+        let quiet_since = liveness.observe(
+            &id,
+            Observation {
+                at_ms: now_millis(),
+                cpu_nanos: cpu_time_of(&pids),
+                output_tail,
+                pids: pids.clone(),
+            },
+            &config,
+        );
+
+        // Eligibility for ANY auto-hibernation: idle by status, unattended,
+        // not serving, and quiet by observation. A working / needs-input
+        // session, one a client is viewing, or one still burning CPU or
+        // writing output is never frozen out from under the user.
+        let Some(record_idle_since) = idle_since(record, attached) else {
+            continue;
+        };
+        let Some(quiet_since) = quiet_since else {
+            continue;
+        };
+        let candidate = Candidate {
+            id,
+            idle_since_ms: record_idle_since.max(quiet_since),
+            footprint,
+            pids,
+        };
+        // The hard per-session limit still waits out the budget's minimum
+        // quiet stretch: one sweep of quiet is a pause, not idleness.
+        if footprint > config.hard_memory_bytes
+            && (now_millis() - candidate.idle_since_ms) / 1000.0 > config.budget_min_idle_seconds
+        {
+            hibernate(
+                registry,
+                events,
+                pr_monitor_wake,
+                &config,
+                &candidate,
+                diri_proto::HibernationReason::MemoryPressure,
+            );
+            continue;
         }
+        idle_candidates.push(candidate);
     }
 
     let now_ms = now_millis();
 
-    // Sustained-idle freeze.
+    // Sustained-idle freeze. Whatever it freezes leaves the candidate list
+    // so the budget pass below does not freeze it a second time.
     if config.idle_threshold_seconds > 0.0 {
-        for (id, idle_since, _) in &idle_candidates {
-            if (now_ms - idle_since) / 1000.0 > config.idle_threshold_seconds {
-                let _ = hibernate(registry, events, id, diri_proto::HibernationReason::Idle);
+        let mut still_awake = Vec::with_capacity(idle_candidates.len());
+        for candidate in idle_candidates {
+            if (now_ms - candidate.idle_since_ms) / 1000.0 > config.idle_threshold_seconds
+                && hibernate(
+                    registry,
+                    events,
+                    pr_monitor_wake,
+                    &config,
+                    &candidate,
+                    diri_proto::HibernationReason::Idle,
+                )
+            {
+                continue;
             }
+            still_awake.push(candidate);
         }
+        idle_candidates = still_awake;
     }
 
     // Global budget: over → freeze idle sessions oldest-first until under.
@@ -188,19 +378,26 @@ fn sweep(
     if total_footprint > budget {
         let mut excess = total_footprint - budget;
         let mut by_oldest = idle_candidates;
-        by_oldest.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
-        for (id, idle_since, footprint) in by_oldest {
+        by_oldest.sort_by(|a, b| {
+            a.idle_since_ms
+                .partial_cmp(&b.idle_since_ms)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        for candidate in by_oldest {
             if excess == 0 {
                 break;
             }
-            if (now_ms - idle_since) / 1000.0 > config.budget_min_idle_seconds {
-                let _ = hibernate(
+            if (now_ms - candidate.idle_since_ms) / 1000.0 > config.budget_min_idle_seconds
+                && hibernate(
                     registry,
                     events,
-                    &id,
+                    pr_monitor_wake,
+                    &config,
+                    &candidate,
                     diri_proto::HibernationReason::MemoryPressure,
-                );
-                excess = excess.saturating_sub(footprint);
+                )
+            {
+                excess = excess.saturating_sub(candidate.footprint);
             }
         }
     }
@@ -229,30 +426,64 @@ fn apply_sample(
     }
 }
 
+/// Freezes `candidate`, unless a last look at its tree finds a listening
+/// port. A server nobody is viewing is still serving, and a quiet one shows
+/// the sweep neither CPU nor output — only lsof can tell. Ports found here
+/// go on the record, which keeps the session off the candidate list until a
+/// client's own scan refreshes them. Returns whether the tree was frozen.
 fn hibernate(
     registry: &Arc<Mutex<Registry>>,
     events: &EventBus,
-    id: &str,
+    pr_monitor_wake: &crate::pr_monitor::PrMonitorWake,
+    config: &GovernorConfig,
+    candidate: &Candidate,
     reason: diri_proto::HibernationReason,
-) -> std::io::Result<()> {
+) -> bool {
+    if config.port_scan_enabled
+        && let Some(ports) = listening_ports(&candidate.pids, Duration::from_secs(3))
+        && !ports.is_empty()
+    {
+        apply_sample(
+            registry,
+            events,
+            pr_monitor_wake,
+            &candidate.id,
+            None,
+            Some(ports),
+            None,
+        );
+        return false;
+    }
+    let id = candidate.id.as_str();
     let record = {
         let Ok(mut guard) = registry.lock() else {
-            return Ok(());
+            return false;
         };
-        guard.hibernate(id, reason)?;
+        if guard.hibernate(id, reason).is_err() {
+            return false;
+        }
         let _ = guard.persist();
         guard.records().into_iter().find(|record| record.id.0 == id)
     };
     if let Some(record) = record {
         events.publish_encoded(diri_proto::EventName::SESSION_UPDATED, &record, Some(id));
     }
-    Ok(())
+    true
 }
 
-/// Non-nil (ms since epoch of the idle stretch's start) when the session is
-/// eligible for idle hibernation.
-fn idle_since(record: &diri_proto::SessionRecord, attached: bool) -> Option<f64> {
+/// Non-nil (ms since epoch of the idle stretch's start) when the record
+/// alone says the session may be frozen: idle by status, not pinned, not
+/// attached, and not known to be serving a port. The governor's own quiet
+/// observation is layered on top of this by the sweep.
+pub fn idle_since(record: &diri_proto::SessionRecord, attached: bool) -> Option<f64> {
     if record.hibernation.is_some() || record.pinned || attached {
+        return None;
+    }
+    if record
+        .listening_ports
+        .as_deref()
+        .is_some_and(|ports| !ports.is_empty())
+    {
         return None;
     }
     if !matches!(record.status, SessionStatus::Idle) {
@@ -289,32 +520,72 @@ pub fn footprint_of(pids: &[i32]) -> u64 {
     pids.iter().map(|&pid| footprint_of_pid(pid)).sum()
 }
 
+/// Summed user+system CPU time of the trees, in nanoseconds. Dead pids
+/// contribute 0, so a total can only shrink when a member exits — which the
+/// quiet check reads as activity.
+pub fn cpu_time_of(pids: &[i32]) -> u64 {
+    pids.iter().map(|&pid| cpu_time_of_pid(pid)).sum()
+}
+
 #[cfg(target_os = "macos")]
 fn footprint_of_pid(pid: i32) -> u64 {
-    // rusage_info_v2, laid out exactly as <sys/resource.h>.
+    rusage_v2(pid).map_or(0, |info| info.ri_phys_footprint)
+}
+
+#[cfg(target_os = "macos")]
+fn cpu_time_of_pid(pid: i32) -> u64 {
+    // ri_user_time / ri_system_time are in Mach absolute time units, which
+    // are nanoseconds on Intel and 125/3 ns per unit on Apple silicon.
+    // Declared here rather than taken from `libc`, whose binding is
+    // deprecated in favour of a crate this workspace does not otherwise need.
     #[repr(C)]
     #[derive(Default)]
-    struct RusageInfoV2 {
-        ri_uuid: [u8; 16],
-        ri_user_time: u64,
-        ri_system_time: u64,
-        ri_pkg_idle_wkups: u64,
-        ri_interrupt_wkups: u64,
-        ri_pageins: u64,
-        ri_wired_size: u64,
-        ri_resident_size: u64,
-        ri_phys_footprint: u64,
-        ri_proc_start_abstime: u64,
-        ri_proc_exit_abstime: u64,
-        ri_child_user_time: u64,
-        ri_child_system_time: u64,
-        ri_child_pkg_idle_wkups: u64,
-        ri_child_interrupt_wkups: u64,
-        ri_child_pageins: u64,
-        ri_child_elapsed_abstime: u64,
-        ri_diskio_bytesread: u64,
-        ri_diskio_byteswritten: u64,
+    struct MachTimebaseInfo {
+        numer: u32,
+        denom: u32,
     }
+    unsafe extern "C" {
+        fn mach_timebase_info(info: *mut MachTimebaseInfo) -> libc::c_int;
+    }
+    let Some(info) = rusage_v2(pid) else { return 0 };
+    let mut timebase = MachTimebaseInfo::default();
+    // SAFETY: plain out-parameter call with a properly sized struct.
+    unsafe { mach_timebase_info(&mut timebase) };
+    let ticks = info.ri_user_time.saturating_add(info.ri_system_time);
+    if timebase.denom == 0 || timebase.numer == 0 {
+        return ticks;
+    }
+    (u128::from(ticks) * u128::from(timebase.numer) / u128::from(timebase.denom)) as u64
+}
+
+// rusage_info_v2, laid out exactly as <sys/resource.h>.
+#[cfg(target_os = "macos")]
+#[repr(C)]
+#[derive(Default)]
+struct RusageInfoV2 {
+    ri_uuid: [u8; 16],
+    ri_user_time: u64,
+    ri_system_time: u64,
+    ri_pkg_idle_wkups: u64,
+    ri_interrupt_wkups: u64,
+    ri_pageins: u64,
+    ri_wired_size: u64,
+    ri_resident_size: u64,
+    ri_phys_footprint: u64,
+    ri_proc_start_abstime: u64,
+    ri_proc_exit_abstime: u64,
+    ri_child_user_time: u64,
+    ri_child_system_time: u64,
+    ri_child_pkg_idle_wkups: u64,
+    ri_child_interrupt_wkups: u64,
+    ri_child_pageins: u64,
+    ri_child_elapsed_abstime: u64,
+    ri_diskio_bytesread: u64,
+    ri_diskio_byteswritten: u64,
+}
+
+#[cfg(target_os = "macos")]
+fn rusage_v2(pid: i32) -> Option<RusageInfoV2> {
     const RUSAGE_INFO_V2: libc::c_int = 2;
     // The header spells the parameter `rusage_info_t *buffer`, but
     // `rusage_info_t` is `void *` and every caller passes the STRUCT address
@@ -330,7 +601,29 @@ fn footprint_of_pid(pid: i32) -> u64 {
     let mut info = RusageInfoV2::default();
     // SAFETY: the buffer is a properly sized, writable rusage_info_v2.
     let rc = unsafe { proc_pid_rusage(pid, RUSAGE_INFO_V2, std::ptr::from_mut(&mut info).cast()) };
-    if rc == 0 { info.ri_phys_footprint } else { 0 }
+    (rc == 0).then_some(info)
+}
+
+#[cfg(target_os = "linux")]
+fn cpu_time_of_pid(pid: i32) -> u64 {
+    let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+        return 0;
+    };
+    // comm may contain spaces and parentheses; fields resume after the LAST
+    // closing parenthesis. utime and stime are fields 14 and 15 overall,
+    // i.e. the 12th and 13th after comm.
+    let Some(close) = stat.rfind(')') else {
+        return 0;
+    };
+    let mut fields = stat[close + 2..].split_whitespace().skip(11);
+    let utime: u64 = fields.next().and_then(|f| f.parse().ok()).unwrap_or(0);
+    let stime: u64 = fields.next().and_then(|f| f.parse().ok()).unwrap_or(0);
+    // SAFETY: plain sysconf.
+    let hz = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
+    let hz = if hz > 0 { hz as u64 } else { 100 };
+    utime
+        .saturating_add(stime)
+        .saturating_mul(1_000_000_000 / hz)
 }
 
 #[cfg(target_os = "linux")]
@@ -503,5 +796,222 @@ mod tests {
     fn physical_memory_is_plausible() {
         let memory = physical_memory();
         assert!(memory >= 4 << 30, "at least 4 GiB: {memory}");
+    }
+
+    // MARK: Liveness
+
+    fn observation(at_ms: f64, cpu_nanos: u64, output_tail: u64) -> Observation {
+        Observation {
+            at_ms,
+            cpu_nanos,
+            output_tail,
+            pids: vec![100, 101],
+        }
+    }
+
+    /// Thirty seconds apart, like real sweeps.
+    const SWEEP_MS: f64 = 30_000.0;
+
+    #[test]
+    fn first_sighting_is_not_evidence_of_quiet() {
+        let config = GovernorConfig::default();
+        let mut liveness = Liveness::default();
+        assert_eq!(liveness.observe("s", observation(0.0, 0, 0), &config), None);
+        // The stretch starts at the first sighting once a quiet sweep confirms it.
+        assert_eq!(
+            liveness.observe("s", observation(SWEEP_MS, 0, 0), &config),
+            Some(0.0)
+        );
+    }
+
+    #[test]
+    fn quiet_sweeps_keep_the_original_quiet_start() {
+        let config = GovernorConfig::default();
+        let mut liveness = Liveness::default();
+        liveness.observe("s", observation(0.0, 1_000, 500), &config);
+        for sweep in 1..=5 {
+            // Idle-agent noise: ~1.2% CPU and a few bytes of redraw per sweep.
+            let at = SWEEP_MS * sweep as f64;
+            let cpu = 1_000 + (at * 1_000_000.0 * 0.012) as u64;
+            let tail = 500 + sweep * 40;
+            assert_eq!(
+                liveness.observe("s", observation(at, cpu, tail), &config),
+                Some(0.0),
+                "sweep {sweep}"
+            );
+        }
+    }
+
+    #[test]
+    fn cpu_burn_resets_the_quiet_stretch() {
+        let config = GovernorConfig::default();
+        let mut liveness = Liveness::default();
+        liveness.observe("s", observation(0.0, 0, 0), &config);
+        liveness.observe("s", observation(SWEEP_MS, 0, 0), &config);
+        // A build: 100% of one core for the whole interval.
+        let burned = (SWEEP_MS * 1_000_000.0) as u64;
+        assert_eq!(
+            liveness.observe("s", observation(2.0 * SWEEP_MS, burned, 0), &config),
+            None
+        );
+        // Quiet again: the stretch restarts at the busy sweep, not at zero.
+        assert_eq!(
+            liveness.observe("s", observation(3.0 * SWEEP_MS, burned, 0), &config),
+            Some(2.0 * SWEEP_MS)
+        );
+    }
+
+    #[test]
+    fn output_growth_resets_the_quiet_stretch() {
+        let config = GovernorConfig::default();
+        let mut liveness = Liveness::default();
+        liveness.observe("s", observation(0.0, 0, 0), &config);
+        liveness.observe("s", observation(SWEEP_MS, 0, 0), &config);
+        // A streaming turn or a chatty dev server: kilobytes per sweep.
+        assert_eq!(
+            liveness.observe("s", observation(2.0 * SWEEP_MS, 0, 64 << 10), &config),
+            None
+        );
+    }
+
+    #[test]
+    fn tree_membership_change_resets_the_quiet_stretch() {
+        let config = GovernorConfig::default();
+        let mut liveness = Liveness::default();
+        liveness.observe("s", observation(0.0, 0, 0), &config);
+        let mut grew = observation(SWEEP_MS, 0, 0);
+        grew.pids.push(102);
+        assert_eq!(liveness.observe("s", grew, &config), None);
+    }
+
+    #[test]
+    fn cpu_total_going_backwards_reads_as_busy() {
+        // A member exited between sweeps and took its CPU total with it.
+        let config = GovernorConfig::default();
+        assert!(is_busy(
+            &observation(0.0, 5_000_000, 0),
+            &observation(SWEEP_MS, 1_000_000, 0),
+            &config
+        ));
+        assert!(
+            is_busy(
+                &observation(SWEEP_MS, 0, 0),
+                &observation(SWEEP_MS, 0, 0),
+                &config
+            ),
+            "a clock that did not advance proves nothing"
+        );
+    }
+
+    #[test]
+    fn forgetting_a_session_restarts_its_clock_on_wake() {
+        let config = GovernorConfig::default();
+        let mut liveness = Liveness::default();
+        liveness.observe("s", observation(0.0, 0, 0), &config);
+        liveness.observe("s", observation(SWEEP_MS, 0, 0), &config);
+        liveness.forget("s");
+        assert_eq!(
+            liveness.observe("s", observation(2.0 * SWEEP_MS, 0, 0), &config),
+            None
+        );
+        assert_eq!(
+            liveness.observe("s", observation(3.0 * SWEEP_MS, 0, 0), &config),
+            Some(2.0 * SWEEP_MS)
+        );
+    }
+
+    #[test]
+    fn retain_drops_sessions_that_left_the_registry() {
+        let config = GovernorConfig::default();
+        let mut liveness = Liveness::default();
+        liveness.observe("gone", observation(0.0, 0, 0), &config);
+        liveness.observe("kept", observation(0.0, 0, 0), &config);
+        liveness.retain(["kept"]);
+        assert!(liveness.seen.contains_key("kept"));
+        assert!(!liveness.seen.contains_key("gone"));
+    }
+
+    #[test]
+    fn cpu_time_of_own_process_is_in_nanoseconds_and_grows() {
+        let own = std::process::id() as i32;
+        let before = cpu_time_of(&[own]);
+        // Burn roughly 150 ms of CPU.
+        let started = std::time::Instant::now();
+        let mut sink: u64 = 0;
+        while started.elapsed() < Duration::from_millis(150) {
+            for i in 0..10_000u64 {
+                sink = sink.wrapping_mul(31).wrapping_add(i);
+            }
+        }
+        std::hint::black_box(sink);
+        let delta = cpu_time_of(&[own]).saturating_sub(before);
+        // The unit conversion is the thing under test: mach absolute units
+        // left unconverted would read ~24x too small on Apple silicon.
+        assert!(
+            (50_000_000..=5_000_000_000).contains(&delta),
+            "150 ms of burn should read as 50 ms–5 s of CPU, got {delta} ns"
+        );
+        assert_eq!(cpu_time_of(&[i32::MAX - 7]), 0, "a dead pid contributes 0");
+    }
+
+    // MARK: Record eligibility
+
+    fn record(status: SessionStatus) -> diri_proto::SessionRecord {
+        use diri_proto::{AgentKind, DateMillis, ProjectId, Resumability, SessionId, TitleSource};
+        diri_proto::SessionRecord {
+            id: SessionId::new("s_one"),
+            kind: AgentKind::CLAUDE_CODE,
+            cwd: "/tmp/project".into(),
+            project_id: ProjectId::new("p_project"),
+            worktree_path: None,
+            git_branch: None,
+            title: "Session".into(),
+            title_source: TitleSource::Placeholder,
+            originating_prompt: None,
+            agent_session_id: None,
+            transcript_path: None,
+            status,
+            status_evidence: None,
+            needs_input: None,
+            resumability: Resumability::Live,
+            capabilities: None,
+            parent: None,
+            created_at: DateMillis(1.0),
+            updated_at: DateMillis(1.0),
+            last_turn_completed_at: None,
+            last_seen_at: None,
+            pinned: false,
+            archived_at: None,
+            host: None,
+            remote_persistence: None,
+            hibernation: None,
+            memory_bytes: None,
+            artifacts: None,
+            pull_requests: None,
+            listening_ports: None,
+            foreground_agent: None,
+        }
+    }
+
+    #[test]
+    fn only_unattended_idle_records_are_eligible() {
+        assert_eq!(idle_since(&record(SessionStatus::Idle), false), Some(1.0));
+        assert_eq!(idle_since(&record(SessionStatus::Idle), true), None);
+        assert_eq!(idle_since(&record(SessionStatus::Working), false), None);
+        let mut pinned = record(SessionStatus::Idle);
+        pinned.pinned = true;
+        assert_eq!(idle_since(&pinned, false), None);
+    }
+
+    #[test]
+    fn a_record_with_listening_ports_is_never_eligible() {
+        let mut serving = record(SessionStatus::Idle);
+        serving.listening_ports = Some(vec![PortInfo {
+            port: 3000,
+            process_name: "node".into(),
+        }]);
+        assert_eq!(idle_since(&serving, false), None);
+        serving.listening_ports = Some(Vec::new());
+        assert_eq!(idle_since(&serving, false), Some(1.0));
     }
 }

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -1131,6 +1131,13 @@ impl Session {
         self.shared.status.lock().expect("status").clone()
     }
 
+    /// Total bytes the child has ever written. The governor compares this
+    /// across sweeps: a growing tail is a working session, whatever the
+    /// status heuristics currently believe.
+    pub fn output_tail(&self) -> u64 {
+        self.shared.log.lock().expect("log").tail_offset()
+    }
+
     /// Reads recorded output by absolute stream offset, for attach and replay.
     pub fn read_output(&self, from_offset: u64, max_bytes: usize) -> (u64, Vec<u8>) {
         self.shared


### PR DESCRIPTION
## Problem

Auto-hibernation (the "zzz" freeze) took `status == Idle` as its only evidence that a session was safe to SIGSTOP. Status is a heuristic, and whenever it misread a working session the governor froze it, which from the outside looks like the agent being killed:

- a shell tab running a dev server or a long silent build
- an agent inside a long tool call with nothing new on screen
- a Cursor turn the transcript reported as ended early
- any session right after a daemon restart, since the idle clock came from stale record timestamps

Frozen mid-work means dropped API connections, servers that stop answering, and parents waiting on a child that never resumes. On top of that, the defaults were eager: 15 minutes, a 6 GB per-session limit, and a global budget that froze after 5 minutes once trees summed past 75% of RAM.

## Fix 1: freeze only what the governor has watched go quiet

The governor keeps its own per-session liveness record, independent of status, and only freezes after a whole idle-threshold of consecutive *quiet* sweeps on top of the record reading idle. A sweep is busy when the tree:

- burned more than 3% CPU of wall time since the last sweep (rusage_info on macOS, `/proc/<pid>/stat` on Linux)
- wrote 1 KiB or more to its PTY
- gained or lost a process, or its CPU total went backwards

Measured on this machine over 20 s with 14 live sessions: idle Claude trees of 5–23 processes sat at 0.4–1.0% CPU; trees with a turn in flight read 3.7% and 8.7%.

Sessions with a listening port on their record are never candidates, and a final `lsof` right before any freeze catches a quiet server the record does not know about (the ports found go on the record).

The quiet clock starts empty at daemon boot and is reset whenever a session is frozen, so a woken session needs a fresh full quiet stretch before it can be frozen again.

## Fix 2: far less eager defaults

| Setting | Before | After |
|---|---|---|
| Hibernate idle sessions (app default) | 15 min | 1 hour, options up to 4 hours |
| Memory limit per session (app default) | 6 GB | 16 GB, options up to 128 GB |
| Quiet required before a memory-pressure freeze | 5 min | 30 min |
| Global budget trip point | 75% of RAM | 90% of RAM |

Prefs are written wholesale, so a stored old default is indistinguishable from a choice. A one-time, revision-gated migration moves values still sitting on the old defaults (15 min, 6 GB) to the new ones and leaves anything else alone.

## Tests

- 12 new governor unit tests: liveness first-sighting, quiet-stretch continuity under idle-agent noise, CPU / output / tree-change resets, backwards CPU, forget-on-freeze, retain, record eligibility with ports, and a CPU-time unit check that burns 150 ms and asserts the nanosecond conversion (mach timebase on Apple silicon)
- 1 new prefs test covering the migration in all three cases (old default moves, a choice stays, re-choosing the old default after migration sticks)
- `cargo test -p diri-engine` all green, app prefs tests green, `cargo clippy --all-targets -D warnings` and `cargo fmt --check` clean

No protocol change. Needs a `dirijord-rs` reinstall + restart for the governor change; the app change needs an app reinstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Br1U229tdTX4Dc22v8bCmf
