### PR TITLE
Fix native chat title synchronization

### DIFF
--- a/diri/Cargo.lock
+++ b/diri/Cargo.lock
@@ -1595,6 +1595,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "plist",
  "regex",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/diri/crates/diri-app/src/menu_inbox.rs
+++ b/diri/crates/diri-app/src/menu_inbox.rs
@@ -6,6 +6,7 @@
 use diri_proto::{AttentionLevel, SessionRecord};
 
 use crate::store::{SidebarProject, SidebarProjection};
+use crate::switcher::display_title;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum TrailingStatus {
@@ -94,7 +95,7 @@ fn session_row(session: &SessionRecord, depth: u16) -> InboxSessionRow {
         .is_some_and(|detail| detail.risk_hint == diri_proto::RiskHint::Destructive);
     InboxSessionRow {
         session_id: session.id.0.clone(),
-        title: display_title(session).to_owned(),
+        title: display_title(session),
         agent_id: session.effective_kind().id().to_owned(),
         depth,
         trailing,
@@ -102,14 +103,6 @@ fn session_row(session: &SessionRecord, depth: u16) -> InboxSessionRow {
             && !session.effective_kind().is_terminal()
             && attention == AttentionLevel::Working,
         destructive,
-    }
-}
-
-fn display_title(session: &SessionRecord) -> &str {
-    if session.title.is_empty() {
-        "Untitled"
-    } else {
-        &session.title
     }
 }
 

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -34,6 +34,7 @@ use crate::settings::{SettingsNav, SettingsSection, SettingsTab};
 use crate::store::{
     ClickModifiers, DirectoryListingState, SessionStore, SpawnOptions, StoreEffect, StoreRuntime,
 };
+use crate::switcher::display_title;
 use crate::updates::{UpdateCommand, UpdatePhase, UpdateState};
 use crate::usage::{UsageFormat, UsageSnapshot};
 
@@ -5746,23 +5747,6 @@ fn hover_detail(icon: &str, text: &str, mono: bool, colors: SemanticColors) -> A
         .into_any_element()
 }
 
-fn display_title(session: &SessionRecord) -> String {
-    if session.title_source == diri_proto::TitleSource::Placeholder {
-        if matches!(
-            session.status,
-            diri_proto::SessionStatus::Starting
-                | diri_proto::SessionStatus::Working
-                | diri_proto::SessionStatus::NeedsInput(_)
-        ) {
-            "Untitled".into()
-        } else {
-            "Ended".into()
-        }
-    } else {
-        session.title.clone()
-    }
-}
-
 fn status_state(session: &SessionRecord, migrating: bool) -> StatusState {
     if migrating {
         return StatusState::Working;
@@ -6020,6 +6004,27 @@ mod tests {
     fn compact_duration_matches_usage_copy() {
         assert_eq!(compact_duration(8_040), "2h 14m");
         assert_eq!(compact_duration(540), "9m");
+    }
+
+    #[test]
+    fn a_placeholder_named_live_session_is_untitled_not_ended() {
+        let mut session = SidebarPreviewFixture::make(PreviewScenario::Typical)
+            .list
+            .sessions
+            .into_iter()
+            .next()
+            .expect("fixture session");
+        session.title_source = diri_proto::TitleSource::Placeholder;
+        session.status = diri_proto::SessionStatus::Idle;
+
+        assert_eq!(display_title(&session), "Untitled");
+
+        session.status = diri_proto::SessionStatus::Exited(diri_proto::ExitInfo {
+            reason: diri_proto::ExitReason::Exited,
+            code: Some(0),
+            signal: None,
+        });
+        assert_eq!(display_title(&session), "Ended");
     }
 
     #[test]

--- a/diri/crates/diri-engine/Cargo.toml
+++ b/diri/crates/diri-engine/Cargo.toml
@@ -14,6 +14,7 @@ diri-terminal-state.workspace = true
 getrandom.workspace = true
 plist.workspace = true
 regex.workspace = true
+rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/diri/crates/diri-engine/src/events.rs
+++ b/diri/crates/diri-engine/src/events.rs
@@ -429,21 +429,25 @@ pub fn spawn_registry_watcher(
             // every pass, all under the registry lock.
             let mut published: HashMap<String, u64> = HashMap::new();
             while !stop.load(Ordering::SeqCst) {
-                let (mut changed, cursor_requests) = {
+                let (mut changed, cursor_requests, native_title_requests) = {
                     let Ok(mut registry) = registry.lock() else {
                         break;
                     };
                     (
                         registry.changed_since(&mut published),
                         registry.cursor_refresh_requests(),
+                        registry.native_title_refresh_requests(),
                     )
                 };
                 let cursor_refreshes = crate::registry::scan_cursor_refreshes(cursor_requests);
-                if !cursor_refreshes.is_empty() {
+                let native_title_refreshes =
+                    crate::registry::scan_native_title_refreshes(native_title_requests);
+                if !cursor_refreshes.is_empty() || !native_title_refreshes.is_empty() {
                     let Ok(mut registry) = registry.lock() else {
                         break;
                     };
                     changed.extend(registry.apply_cursor_refreshes(cursor_refreshes));
+                    changed.extend(registry.apply_native_title_refreshes(native_title_refreshes));
                 }
                 for (id, record) in changed {
                     events.publish_encoded(

--- a/diri/crates/diri-engine/src/history.rs
+++ b/diri/crates/diri-engine/src/history.rs
@@ -20,12 +20,13 @@ use std::collections::{HashMap, HashSet};
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 #[cfg(unix)]
 use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _};
 
 use diri_proto::AgentKind;
+use rusqlite::{Connection, OpenFlags, OptionalExtension as _, params};
 use serde_json::Value;
 
 /// Defensive cap on returned entries.
@@ -33,8 +34,12 @@ const MAX_ENTRIES: usize = 500;
 /// How far into a Claude transcript to read looking for the first line with a
 /// `cwd`. That is the first user message, which can be large.
 const CLAUDE_HEAD_CAP: usize = 8 << 20;
-/// Tail window scanned for the newest Claude `ai-title`.
+/// Tail window scanned for Claude's generated and custom titles.
 const CLAUDE_TAIL_BYTES: usize = 16 << 10;
+/// Tail of Codex's append-only title index considered for live sessions.
+const CODEX_INDEX_BYTES: usize = 4 << 20;
+/// Provider databases considered, newest first. Codex normally has one.
+const CODEX_STATE_FILES: usize = 16;
 /// Tail window for Cursor's last jsonl object (turn working/idle).
 const CURSOR_TAIL_BYTES: usize = 64 << 10;
 /// Candidate transcript directories considered while associating a live
@@ -97,8 +102,8 @@ impl TrustedTranscript {
         &self.path
     }
 
-    pub(crate) fn latest_claude_ai_title(&mut self) -> Option<String> {
-        latest_claude_ai_title_from(&mut self.file)
+    pub(crate) fn latest_claude_title(&mut self) -> Option<String> {
+        latest_claude_title_from(&mut self.file)
     }
 }
 
@@ -347,7 +352,7 @@ fn claude_entry(path: &Path) -> Option<HistoryEntry> {
     // No cwd means nothing to resume into.
     let cwd = cwd?;
 
-    let title = latest_claude_ai_title(path).or_else(|| first_prompt.map(|text| title_from(&text)));
+    let title = latest_claude_title(path).or_else(|| first_prompt.map(|text| title_from(&text)));
 
     Some(HistoryEntry {
         id: uuid,
@@ -411,14 +416,14 @@ fn read_claude_head(path: &Path) -> Vec<String> {
         .collect()
 }
 
-/// The newest `ai-title` in the tail — the title Claude generated for the
-/// conversation.
-pub(crate) fn latest_claude_ai_title(path: &Path) -> Option<String> {
+/// Claude's current native conversation title from the bounded transcript
+/// tail. A `/rename` `custom-title` wins over any generated `ai-title`.
+pub(crate) fn latest_claude_title(path: &Path) -> Option<String> {
     let mut handle = open_regular_readonly(path)?;
-    latest_claude_ai_title_from(&mut handle)
+    latest_claude_title_from(&mut handle)
 }
 
-fn latest_claude_ai_title_from(handle: &mut File) -> Option<String> {
+fn latest_claude_title_from(handle: &mut File) -> Option<String> {
     let end = handle.seek(SeekFrom::End(0)).ok()?;
     let start = end.saturating_sub(CLAUDE_TAIL_BYTES as u64);
     handle.seek(SeekFrom::Start(start)).ok()?;
@@ -430,22 +435,38 @@ fn latest_claude_ai_title_from(handle: &mut File) -> Option<String> {
         .read_to_end(&mut data)
         .ok()?;
 
-    let mut newest = None;
+    let mut newest_ai = None;
+    let mut newest_custom = None;
     for line in String::from_utf8_lossy(&data).split('\n') {
-        if !line.contains("\"ai-title\"") {
+        if !line.contains("\"ai-title\"") && !line.contains("\"custom-title\"") {
             continue;
         }
         let Ok(object) = serde_json::from_str::<Value>(line) else {
             continue;
         };
-        if object.get("type").and_then(Value::as_str) == Some("ai-title")
-            && let Some(title) = object.get("aiTitle").and_then(Value::as_str)
-            && !title.is_empty()
-        {
-            newest = Some(title.to_string());
+        match object.get("type").and_then(Value::as_str) {
+            Some("custom-title") => {
+                if let Some(title) = object
+                    .get("customTitle")
+                    .and_then(Value::as_str)
+                    .filter(|title| !title.is_empty())
+                {
+                    newest_custom = Some(title.to_owned());
+                }
+            }
+            Some("ai-title") => {
+                if let Some(title) = object
+                    .get("aiTitle")
+                    .and_then(Value::as_str)
+                    .filter(|title| !title.is_empty())
+                {
+                    newest_ai = Some(title.to_owned());
+                }
+            }
+            _ => {}
         }
     }
-    newest
+    newest_custom.or(newest_ai)
 }
 
 /// Cursor conversation identity plus the generated title Cursor writes to
@@ -728,6 +749,176 @@ fn system_time_ms(time: SystemTime) -> f64 {
 
 // MARK: Codex
 
+#[derive(Default)]
+struct CodexTitleCandidates {
+    explicit: Option<String>,
+    fallback: Option<String>,
+}
+
+/// Resolves the title Codex currently exposes for `thread_id`. This follows
+/// the provider's own priority: an explicit `/rename`, then the append-only
+/// session index, then Codex's generated title or first prompt in its state
+/// database. All files are local, read-only, owner-controlled, and bounded.
+pub(crate) fn codex_title(home: &Path, thread_id: &str) -> Option<String> {
+    if !safe_agent_id(thread_id) {
+        return None;
+    }
+    let codex_home = home.join(".codex");
+    let database = codex_database_titles(&codex_home, thread_id).unwrap_or_default();
+    database
+        .explicit
+        .or_else(|| codex_indexed_title(&codex_home, thread_id))
+        .or(database.fallback)
+}
+
+fn codex_database_titles(codex_home: &Path, thread_id: &str) -> Option<CodexTitleCandidates> {
+    for path in newest_codex_state_files(codex_home) {
+        if let Some(titles) = codex_database_title(&path, thread_id) {
+            return Some(titles);
+        }
+    }
+    None
+}
+
+fn newest_codex_state_files(codex_home: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(codex_home) else {
+        return Vec::new();
+    };
+    let mut paths = entries
+        .take(256)
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_file()))
+        .filter_map(|entry| {
+            let name = entry.file_name();
+            let name = name.to_str()?;
+            (name.starts_with("state_") && name.ends_with(".sqlite")).then(|| entry.path())
+        })
+        .filter(|path| owner_regular_file(path))
+        .collect::<Vec<_>>();
+    paths.sort_by_key(|path| {
+        std::cmp::Reverse(
+            std::fs::metadata(path)
+                .and_then(|metadata| metadata.modified())
+                .unwrap_or(SystemTime::UNIX_EPOCH),
+        )
+    });
+    paths.truncate(CODEX_STATE_FILES);
+    paths
+}
+
+fn codex_database_title(path: &Path, thread_id: &str) -> Option<CodexTitleCandidates> {
+    let connection = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .ok()?;
+    let _ = connection.busy_timeout(Duration::from_millis(50));
+    let columns = {
+        let mut statement = connection.prepare("PRAGMA table_info(threads)").ok()?;
+        statement
+            .query_map([], |row| row.get::<_, String>(1))
+            .ok()?
+            .filter_map(Result::ok)
+            .collect::<HashSet<_>>()
+    };
+    if !columns.contains("id") {
+        return None;
+    }
+    let field = |name: &str| {
+        if columns.contains(name) {
+            name.to_owned()
+        } else {
+            "NULL".to_owned()
+        }
+    };
+    let query = format!(
+        "SELECT {}, {}, {} FROM threads WHERE id = ?1 LIMIT 1",
+        field("name"),
+        field("title"),
+        field("first_user_message"),
+    );
+    connection
+        .query_row(&query, params![thread_id], |row| {
+            let explicit = row.get::<_, Option<String>>(0)?;
+            let generated = row.get::<_, Option<String>>(1)?;
+            let first_prompt = row.get::<_, Option<String>>(2)?;
+            Ok(CodexTitleCandidates {
+                explicit: explicit.and_then(clean_provider_title),
+                fallback: generated
+                    .and_then(clean_provider_title)
+                    .or_else(|| first_prompt.and_then(clean_provider_title)),
+            })
+        })
+        .optional()
+        .ok()?
+}
+
+fn codex_indexed_title(codex_home: &Path, thread_id: &str) -> Option<String> {
+    let mut handle = open_regular_readonly(&codex_home.join("session_index.jsonl"))?;
+    let end = handle.seek(SeekFrom::End(0)).ok()?;
+    let start = end.saturating_sub(CODEX_INDEX_BYTES as u64);
+    handle.seek(SeekFrom::Start(start)).ok()?;
+    let mut data = Vec::new();
+    handle
+        .take((CODEX_INDEX_BYTES + (4 << 10)) as u64)
+        .read_to_end(&mut data)
+        .ok()?;
+    let text = String::from_utf8_lossy(&data);
+    let mut lines = text.split('\n').filter(|line| !line.is_empty());
+    if start > 0 {
+        lines.next();
+    }
+    let mut newest = None;
+    for line in lines {
+        if !line.contains(thread_id) {
+            continue;
+        }
+        let Ok(object) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if object.get("id").and_then(Value::as_str) == Some(thread_id)
+            && let Some(title) = object
+                .get("thread_name")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+                .and_then(clean_provider_title)
+        {
+            newest = Some(title);
+        }
+    }
+    newest
+}
+
+fn clean_provider_title(title: String) -> Option<String> {
+    let title = title
+        .chars()
+        .map(|character| {
+            if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>();
+    let title = title.split_whitespace().collect::<Vec<_>>().join(" ");
+    let title = title.chars().take(160).collect::<String>();
+    (!title.is_empty()).then_some(title)
+}
+
+fn owner_regular_file(path: &Path) -> bool {
+    let Ok(metadata) = std::fs::symlink_metadata(path) else {
+        return false;
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    if metadata.uid() != unsafe { libc::geteuid() } {
+        return false;
+    }
+    true
+}
+
 fn scan_codex(root: &Path) -> Vec<HistoryEntry> {
     let mut result = Vec::new();
     // A bounded YYYY/MM/DD walk, not a general recursive one.
@@ -947,6 +1138,24 @@ mod tests {
     }
 
     #[test]
+    fn the_latest_custom_title_wins_over_claudes_generated_title() {
+        let temp = tempfile::tempdir().expect("temp");
+        let claude = temp.path().join("claude");
+        let uuid = "0199f2c4-1a2b-4c3d-8e9f-000000000010";
+        write(
+            &claude.join(format!("-p/{uuid}.jsonl")),
+            &format!(
+                "{}{}\n",
+                claude_transcript("/tmp", "vague first prompt", Some("Generated title")),
+                r#"{"type":"custom-title","customTitle":"My chosen title"}"#,
+            ),
+        );
+
+        let entries = scan_roots(&claude, &temp.path().join("codex"), &[]);
+        assert_eq!(entries[0].title.as_deref(), Some("My chosen title"));
+    }
+
+    #[test]
     fn a_transcript_without_a_cwd_is_not_resumable() {
         // There is nowhere to resume it into, so offering it would only fail.
         let temp = tempfile::tempdir().expect("temp");
@@ -1002,6 +1211,54 @@ mod tests {
         assert_eq!(entries[0].id, "thread-9");
         assert_eq!(entries[0].kind, HistoryKind::Codex);
         assert_eq!(entries[0].cwd, "/tmp");
+    }
+
+    #[test]
+    fn codex_title_prefers_explicit_name_then_index_then_database_fallback() {
+        let home = tempfile::tempdir().expect("home");
+        let codex_home = home.path().join(".codex");
+        std::fs::create_dir_all(&codex_home).expect("codex home");
+        let database = codex_home.join("state_5.sqlite");
+        let connection = Connection::open(&database).expect("database");
+        connection
+            .execute_batch(
+                "CREATE TABLE threads (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    title TEXT,
+                    first_user_message TEXT
+                );
+                INSERT INTO threads VALUES (
+                    'thread-9',
+                    'Explicit slash rename',
+                    'Generated database title',
+                    'First prompt fallback'
+                );",
+            )
+            .expect("schema");
+        write(
+            &codex_home.join("session_index.jsonl"),
+            "{\"id\":\"thread-9\",\"thread_name\":\"Indexed title\",\"updated_at\":1}\n",
+        );
+
+        assert_eq!(
+            codex_title(home.path(), "thread-9").as_deref(),
+            Some("Explicit slash rename")
+        );
+
+        connection
+            .execute("UPDATE threads SET name = NULL WHERE id = 'thread-9'", [])
+            .expect("clear name");
+        assert_eq!(
+            codex_title(home.path(), "thread-9").as_deref(),
+            Some("Indexed title")
+        );
+
+        std::fs::remove_file(codex_home.join("session_index.jsonl")).expect("remove index");
+        assert_eq!(
+            codex_title(home.path(), "thread-9").as_deref(),
+            Some("Generated database title")
+        );
     }
 
     #[test]
@@ -1098,7 +1355,7 @@ mod tests {
         symlink(&replacement, &path).expect("swap final component");
 
         assert_eq!(
-            trusted.latest_claude_ai_title().as_deref(),
+            trusted.latest_claude_title().as_deref(),
             Some("validated inode")
         );
     }

--- a/diri/crates/diri-engine/src/registry.rs
+++ b/diri/crates/diri-engine/src/registry.rs
@@ -62,6 +62,7 @@ pub struct Registry {
     dirty: bool,
     last_persist: Option<std::time::Instant>,
     cursor_title_refresh_at: Option<std::time::Instant>,
+    native_title_refresh_at: Option<std::time::Instant>,
 }
 
 /// Immutable input for a Cursor provider-store scan. The events watcher builds
@@ -80,6 +81,21 @@ pub(crate) struct CursorRefreshResult {
     request: CursorRefreshRequest,
     conversation: Option<crate::history::CursorConversation>,
     turn: Option<CursorTranscriptTurn>,
+}
+
+/// Immutable input for a local provider-title refresh. Like Cursor metadata,
+/// provider file/database reads happen after releasing the Registry lock.
+pub(crate) struct NativeTitleRefreshRequest {
+    id: String,
+    kind: AgentKind,
+    cwd: String,
+    agent_session_id: String,
+    transcript_path: Option<String>,
+}
+
+pub(crate) struct NativeTitleRefreshResult {
+    request: NativeTitleRefreshRequest,
+    title: Option<String>,
 }
 
 /// How long consecutive persists coalesce. Matches the Swift daemon's
@@ -132,6 +148,7 @@ impl Registry {
             dirty: false,
             last_persist: None,
             cursor_title_refresh_at: None,
+            native_title_refresh_at: None,
         }
     }
 
@@ -688,6 +705,77 @@ impl Registry {
         changed
     }
 
+    /// Captures live local Claude/Codex sessions due for a native title read.
+    /// The one-second bound mirrors provider title-generation cadence while
+    /// keeping transcript/database I/O off the 150 ms state watcher path.
+    pub(crate) fn native_title_refresh_requests(&mut self) -> Vec<NativeTitleRefreshRequest> {
+        let now = std::time::Instant::now();
+        if self.native_title_refresh_at.is_some_and(|previous| {
+            now.duration_since(previous) < std::time::Duration::from_secs(1)
+        }) {
+            return Vec::new();
+        }
+        self.native_title_refresh_at = Some(now);
+        self.sessions
+            .keys()
+            .filter_map(|id| {
+                let record = self.records.get(id)?;
+                if record.host.is_some()
+                    || !matches!(
+                        record.kind.id(),
+                        AgentKind::CLAUDE_CODE_ID | AgentKind::CODEX_ID
+                    )
+                    || !accepts_native_title(record.title_source)
+                {
+                    return None;
+                }
+                Some(NativeTitleRefreshRequest {
+                    id: id.clone(),
+                    kind: record.kind.clone(),
+                    cwd: record.cwd.clone(),
+                    agent_session_id: record.agent_session_id.clone()?,
+                    transcript_path: record.transcript_path.clone(),
+                })
+            })
+            .collect()
+    }
+
+    /// Applies a title only if the request still describes the same live
+    /// local conversation. Diri/user renames always remain authoritative.
+    pub(crate) fn apply_native_title_refreshes(
+        &mut self,
+        refreshes: Vec<NativeTitleRefreshResult>,
+    ) -> Vec<(String, SessionRecord)> {
+        let mut changed = Vec::new();
+        for refresh in refreshes {
+            let request = refresh.request;
+            if !self.sessions.contains_key(&request.id) {
+                continue;
+            }
+            let Some(record) = self.records.get_mut(&request.id) else {
+                continue;
+            };
+            if record.host.is_some()
+                || record.kind != request.kind
+                || record.cwd != request.cwd
+                || record.agent_session_id.as_deref() != Some(&request.agent_session_id)
+                || !accepts_native_title(record.title_source)
+            {
+                continue;
+            }
+            let Some(title) = refresh.title else {
+                continue;
+            };
+            if !apply_native_title(record, &title) {
+                continue;
+            }
+            record.updated_at = DateMillis::from(std::time::SystemTime::now());
+            self.dirty = true;
+            changed.push((request.id, record.clone()));
+        }
+        changed
+    }
+
     /// Ends a session but keeps its record, which is what archiving means here.
     pub fn terminate(
         &mut self,
@@ -830,8 +918,8 @@ impl Registry {
     /// Folds identity a hook payload carried into the record: the agent-side
     /// conversation id (what makes resume possible), the live transcript path
     /// (it MOVES when the agent enters a worktree), a first-prompt fallback,
-    /// and Claude's generated `ai-title` when it becomes available. Returns
-    /// whether anything changed.
+    /// and the provider's native conversation title when it becomes available.
+    /// Returns whether anything changed.
     pub fn apply_hook_metadata(&mut self, id: &str, meta: &crate::hooks::HookMetadata) -> bool {
         let Ok(home) = std::env::var("HOME") else {
             return self.apply_hook_metadata_with_home(id, meta, None);
@@ -877,17 +965,25 @@ impl Registry {
                         .flatten()
                 })
         });
-        let generated_title = self.records.get(id).and_then(|record| {
-            let accepts_generated_title = record.kind == diri_proto::AgentKind::CLAUDE_CODE
-                && matches!(
-                    record.title_source,
-                    TitleSource::Placeholder | TitleSource::FirstPrompt | TitleSource::Unknown
-                );
-            accepts_generated_title
-                .then_some(transcript.as_mut())
-                .flatten()
-                .and_then(|transcript| transcript.latest_claude_ai_title())
-                .and_then(|title| normalize_agent_title(&title))
+        let native_title = self.records.get(id).and_then(|record| {
+            if record.host.is_some() || !accepts_native_title(record.title_source) {
+                return None;
+            }
+            let title = match record.kind.id() {
+                diri_proto::AgentKind::CLAUDE_CODE_ID => transcript
+                    .as_mut()
+                    .and_then(|transcript| transcript.latest_claude_title()),
+                diri_proto::AgentKind::CODEX_ID => {
+                    let home = home?;
+                    let agent_id = meta
+                        .agent_session_id
+                        .as_deref()
+                        .or(record.agent_session_id.as_deref())?;
+                    crate::history::codex_title(home, agent_id)
+                }
+                _ => None,
+            }?;
+            normalize_agent_title(&title).filter(|title| !is_generic_terminal_title(title, record))
         });
         let cursor = self.records.get(id).and_then(|record| {
             if !is_local_cursor_record(record) {
@@ -934,7 +1030,7 @@ impl Registry {
             record.title_source = TitleSource::FirstPrompt;
             changed = true;
         }
-        if let Some(title) = generated_title
+        if let Some(title) = native_title
             && (record.title != title || record.title_source != TitleSource::AgentProvided)
         {
             record.title = title;
@@ -1285,6 +1381,39 @@ pub(crate) fn scan_cursor_refreshes(
         .collect()
 }
 
+pub(crate) fn scan_native_title_refreshes(
+    requests: Vec<NativeTitleRefreshRequest>,
+) -> Vec<NativeTitleRefreshResult> {
+    let Some(home) = user_home() else {
+        return Vec::new();
+    };
+    requests
+        .into_iter()
+        .map(|request| {
+            let title = match request.kind.id() {
+                AgentKind::CLAUDE_CODE_ID => request
+                    .transcript_path
+                    .as_deref()
+                    .and_then(|path| {
+                        crate::history::validate_transcript_path(
+                            &home,
+                            &request.kind,
+                            &request.agent_session_id,
+                            &request.cwd,
+                            Path::new(path),
+                        )
+                    })
+                    .and_then(|mut transcript| transcript.latest_claude_title()),
+                AgentKind::CODEX_ID => {
+                    crate::history::codex_title(&home, &request.agent_session_id)
+                }
+                _ => None,
+            };
+            NativeTitleRefreshResult { request, title }
+        })
+        .collect()
+}
+
 fn apply_cursor_conversation(
     record: &mut SessionRecord,
     conversation: crate::history::CursorConversation,
@@ -1317,6 +1446,33 @@ fn apply_cursor_conversation(
         changed = true;
     }
     changed
+}
+
+fn accepts_native_title(source: TitleSource) -> bool {
+    matches!(
+        source,
+        TitleSource::Placeholder
+            | TitleSource::FirstPrompt
+            | TitleSource::AgentProvided
+            | TitleSource::Unknown
+    )
+}
+
+fn apply_native_title(record: &mut SessionRecord, title: &str) -> bool {
+    if !accepts_native_title(record.title_source) {
+        return false;
+    }
+    let Some(title) =
+        normalize_agent_title(title).filter(|title| !is_generic_terminal_title(title, record))
+    else {
+        return false;
+    };
+    if record.title == title && record.title_source == TitleSource::AgentProvided {
+        return false;
+    }
+    record.title = title;
+    record.title_source = TitleSource::AgentProvided;
+    true
 }
 
 fn is_local_cursor_record(record: &SessionRecord) -> bool {
@@ -2160,6 +2316,58 @@ mod tests {
     }
 
     #[test]
+    fn codex_native_titles_promote_and_follow_rename() {
+        let temp = tempfile::tempdir().expect("temp");
+        let transcript = temp
+            .path()
+            .join(".codex/sessions/2026/08/13/rollout-now-thread-9.jsonl");
+        std::fs::create_dir_all(transcript.parent().expect("parent")).expect("mkdir");
+        std::fs::write(
+            &transcript,
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"thread-9\",\"cwd\":\"/tmp\"}}\n",
+        )
+        .expect("write transcript");
+        let index = temp.path().join(".codex/session_index.jsonl");
+        std::fs::write(
+            &index,
+            "{\"id\":\"thread-9\",\"thread_name\":\"Repair chat titles\",\"updated_at\":1}\n",
+        )
+        .expect("write index");
+        let mut registry = Registry::new(engine(), temp.path().join("state.json"));
+        let mut session = record("codex");
+        session.kind = AgentKind::CODEX;
+        session.agent_session_id = Some("thread-9".to_owned());
+        session.title = "initial vague prompt".to_owned();
+        session.title_source = TitleSource::FirstPrompt;
+        registry.insert_record(session);
+
+        assert!(registry.apply_hook_metadata_with_home(
+            "codex",
+            &crate::hooks::HookMetadata::default(),
+            Some(temp.path()),
+        ));
+        let titled = registry.record("codex").expect("record");
+        assert_eq!(titled.title, "Repair chat titles");
+        assert_eq!(titled.title_source, TitleSource::AgentProvided);
+
+        std::fs::write(
+            &index,
+            "{\"id\":\"thread-9\",\"thread_name\":\"Repair chat titles\",\"updated_at\":1}\n\
+             {\"id\":\"thread-9\",\"thread_name\":\"Chosen with slash rename\",\"updated_at\":2}\n",
+        )
+        .expect("rename index");
+        assert!(registry.apply_hook_metadata_with_home(
+            "codex",
+            &crate::hooks::HookMetadata::default(),
+            Some(temp.path()),
+        ));
+        assert_eq!(
+            registry.record("codex").expect("record").title,
+            "Chosen with slash rename"
+        );
+    }
+
+    #[test]
     fn arbitrary_hook_transcript_paths_never_enter_the_record() {
         let temp = tempfile::tempdir().expect("temp");
         let outside = temp.path().join("outside.jsonl");
@@ -2327,6 +2535,26 @@ mod tests {
         fold_session_view(&mut cursor, &named_working);
         assert_eq!(cursor.title, "Fix the cursor session title");
         assert_eq!(cursor.title_source, TitleSource::FirstPrompt);
+    }
+
+    #[test]
+    fn native_title_updates_follow_the_provider_but_respect_diri_renames() {
+        let mut session = record("codex");
+        session.kind = AgentKind::CODEX;
+        session.title = "first prompt".into();
+        session.title_source = TitleSource::FirstPrompt;
+
+        assert!(apply_native_title(&mut session, "Generated title"));
+        assert_eq!(session.title, "Generated title");
+        assert_eq!(session.title_source, TitleSource::AgentProvided);
+
+        assert!(apply_native_title(&mut session, "Chosen with slash rename"));
+        assert_eq!(session.title, "Chosen with slash rename");
+
+        session.title = "Diri sidebar rename".into();
+        session.title_source = TitleSource::UserRename;
+        assert!(!apply_native_title(&mut session, "Provider changed again"));
+        assert_eq!(session.title, "Diri sidebar rename");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- show live placeholder sessions as Untitled and reserve Ended for exited sessions
- synchronize Claude custom and generated titles from transcripts
- synchronize Codex explicit and generated titles from its native state database and session index
- keep manual Diri renames authoritative and share title display behavior across sidebar surfaces

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --workspace --release`