### PR TITLE
Add customizable keyboard shortcuts

### DIFF
--- a/diri/crates/diri-app/src/commands.rs
+++ b/diri/crates/diri-app/src/commands.rs
@@ -4,7 +4,8 @@
 //! presentation live together here. Views execute actions; they do not decode
 //! keystrokes or maintain their own copies of shortcut labels.
 
-use std::borrow::Cow;
+use std::collections::BTreeMap;
+use std::sync::{OnceLock, RwLock};
 
 use gpui::{Action, App, KeyBinding, Keystroke, actions};
 
@@ -13,6 +14,10 @@ pub const SESSION_NAVIGATION_CONTEXT: &str = "DiriSessionNavigation";
 pub const TERMINAL_CONTEXT: &str = "DiriTerminal";
 pub const NAVIGATION_CONTEXT: &str = "DiriNavigation";
 pub const UTILITY_CONTEXT: &str = "DiriUtility";
+
+pub type ShortcutOverrides = BTreeMap<String, Option<String>>;
+
+static ACTIVE_SHORTCUT_OVERRIDES: OnceLock<RwLock<ShortcutOverrides>> = OnceLock::new();
 
 actions!(diri_app, [Quit, HideApp, CloseWindow]);
 
@@ -126,6 +131,42 @@ pub enum CommandId {
     ResetZoom,
     Paste,
     CopySelection,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ShortcutCategory {
+    Sessions,
+    Navigation,
+    Workspace,
+    Terminal,
+    Application,
+}
+
+impl ShortcutCategory {
+    pub const ALL: [Self; 5] = [
+        Self::Sessions,
+        Self::Navigation,
+        Self::Workspace,
+        Self::Terminal,
+        Self::Application,
+    ];
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Sessions => "Sessions",
+            Self::Navigation => "Navigation",
+            Self::Workspace => "Workspace",
+            Self::Terminal => "Terminal",
+            Self::Application => "Application",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ShortcutMetadata {
+    pub title: &'static str,
+    pub description: &'static str,
+    pub category: ShortcutCategory,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -550,11 +591,12 @@ pub fn command(id: CommandId) -> &'static CommandSpec {
 /// bindings. Modal surfaces use this to decide which application commands may
 /// continue through capture without duplicating raw shortcut strings.
 pub fn matches_keystroke(id: CommandId, keystroke: &Keystroke) -> bool {
+    let overrides = active_shortcut_overrides()
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     command(id)
-        .keystroke
+        .effective_keystrokes(&overrides)
         .into_iter()
-        .chain(command(id).alternate_keystrokes.iter().copied())
-        .filter_map(|binding| platform_keystroke(id, binding))
         .filter_map(|binding| Keystroke::parse(&binding).ok())
         .any(|binding| {
             binding.modifiers == keystroke.modifiers
@@ -563,22 +605,82 @@ pub fn matches_keystroke(id: CommandId, keystroke: &Keystroke) -> bool {
         })
 }
 
-pub fn bind_default_keys(cx: &mut App) {
-    cx.bind_keys(COMMANDS.iter().flat_map(CommandSpec::key_bindings));
+/// Installs the shipped keymap plus persisted user overrides at app startup.
+pub fn bind_keys(cx: &mut App, overrides: &ShortcutOverrides) {
+    set_active_shortcut_overrides(overrides);
+    bind_active_keys(cx, overrides);
+}
+
+/// Replaces the live keymap after an edit. Diri is the only owner of GPUI key
+/// bindings in this application, so rebuilding avoids leaving stale custom
+/// bindings active after a user changes or clears one.
+pub fn rebind_keys(cx: &mut App, overrides: &ShortcutOverrides) {
+    set_active_shortcut_overrides(overrides);
+    cx.clear_key_bindings();
+    bind_active_keys(cx, overrides);
+}
+
+fn bind_active_keys(cx: &mut App, overrides: &ShortcutOverrides) {
+    cx.bind_keys(
+        COMMANDS
+            .iter()
+            .flat_map(|command| command.key_bindings(overrides)),
+    );
+}
+
+fn active_shortcut_overrides() -> &'static RwLock<ShortcutOverrides> {
+    ACTIVE_SHORTCUT_OVERRIDES.get_or_init(|| RwLock::new(ShortcutOverrides::new()))
+}
+
+fn set_active_shortcut_overrides(overrides: &ShortcutOverrides) {
+    *active_shortcut_overrides()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = overrides.clone();
 }
 
 impl CommandSpec {
-    fn key_bindings(&self) -> Vec<KeyBinding> {
-        self.keystroke
+    fn key_bindings(&self, overrides: &ShortcutOverrides) -> Vec<KeyBinding> {
+        self.effective_keystrokes(overrides)
             .into_iter()
-            .chain(self.alternate_keystrokes.iter().copied())
-            .filter_map(|key| platform_keystroke(self.id, key))
             .map(|key| self.key_binding(&key))
             .collect()
     }
 
     pub fn shortcut_label(&self) -> Option<String> {
-        self.shortcut.map(platform_shortcut_label)
+        let overrides = active_shortcut_overrides()
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        self.shortcut_label_for(&overrides)
+    }
+
+    pub fn shortcut_label_for(&self, overrides: &ShortcutOverrides) -> Option<String> {
+        match overrides.get(self.stable_id) {
+            Some(None) => None,
+            Some(Some(binding)) if Keystroke::parse(binding).is_ok() => Keystroke::parse(binding)
+                .ok()
+                .map(|key| shortcut_label_for_keystroke(&key)),
+            _ => self
+                .keystroke
+                .and_then(|binding| platform_keystroke(self.id, binding))
+                .and_then(|_| self.shortcut.map(platform_shortcut_label)),
+        }
+    }
+
+    pub fn is_overridden(&self, overrides: &ShortcutOverrides) -> bool {
+        overrides.contains_key(self.stable_id)
+    }
+
+    pub fn effective_keystrokes(&self, overrides: &ShortcutOverrides) -> Vec<String> {
+        match overrides.get(self.stable_id) {
+            Some(None) => Vec::new(),
+            Some(Some(binding)) if Keystroke::parse(binding).is_ok() => vec![binding.clone()],
+            _ => self
+                .keystroke
+                .into_iter()
+                .chain(self.alternate_keystrokes.iter().copied())
+                .filter_map(|key| platform_keystroke(self.id, key))
+                .collect(),
+        }
     }
 
     fn key_binding(&self, key: &str) -> KeyBinding {
@@ -654,19 +756,19 @@ impl CommandSpec {
 }
 
 #[cfg(target_os = "macos")]
-fn platform_keystroke(_id: CommandId, key: &'static str) -> Option<Cow<'static, str>> {
-    Some(Cow::Borrowed(key))
+fn platform_keystroke(_id: CommandId, key: &str) -> Option<String> {
+    Some(key.to_owned())
 }
 
 #[cfg(not(target_os = "macos"))]
-fn platform_keystroke(id: CommandId, key: &'static str) -> Option<Cow<'static, str>> {
+fn platform_keystroke(id: CommandId, key: &str) -> Option<String> {
     if id == CommandId::HideApp {
         return None;
     }
     let key = key
         .replace("cmd-ctrl-", "ctrl-shift-")
         .replace("cmd-", "ctrl-");
-    Some(Cow::Owned(key))
+    Some(key)
 }
 
 #[cfg(target_os = "macos")]
@@ -688,6 +790,67 @@ fn platform_shortcut_label(label: &str) -> String {
     modifiers.join("+")
 }
 
+#[cfg(target_os = "macos")]
+fn shortcut_label_for_keystroke(keystroke: &Keystroke) -> String {
+    let mut label = String::new();
+    if keystroke.modifiers.function {
+        label.push_str("fn");
+    }
+    if keystroke.modifiers.control {
+        label.push('⌃');
+    }
+    if keystroke.modifiers.alt {
+        label.push('⌥');
+    }
+    if keystroke.modifiers.shift {
+        label.push('⇧');
+    }
+    if keystroke.modifiers.platform {
+        label.push('⌘');
+    }
+    label.push_str(match keystroke.key.as_str() {
+        "backspace" => "⌫",
+        "delete" => "⌦",
+        "enter" => "↩",
+        "tab" => "⇥",
+        "escape" => "⎋",
+        "space" => "Space",
+        "up" => "↑",
+        "down" => "↓",
+        "left" => "←",
+        "right" => "→",
+        key => return format!("{label}{}", key.to_ascii_uppercase()),
+    });
+    label
+}
+
+#[cfg(not(target_os = "macos"))]
+fn shortcut_label_for_keystroke(keystroke: &Keystroke) -> String {
+    let mut parts = Vec::new();
+    if keystroke.modifiers.control {
+        parts.push("Ctrl".to_owned());
+    }
+    if keystroke.modifiers.alt {
+        parts.push("Alt".to_owned());
+    }
+    if keystroke.modifiers.shift {
+        parts.push("Shift".to_owned());
+    }
+    if keystroke.modifiers.platform {
+        parts.push("Super".to_owned());
+    }
+    if keystroke.modifiers.function {
+        parts.push("Fn".to_owned());
+    }
+    let key = match keystroke.key.as_str() {
+        "escape" => "Esc".to_owned(),
+        "space" => "Space".to_owned(),
+        key => key.to_ascii_uppercase(),
+    };
+    parts.push(key);
+    parts.join("+")
+}
+
 pub fn primary_shortcut_label(key: &str) -> String {
     platform_shortcut_label(&format!("⌘{key}"))
 }
@@ -697,6 +860,262 @@ pub fn primary_click_label() -> &'static str {
         "Command-click"
     } else {
         "Ctrl-click"
+    }
+}
+
+/// Finds another command that already owns `binding`. Contexts are
+/// deliberately treated as overlapping: application shortcuts remain active
+/// while terminal and navigation contexts are focused, so allowing a duplicate
+/// would make the result depend on focus in ways the settings row cannot show.
+pub fn shortcut_conflict(
+    id: CommandId,
+    binding: &str,
+    overrides: &ShortcutOverrides,
+) -> Option<&'static CommandSpec> {
+    let candidate = Keystroke::parse(binding).ok()?;
+    COMMANDS.iter().find(|command| {
+        command.id != id
+            && command
+                .effective_keystrokes(overrides)
+                .iter()
+                .any(|current| {
+                    Keystroke::parse(current).is_ok_and(|current| {
+                        current.modifiers == candidate.modifiers && current.key == candidate.key
+                    })
+                })
+    })
+}
+
+impl CommandId {
+    pub const fn shortcut_metadata(self) -> ShortcutMetadata {
+        use ShortcutCategory::{Application, Navigation, Sessions, Terminal, Workspace};
+        match self {
+            Self::CloseSession => ShortcutMetadata {
+                title: "Close session",
+                description: "Close the selected session",
+                category: Sessions,
+            },
+            Self::ReopenSession => ShortcutMetadata {
+                title: "Reopen closed session",
+                description: "Restore the most recently closed session",
+                category: Sessions,
+            },
+            Self::OpenLauncher => ShortcutMetadata {
+                title: "New session",
+                description: "Open the new session picker",
+                category: Sessions,
+            },
+            Self::NewDefaultSession => ShortcutMetadata {
+                title: "New default session",
+                description: "Start a session with the default agent",
+                category: Sessions,
+            },
+            Self::NewTerminal => ShortcutMetadata {
+                title: "New terminal",
+                description: "Start a standalone shell session",
+                category: Sessions,
+            },
+            Self::NewCodexSession => ShortcutMetadata {
+                title: "New Codex session",
+                description: "Start a new Codex session",
+                category: Sessions,
+            },
+            Self::ArchiveSelectedSession => ShortcutMetadata {
+                title: "Archive session",
+                description: "Archive the selected session",
+                category: Sessions,
+            },
+            Self::RenameSelectedSession => ShortcutMetadata {
+                title: "Rename session",
+                description: "Rename the selected session",
+                category: Sessions,
+            },
+            Self::DelegateSelectedSession => ShortcutMetadata {
+                title: "Delegate session",
+                description: "Hand off work from the selected session",
+                category: Sessions,
+            },
+            Self::SelectNextAttentionSession => ShortcutMetadata {
+                title: "Next session needing attention",
+                description: "Jump to the next session waiting for you",
+                category: Sessions,
+            },
+            Self::QuoteSelection => ShortcutMetadata {
+                title: "Quote selection",
+                description: "Add the terminal selection to this session's composer",
+                category: Sessions,
+            },
+            Self::QuoteSelectionToSession => ShortcutMetadata {
+                title: "Quote selection to session",
+                description: "Send the terminal selection to another session",
+                category: Sessions,
+            },
+            Self::ToggleHistory => ShortcutMetadata {
+                title: "Conversation history",
+                description: "Open or close conversation history",
+                category: Navigation,
+            },
+            Self::ToggleOverview => ShortcutMetadata {
+                title: "Session overview",
+                description: "Open or close the session overview",
+                category: Navigation,
+            },
+            Self::OpenWorktrees => ShortcutMetadata {
+                title: "Worktrees overview",
+                description: "Open the Git worktrees overview",
+                category: Navigation,
+            },
+            Self::ToggleCommandPalette => ShortcutMetadata {
+                title: "Command palette",
+                description: "Search all available commands",
+                category: Navigation,
+            },
+            Self::ToggleQuickOpen => ShortcutMetadata {
+                title: "Quick Open",
+                description: "Find and open a project folder",
+                category: Navigation,
+            },
+            Self::SelectPreviousSession => ShortcutMetadata {
+                title: "Previous session",
+                description: "Select the previous session in the sidebar",
+                category: Navigation,
+            },
+            Self::SelectNextSession => ShortcutMetadata {
+                title: "Next session",
+                description: "Select the next session in the sidebar",
+                category: Navigation,
+            },
+            Self::MoveSelectedSessionUp => ShortcutMetadata {
+                title: "Move session up",
+                description: "Move the selected session up in the sidebar",
+                category: Navigation,
+            },
+            Self::MoveSelectedSessionDown => ShortcutMetadata {
+                title: "Move session down",
+                description: "Move the selected session down in the sidebar",
+                category: Navigation,
+            },
+            Self::SelectSession1 => {
+                session_slot_metadata("Select session 1", "Select the first session")
+            }
+            Self::SelectSession2 => {
+                session_slot_metadata("Select session 2", "Select the second session")
+            }
+            Self::SelectSession3 => {
+                session_slot_metadata("Select session 3", "Select the third session")
+            }
+            Self::SelectSession4 => {
+                session_slot_metadata("Select session 4", "Select the fourth session")
+            }
+            Self::SelectSession5 => {
+                session_slot_metadata("Select session 5", "Select the fifth session")
+            }
+            Self::SelectSession6 => {
+                session_slot_metadata("Select session 6", "Select the sixth session")
+            }
+            Self::SelectSession7 => {
+                session_slot_metadata("Select session 7", "Select the seventh session")
+            }
+            Self::SelectSession8 => {
+                session_slot_metadata("Select session 8", "Select the eighth session")
+            }
+            Self::SelectLastSession => {
+                session_slot_metadata("Select last session", "Select the last session")
+            }
+            Self::ToggleSidebar => ShortcutMetadata {
+                title: "Toggle sidebar",
+                description: "Show or hide the sessions sidebar",
+                category: Workspace,
+            },
+            Self::FocusSidebar => ShortcutMetadata {
+                title: "Focus sidebar",
+                description: "Move keyboard focus to the sessions sidebar",
+                category: Workspace,
+            },
+            Self::ToggleInspector => ShortcutMetadata {
+                title: "Toggle inspector",
+                description: "Show or hide the session inspector",
+                category: Workspace,
+            },
+            Self::ToggleAuxiliaryTerminal => ShortcutMetadata {
+                title: "Toggle auxiliary terminal",
+                description: "Show or hide the lower terminal pane",
+                category: Workspace,
+            },
+            Self::OpenFind => ShortcutMetadata {
+                title: "Find in terminal",
+                description: "Search the active terminal output",
+                category: Terminal,
+            },
+            Self::FindNext => ShortcutMetadata {
+                title: "Find next",
+                description: "Move to the next terminal search result",
+                category: Terminal,
+            },
+            Self::FindPrevious => ShortcutMetadata {
+                title: "Find previous",
+                description: "Move to the previous terminal search result",
+                category: Terminal,
+            },
+            Self::ZoomIn => ShortcutMetadata {
+                title: "Increase text size",
+                description: "Make terminal text larger",
+                category: Terminal,
+            },
+            Self::ZoomOut => ShortcutMetadata {
+                title: "Decrease text size",
+                description: "Make terminal text smaller",
+                category: Terminal,
+            },
+            Self::ResetZoom => ShortcutMetadata {
+                title: "Reset text size",
+                description: "Restore the default terminal text size",
+                category: Terminal,
+            },
+            Self::Paste => ShortcutMetadata {
+                title: "Paste",
+                description: "Paste clipboard contents into the terminal",
+                category: Terminal,
+            },
+            Self::CopySelection => ShortcutMetadata {
+                title: "Copy selection",
+                description: "Copy the terminal selection",
+                category: Terminal,
+            },
+            Self::OpenSettings => ShortcutMetadata {
+                title: "Open settings",
+                description: "Open or close Diri settings",
+                category: Application,
+            },
+            Self::CheckForUpdates => ShortcutMetadata {
+                title: "Check for updates",
+                description: "Look for a newer version of Diri",
+                category: Application,
+            },
+            Self::CloseWindow => ShortcutMetadata {
+                title: "Close window",
+                description: "Close the current Diri window",
+                category: Application,
+            },
+            Self::HideApp => ShortcutMetadata {
+                title: "Hide Diri",
+                description: "Hide all Diri windows",
+                category: Application,
+            },
+            Self::Quit => ShortcutMetadata {
+                title: "Quit Diri",
+                description: "Close Diri and leave no windows open",
+                category: Application,
+            },
+        }
+    }
+}
+
+const fn session_slot_metadata(title: &'static str, description: &'static str) -> ShortcutMetadata {
+    ShortcutMetadata {
+        title,
+        description,
+        category: ShortcutCategory::Navigation,
     }
 }
 
@@ -853,9 +1272,51 @@ mod tests {
     fn every_registered_keystroke_parses() {
         let binding_count: usize = COMMANDS
             .iter()
-            .map(|command| command.key_bindings().len())
+            .map(|command| command.key_bindings(&ShortcutOverrides::new()).len())
             .sum();
         assert!(binding_count > COMMANDS.len());
+    }
+
+    #[test]
+    fn overrides_replace_all_shipped_bindings_and_can_unassign_a_command() {
+        let previous = command(CommandId::SelectPreviousSession);
+        let mut overrides = ShortcutOverrides::new();
+        overrides.insert(
+            previous.stable_id.to_owned(),
+            Some("cmd-shift-y".to_owned()),
+        );
+        assert_eq!(previous.effective_keystrokes(&overrides), ["cmd-shift-y"]);
+        #[cfg(target_os = "macos")]
+        assert_eq!(
+            previous.shortcut_label_for(&overrides).as_deref(),
+            Some("⇧⌘Y")
+        );
+        #[cfg(not(target_os = "macos"))]
+        assert_eq!(
+            previous.shortcut_label_for(&overrides).as_deref(),
+            Some("Shift+Super+Y")
+        );
+
+        overrides.insert(previous.stable_id.to_owned(), None);
+        assert!(previous.effective_keystrokes(&overrides).is_empty());
+        assert_eq!(previous.shortcut_label_for(&overrides), None);
+    }
+
+    #[test]
+    fn conflicts_include_alternate_bindings() {
+        let overrides = ShortcutOverrides::new();
+        let conflict = shortcut_conflict(CommandId::OpenLauncher, "cmd-[", &overrides)
+            .expect("navigation alternate should be reserved");
+        assert_eq!(conflict.id, CommandId::SelectPreviousSession);
+    }
+
+    #[test]
+    fn every_command_has_shortcut_page_copy() {
+        for command in COMMANDS {
+            let metadata = command.id.shortcut_metadata();
+            assert!(!metadata.title.is_empty());
+            assert!(!metadata.description.is_empty());
+        }
     }
 
     #[test]

--- a/diri/crates/diri-app/src/main.rs
+++ b/diri/crates/diri-app/src/main.rs
@@ -107,6 +107,12 @@ fn install_app_menus(cx: &mut App) {
             let _ = window.update(cx, |_, window, _| window.remove_window());
         }
     });
+    refresh_app_menus(cx);
+}
+
+/// Rebuild native menu shortcut labels after the user edits the live keymap.
+/// Action handlers are installed only once by `install_app_menus`.
+pub(crate) fn refresh_app_menus(cx: &mut App) {
     #[cfg(target_os = "macos")]
     cx.set_menus([
         Menu::new("diri").items([
@@ -354,7 +360,15 @@ fn main() {
         load_system_fonts(cx);
         #[cfg(target_os = "macos")]
         diri_ui::set_mark_rasterizer(macos::brand_raster::raster_mark);
-        commands::bind_default_keys(cx);
+        let shortcut_overrides = services
+            .store
+            .store
+            .read()
+            .expect("session store lock poisoned")
+            .preferences()
+            .shortcut_overrides
+            .clone();
+        commands::bind_keys(cx, &shortcut_overrides);
         install_app_menus(cx);
         let quit_services = Arc::clone(&services);
         let quit_updates = services.updates.clone();

--- a/diri/crates/diri-app/src/settings.rs
+++ b/diri/crates/diri-app/src/settings.rs
@@ -44,15 +44,17 @@ pub enum SettingsTab {
     #[default]
     General,
     Agents,
+    Shortcuts,
     Terminal,
     Resources,
     Remote,
 }
 
 impl SettingsTab {
-    pub const ALL: [Self; 5] = [
+    pub const ALL: [Self; 6] = [
         Self::General,
         Self::Agents,
+        Self::Shortcuts,
         Self::Terminal,
         Self::Resources,
         Self::Remote,
@@ -62,6 +64,7 @@ impl SettingsTab {
         match self {
             Self::General => "General",
             Self::Agents => "Agents",
+            Self::Shortcuts => "Shortcuts",
             Self::Terminal => "Terminal",
             Self::Resources => "Resources",
             Self::Remote => "Remote",
@@ -72,6 +75,7 @@ impl SettingsTab {
         match self {
             Self::General => "Startup, sessions, and updates",
             Self::Agents => "Installed CLIs and quick create",
+            Self::Shortcuts => "Keyboard commands and bindings",
             Self::Terminal => "Appearance and text size",
             Self::Resources => "Idle sessions and memory",
             Self::Remote => "SSH execution hosts",
@@ -82,7 +86,9 @@ impl SettingsTab {
     /// describe the machines and resources sessions run on.
     pub const fn section(self) -> SettingsSection {
         match self {
-            Self::General | Self::Agents | Self::Terminal => SettingsSection::Personal,
+            Self::General | Self::Agents | Self::Shortcuts | Self::Terminal => {
+                SettingsSection::Personal
+            }
             Self::Resources | Self::Remote => SettingsSection::System,
         }
     }
@@ -91,6 +97,7 @@ impl SettingsTab {
         match self {
             Self::General => "gearshape",
             Self::Agents => "sparkles",
+            Self::Shortcuts => "keyboard",
             Self::Terminal => "terminal",
             Self::Resources => "server.rack",
             Self::Remote => "network",

--- a/diri/crates/diri-app/src/store/prefs.rs
+++ b/diri/crates/diri-app/src/store/prefs.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -122,6 +123,12 @@ pub struct Prefs {
     /// Versioned, locally owned one-action Agent workflows.
     #[serde(default, deserialize_with = "deserialize_recipe_book")]
     pub launch_recipes: LaunchRecipeBook,
+    /// Per-command keyboard overrides keyed by the command registry's stable
+    /// id. A missing entry uses the shipped binding, `null` leaves the command
+    /// unassigned, and a string contains a GPUI keystroke such as `cmd-shift-p`.
+    /// Unknown ids are retained so opening these preferences in an older diri
+    /// build does not erase settings written by a newer one.
+    pub shortcut_overrides: BTreeMap<String, Option<String>>,
     /// Session that should regain focus after the daemon's initial hydrate.
     pub last_selected_session: Option<SessionId>,
 }
@@ -156,6 +163,7 @@ impl Default for Prefs {
             sidebar_collapsed_sessions: Vec::new(),
             sidebar_expanded_archives: Vec::new(),
             launch_recipes: LaunchRecipeBook::default(),
+            shortcut_overrides: BTreeMap::new(),
             last_selected_session: None,
         }
     }
@@ -266,6 +274,17 @@ mod tests {
             .remove("launchRecipes");
         let prefs: Prefs = serde_json::from_value(value).expect("old preferences remain readable");
         assert!(prefs.launch_recipes.items().is_empty());
+    }
+
+    #[test]
+    fn older_preferences_migrate_to_default_shortcuts() {
+        let mut value = serde_json::to_value(Prefs::default()).expect("serialize prefs");
+        value
+            .as_object_mut()
+            .expect("prefs object")
+            .remove("shortcutOverrides");
+        let prefs: Prefs = serde_json::from_value(value).expect("old preferences remain readable");
+        assert!(prefs.shortcut_overrides.is_empty());
     }
 
     #[test]

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -29,8 +29,8 @@ use gpui::{
 use tokio::runtime::Runtime;
 
 use crate::commands::{
-    Activate, CloseSurface, CommandId, MoveDown, MoveUp, OpenSettings, OpenWorktrees,
-    ToggleHistory, UTILITY_CONTEXT,
+    Activate, COMMANDS, CloseSurface, CommandId, MoveDown, MoveUp, OpenSettings, OpenWorktrees,
+    ShortcutCategory, ToggleHistory, UTILITY_CONTEXT,
 };
 const SETTINGS_CONTENT_MAX_WIDTH: f32 = 760.0;
 const SETTINGS_TRANSITION_DURATION: Duration = Duration::from_millis(190);
@@ -122,6 +122,12 @@ struct AgentPathEditor {
     host: Option<String>,
     path: QueryEditor,
     show_in_quick_create: bool,
+    error: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct ShortcutEditor {
+    command: CommandId,
     error: Option<String>,
 }
 
@@ -254,6 +260,9 @@ pub struct UtilitySurfaces {
     settings_scroll: ScrollHandle,
     settings_search: QueryEditor,
     settings_search_active: bool,
+    shortcut_search: QueryEditor,
+    shortcut_search_active: bool,
+    shortcut_editor: Option<ShortcutEditor>,
     settings_transition_generation: u64,
     settings_menu: Option<SettingsMenu>,
     agents_host: Option<String>,
@@ -304,6 +313,7 @@ impl UtilitySurfaces {
         let settings_tab = match settings_preview.as_deref() {
             Some("terminal") => SettingsTab::Terminal,
             Some("agents") => SettingsTab::Agents,
+            Some("shortcuts") => SettingsTab::Shortcuts,
             Some("resources") => SettingsTab::Resources,
             Some("remote") => SettingsTab::Remote,
             _ => SettingsTab::General,
@@ -364,6 +374,9 @@ impl UtilitySurfaces {
             settings_scroll: ScrollHandle::new(),
             settings_search: QueryEditor::default(),
             settings_search_active: false,
+            shortcut_search: QueryEditor::default(),
+            shortcut_search_active: false,
+            shortcut_editor: None,
             settings_transition_generation: 0,
             settings_menu: None,
             agents_host,
@@ -554,7 +567,7 @@ impl UtilitySurfaces {
         cx.notify();
     }
 
-    fn persist_prefs(&mut self) {
+    fn persist_prefs(&mut self) -> bool {
         self.prefs.normalize();
         let prefs = self.prefs.clone();
         if let Err(error) = self
@@ -564,9 +577,11 @@ impl UtilitySurfaces {
             .update_preferences(|shared| *shared = prefs)
         {
             self.activity = format!("Could not save settings: {error}");
+            false
         } else {
             self.store_runtime.publish_local_change();
             self.activity = "Settings saved for diri".to_owned();
+            true
         }
     }
 
@@ -1038,6 +1053,9 @@ impl UtilitySurfaces {
         self.settings_menu = None;
         self.host_editor = None;
         self.agent_path_editor = None;
+        self.shortcut_search.clear();
+        self.shortcut_search_active = false;
+        self.shortcut_editor = None;
         cx.notify();
     }
 
@@ -1111,6 +1129,8 @@ impl UtilitySurfaces {
         self.settings_menu = None;
         self.host_editor = None;
         self.agent_path_editor = None;
+        self.shortcut_search_active = false;
+        self.shortcut_editor = None;
         if tab == SettingsTab::Remote {
             self.reload_hosts();
         } else if tab == SettingsTab::Agents {
@@ -1120,6 +1140,199 @@ impl UtilitySurfaces {
                 .request_agent_catalog(self.agents_host.clone(), false);
         }
         cx.notify();
+    }
+
+    fn begin_shortcut_edit(
+        &mut self,
+        command: CommandId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.settings_search_active = false;
+        self.shortcut_search_active = false;
+        self.shortcut_editor = Some(ShortcutEditor {
+            command,
+            error: None,
+        });
+        self.focus.focus(window, cx);
+        cx.notify();
+    }
+
+    fn focus_shortcut_search(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.shortcut_editor = None;
+        self.settings_search_active = false;
+        self.shortcut_search_active = true;
+        self.focus.focus(window, cx);
+        cx.notify();
+    }
+
+    fn clear_shortcut_search(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.shortcut_search.clear();
+        self.focus_shortcut_search(window, cx);
+    }
+
+    fn save_shortcut_override(
+        &mut self,
+        command: CommandId,
+        value: Option<Option<String>>,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let stable_id = crate::commands::command(command).stable_id.to_owned();
+        let previous = match value {
+            Some(value) => self
+                .prefs
+                .shortcut_overrides
+                .insert(stable_id.clone(), value),
+            None => self.prefs.shortcut_overrides.remove(&stable_id),
+        };
+        if !self.persist_prefs() {
+            match previous {
+                Some(previous) => {
+                    self.prefs.shortcut_overrides.insert(stable_id, previous);
+                }
+                None => {
+                    self.prefs.shortcut_overrides.remove(&stable_id);
+                }
+            }
+            return false;
+        }
+
+        crate::commands::rebind_keys(cx, &self.prefs.shortcut_overrides);
+        crate::refresh_app_menus(cx);
+        self.activity = format!("Updated {}", command.shortcut_metadata().title);
+        true
+    }
+
+    fn assign_shortcut(&mut self, command: CommandId, binding: String, cx: &mut Context<Self>) {
+        if let Some(conflict) =
+            crate::commands::shortcut_conflict(command, &binding, &self.prefs.shortcut_overrides)
+        {
+            if let Some(editor) = &mut self.shortcut_editor {
+                editor.error = Some(format!(
+                    "Already used by {}.",
+                    conflict.id.shortcut_metadata().title
+                ));
+            }
+            cx.notify();
+            return;
+        }
+        if self.save_shortcut_override(command, Some(Some(binding)), cx) {
+            self.shortcut_editor = None;
+        } else if let Some(editor) = &mut self.shortcut_editor {
+            editor.error = Some("Could not save this shortcut.".to_owned());
+        }
+        cx.notify();
+    }
+
+    fn unassign_shortcut(&mut self, command: CommandId, cx: &mut Context<Self>) {
+        if self.save_shortcut_override(command, Some(None), cx) {
+            self.shortcut_editor = None;
+        }
+        cx.notify();
+    }
+
+    fn restore_shortcut(&mut self, command: CommandId, cx: &mut Context<Self>) {
+        if self.save_shortcut_override(command, None, cx) {
+            self.shortcut_editor = None;
+        }
+        cx.notify();
+    }
+
+    fn restore_all_shortcuts(&mut self, cx: &mut Context<Self>) {
+        if self.prefs.shortcut_overrides.is_empty() {
+            return;
+        }
+        let previous = std::mem::take(&mut self.prefs.shortcut_overrides);
+        if self.persist_prefs() {
+            crate::commands::rebind_keys(cx, &self.prefs.shortcut_overrides);
+            crate::refresh_app_menus(cx);
+            self.shortcut_editor = None;
+            self.activity = "Restored every keyboard shortcut".to_owned();
+        } else {
+            self.prefs.shortcut_overrides = previous;
+        }
+        cx.notify();
+    }
+
+    fn handle_shortcut_editor_key(&mut self, event: &KeyDownEvent, cx: &mut Context<Self>) -> bool {
+        if self.surface != Surface::Settings || self.settings_tab != SettingsTab::Shortcuts {
+            return false;
+        }
+        let Some(command) = self.shortcut_editor.as_ref().map(|editor| editor.command) else {
+            return false;
+        };
+        let key = &event.keystroke;
+        if key.key == "escape" {
+            self.shortcut_editor = None;
+            cx.notify();
+            return true;
+        }
+        if matches!(key.key.as_str(), "backspace" | "delete") && !key.modifiers.modified() {
+            self.unassign_shortcut(command, cx);
+            return true;
+        }
+        if matches!(
+            key.key.as_str(),
+            "shift" | "control" | "ctrl" | "alt" | "platform" | "function" | "fn"
+        ) {
+            return true;
+        }
+        let function_key = key
+            .key
+            .strip_prefix('f')
+            .and_then(|number| number.parse::<u8>().ok())
+            .is_some_and(|number| (1..=35).contains(&number));
+        if !key.modifiers.modified() && !function_key {
+            if let Some(editor) = &mut self.shortcut_editor {
+                editor.error = Some("Include Command, Control, Option, or a function key.".into());
+            }
+            cx.notify();
+            return true;
+        }
+        self.assign_shortcut(command, key.unparse(), cx);
+        true
+    }
+
+    fn handle_shortcut_search_key(&mut self, event: &KeyDownEvent, cx: &mut Context<Self>) -> bool {
+        if self.surface != Surface::Settings
+            || self.settings_tab != SettingsTab::Shortcuts
+            || !self.shortcut_search_active
+        {
+            return false;
+        }
+        match event.keystroke.key.as_str() {
+            "escape" => {
+                if self.shortcut_search.is_empty() {
+                    self.shortcut_search_active = false;
+                } else {
+                    self.shortcut_search.clear();
+                }
+                cx.notify();
+            }
+            _ => {
+                let Some(edit) = query_editor::edit_for(&event.keystroke) else {
+                    return true;
+                };
+                match edit {
+                    Edit::Local(local) => {
+                        self.shortcut_search.apply(local);
+                    }
+                    Edit::Clipboard(ClipboardEdit::Copy) => {
+                        query_editor::copy_selection(&self.shortcut_search, cx);
+                    }
+                    Edit::Clipboard(ClipboardEdit::Cut) => {
+                        query_editor::cut_selection(&mut self.shortcut_search, cx);
+                    }
+                    Edit::Clipboard(ClipboardEdit::Paste) => {
+                        if let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) {
+                            self.shortcut_search.insert(&text);
+                        }
+                    }
+                }
+                cx.notify();
+            }
+        }
+        true
     }
 
     fn handle_settings_search_key(&mut self, event: &KeyDownEvent, cx: &mut Context<Self>) -> bool {
@@ -1209,6 +1422,11 @@ impl UtilitySurfaces {
         cx: &mut Context<Self>,
     ) {
         if self.surface == Surface::None {
+            return;
+        }
+        if self.handle_shortcut_editor_key(event, cx) || self.handle_shortcut_search_key(event, cx)
+        {
+            cx.stop_propagation();
             return;
         }
         if self.handle_agent_path_key(event, cx) || self.handle_host_editor_key(event, cx) {
@@ -1813,6 +2031,7 @@ impl UtilitySurfaces {
         let pane = match self.settings_tab {
             SettingsTab::General => self.general_settings(cx).into_any_element(),
             SettingsTab::Agents => self.agents_settings(cx).into_any_element(),
+            SettingsTab::Shortcuts => self.shortcuts_settings(cx).into_any_element(),
             SettingsTab::Terminal => self.terminal_settings(cx).into_any_element(),
             SettingsTab::Resources => self.resource_settings(cx).into_any_element(),
             SettingsTab::Remote => self.remote_settings(cx).into_any_element(),
@@ -2014,6 +2233,181 @@ impl UtilitySurfaces {
                         ),
                     colors,
                 )),
+            colors,
+        )
+    }
+
+    fn shortcuts_settings(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let colors = self.settings_colors();
+        let query = self.shortcut_search.text();
+        let search_content = if self.shortcut_search_active {
+            query_label(&self.shortcut_search)
+        } else if self.shortcut_search.is_empty() {
+            div()
+                .text_color(colors.tertiary)
+                .child("Search shortcuts…")
+                .into_any_element()
+        } else {
+            div()
+                .text_color(colors.primary)
+                .child(query.to_owned())
+                .into_any_element()
+        };
+
+        let search = div()
+            .id("shortcut-search")
+            .debug_selector(|| "shortcut-search".into())
+            .relative()
+            .h(px(34.0))
+            .flex_1()
+            .min_w(px(0.0))
+            .px(px(10.0))
+            .rounded(px(17.0))
+            .border_1()
+            .border_color(colors.primary.alpha(if self.shortcut_search_active {
+                0.22
+            } else {
+                0.10
+            }))
+            .bg(colors.primary.alpha(0.025))
+            .flex()
+            .items_center()
+            .gap(px(8.0))
+            .cursor(CursorStyle::IBeam)
+            .on_click(cx.listener(|this, _, window, cx| {
+                this.focus_shortcut_search(window, cx);
+            }))
+            .child(sf_symbol("magnifyingglass", 12.0, colors.tertiary))
+            .child(
+                div()
+                    .flex_1()
+                    .min_w(px(0.0))
+                    .overflow_hidden()
+                    .whitespace_nowrap()
+                    .text_ellipsis()
+                    .text_size(px(Typo::ROW.size))
+                    .child(search_content),
+            )
+            .when(!self.shortcut_search.is_empty(), |search| {
+                search.child(
+                    div()
+                        .id("clear-shortcut-search")
+                        .debug_selector(|| "clear-shortcut-search".into())
+                        .size(px(18.0))
+                        .flex_none()
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .rounded_full()
+                        .cursor_pointer()
+                        .hover(move |style| style.bg(Fill::subtle(colors)))
+                        .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            this.clear_shortcut_search(window, cx);
+                        }))
+                        .child(sf_symbol("xmark", 8.0, colors.tertiary)),
+                )
+            })
+            .child(sf_symbol("keyboard", 12.0, colors.tertiary));
+
+        let mut groups = div()
+            .debug_selector(|| "shortcut-groups".into())
+            .flex()
+            .flex_col()
+            .gap(px(SETTINGS_SECTION_GAP));
+        let mut found = false;
+        for category in ShortcutCategory::ALL {
+            let commands = COMMANDS
+                .iter()
+                .filter(|command| {
+                    command.id.shortcut_metadata().category == category
+                        && shortcut_matches(command, query, &self.prefs.shortcut_overrides)
+                })
+                .collect::<Vec<_>>();
+            if commands.is_empty() {
+                continue;
+            }
+            found = true;
+            let mut rows = div().flex().flex_col();
+            for (index, command) in commands.into_iter().enumerate() {
+                if index > 0 {
+                    rows = rows.child(setting_divider(colors));
+                }
+                rows = rows.child(shortcut_row(
+                    command,
+                    self.shortcut_editor.as_ref(),
+                    &self.prefs.shortcut_overrides,
+                    colors,
+                    cx,
+                ));
+            }
+            groups = groups.child(setting_section(category.label(), rows, colors));
+        }
+
+        let results = if found {
+            groups.into_any_element()
+        } else {
+            div()
+                .min_h(px(180.0))
+                .rounded(px(Radius::ROW))
+                .border_1()
+                .border_color(colors.primary.alpha(0.065))
+                .bg(colors.primary.alpha(0.02))
+                .flex()
+                .flex_col()
+                .items_center()
+                .justify_center()
+                .gap(px(8.0))
+                .child(sf_symbol("keyboard", 22.0, colors.tertiary))
+                .child(
+                    div()
+                        .text_size(px(Typo::ROW_EMPHASIZED.size))
+                        .font_weight(Typo::ROW_EMPHASIZED.weight)
+                        .text_color(colors.primary)
+                        .child("No shortcuts found"),
+                )
+                .child(
+                    div()
+                        .text_size(px(Typo::META.size))
+                        .text_color(colors.tertiary)
+                        .child("Try an action name, description, or key."),
+                )
+                .into_any_element()
+        };
+
+        let modified_count = self.prefs.shortcut_overrides.len();
+        settings_page(
+            "Keyboard shortcuts",
+            div()
+                .flex()
+                .flex_col()
+                .gap(px(16.0))
+                .child(
+                    div()
+                        .text_size(px(Typo::ROW.size))
+                        .line_height(px(18.0))
+                        .text_color(colors.secondary)
+                        .child(
+                            "Choose an action, then press a new key combination. Changes apply immediately.",
+                        ),
+                )
+                .child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap(px(10.0))
+                        .child(search)
+                        .when(modified_count > 0, |toolbar| {
+                            toolbar.child(surface_button(
+                                format!("Reset all ({modified_count})"),
+                                "reset-all-shortcuts",
+                                colors,
+                                cx,
+                                |this, cx| this.restore_all_shortcuts(cx),
+                            ))
+                        }),
+                )
+                .child(results),
             colors,
         )
     }
@@ -4228,6 +4622,241 @@ fn setting_row(
         .child(control)
 }
 
+fn shortcut_matches(
+    command: &crate::commands::CommandSpec,
+    query: &str,
+    overrides: &crate::commands::ShortcutOverrides,
+) -> bool {
+    let query = query.trim().to_ascii_lowercase();
+    if query.is_empty() {
+        return true;
+    }
+    let metadata = command.id.shortcut_metadata();
+    let searchable = format!(
+        "{} {} {} {} {}",
+        metadata.title,
+        metadata.description,
+        metadata.category.label(),
+        command.stable_id,
+        command.shortcut_label_for(overrides).unwrap_or_default()
+    )
+    .to_ascii_lowercase();
+    query
+        .split_whitespace()
+        .all(|word| searchable.contains(word))
+}
+
+fn shortcut_row(
+    command: &'static crate::commands::CommandSpec,
+    editor: Option<&ShortcutEditor>,
+    overrides: &crate::commands::ShortcutOverrides,
+    colors: SemanticColors,
+    cx: &mut Context<UtilitySurfaces>,
+) -> AnyElement {
+    let metadata = command.id.shortcut_metadata();
+    let editing = editor.is_some_and(|editor| editor.command == command.id);
+    let error = editor
+        .filter(|editor| editor.command == command.id)
+        .and_then(|editor| editor.error.as_deref());
+    let assignment = command.shortcut_label_for(overrides);
+    let modified = command.is_overridden(overrides);
+    let command_id = command.id;
+    let binding_label: SharedString = if editing {
+        "Press keys…".into()
+    } else {
+        assignment
+            .as_deref()
+            .unwrap_or("Unassigned")
+            .to_owned()
+            .into()
+    };
+    let detail: SharedString = error.unwrap_or(metadata.description).to_owned().into();
+
+    let binding = div()
+        .id(SharedString::from(format!(
+            "shortcut-binding-{}",
+            command.stable_id
+        )))
+        .debug_selector({
+            let stable_id = command.stable_id;
+            move || format!("SHORTCUT_BINDING_{stable_id}")
+        })
+        .h(px(27.0))
+        .min_w(px(if editing { 92.0 } else { 42.0 }))
+        .px(px(9.0))
+        .rounded(px(Radius::BADGE))
+        .border_1()
+        .border_color(if error.is_some() {
+            Ink::DANGER.alpha(0.60)
+        } else if editing {
+            Palette::CLAY.alpha(0.72)
+        } else {
+            colors.primary.alpha(0.09)
+        })
+        .bg(if editing {
+            Palette::CLAY.alpha(0.10)
+        } else {
+            colors.primary.alpha(0.045)
+        })
+        .flex()
+        .items_center()
+        .justify_center()
+        .font_family(crate::fonts::mono_family())
+        .text_size(px(11.0))
+        .text_color(if assignment.is_none() && !editing {
+            colors.tertiary
+        } else {
+            colors.primary
+        })
+        .cursor_pointer()
+        .hover(move |style| style.bg(colors.primary.alpha(0.08)))
+        .on_click(cx.listener(move |this, _, window, cx| {
+            this.begin_shortcut_edit(command_id, window, cx);
+        }))
+        .child(binding_label);
+
+    let mut actions = div()
+        .flex_none()
+        .flex()
+        .items_center()
+        .gap(px(4.0))
+        .child(binding)
+        .child(
+            div()
+                .id(SharedString::from(format!(
+                    "edit-shortcut-{}",
+                    command.stable_id
+                )))
+                .size(px(26.0))
+                .rounded(px(Radius::BADGE))
+                .flex()
+                .items_center()
+                .justify_center()
+                .cursor_pointer()
+                .hover(move |style| style.bg(colors.primary.alpha(0.07)))
+                .on_click(cx.listener(move |this, _, window, cx| {
+                    if editing {
+                        this.shortcut_editor = None;
+                        cx.notify();
+                    } else {
+                        this.begin_shortcut_edit(command_id, window, cx);
+                    }
+                }))
+                .child(sf_symbol(
+                    if editing { "xmark" } else { "pencil" },
+                    10.0,
+                    if editing {
+                        colors.secondary
+                    } else {
+                        colors.tertiary
+                    },
+                )),
+        );
+
+    if modified {
+        actions = actions.child(
+            div()
+                .id(SharedString::from(format!(
+                    "restore-shortcut-{}",
+                    command.stable_id
+                )))
+                .debug_selector({
+                    let stable_id = command.stable_id;
+                    move || format!("RESTORE_SHORTCUT_{stable_id}")
+                })
+                .size(px(26.0))
+                .rounded(px(Radius::BADGE))
+                .flex()
+                .items_center()
+                .justify_center()
+                .cursor_pointer()
+                .hover(move |style| style.bg(colors.primary.alpha(0.07)))
+                .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+                .on_click(cx.listener(move |this, _, _, cx| {
+                    this.restore_shortcut(command_id, cx);
+                }))
+                .child(sf_symbol("arrow.counterclockwise", 10.0, colors.tertiary)),
+        );
+    }
+    if assignment.is_some() {
+        actions = actions.child(
+            div()
+                .id(SharedString::from(format!(
+                    "clear-shortcut-{}",
+                    command.stable_id
+                )))
+                .debug_selector({
+                    let stable_id = command.stable_id;
+                    move || format!("CLEAR_SHORTCUT_{stable_id}")
+                })
+                .size(px(26.0))
+                .rounded(px(Radius::BADGE))
+                .flex()
+                .items_center()
+                .justify_center()
+                .cursor_pointer()
+                .hover(move |style| style.bg(Ink::DANGER.alpha(0.10)))
+                .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+                .on_click(cx.listener(move |this, _, _, cx| {
+                    this.unassign_shortcut(command_id, cx);
+                }))
+                .child(sf_symbol("trash", 10.0, colors.tertiary)),
+        );
+    }
+
+    div()
+        .id(SharedString::from(format!(
+            "shortcut-row-{}",
+            command.stable_id
+        )))
+        .debug_selector({
+            let stable_id = command.stable_id;
+            move || format!("SHORTCUT_ROW_{stable_id}")
+        })
+        .min_h(px(58.0))
+        .px(px(12.0))
+        .py(px(8.0))
+        .flex()
+        .items_center()
+        .justify_between()
+        .gap(px(12.0))
+        .bg(if editing {
+            Palette::CLAY.alpha(0.035)
+        } else {
+            colors.background.alpha(0.0)
+        })
+        .child(
+            div()
+                .flex_1()
+                .min_w(px(0.0))
+                .flex()
+                .flex_col()
+                .gap(px(2.0))
+                .child(
+                    div()
+                        .whitespace_normal()
+                        .text_size(px(Typo::ROW_EMPHASIZED.size))
+                        .font_weight(Typo::ROW_EMPHASIZED.weight)
+                        .text_color(colors.primary)
+                        .child(metadata.title),
+                )
+                .child(
+                    div()
+                        .whitespace_normal()
+                        .text_size(px(Typo::META.size))
+                        .line_height(px(14.0))
+                        .text_color(if error.is_some() {
+                            Ink::DANGER
+                        } else {
+                            colors.tertiary
+                        })
+                        .child(wrappable_setting_copy(detail)),
+                ),
+        )
+        .child(actions)
+        .into_any_element()
+}
+
 fn setting_text_stack(
     label: SharedString,
     detail: SharedString,
@@ -4348,6 +4977,9 @@ fn settings_tab_matches(tab: SettingsTab, query: &str) -> bool {
         }
         SettingsTab::Agents => {
             "agents codex claude cursor gemini executable installed command line quick create default"
+        }
+        SettingsTab::Shortcuts => {
+            "shortcuts keyboard bindings hotkeys commands keys navigation sessions workspace terminal"
         }
         SettingsTab::Terminal => "terminal appearance color theme font text size zoom",
         SettingsTab::Resources => {
@@ -4759,6 +5391,14 @@ mod tests {
         let output = std::env::var_os("DIRI_VISUAL_OUTPUT")
             .map(PathBuf::from)
             .expect("set DIRI_VISUAL_OUTPUT to the target PNG path");
+        let tab = match std::env::var("DIRI_VISUAL_SETTINGS_TAB").as_deref() {
+            Ok("shortcuts") => SettingsTab::Shortcuts,
+            Ok("general") => SettingsTab::General,
+            Ok("agents") => SettingsTab::Agents,
+            Ok("terminal") => SettingsTab::Terminal,
+            Ok("resources") => SettingsTab::Resources,
+            _ => SettingsTab::Remote,
+        };
         let platform = gpui_platform::current_platform(true);
         let mut cx = HeadlessAppContext::with_platform(
             platform.text_system(),
@@ -4775,10 +5415,9 @@ mod tests {
 
         let window = cx
             .open_window(size(px(1200.0), px(800.0)), move |window, cx| {
-                // Exercise the user-reported state: Remote selected, from a
-                // sidebar the user had previously widened.
-                let harness =
-                    cx.new(|cx| SettingsWorkbenchHarness::open_at(SettingsTab::Remote, window, cx));
+                // Exercise the requested destination from a sidebar the user
+                // had previously widened. Remote remains the default capture.
+                let harness = cx.new(|cx| SettingsWorkbenchHarness::open_at(tab, window, cx));
                 harness.update(cx, |harness, cx| {
                     harness
                         .sidebar
@@ -5550,7 +6189,66 @@ mod tests {
         assert!(settings_tab_matches(SettingsTab::Remote, "ssh"));
         assert!(settings_tab_matches(SettingsTab::Resources, "memory"));
         assert!(settings_tab_matches(SettingsTab::General, "login"));
+        assert!(settings_tab_matches(SettingsTab::Shortcuts, "keyboard"));
         assert!(!settings_tab_matches(SettingsTab::Terminal, "ssh"));
+    }
+
+    #[gpui::test]
+    fn shortcut_page_searches_edits_unassigns_and_restores(cx: &mut TestAppContext) {
+        let (harness, cx) = open_settings_workbench(cx);
+        let surfaces = harness.read_with(cx, |harness, _| harness.surfaces.clone());
+        surfaces.update(cx, |surfaces, cx| {
+            surfaces.open_settings_tab(SettingsTab::Shortcuts, cx);
+        });
+
+        let search = cx
+            .debug_bounds("shortcut-search")
+            .expect("shortcut search should render");
+        cx.simulate_click(search.center(), Modifiers::default());
+        cx.simulate_input("new session");
+        assert!(cx.debug_bounds("SHORTCUT_ROW_open-launcher").is_some());
+        assert!(cx.debug_bounds("SHORTCUT_ROW_terminal-paste").is_none());
+
+        let binding = cx
+            .debug_bounds("SHORTCUT_BINDING_open-launcher")
+            .expect("filtered shortcut binding should render");
+        cx.simulate_click(binding.center(), Modifiers::default());
+        cx.simulate_keystrokes("cmd-shift-y");
+        surfaces.read_with(cx, |surfaces, _| {
+            assert_eq!(
+                surfaces
+                    .prefs
+                    .shortcut_overrides
+                    .get("open-launcher")
+                    .and_then(|binding| binding.as_deref()),
+                Some("cmd-shift-y")
+            );
+            assert!(surfaces.shortcut_editor.is_none());
+        });
+
+        let clear = cx
+            .debug_bounds("CLEAR_SHORTCUT_open-launcher")
+            .expect("assigned shortcut should offer unassign");
+        cx.simulate_click(clear.center(), Modifiers::default());
+        surfaces.read_with(cx, |surfaces, _| {
+            assert_eq!(
+                surfaces.prefs.shortcut_overrides.get("open-launcher"),
+                Some(&None)
+            );
+        });
+
+        let restore = cx
+            .debug_bounds("RESTORE_SHORTCUT_open-launcher")
+            .expect("modified shortcut should offer restore");
+        cx.simulate_click(restore.center(), Modifiers::default());
+        surfaces.read_with(cx, |surfaces, _| {
+            assert!(
+                !surfaces
+                    .prefs
+                    .shortcut_overrides
+                    .contains_key("open-launcher")
+            );
+        });
     }
 
     #[gpui::test]

--- a/diri/crates/diri-ui/assets/icons/keyboard.svg
+++ b/diri/crates/diri-ui/assets/icons/keyboard.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" viewBox="0 0 24 24"><rect width="19" height="14" x="2.5" y="5" rx="3"/><path d="M6.5 9h.01M10.2 9h.01M13.8 9h.01M17.5 9h.01M6.5 12.5h.01M10.2 12.5h.01M13.8 12.5h.01M17.5 12.5h.01M7 16h10"/></svg>

--- a/diri/crates/diri-ui/assets/icons/pencil.svg
+++ b/diri/crates/diri-ui/assets/icons/pencil.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" viewBox="0 0 24 24"><path d="M4 20h4.2L19 9.2a2.1 2.1 0 0 0-4.2-4.2L4 15.8V20Z"/><path d="m13.3 6.5 4.2 4.2M4 15.8 8.2 20"/></svg>

--- a/diri/crates/diri-ui/src/icon.rs
+++ b/diri/crates/diri-ui/src/icon.rs
@@ -68,6 +68,7 @@ pub enum IconName {
     ExternalLink,
     Folder,
     Grid,
+    Keyboard,
     LocalAgents,
     Merge,
     Monitor,
@@ -75,6 +76,7 @@ pub enum IconName {
     More,
     Network,
     NewAgent,
+    Pencil,
     Plus,
     Pointer,
     Power,
@@ -96,7 +98,7 @@ pub enum IconName {
 }
 
 impl IconName {
-    pub const ALL: [Self; 47] = [
+    pub const ALL: [Self; 49] = [
         Self::Activity,
         Self::Archive,
         Self::ArrowDown,
@@ -119,6 +121,7 @@ impl IconName {
         Self::ExternalLink,
         Self::Folder,
         Self::Grid,
+        Self::Keyboard,
         Self::LocalAgents,
         Self::Merge,
         Self::Monitor,
@@ -126,6 +129,7 @@ impl IconName {
         Self::More,
         Self::Network,
         Self::NewAgent,
+        Self::Pencil,
         Self::Plus,
         Self::Pointer,
         Self::Power,
@@ -170,6 +174,7 @@ impl IconName {
             Self::ExternalLink => "icons/external-link.svg",
             Self::Folder => "icons/folder.svg",
             Self::Grid => "icons/grid.svg",
+            Self::Keyboard => "icons/keyboard.svg",
             Self::LocalAgents => "icons/local-agents.svg",
             Self::Merge => "icons/merge.svg",
             Self::Monitor => "icons/monitor.svg",
@@ -177,6 +182,7 @@ impl IconName {
             Self::More => "icons/more.svg",
             Self::Network => "icons/network.svg",
             Self::NewAgent => "icons/new-agent.svg",
+            Self::Pencil => "icons/pencil.svg",
             Self::Plus => "icons/plus.svg",
             Self::Pointer => "icons/pointer.svg",
             Self::Power => "icons/power.svg",
@@ -224,6 +230,7 @@ impl IconName {
             "link" => Self::ExternalLink,
             "folder" | "folder.fill" => Self::Folder,
             "square.grid.2x2" | "terminal.grid" => Self::Grid,
+            "keyboard" => Self::Keyboard,
             "person.crop.circle" => Self::LocalAgents,
             "arrow.triangle.merge" => Self::Merge,
             "desktopcomputer" => Self::Monitor,
@@ -231,11 +238,14 @@ impl IconName {
             "ellipsis" => Self::More,
             "network" => Self::Network,
             "square.and.pencil" => Self::NewAgent,
+            "pencil" => Self::Pencil,
             "plus" => Self::Plus,
             "cursorarrow.rays" | "cursorarrow.click.2" => Self::Pointer,
             "power" => Self::Power,
             "arrow.triangle.pull" => Self::PullRequest,
-            "arrow.triangle.2.circlepath" | "arrow.clockwise.circle" => Self::Refresh,
+            "arrow.triangle.2.circlepath" | "arrow.clockwise.circle" | "arrow.counterclockwise" => {
+                Self::Refresh
+            }
             "arrow.left.and.right" | "arrow.left.arrow.right" => Self::ResizeHorizontal,
             "magnifyingglass" => Self::Search,
             "server.rack" => Self::Server,
@@ -328,6 +338,7 @@ fn embedded_svg(path: &str) -> Option<&'static [u8]> {
         "icons/external-link.svg" => include_bytes!("../assets/icons/external-link.svg"),
         "icons/folder.svg" => include_bytes!("../assets/icons/folder.svg"),
         "icons/grid.svg" => include_bytes!("../assets/icons/grid.svg"),
+        "icons/keyboard.svg" => include_bytes!("../assets/icons/keyboard.svg"),
         "icons/local-agents.svg" => include_bytes!("../assets/icons/local-agents.svg"),
         "icons/merge.svg" => include_bytes!("../assets/icons/merge.svg"),
         "icons/monitor.svg" => include_bytes!("../assets/icons/monitor.svg"),
@@ -335,6 +346,7 @@ fn embedded_svg(path: &str) -> Option<&'static [u8]> {
         "icons/more.svg" => include_bytes!("../assets/icons/more.svg"),
         "icons/network.svg" => include_bytes!("../assets/icons/network.svg"),
         "icons/new-agent.svg" => include_bytes!("../assets/icons/new-agent.svg"),
+        "icons/pencil.svg" => include_bytes!("../assets/icons/pencil.svg"),
         "icons/plus.svg" => include_bytes!("../assets/icons/plus.svg"),
         "icons/pointer.svg" => include_bytes!("../assets/icons/pointer.svg"),
         "icons/power.svg" => include_bytes!("../assets/icons/power.svg"),


### PR DESCRIPTION
## Summary

- add a searchable Keyboard Shortcuts settings page
- persist and apply per-command overrides immediately, with conflict checks, unassign, restore, and reset controls
- add shortcut command metadata and native keyboard/pencil icons

## Testing

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo build --workspace --release
- visual screenshot verification