### PR TITLE
Remove green sidebar focus outline

### DIFF
--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -1949,7 +1949,7 @@ impl Sidebar {
             RowFill::Selected
         } else if multi {
             RowFill::MultiSelected
-        } else if hovered {
+        } else if hovered || focused {
             RowFill::Hover
         } else {
             RowFill::Clear
@@ -2060,8 +2060,6 @@ impl Sidebar {
             .border_1()
             .border_color(if marked {
                 Palette::CLAY.alpha(0.78)
-            } else if focused {
-                Ink::FRESH.alpha(0.82)
             } else {
                 colors.primary.alpha(0.0)
             })
@@ -2529,17 +2527,13 @@ impl Sidebar {
             .opacity(if focused { 0.82 } else { 0.58 })
             .bg(if selected {
                 RowFill::Selected.color(colors)
-            } else if hovered {
+            } else if hovered || focused {
                 RowFill::Hover.color(colors)
             } else {
                 RowFill::Clear.color(colors)
             })
             .border_1()
-            .border_color(if focused {
-                Ink::FRESH.alpha(0.82)
-            } else {
-                colors.primary.alpha(0.0)
-            })
+            .border_color(colors.primary.alpha(0.0))
             .cursor_pointer()
             .on_hover(cx.listener({
                 let id = id.clone();


### PR DESCRIPTION
Keyboard focus still drew a green outline around sidebar sessions, including the Dev server row shown in the report. Remove that outline from regular and archived session rows and use the existing subtle hover fill to keep the keyboard cursor visible. Selected rows retain their selected fill.

Validation:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p diri-app sidebar:: --locked` — 53 passed, 1 ignored
- `cargo test --workspace --locked` — passed with local socket access
- `cargo build --workspace --release --locked`
- Release UI smoke check — window opened successfully

No new tests were added for this styling-only change; existing keyboard navigation and pointer-selection tests pass. The launch smoke check does not verify the rendered focus styling.
