### PR TITLE
Add detailed usage dashboard to Settings

### DIFF
--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -439,7 +439,14 @@ impl RootView {
         let mut snapshots = services.store.snapshots();
         let mut usage = services.usage_tx.subscribe();
         let mut updates = services.updates.subscribe();
-        sidebar.update(cx, |sidebar, cx| sidebar.set_usage(*usage.borrow(), cx));
+        sidebar.update(cx, |sidebar, cx| {
+            sidebar.set_usage(usage.borrow().clone(), cx)
+        });
+        if let Some(surfaces) = &utility_surfaces {
+            surfaces.update(cx, |surfaces, cx| {
+                surfaces.set_usage(usage.borrow().clone(), cx)
+            });
+        }
         // Seed the current state: `watch` only wakes on changes, and an
         // unsupported build settles before this view exists.
         let initial_update = services.updates.state();
@@ -534,9 +541,14 @@ impl RootView {
                     }
                     changed = usage.changed() => {
                         if changed.is_err() { break; }
-                        let snapshot = *usage.borrow_and_update();
+                        let snapshot = usage.borrow_and_update().clone();
                         service_sidebar.update(cx, |sidebar, cx| {
-                            sidebar.set_usage(snapshot, cx);
+                            sidebar.set_usage(snapshot.clone(), cx);
+                        });
+                        let _ = this.update(cx, |this, cx| {
+                            if let Some(surfaces) = &this.utility_surfaces {
+                                surfaces.update(cx, |surfaces, cx| surfaces.set_usage(snapshot, cx));
+                            }
                         });
                     }
                     changed = updates.changed() => {

--- a/diri/crates/diri-app/src/settings.rs
+++ b/diri/crates/diri-app/src/settings.rs
@@ -45,15 +45,17 @@ pub enum SettingsTab {
     General,
     Agents,
     Terminal,
+    Usage,
     Resources,
     Remote,
 }
 
 impl SettingsTab {
-    pub const ALL: [Self; 5] = [
+    pub const ALL: [Self; 6] = [
         Self::General,
         Self::Agents,
         Self::Terminal,
+        Self::Usage,
         Self::Resources,
         Self::Remote,
     ];
@@ -63,6 +65,7 @@ impl SettingsTab {
             Self::General => "General",
             Self::Agents => "Agents",
             Self::Terminal => "Terminal",
+            Self::Usage => "Usage",
             Self::Resources => "Resources",
             Self::Remote => "Remote",
         }
@@ -73,6 +76,7 @@ impl SettingsTab {
             Self::General => "Startup, sessions, and updates",
             Self::Agents => "Installed CLIs and quick create",
             Self::Terminal => "Appearance and text size",
+            Self::Usage => "Costs, tokens, and cache savings",
             Self::Resources => "Idle sessions and memory",
             Self::Remote => "SSH execution hosts",
         }
@@ -82,7 +86,9 @@ impl SettingsTab {
     /// describe the machines and resources sessions run on.
     pub const fn section(self) -> SettingsSection {
         match self {
-            Self::General | Self::Agents | Self::Terminal => SettingsSection::Personal,
+            Self::General | Self::Agents | Self::Terminal | Self::Usage => {
+                SettingsSection::Personal
+            }
             Self::Resources | Self::Remote => SettingsSection::System,
         }
     }
@@ -92,6 +98,7 @@ impl SettingsTab {
             Self::General => "gearshape",
             Self::Agents => "sparkles",
             Self::Terminal => "terminal",
+            Self::Usage => "chart.bar.xaxis",
             Self::Resources => "server.rack",
             Self::Remote => "network",
         }

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -2605,6 +2605,7 @@ impl Sidebar {
             Some(PREVIEW_USAGE)
         } else {
             self.usage
+                .as_ref()
                 .map(|snapshot| snapshot.today().cost)
                 .filter(|cost| *cost > 0.0)
         };
@@ -3624,7 +3625,7 @@ impl Sidebar {
                     "$86.40",
                     colors,
                 ));
-        } else if let Some(snapshot) = self.usage {
+        } else if let Some(snapshot) = &self.usage {
             usage = usage
                 .child(usage_menu_row(
                     "account-usage-session",

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -1,3 +1,6 @@
+#[path = "usage_page.rs"]
+mod usage_page;
+
 use std::cell::Cell;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -251,6 +254,10 @@ pub struct UtilitySurfaces {
     history_error: Option<String>,
     worktrees: WorktreesSheet,
     settings_tab: SettingsTab,
+    usage: crate::usage::UsageSnapshot,
+    usage_days: usize,
+    usage_tokens: bool,
+    usage_by_day: bool,
     settings_scroll: ScrollHandle,
     settings_search: QueryEditor,
     settings_search_active: bool,
@@ -306,6 +313,7 @@ impl UtilitySurfaces {
             Some("agents") => SettingsTab::Agents,
             Some("resources") => SettingsTab::Resources,
             Some("remote") => SettingsTab::Remote,
+            Some("usage") => SettingsTab::Usage,
             _ => SettingsTab::General,
         };
         let diagnostics_preview = settings_preview.as_deref() == Some("diagnostics");
@@ -361,6 +369,10 @@ impl UtilitySurfaces {
             history_error: None,
             worktrees: WorktreesSheet::default(),
             settings_tab,
+            usage: crate::usage::UsageSnapshot::default(),
+            usage_days: 30,
+            usage_tokens: false,
+            usage_by_day: false,
             settings_scroll: ScrollHandle::new(),
             settings_search: QueryEditor::default(),
             settings_search_active: false,
@@ -1816,6 +1828,7 @@ impl UtilitySurfaces {
             SettingsTab::Terminal => self.terminal_settings(cx).into_any_element(),
             SettingsTab::Resources => self.resource_settings(cx).into_any_element(),
             SettingsTab::Remote => self.remote_settings(cx).into_any_element(),
+            SettingsTab::Usage => self.usage_settings(cx).into_any_element(),
         };
         let pane = div()
             .id("settings-pane")
@@ -1830,7 +1843,11 @@ impl UtilitySurfaces {
             .child(
                 div()
                     .w_full()
-                    .max_w(px(SETTINGS_CONTENT_MAX_WIDTH))
+                    .max_w(px(if self.settings_tab == SettingsTab::Usage {
+                        1040.0
+                    } else {
+                        SETTINGS_CONTENT_MAX_WIDTH
+                    }))
                     .mx_auto()
                     .child(pane),
             );
@@ -4350,6 +4367,7 @@ fn settings_tab_matches(tab: SettingsTab, query: &str) -> bool {
             "agents codex claude cursor gemini executable installed command line quick create default"
         }
         SettingsTab::Terminal => "terminal appearance color theme font text size zoom",
+        SettingsTab::Usage => "usage cost tokens spending cache savings model daily claude codex",
         SettingsTab::Resources => {
             "resources idle sessions hibernate freeze memory limit performance"
         }
@@ -4799,6 +4817,138 @@ mod tests {
             std::fs::create_dir_all(parent).expect("create screenshot directory");
         }
         screenshot.save(output).expect("save settings screenshot");
+    }
+
+    #[gpui::test]
+    fn usage_settings_controls_and_search(cx: &mut TestAppContext) {
+        let (harness, cx) = open_settings_workbench(cx);
+        let surfaces = harness.read_with(cx, |harness, _| harness.surfaces.clone());
+        surfaces.update(cx, |surfaces, cx| {
+            surfaces.open_settings_tab(SettingsTab::Usage, cx);
+            surfaces.usage.updated_at = 1_788_523_200;
+        });
+        cx.run_until_parked();
+        for selector in ["usage-range-7", "usage-tokens", "usage-by-day"] {
+            let bounds = cx.debug_bounds(selector).expect("visible usage control");
+            cx.simulate_click(bounds.center(), Modifiers::default());
+            cx.run_until_parked();
+        }
+        surfaces.read_with(cx, |surfaces, _| {
+            assert_eq!(surfaces.usage_days, 7);
+            assert!(surfaces.usage_tokens);
+            assert!(surfaces.usage_by_day);
+        });
+        assert!(settings_tab_matches(SettingsTab::Usage, "cache savings"));
+        assert!(settings_tab_matches(SettingsTab::Usage, "cost"));
+    }
+
+    /// Fixture-only visual review, never populates the live usage tracker.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "writes the usage settings screenshot artifact"]
+    fn render_usage_settings_preview_screenshot() {
+        let output = std::env::var_os("DIRI_VISUAL_OUTPUT")
+            .map(PathBuf::from)
+            .expect("output PNG path");
+        let platform = gpui_platform::current_platform(true);
+        let mut cx = HeadlessAppContext::with_platform(
+            platform.text_system(),
+            Arc::new(diri_ui::IconAssets),
+            gpui_platform::current_headless_renderer,
+        );
+        cx.update(|cx| {
+            crate::fonts::init(cx);
+            cx.set_reduce_motion(true);
+        });
+        let width = std::env::var("DIRI_VISUAL_WIDTH")
+            .ok()
+            .and_then(|v| v.parse::<f32>().ok())
+            .unwrap_or(1200.0);
+        let window = cx
+            .open_window(size(px(width), px(900.0)), move |window, cx| {
+                let harness =
+                    cx.new(|cx| SettingsWorkbenchHarness::open_at(SettingsTab::Usage, window, cx));
+                harness.update(cx, |harness, cx| {
+                    harness.surfaces.update(cx, |surfaces, cx| {
+                        let mut history = crate::usage::dashboard::UsageHistory::default();
+                        let mut models = crate::usage::dashboard::ModelHours::default();
+                        let now = 1_788_523_200;
+                        for day in 0..30 {
+                            if day % 5 == 0 {
+                                continue;
+                            }
+                            for (index, model) in ["claude-opus-4-6", "claude-sonnet-4-6"]
+                                .into_iter()
+                                .enumerate()
+                            {
+                                let volume = ((day * 7 + index * 11) % 19 + 1) as i64;
+                                crate::usage::dashboard::record(
+                                    &mut models,
+                                    model,
+                                    now / 3600 - day as i64 * 24,
+                                    crate::usage::UsageHourAgg {
+                                        i: volume * 1000,
+                                        o: volume * 10_000,
+                                        cr: volume * 1_000_000,
+                                        cw: volume * 100_000,
+                                        c: volume as f64 * 0.9,
+                                    },
+                                    diri_usage::match_claude(model),
+                                    0,
+                                );
+                            }
+                        }
+                        history.merge(crate::usage::UsageProvider::Claude, &models);
+                        models.clear();
+                        for day in 0..30 {
+                            let volume = (day * 3) % 13 + 1;
+                            crate::usage::dashboard::record(
+                                &mut models,
+                                "gpt-5.4",
+                                now / 3600 - day * 24,
+                                crate::usage::UsageHourAgg {
+                                    i: volume * 2000,
+                                    o: volume * 8000,
+                                    cr: volume * 200_000,
+                                    cw: 0,
+                                    c: volume as f64 * 0.3,
+                                },
+                                diri_usage::match_openai("gpt-5.4"),
+                                volume * 3000,
+                            );
+                        }
+                        history.merge(crate::usage::UsageProvider::Codex, &models);
+                        if std::env::var_os("DIRI_VISUAL_EMPTY").is_some() {
+                            history = Default::default();
+                        }
+                        if std::env::var_os("DIRI_VISUAL_LIGHT").is_some() {
+                            surfaces.prefs.terminal_theme = "dirijor-light".into();
+                        }
+                        surfaces.usage_days = std::env::var("DIRI_VISUAL_DAYS")
+                            .ok()
+                            .and_then(|v| v.parse().ok())
+                            .unwrap_or(30);
+                        surfaces.set_usage(
+                            crate::usage::UsageSnapshot {
+                                updated_at: now,
+                                history: Arc::new(history),
+                                ..Default::default()
+                            },
+                            cx,
+                        );
+                    });
+                });
+                harness
+            })
+            .expect("open usage screenshot");
+        cx.run_until_parked();
+        let screenshot = cx
+            .capture_screenshot(window.into())
+            .expect("capture usage settings");
+        if let Some(parent) = output.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        screenshot.save(output).expect("save usage settings");
     }
 
     struct SettingsModalHarness {

--- a/diri/crates/diri-app/src/usage/cache.rs
+++ b/diri/crates/diri-app/src/usage/cache.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use super::model::UsageHourAgg;
 
-pub(crate) const CACHE_VERSION: u32 = 2;
+pub(crate) const CACHE_VERSION: u32 = 3;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct UsageFileEntry {
@@ -19,6 +19,7 @@ pub(crate) struct UsageFileEntry {
     pub inode: Option<u64>,
     pub tail_hash: u64,
     pub hours: BTreeMap<i64, UsageHourAgg>,
+    pub details: super::dashboard::ModelHours,
     pub model: Option<String>,
 }
 
@@ -32,6 +33,7 @@ impl UsageFileEntry {
             inode,
             tail_hash: 0,
             hours: BTreeMap::new(),
+            details: BTreeMap::new(),
             model: None,
         }
     }

--- a/diri/crates/diri-app/src/usage/dashboard.rs
+++ b/diri/crates/diri-app/src/usage/dashboard.rs
@@ -1,0 +1,187 @@
+//! Historical projections from the same deduplicated transcript ledger as the
+//! account menu. Days use UTC, explicitly labeled in the UI. No transcript text
+//! or identifiers cross this boundary.
+use super::{UsageHourAgg, UsageProvider, UsageTotals};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+pub(crate) type ModelHours = BTreeMap<String, BTreeMap<i64, UsageDetail>>;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct UsageDetail {
+    pub tokens: UsageHourAgg,
+    pub reasoning: i64,
+    pub priced_tokens: i64,
+    /// Cache reads at the uncached input rate minus their estimated read cost.
+    /// Cache writes are excluded: this is read savings, not net savings.
+    pub read_savings: f64,
+}
+
+impl UsageDetail {
+    pub fn totals(self) -> UsageTotals {
+        let mut totals = UsageTotals::default();
+        totals += self.tokens;
+        totals
+    }
+
+    fn merge(&mut self, other: Self) {
+        self.tokens.merge(other.tokens);
+        self.reasoning += other.reasoning;
+        self.priced_tokens += other.priced_tokens;
+        self.read_savings += other.read_savings;
+    }
+}
+
+pub(crate) fn record(
+    hours: &mut ModelHours,
+    model: &str,
+    hour: i64,
+    tokens: UsageHourAgg,
+    pricing: Option<diri_usage::ModelPricing>,
+    reasoning: i64,
+) {
+    let detail = UsageDetail {
+        tokens,
+        reasoning,
+        priced_tokens: pricing.map_or(0, |_| tokens.i + tokens.o + tokens.cr + tokens.cw),
+        read_savings: pricing.map_or(0.0, |price| {
+            tokens.cr as f64 * (price.input - price.cache_read()) / 1_000_000.0
+        }),
+    };
+    hours
+        .entry(
+            if model.is_empty() {
+                "Unknown model"
+            } else {
+                model
+            }
+            .to_owned(),
+        )
+        .or_default()
+        .entry(hour)
+        .or_default()
+        .merge(detail);
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct UsageHistory {
+    pub(crate) claude: ModelHours,
+    pub(crate) codex: ModelHours,
+}
+
+#[derive(Clone, Debug)]
+pub struct ModelRow {
+    pub model: String,
+    pub provider: usize,
+    pub detail: UsageDetail,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DayRow {
+    pub day: i64,
+    pub providers: [UsageDetail; 2],
+}
+
+impl DayRow {
+    pub fn total(&self) -> UsageDetail {
+        let mut detail = self.providers[0];
+        detail.merge(self.providers[1]);
+        detail
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct UsageReport {
+    pub total: UsageDetail,
+    pub providers: [UsageDetail; 2],
+    pub days: Vec<DayRow>,
+    pub models: Vec<ModelRow>,
+    pub active_days: usize,
+}
+
+impl UsageHistory {
+    pub(crate) fn merge(&mut self, provider: UsageProvider, details: &ModelHours) {
+        let destination = match provider {
+            UsageProvider::Claude => &mut self.claude,
+            UsageProvider::Codex => &mut self.codex,
+        };
+        for (model, hours) in details {
+            for (&hour, &detail) in hours {
+                destination
+                    .entry(model.clone())
+                    .or_default()
+                    .entry(hour)
+                    .or_default()
+                    .merge(detail);
+            }
+        }
+    }
+
+    pub fn report(&self, now: i64, days: usize) -> UsageReport {
+        let days = days.clamp(1, 90);
+        let end = now.div_euclid(86_400);
+        let start = end - days as i64 + 1;
+        let mut report = UsageReport {
+            days: (start..=end)
+                .map(|day| DayRow {
+                    day,
+                    ..DayRow::default()
+                })
+                .collect(),
+            ..UsageReport::default()
+        };
+        for (provider, models) in [&self.claude, &self.codex].into_iter().enumerate() {
+            for (model, hours) in models {
+                let mut detail = UsageDetail::default();
+                for (&hour, &value) in hours.range(start * 24..=now.div_euclid(3_600)) {
+                    detail.merge(value);
+                    let index = (hour.div_euclid(24) - start) as usize;
+                    report.days[index].providers[provider].merge(value);
+                }
+                if detail.totals().total_tokens() == 0 {
+                    continue;
+                }
+                report.providers[provider].merge(detail);
+                report.total.merge(detail);
+                report.models.push(ModelRow {
+                    model: model.clone(),
+                    provider,
+                    detail,
+                });
+            }
+        }
+        report.models.sort_by(|a, b| {
+            b.detail
+                .tokens
+                .c
+                .total_cmp(&a.detail.tokens.c)
+                .then_with(|| {
+                    b.detail
+                        .totals()
+                        .total_tokens()
+                        .cmp(&a.detail.totals().total_tokens())
+                })
+                .then_with(|| a.model.cmp(&b.model))
+        });
+        report.active_days = report
+            .days
+            .iter()
+            .filter(|day| day.total().totals().total_tokens() > 0)
+            .count();
+        report
+    }
+}
+
+/// Gregorian date from epoch day (inverse of days_from_civil).
+pub fn date_label(day: i64) -> String {
+    let z = day + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = mp + if mp < 10 { 3 } else { -9 };
+    let y = yoe + era * 400 + i64::from(m <= 2);
+    format!("{y:04}-{m:02}-{d:02}")
+}

--- a/diri/crates/diri-app/src/usage/mod.rs
+++ b/diri/crates/diri-app/src/usage/mod.rs
@@ -4,6 +4,7 @@
 //! anywhere and no provider API is queried.
 
 mod cache;
+pub mod dashboard;
 mod fleet;
 mod model;
 mod parser;

--- a/diri/crates/diri-app/src/usage/model.rs
+++ b/diri/crates/diri-app/src/usage/model.rs
@@ -50,7 +50,7 @@ pub struct ProviderUsage {
 }
 
 /// The UI-facing usage projection. Dates are Unix seconds.
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct UsageSnapshot {
     pub claude: ProviderUsage,
     pub codex: ProviderUsage,
@@ -59,18 +59,20 @@ pub struct UsageSnapshot {
     pub session_ends_at: Option<i64>,
     pub session_remaining_seconds: Option<i64>,
     pub updated_at: i64,
+    /// Local transcript history; fleet summaries do not provide this detail.
+    pub history: std::sync::Arc<super::dashboard::UsageHistory>,
 }
 
 impl UsageSnapshot {
     #[must_use]
-    pub fn today(self) -> UsageTotals {
+    pub fn today(&self) -> UsageTotals {
         let mut totals = self.claude.today;
         totals += self.codex.today;
         totals
     }
 
     #[must_use]
-    pub fn month(self) -> UsageTotals {
+    pub fn month(&self) -> UsageTotals {
         let mut totals = self.claude.month;
         totals += self.codex.month;
         totals

--- a/diri/crates/diri-app/src/usage/parser.rs
+++ b/diri/crates/diri-app/src/usage/parser.rs
@@ -18,6 +18,7 @@ pub(crate) fn parse_claude(
     offset: u64,
     cutoff_hour: i64,
     hours: &mut BTreeMap<i64, UsageHourAgg>,
+    details: &mut super::dashboard::ModelHours,
     seen_all: &mut HashSet<u64>,
     seen_by_hour: &mut BTreeMap<i64, Vec<u64>>,
 ) -> io::Result<u64> {
@@ -97,6 +98,7 @@ pub(crate) fn parse_claude(
                 + write_1h as f64 * pricing.cache_write_1h())
                 / 1_000_000.0;
         }
+        super::dashboard::record(details, model, hour, aggregate, match_claude(model), 0);
         hours.entry(hour).or_default().merge(aggregate);
     }
     Ok(consumed)
@@ -107,6 +109,7 @@ pub(crate) fn parse_codex(
     offset: u64,
     cutoff_hour: i64,
     hours: &mut BTreeMap<i64, UsageHourAgg>,
+    details: &mut super::dashboard::ModelHours,
     model: &mut Option<String>,
 ) -> io::Result<u64> {
     let Some((data, consumed)) = read_complete_lines(path, offset)? else {
@@ -183,6 +186,14 @@ pub(crate) fn parse_codex(
                 + output as f64 * pricing.output)
                 / 1_000_000.0;
         }
+        super::dashboard::record(
+            details,
+            model.as_deref().unwrap_or("Unknown model"),
+            hour,
+            aggregate,
+            model.as_deref().and_then(match_openai),
+            integer(last.get("reasoning_output_tokens")).min(output),
+        );
         hours.entry(hour).or_default().merge(aggregate);
     }
     Ok(consumed)
@@ -222,7 +233,7 @@ fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
 }
 
 fn integer(value: Option<&Value>) -> i64 {
-    value.and_then(Value::as_i64).unwrap_or(0)
+    value.and_then(Value::as_i64).unwrap_or(0).max(0)
 }
 
 pub(crate) fn fnv1a(value: &str) -> u64 {

--- a/diri/crates/diri-app/src/usage/store.rs
+++ b/diri/crates/diri-app/src/usage/store.rs
@@ -14,7 +14,7 @@ use super::{
     timestamp::days_from_civil,
 };
 
-const RETENTION_DAYS: i64 = 35;
+const RETENTION_DAYS: i64 = 91;
 const BLOCK_HOURS: i64 = 5;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -347,6 +347,7 @@ fn scan(
                 live.offset,
                 cutoff_hour,
                 &mut live.hours,
+                &mut live.details,
                 &mut seen_all,
                 &mut cache.seen,
             ),
@@ -355,6 +356,7 @@ fn scan(
                 live.offset,
                 cutoff_hour,
                 &mut live.hours,
+                &mut live.details,
                 &mut live.model,
             ),
         };
@@ -379,6 +381,10 @@ fn scan(
     for entry in cache.files.values_mut() {
         let hours_before_retain = entry.hours.len();
         entry.hours.retain(|hour, _| *hour >= cutoff_hour);
+        entry.details.retain(|_, hours| {
+            hours.retain(|hour, _| *hour >= cutoff_hour);
+            !hours.is_empty()
+        });
         changed |= hours_before_retain != entry.hours.len();
     }
     if full_scan {
@@ -413,11 +419,15 @@ fn scan(
         }
     }
 
-    (
-        snapshot(&claude_hours, &codex_hours, reading),
-        stats,
-        changed,
-    )
+    let mut result = snapshot(&claude_hours, &codex_hours, reading);
+    let mut history = super::dashboard::UsageHistory::default();
+    for (path, entry) in &cache.files {
+        if let Some(provider) = provider_for_path(Path::new(path), &paths.roots) {
+            history.merge(provider, &entry.details);
+        }
+    }
+    result.history = std::sync::Arc::new(history);
+    (result, stats, changed)
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/diri/crates/diri-app/src/usage/tests.rs
+++ b/diri/crates/diri-app/src/usage/tests.rs
@@ -130,7 +130,7 @@ fn aggregates_costs_dedupes_claude_and_preserves_provider_totals() {
     assert_eq!(snapshot.session_remaining_seconds, Some(3 * 3_600));
 
     let cache: Value = serde_json::from_slice(&fs::read(&fixture.cache).unwrap()).unwrap();
-    assert_eq!(cache["version"], 2);
+    assert_eq!(cache["version"], super::cache::CACHE_VERSION);
     assert_eq!(
         cache["seen"]
             .as_object()
@@ -510,4 +510,160 @@ fn append(path: &Path, bytes: &[u8]) {
 
 fn assert_close(actual: f64, expected: f64) {
     assert!((actual - expected).abs() < 1e-12, "{actual} != {expected}");
+}
+
+#[test]
+fn dashboard_preserves_deduplication_model_changes_and_cached_history() {
+    let fixture = Fixture::new();
+    let message = claude_line(
+        "2026-07-22T10:00:00Z",
+        "claude-sonnet-5",
+        "m",
+        "r",
+        100,
+        20,
+        1_000,
+        50,
+        None,
+    );
+    write_lines(
+        &fixture.claude.join("a.jsonl"),
+        std::slice::from_ref(&message),
+    );
+    write_lines(&fixture.claude.join("b.jsonl"), &[message]);
+    let codex = fixture.codex.join("rollout.jsonl");
+    write_lines(
+        &codex,
+        &[
+            json!({"type":"turn_context","payload":{"model":"gpt-5.4"}}),
+            json!({"timestamp":"2026-07-22T10:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":50,"output_tokens":20,"reasoning_output_tokens":8}}}}),
+            json!({"type":"turn_context","payload":{"model":"unrecognized-model"}}),
+            json!({"timestamp":"2026-07-22T11:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":200,"output_tokens":30}}}}),
+        ],
+    );
+    let mut store = fixture.store(
+        "2026-07-22T12:00:00Z",
+        "2026-07-22T00:00:00Z",
+        "2026-07-01T00:00:00Z",
+    );
+    let snapshot = store.refresh();
+    let report = snapshot.history.report(snapshot.updated_at, 30);
+    assert_eq!(report.total.totals(), snapshot.today());
+    assert_eq!(report.models.len(), 3);
+    assert_eq!(report.active_days, 1);
+    assert_eq!(report.total.reasoning, 8); // Already a subset of output.
+    assert_eq!(report.total.priced_tokens, 1_290);
+    assert_eq!(
+        report.total.totals().total_tokens() - report.total.priced_tokens,
+        230
+    );
+    assert_close(report.total.read_savings, 0.002_812_5);
+    assert_eq!(report.days.last().unwrap().total(), report.total);
+    let warm = store.refresh();
+    assert_eq!(warm.history, snapshot.history);
+    assert_eq!(store.last_stats().bytes_parsed, 0);
+    let mut restarted = fixture.store(
+        "2026-07-22T12:00:00Z",
+        "2026-07-22T00:00:00Z",
+        "2026-07-01T00:00:00Z",
+    );
+    assert_eq!(restarted.refresh().history, snapshot.history);
+    assert_eq!(restarted.last_stats().bytes_parsed, 0);
+    append(
+        &codex,
+        &line_bytes(
+            &json!({"timestamp":"2026-07-22T12:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":10,"output_tokens":1}}}}),
+        ),
+    );
+    let appended = restarted.refresh_paths(&[codex]);
+    let report = appended.history.report(appended.updated_at, 7);
+    assert_eq!(report.total.totals(), appended.today());
+    assert_eq!(report.total.totals().total_tokens(), 1_531);
+}
+
+#[test]
+fn dashboard_ranges_zero_fill_and_rebuild_old_caches_for_ninety_days() {
+    let fixture = Fixture::new();
+    write_lines(
+        &fixture.claude.join("history.jsonl"),
+        &[
+            claude_line(
+                "2026-04-24T00:00:00Z",
+                "claude-sonnet",
+                "a",
+                "a",
+                10,
+                0,
+                0,
+                0,
+                None,
+            ),
+            claude_line(
+                "2026-06-23T00:00:00Z",
+                "claude-sonnet",
+                "b",
+                "b",
+                20,
+                0,
+                0,
+                0,
+                None,
+            ),
+            claude_line(
+                "2026-07-16T00:00:00Z",
+                "claude-sonnet",
+                "c",
+                "c",
+                30,
+                0,
+                0,
+                0,
+                None,
+            ),
+            claude_line(
+                "2026-07-23T00:00:00Z",
+                "claude-sonnet",
+                "future",
+                "future",
+                99,
+                0,
+                0,
+                0,
+                None,
+            ),
+        ],
+    );
+    let mut store = fixture.store(
+        "2026-07-22T12:00:00Z",
+        "2026-07-22T00:00:00Z",
+        "2026-07-01T00:00:00Z",
+    );
+    let first = store.refresh();
+    for (days, tokens, active) in [(7, 30, 1), (30, 50, 2), (90, 60, 3)] {
+        let report = first.history.report(first.updated_at, days);
+        assert_eq!(report.days.len(), days);
+        assert_eq!(report.total.totals().total_tokens(), tokens);
+        assert_eq!(report.active_days, active);
+        assert_eq!(
+            report.days.last().unwrap().total().totals().total_tokens(),
+            0
+        );
+    }
+    let mut cache: Value = serde_json::from_slice(&fs::read(&fixture.cache).unwrap()).unwrap();
+    cache["version"] = json!(2);
+    for entry in cache["files"].as_object_mut().unwrap().values_mut() {
+        entry.as_object_mut().unwrap().remove("details");
+    }
+    fs::write(&fixture.cache, serde_json::to_vec(&cache).unwrap()).unwrap();
+    let mut restarted = fixture.store(
+        "2026-07-22T12:00:00Z",
+        "2026-07-22T00:00:00Z",
+        "2026-07-01T00:00:00Z",
+    );
+    assert_eq!(restarted.refresh().history, first.history);
+    assert!(restarted.last_stats().bytes_parsed > 0);
+    assert_eq!(
+        super::dashboard::date_label(timestamp("2024-02-29T00:00:00Z") / 86400),
+        "2024-02-29"
+    );
 }

--- a/diri/crates/diri-app/src/usage_page.rs
+++ b/diri/crates/diri-app/src/usage_page.rs
@@ -1,0 +1,568 @@
+//! Usage settings use the existing ledger and settings shell.
+use super::*;
+use crate::usage::dashboard::{UsageReport, date_label};
+use crate::usage::{UsageFormat, UsageSnapshot};
+use gpui::relative;
+
+const PROVIDERS: [&str; 2] = ["Claude Code", "Codex"];
+fn provider_color(provider: usize, colors: SemanticColors) -> Rgba {
+    if provider == 0 {
+        rgba(0xcf876dff)
+    } else {
+        colors.secondary
+    }
+}
+
+impl UtilitySurfaces {
+    pub(crate) fn set_usage(&mut self, usage: UsageSnapshot, cx: &mut Context<Self>) {
+        self.usage = usage;
+        if self.surface == Surface::Settings && self.settings_tab == SettingsTab::Usage {
+            cx.notify();
+        }
+    }
+
+    pub(super) fn usage_settings(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let colors = self.settings_colors();
+        if self.usage.updated_at == 0 {
+            return settings_page("Usage", div().flex().flex_col().gap(px(8.0)).py(px(24.0))
+                .child(label("Reading local usage…", 14.0, colors.primary))
+                .child(label("Preparing costs and token history from your Claude Code and Codex transcripts.", 12.0, colors.secondary)), colors).into_any_element();
+        }
+        let report = self
+            .usage
+            .history
+            .report(self.usage.updated_at, self.usage_days);
+        let total = report.total.totals();
+        let loaded = self.usage.updated_at > 0;
+        let subtitle = if loaded {
+            format!(
+                "{} — {} · UTC · Local transcripts",
+                date_label(report.days[0].day),
+                date_label(report.days.last().unwrap().day)
+            )
+        } else {
+            "Reading local usage…".to_owned()
+        };
+        let mut ranges = div().flex().gap(px(3.0));
+        for days in [7, 30, 90] {
+            ranges = ranges.child(
+                usage_control(
+                    format!("usage-range-{days}"),
+                    format!("{days} days"),
+                    self.usage_days == days,
+                    colors,
+                )
+                .on_click(cx.listener(move |this, _, _, cx| {
+                    this.usage_days = days;
+                    cx.notify();
+                })),
+            );
+        }
+        let mut providers = div().flex().flex_col().gap(px(12.0));
+        for (index, provider) in report.providers.iter().enumerate() {
+            let share = ratio(provider.tokens.c, total.cost);
+            providers = providers.child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap(px(5.0))
+                    .child(
+                        div()
+                            .flex()
+                            .justify_between()
+                            .gap(px(12.0))
+                            .child(provider_label(index, colors))
+                            .child(label(money(provider.tokens.c), 12.0, colors.primary)),
+                    )
+                    .child(
+                        div()
+                            .h(px(3.0))
+                            .w_full()
+                            .rounded(px(2.0))
+                            .bg(colors.primary.alpha(0.06))
+                            .child(
+                                div()
+                                    .h_full()
+                                    .w(relative(share as f32))
+                                    .rounded(px(2.0))
+                                    .bg(provider_color(index, colors)),
+                            ),
+                    )
+                    .child(label(
+                        format!(
+                            "{:.1}% of cost · {} tokens",
+                            share * 100.0,
+                            UsageFormat::tokens(provider.totals().total_tokens())
+                        ),
+                        11.0,
+                        colors.tertiary,
+                    )),
+            );
+        }
+        let hero = div()
+            .flex()
+            .flex_wrap()
+            .gap(px(28.0))
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap(px(16.0))
+                    .w(px(220.0))
+                    .flex_grow(1.0)
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap(px(4.0))
+                            .child(label("Estimated API cost", 12.0, colors.secondary))
+                            .child(
+                                label(
+                                    if loaded {
+                                        money(total.cost)
+                                    } else {
+                                        "—".into()
+                                    },
+                                    34.0,
+                                    colors.primary,
+                                )
+                                .font_weight(FontWeight::MEDIUM),
+                            )
+                            .child(label(
+                                "At model rates, not your subscription bill",
+                                11.0,
+                                colors.tertiary,
+                            )),
+                    )
+                    .child(providers),
+            )
+            .child(self.usage_chart(&report, colors, cx));
+        let input = total.input_tokens + total.cache_read_tokens + total.cache_write_tokens;
+        let metrics = div()
+            .flex()
+            .flex_wrap()
+            .gap(px(1.0))
+            .rounded(px(8.0))
+            .overflow_hidden()
+            .bg(colors.primary.alpha(0.06))
+            .child(metric(
+                "Processed tokens",
+                UsageFormat::tokens(total.total_tokens()),
+                format!(
+                    "{} per active day",
+                    UsageFormat::tokens(total.total_tokens() / report.active_days.max(1) as i64)
+                ),
+                colors,
+            ))
+            .child(metric(
+                "Cached input",
+                UsageFormat::tokens(total.cache_read_tokens),
+                format!(
+                    "{:.1}% of input",
+                    ratio(total.cache_read_tokens as f64, input as f64) * 100.0
+                ),
+                colors,
+            ))
+            .child(metric(
+                "Uncached input",
+                UsageFormat::tokens(total.input_tokens),
+                format!(
+                    "{} cache writes",
+                    UsageFormat::tokens(total.cache_write_tokens)
+                ),
+                colors,
+            ))
+            .child(metric(
+                "Output",
+                UsageFormat::tokens(total.output_tokens),
+                format!(
+                    "{} reasoning reported",
+                    UsageFormat::tokens(report.total.reasoning)
+                ),
+                colors,
+            ))
+            .child(metric(
+                "Cache read savings",
+                money(report.total.read_savings),
+                "Estimated · excludes writes".into(),
+                colors,
+            ));
+        let mut content = div().flex().flex_col().gap(px(24.0)).child(
+            div()
+                .flex()
+                .flex_wrap()
+                .items_center()
+                .justify_between()
+                .gap(px(12.0))
+                .child(label(subtitle, 11.0, colors.secondary))
+                .child(ranges),
+        );
+        if loaded && total.total_tokens() == 0 {
+            content = content.child(div().p(px(20.0)).rounded(px(8.0)).bg(colors.primary.alpha(0.035)).flex().flex_col().gap(px(6.0))
+                .child(label("Your usage starts with a conversation", 14.0, colors.primary))
+                .child(label("Use Claude Code or Codex on this Mac. Available transcript history appears here automatically.", 12.0, colors.secondary))
+                .child(label("Try a longer date range to see earlier activity.", 12.0, colors.secondary)));
+        }
+        content = content.child(hero).child(metrics).child(self.usage_breakdown(&report, colors, cx))
+            .child(div().flex().flex_col().gap(px(7.0))
+                .child(label("About these estimates", 12.0, colors.primary).font_weight(FontWeight::MEDIUM))
+                .child(label(format!("{:.1}% of tokens model priced · {} unpriced tokens · No provider billing data", ratio(report.total.priced_tokens as f64, total.total_tokens() as f64) * 100.0, UsageFormat::tokens(total.total_tokens() - report.total.priced_tokens)), 11.0, colors.secondary))
+                .child(label("Uses Diri’s bundled model rates. Unpriced usage is excluded from cost. Cache read savings compare cached reads with uncached input rates; cache write premiums are excluded.", 11.0, colors.tertiary))
+                .child(label("Updates automatically from available local Claude Code and Codex transcripts, including sessions outside Diri. Remote usage is not included in this detailed view.", 11.0, colors.tertiary)));
+        settings_page("Usage", content, colors).into_any_element()
+    }
+
+    fn usage_chart(
+        &self,
+        report: &UsageReport,
+        colors: SemanticColors,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let tokens = self.usage_tokens;
+        let value = |detail: crate::usage::dashboard::UsageDetail| {
+            if tokens {
+                detail.totals().total_tokens() as f64
+            } else {
+                detail.tokens.c
+            }
+        };
+        let maximum = report
+            .days
+            .iter()
+            .map(|day| value(day.total()))
+            .fold(0.0_f64, f64::max);
+        let mut bars = div()
+            .flex()
+            .items_end()
+            .gap(px(if self.usage_days == 90 { 2.0 } else { 4.0 }))
+            .h(px(156.0))
+            .w_full()
+            .border_b_1()
+            .border_color(colors.primary.alpha(0.12));
+        for day in &report.days {
+            let mut bar = div()
+                .id(SharedString::from(format!("usage-day-{}", day.day)))
+                .flex_1()
+                .min_w(px(0.0))
+                .h_full()
+                .flex()
+                .flex_col()
+                .justify_end()
+                .rounded_t(px(2.0))
+                .hover(|style| style.bg(colors.primary.alpha(0.06)));
+            let tooltip = format!(
+                "{} · {} · {} tokens",
+                date_label(day.day),
+                money(day.total().tokens.c),
+                UsageFormat::tokens(day.total().totals().total_tokens())
+            );
+            bar =
+                bar.tooltip(move |_, cx| cx.new(|_| UsageTooltip(tooltip.clone(), colors)).into());
+            for provider in (0..2).rev() {
+                bar = bar.child(
+                    div()
+                        .w_full()
+                        .h(px(
+                            (ratio(value(day.providers[provider]), maximum) * 148.0) as f32
+                        ))
+                        .flex_none()
+                        .bg(provider_color(provider, colors)),
+                );
+            }
+            bars = bars.child(bar);
+        }
+        let bars = if cx.reduce_motion() {
+            bars.into_any_element()
+        } else {
+            bars.with_animation(
+                SharedString::from(format!("usage-chart-{}-{tokens}", self.usage_days)),
+                Animation::new(Duration::from_millis(160)).with_easing(ease_out_quint()),
+                |bars, progress| bars.opacity(0.5 + 0.5 * progress),
+            )
+            .into_any_element()
+        };
+        div()
+            .flex()
+            .flex_col()
+            .gap(px(10.0))
+            .w(px(340.0))
+            .min_w(px(240.0))
+            .flex_grow(1.0)
+            .child(
+                div()
+                    .flex()
+                    .justify_between()
+                    .items_center()
+                    .gap(px(10.0))
+                    .child(
+                        label(
+                            if tokens { "Daily tokens" } else { "Daily cost" },
+                            13.0,
+                            colors.primary,
+                        )
+                        .font_weight(FontWeight::MEDIUM),
+                    )
+                    .child(
+                        div()
+                            .flex()
+                            .gap(px(3.0))
+                            .child(
+                                usage_control("usage-cost", "Cost", !tokens, colors).on_click(
+                                    cx.listener(|this, _, _, cx| {
+                                        this.usage_tokens = false;
+                                        cx.notify();
+                                    }),
+                                ),
+                            )
+                            .child(
+                                usage_control("usage-tokens", "Tokens", tokens, colors).on_click(
+                                    cx.listener(|this, _, _, cx| {
+                                        this.usage_tokens = true;
+                                        cx.notify();
+                                    }),
+                                ),
+                            ),
+                    ),
+            )
+            .child(label(
+                format!(
+                    "Peak {}",
+                    if tokens {
+                        UsageFormat::tokens(maximum as i64)
+                    } else {
+                        money(maximum)
+                    }
+                ),
+                10.0,
+                colors.tertiary,
+            ))
+            .child(bars)
+            .child(
+                div()
+                    .flex()
+                    .justify_between()
+                    .child(label(date_label(report.days[0].day), 10.0, colors.tertiary))
+                    .child(label(
+                        date_label(report.days.last().unwrap().day),
+                        10.0,
+                        colors.tertiary,
+                    )),
+            )
+            .child(
+                div()
+                    .flex()
+                    .justify_end()
+                    .gap(px(12.0))
+                    .child(provider_label(0, colors))
+                    .child(provider_label(1, colors)),
+            )
+    }
+
+    fn usage_breakdown(
+        &self,
+        report: &UsageReport,
+        colors: SemanticColors,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let mut table = div().flex().flex_col().child(table_row(
+            "",
+            if self.usage_by_day {
+                "Day (UTC)"
+            } else {
+                "Model"
+            },
+            "Cost",
+            "Share",
+            "Tokens",
+            colors,
+        ));
+        if self.usage_by_day {
+            for day in report.days.iter().rev() {
+                let total = day.total().totals();
+                table = table.child(table_row(
+                    "",
+                    &date_label(day.day),
+                    &money(total.cost),
+                    &format!("{:.1}%", ratio(total.cost, report.total.tokens.c) * 100.0),
+                    &UsageFormat::tokens(total.total_tokens()),
+                    colors,
+                ));
+            }
+        } else {
+            for row in &report.models {
+                let total = row.detail.totals();
+                table = table.child(table_row(
+                    PROVIDERS[row.provider],
+                    &row.model,
+                    &if row.detail.priced_tokens == 0 {
+                        "Unpriced".into()
+                    } else {
+                        money(total.cost)
+                    },
+                    &format!("{:.1}%", ratio(total.cost, report.total.tokens.c) * 100.0),
+                    &UsageFormat::tokens(total.total_tokens()),
+                    colors,
+                ));
+            }
+        }
+        div()
+            .flex()
+            .flex_col()
+            .gap(px(10.0))
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .justify_between()
+                    .child(label("Breakdown", 13.0, colors.primary).font_weight(FontWeight::MEDIUM))
+                    .child(
+                        div()
+                            .flex()
+                            .gap(px(3.0))
+                            .child(
+                                usage_control("usage-model", "Model", !self.usage_by_day, colors)
+                                    .on_click(cx.listener(|this, _, _, cx| {
+                                        this.usage_by_day = false;
+                                        cx.notify();
+                                    })),
+                            )
+                            .child(
+                                usage_control("usage-by-day", "Day", self.usage_by_day, colors)
+                                    .on_click(cx.listener(|this, _, _, cx| {
+                                        this.usage_by_day = true;
+                                        cx.notify();
+                                    })),
+                            ),
+                    ),
+            )
+            .child(table)
+    }
+}
+
+fn money(value: f64) -> String {
+    format!("${value:.2}")
+}
+fn ratio(value: f64, total: f64) -> f64 {
+    if total > 0.0 {
+        (value / total).clamp(0.0, 1.0)
+    } else {
+        0.0
+    }
+}
+fn label(text: impl Into<SharedString>, size: f32, color: Rgba) -> gpui::Div {
+    div()
+        .text_size(px(size))
+        .text_color(color)
+        .child(text.into())
+}
+fn usage_control(
+    id: impl Into<SharedString>,
+    text: impl Into<SharedString>,
+    selected: bool,
+    colors: SemanticColors,
+) -> gpui::Stateful<gpui::Div> {
+    let id = id.into();
+    div()
+        .id(id.clone())
+        .debug_selector(move || id.to_string())
+        .px(px(10.0))
+        .h(px(27.0))
+        .flex()
+        .items_center()
+        .rounded(px(6.0))
+        .border_1()
+        .border_color(colors.primary.alpha(if selected { 0.1 } else { 0.0 }))
+        .bg(colors.primary.alpha(if selected { 0.065 } else { 0.0 }))
+        .text_size(px(11.0))
+        .text_color(if selected {
+            colors.primary
+        } else {
+            colors.secondary
+        })
+        .cursor_pointer()
+        .hover(|style| style.bg(colors.primary.alpha(0.09)))
+        .active(|style| style.bg(colors.primary.alpha(0.13)))
+        .child(text.into())
+}
+fn provider_label(provider: usize, colors: SemanticColors) -> impl IntoElement {
+    div()
+        .flex()
+        .items_center()
+        .gap(px(6.0))
+        .child(
+            div()
+                .size(px(6.0))
+                .rounded(px(3.0))
+                .bg(provider_color(provider, colors)),
+        )
+        .child(label(PROVIDERS[provider], 11.0, colors.secondary))
+}
+fn metric(title: &str, value: String, detail: String, colors: SemanticColors) -> impl IntoElement {
+    div()
+        .flex()
+        .flex_col()
+        .gap(px(5.0))
+        .p(px(12.0))
+        .w(px(170.0))
+        .flex_grow(1.0)
+        .bg(colors.background)
+        .child(label(title.to_owned(), 11.0, colors.secondary))
+        .child(label(value, 20.0, colors.primary))
+        .child(label(detail, 10.0, colors.tertiary))
+}
+fn table_row(
+    provider: &str,
+    name: &str,
+    cost: &str,
+    share: &str,
+    tokens: &str,
+    colors: SemanticColors,
+) -> impl IntoElement {
+    div()
+        .flex()
+        .items_center()
+        .gap(px(12.0))
+        .min_h(px(39.0))
+        .py(px(7.0))
+        .border_b_1()
+        .border_color(colors.primary.alpha(0.055))
+        .child(
+            div()
+                .flex_1()
+                .min_w(px(0.0))
+                .flex()
+                .flex_col()
+                .gap(px(2.0))
+                .child(label(name.to_owned(), 12.0, colors.primary).truncate())
+                .when(!provider.is_empty(), |row| {
+                    row.child(label(provider.to_owned(), 10.0, colors.tertiary))
+                }),
+        )
+        .child(
+            label(cost.to_owned(), 12.0, colors.primary)
+                .w(px(85.0))
+                .text_right(),
+        )
+        .child(
+            label(share.to_owned(), 12.0, colors.tertiary)
+                .w(px(54.0))
+                .text_right(),
+        )
+        .child(
+            label(tokens.to_owned(), 12.0, colors.secondary)
+                .w(px(64.0))
+                .text_right(),
+        )
+}
+struct UsageTooltip(String, SemanticColors);
+impl Render for UsageTooltip {
+    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+        label(self.0.clone(), 11.0, self.1.primary)
+            .px(px(10.0))
+            .py(px(7.0))
+            .rounded(px(6.0))
+            .bg(self.1.background)
+            .border_1()
+            .border_color(self.1.primary.alpha(0.12))
+    }
+}

--- a/diri/crates/diri-ui/assets/icons/chart-bar.svg
+++ b/diri/crates/diri-ui/assets/icons/chart-bar.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" viewBox="0 0 24 24"><path d="M3 20h18M6 16v-5m6 5V4m6 12V8"/></svg>

--- a/diri/crates/diri-ui/src/icon.rs
+++ b/diri/crates/diri-ui/src/icon.rs
@@ -50,6 +50,7 @@ pub enum IconName {
     Archive,
     ArrowDown,
     Branch,
+    ChartBar,
     Check,
     CheckCircle,
     Checklist,
@@ -96,11 +97,12 @@ pub enum IconName {
 }
 
 impl IconName {
-    pub const ALL: [Self; 47] = [
+    pub const ALL: [Self; 48] = [
         Self::Activity,
         Self::Archive,
         Self::ArrowDown,
         Self::Branch,
+        Self::ChartBar,
         Self::Check,
         Self::CheckCircle,
         Self::Checklist,
@@ -152,6 +154,7 @@ impl IconName {
             Self::Archive => "icons/archive.svg",
             Self::ArrowDown => "icons/arrow-down.svg",
             Self::Branch => "icons/branch.svg",
+            Self::ChartBar => "icons/chart-bar.svg",
             Self::Check => "icons/check.svg",
             Self::CheckCircle => "icons/check-circle.svg",
             Self::Checklist => "icons/checklist.svg",
@@ -206,6 +209,7 @@ impl IconName {
             "archivebox" | "archivebox.fill" => Self::Archive,
             "arrow.down" => Self::ArrowDown,
             "arrow.branch" => Self::Branch,
+            "chart.bar" | "chart.bar.xaxis" => Self::ChartBar,
             "checkmark" => Self::Check,
             "checkmark.circle" | "checkmark.circle.fill" => Self::CheckCircle,
             "checklist" => Self::Checklist,
@@ -310,6 +314,7 @@ fn embedded_svg(path: &str) -> Option<&'static [u8]> {
         "icons/archive.svg" => include_bytes!("../assets/icons/archive.svg"),
         "icons/arrow-down.svg" => include_bytes!("../assets/icons/arrow-down.svg"),
         "icons/branch.svg" => include_bytes!("../assets/icons/branch.svg"),
+        "icons/chart-bar.svg" => include_bytes!("../assets/icons/chart-bar.svg"),
         "icons/check.svg" => include_bytes!("../assets/icons/check.svg"),
         "icons/check-circle.svg" => include_bytes!("../assets/icons/check-circle.svg"),
         "icons/checklist.svg" => include_bytes!("../assets/icons/checklist.svg"),


### PR DESCRIPTION
Adds a Usage destination in Settings so users can explore the costs and tokens already tracked by Diri. It follows the existing settings design and supports 7/30/90-day cost and token charts, provider totals, model/day breakdowns, cache read savings, and pricing coverage.

The existing incremental transcript ledger now retains 91 days and records model-level aggregates. The versioned cache rebuilds from available transcripts on upgrade. Detailed history covers local Claude Code and Codex transcripts; costs are labeled API-rate estimates and unknown models remain visible as unpriced usage. Remote fleet summaries remain separate.

Validation: formatting and workspace Clippy pass, 1,192 workspace tests pass, and the workspace release build succeeds. Added coverage for model changes, deduplication, incremental refresh, cache reload/migration, date ranges, and settings controls. Visually checked dark, light, compact, and empty layouts with the headless renderer.
