### PR TITLE
Improve conversation history search and resume

### DIFF
--- a/diri/Cargo.lock
+++ b/diri/Cargo.lock
@@ -1556,6 +1556,7 @@ dependencies = [
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
  "objc2-user-notifications",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/diri/crates/diri-app/Cargo.toml
+++ b/diri/crates/diri-app/Cargo.toml
@@ -41,6 +41,7 @@ image.workspace = true
 libc = "0.2"
 nucleo-matcher.workspace = true
 notify.workspace = true
+rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/diri/crates/diri-app/src/history.rs
+++ b/diri/crates/diri-app/src/history.rs
@@ -1,25 +1,24 @@
 //! Read-only discovery of Claude and Codex transcripts.
 //!
-//! This is a Rust port of `DirijorDaemonKit/HistoryScanner.swift`. Keeping the
-//! scan client-side lets diri show durable history without requiring a newer
-//! daemon. Transcript files are never modified.
+//! Local history stays available while the Engine connects. Streaming reads
+//! stop at useful metadata; unchanged transcripts are reused between scans.
+//! Provider files are never modified.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs::{self, File, Metadata};
 use std::io::{self, BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::fuzzy::{FuzzyMatcher, FuzzyQuery, PreparedText};
 use diri_client::{ClientError, DaemonClient};
 use diri_proto::{AgentKind, DateMillis, HistoryEntry};
 use serde_json::Value;
 
-const MAX_ENTRIES: usize = 500;
 const CLAUDE_HEAD_CAP: usize = 8 << 20;
 const CLAUDE_TAIL_BYTES: usize = 16 << 10;
 const CODEX_FIRST_LINE_CAP: usize = 512 << 10;
 const CODEX_FIRST_PROMPT_CAP: usize = 8 << 20;
-const RESUME_PROMPT: &str = "This historical conversation has just been resumed. Briefly state the recovered state, inspect the current workspace, and continue the unfinished task without replaying completed work.";
 
 #[derive(Clone, Debug)]
 pub struct HistoryRoots {
@@ -45,21 +44,85 @@ impl HistoryRoots {
 
 /// Scan both transcript stores, excluding agent conversation ids already
 /// represented by daemon sessions. Results are newest-first and deduplicated.
+#[cfg(test)]
 pub fn scan(roots: &HistoryRoots, tracked: &HashSet<String>) -> Vec<HistoryEntry> {
-    let mut entries = scan_claude(&roots.claude);
-    entries.extend(scan_codex(&roots.codex));
+    HistoryScanner::default().scan(roots, tracked)
+}
 
-    let mut seen = tracked.clone();
-    entries.retain(|entry| seen.insert(entry.id.clone()));
-    entries.sort_by(|left, right| {
-        right
-            .last_active_at
-            .partial_cmp(&left.last_active_at)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| left.id.cmp(&right.id))
-    });
-    entries.truncate(MAX_ENTRIES);
-    entries
+#[derive(Default)]
+pub struct HistoryScanner {
+    files: HashMap<PathBuf, CachedTranscript>,
+    visited: HashSet<PathBuf>,
+}
+
+struct CachedTranscript {
+    modified: Option<SystemTime>,
+    len: u64,
+    provider_title: Option<String>,
+    entry: Option<HistoryEntry>,
+}
+
+impl HistoryScanner {
+    pub fn scan(&mut self, roots: &HistoryRoots, tracked: &HashSet<String>) -> Vec<HistoryEntry> {
+        self.visited.clear();
+        let mut entries = scan_claude(&roots.claude, self);
+        entries.extend(scan_codex(&roots.codex, self));
+        self.files.retain(|path, _| self.visited.contains(path));
+
+        let mut seen = tracked.clone();
+        entries.retain(|entry| seen.insert(entry.id.clone()));
+        entries.sort_by(|left, right| {
+            right
+                .last_active_at
+                .partial_cmp(&left.last_active_at)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        entries
+    }
+
+    fn read(
+        &mut self,
+        path: &Path,
+        titles: Option<&HashMap<String, String>>,
+        read: impl FnOnce() -> Option<HistoryEntry>,
+    ) -> Option<HistoryEntry> {
+        let metadata = fs::symlink_metadata(path).ok()?;
+        if !metadata.is_file() {
+            return None;
+        }
+        self.visited.insert(path.to_owned());
+        let modified = metadata.modified().ok();
+        if let Some(cached) = self.files.get(path)
+            && modified.is_some()
+            && cached.modified == modified
+            && cached.len == metadata.len()
+            && cached.provider_title.as_ref()
+                == cached
+                    .entry
+                    .as_ref()
+                    .and_then(|entry| titles.and_then(|titles| titles.get(&entry.id)))
+        {
+            let mut entry = cached.entry.clone()?;
+            entry.cwd_exists = Path::new(&entry.cwd).is_dir();
+            return Some(entry);
+        }
+        let entry = read();
+        let provider_title = entry
+            .as_ref()
+            .and_then(|entry| titles.and_then(|titles| titles.get(&entry.id)))
+            .cloned();
+        self.files.insert(
+            path.to_owned(),
+            CachedTranscript {
+                modified,
+                len: metadata.len(),
+                provider_title,
+                entry: entry.clone(),
+            },
+        );
+        entry
+    }
 }
 
 /// Resume a durable conversation through the first-class Engine path. The
@@ -84,40 +147,56 @@ pub async fn resume(
         )));
     }
     client
-        .resume_from_history_with_prompt(entry.clone(), Some(RESUME_PROMPT.to_owned()))
+        .resume_from_history_with_prompt(entry.clone(), None)
         .await
         .map(|record| record.id)
 }
 
-pub fn matches_query(entry: &HistoryEntry, query: &str) -> bool {
-    let query = query.trim().to_lowercase();
-    if query.is_empty() {
-        return true;
-    }
-    let folder = Path::new(&entry.cwd)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or_default();
-    let candidate =
-        format!("{} {folder}", entry.title.as_deref().unwrap_or_default()).to_lowercase();
-    subsequence_match(&query, &candidate)
+#[derive(Default)]
+pub struct HistorySearch {
+    candidates: Vec<PreparedText>,
+    matcher: FuzzyMatcher,
 }
 
-fn subsequence_match(query: &str, candidate: &str) -> bool {
-    let mut query = query.chars();
-    let mut wanted = query.next();
-    for character in candidate.chars() {
-        if wanted == Some(character) {
-            wanted = query.next();
-            if wanted.is_none() {
-                return true;
-            }
+impl HistorySearch {
+    pub fn rebuild(&mut self, entries: &[HistoryEntry]) {
+        self.candidates = entries
+            .iter()
+            .map(|entry| {
+                PreparedText::new(&format!(
+                    "{} {} {} {}",
+                    entry.title.as_deref().unwrap_or_default(),
+                    entry.cwd,
+                    entry.kind.id(),
+                    entry.id
+                ))
+            })
+            .collect();
+    }
+
+    /// Query parsing and candidate preparation happen once, outside rendering.
+    /// Stable ties preserve newest-first order; words can match in any order.
+    pub fn rank(&mut self, query: &str) -> Vec<usize> {
+        let query = FuzzyQuery::new(query);
+        if query.is_empty() {
+            return (0..self.candidates.len()).collect();
         }
+        let mut matches = self
+            .candidates
+            .iter()
+            .enumerate()
+            .filter_map(|(index, candidate)| {
+                query
+                    .score(candidate, &mut self.matcher)
+                    .map(|score| (index, score))
+            })
+            .collect::<Vec<_>>();
+        matches.sort_by_key(|(_, score)| std::cmp::Reverse(*score));
+        matches.into_iter().map(|(index, _)| index).collect()
     }
-    wanted.is_none()
 }
 
-fn scan_claude(root: &Path) -> Vec<HistoryEntry> {
+fn scan_claude(root: &Path, scanner: &mut HistoryScanner) -> Vec<HistoryEntry> {
     let mut result = Vec::new();
     for project in child_dirs(root) {
         let Ok(files) = fs::read_dir(project) else {
@@ -128,7 +207,7 @@ fn scan_claude(root: &Path) -> Vec<HistoryEntry> {
             if path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
                 continue;
             }
-            if let Some(entry) = claude_entry(&path) {
+            if let Some(entry) = scanner.read(&path, None, || claude_entry(&path)) {
                 result.push(entry);
             }
         }
@@ -144,22 +223,36 @@ fn claude_entry(path: &Path) -> Option<HistoryEntry> {
     let metadata = fs::metadata(path).ok()?;
     let mut cwd = None;
     let mut first_prompt = None;
-    for line in read_capped_lines(path, CLAUDE_HEAD_CAP).ok()? {
+    let provider_title = latest_claude_ai_title(path);
+    for line in capped_lines(path, CLAUDE_HEAD_CAP)
+        .ok()?
+        .map_while(Result::ok)
+    {
         let Ok(object) = serde_json::from_str::<Value>(&line) else {
             continue;
         };
         if first_prompt.is_none() {
-            first_prompt = claude_user_text(&object);
+            first_prompt = claude_user_text(&object).and_then(|text| useful_prompt(&text));
         }
         if let Some(value) = object.get("cwd").and_then(Value::as_str)
             && !value.is_empty()
         {
             cwd = Some(value.to_owned());
+        }
+        if cwd.is_some() && (first_prompt.is_some() || provider_title.is_some()) {
             break;
         }
     }
     let cwd = cwd?;
-    let title = latest_claude_ai_title(path).or_else(|| first_prompt.map(title_from_prompt));
+    let title = provider_title
+        .or_else(|| first_prompt.map(title_from_prompt))
+        .or_else(|| {
+            Some(format!(
+                "Claude · {} · {}",
+                folder_name(&cwd),
+                id.chars().take(8).collect::<String>()
+            ))
+        });
     Some(history_entry(
         id,
         AgentKind::CLAUDE_CODE,
@@ -198,27 +291,37 @@ fn latest_claude_ai_title(path: &Path) -> Option<String> {
         .ok()?;
 
     let mut newest = None;
+    let mut custom = None;
     for line in String::from_utf8_lossy(&bytes).lines() {
-        if !line.contains("\"ai-title\"") {
+        if !line.contains("\"ai-title\"") && !line.contains("\"custom-title\"") {
             continue;
         }
         let Ok(object) = serde_json::from_str::<Value>(line) else {
             continue;
         };
-        if object.get("type").and_then(Value::as_str) == Some("ai-title")
+        if object.get("type").and_then(Value::as_str) == Some("custom-title") {
+            if let Some(title) = object
+                .get("customTitle")
+                .and_then(Value::as_str)
+                .and_then(useful_prompt)
+            {
+                custom = Some(title);
+            }
+        } else if object.get("type").and_then(Value::as_str) == Some("ai-title")
             && let Some(title) = object
                 .get("aiTitle")
                 .and_then(Value::as_str)
-                .filter(|title| !title.is_empty())
+                .and_then(useful_prompt)
         {
-            newest = Some(title.to_owned());
+            newest = Some(title);
         }
     }
-    newest
+    custom.or(newest)
 }
 
-fn scan_codex(root: &Path) -> Vec<HistoryEntry> {
+fn scan_codex(root: &Path, scanner: &mut HistoryScanner) -> Vec<HistoryEntry> {
     let mut result = Vec::new();
+    let titles = provider_titles(root.parent().unwrap_or(root));
     for year in child_dirs(root) {
         for month in child_dirs(&year) {
             for day in child_dirs(&month) {
@@ -233,7 +336,11 @@ fn scan_codex(root: &Path) -> Vec<HistoryEntry> {
                     {
                         continue;
                     }
-                    if let Some(entry) = codex_entry(&path) {
+                    // Names can change without the transcript changing. The
+                    // index revision participates in cache invalidation below.
+                    if let Some(entry) =
+                        scanner.read(&path, Some(&titles), || codex_entry(&path, &titles))
+                    {
                         result.push(entry);
                     }
                 }
@@ -243,22 +350,36 @@ fn scan_codex(root: &Path) -> Vec<HistoryEntry> {
     result
 }
 
-fn codex_entry(path: &Path) -> Option<HistoryEntry> {
+fn codex_entry(path: &Path, titles: &HashMap<String, String>) -> Option<HistoryEntry> {
     let first = read_first_line(path, CODEX_FIRST_LINE_CAP).ok()??;
     let object: Value = serde_json::from_str(&first).ok()?;
     if object.get("type").and_then(Value::as_str) != Some("session_meta") {
         return None;
     }
     let payload = object.get("payload")?;
+    // Internal worker threads are not conversations the user opened.
+    if payload.get("source").is_some_and(|source| {
+        source.get("subagent").is_some() || source.as_str() == Some("subagent")
+    }) {
+        return None;
+    }
     let id = payload.get("id")?.as_str()?.to_owned();
     let cwd = payload.get("cwd")?.as_str()?.to_owned();
     if cwd.is_empty() {
         return None;
     }
     let metadata = fs::metadata(path).ok()?;
-    let title = first_codex_user_prompt(path)
-        .map(title_from_prompt)
-        .or_else(|| Some(format!("Codex — {}", folder_name(&cwd))));
+    let title = titles
+        .get(&id)
+        .cloned()
+        .or_else(|| first_codex_user_prompt(path).map(title_from_prompt))
+        .or_else(|| {
+            Some(format!(
+                "Codex · {} · {}",
+                folder_name(&cwd),
+                id.chars().take(8).collect::<String>()
+            ))
+        });
     Some(history_entry(
         id,
         AgentKind::CODEX,
@@ -270,22 +391,45 @@ fn codex_entry(path: &Path) -> Option<HistoryEntry> {
 }
 
 fn first_codex_user_prompt(path: &Path) -> Option<String> {
-    for line in read_capped_lines(path, CODEX_FIRST_PROMPT_CAP).ok()? {
-        if !line.contains("\"user_message\"") {
+    for line in capped_lines(path, CODEX_FIRST_PROMPT_CAP)
+        .ok()?
+        .map_while(Result::ok)
+    {
+        if !line.contains("\"user_message\"")
+            && !line.contains("\"role\":\"user\"")
+            && !line.contains("\"role\": \"user\"")
+        {
             continue;
         }
         let Ok(object) = serde_json::from_str::<Value>(&line) else {
             continue;
         };
-        let payload = object.get("payload")?;
+        let Some(payload) = object.get("payload") else {
+            continue;
+        };
         if object.get("type").and_then(Value::as_str) == Some("event_msg")
             && payload.get("type").and_then(Value::as_str) == Some("user_message")
             && let Some(message) = payload
                 .get("message")
                 .and_then(Value::as_str)
                 .filter(|message| !message.trim().is_empty())
+            && let Some(prompt) = useful_prompt(message)
         {
-            return Some(message.to_owned());
+            return Some(prompt);
+        }
+        if object.get("type").and_then(Value::as_str) == Some("response_item")
+            && payload.get("role").and_then(Value::as_str) == Some("user")
+            && let Some(content) = payload.get("content").and_then(Value::as_array)
+        {
+            for item in content {
+                if let Some(prompt) = item
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .and_then(useful_prompt)
+                {
+                    return Some(prompt);
+                }
+            }
         }
     }
     None
@@ -318,25 +462,13 @@ fn system_time(time: Option<SystemTime>) -> DateMillis {
     DateMillis(millis)
 }
 
-fn read_capped_lines(path: &Path, cap: usize) -> io::Result<Vec<String>> {
+fn capped_lines(path: &Path, cap: usize) -> io::Result<impl Iterator<Item = io::Result<String>>> {
     let file = File::open(path)?;
-    let mut reader = BufReader::new(file.take(cap as u64));
-    let mut result = Vec::new();
-    let mut line = String::new();
-    while reader.read_line(&mut line)? != 0 {
-        if line.ends_with('\n') {
-            line.pop();
-            if line.ends_with('\r') {
-                line.pop();
-            }
-        }
-        result.push(std::mem::take(&mut line));
-    }
-    Ok(result)
+    Ok(BufReader::new(file.take(cap as u64)).lines())
 }
 
 fn read_first_line(path: &Path, cap: usize) -> io::Result<Option<String>> {
-    Ok(read_capped_lines(path, cap)?.into_iter().next())
+    capped_lines(path, cap)?.next().transpose()
 }
 
 fn child_dirs(root: &Path) -> Vec<PathBuf> {
@@ -353,10 +485,146 @@ fn child_dirs(root: &Path) -> Vec<PathBuf> {
 fn title_from_prompt(prompt: String) -> String {
     let collapsed = prompt.split_whitespace().collect::<Vec<_>>().join(" ");
     let mut characters = collapsed.chars();
-    if characters.clone().count() <= 60 {
+    if characters.clone().count() <= 160 {
         return collapsed;
     }
-    characters.by_ref().take(59).collect::<String>() + "…"
+    characters.by_ref().take(159).collect::<String>() + "…"
+}
+
+/// Provider context and replay wrappers are not a user's conversation title.
+fn useful_prompt(text: &str) -> Option<String> {
+    let mut text = text.trim();
+    for prefix in [
+        "The following is the Codex agent history",
+        "This historical conversation has just been resumed",
+        "# AGENTS.md instructions",
+        "<environment_context>",
+        "<INSTRUCTIONS>",
+        "<permissions instructions>",
+        "<turn_aborted>",
+        "You are an AI assistant",
+    ] {
+        if text.starts_with(prefix) {
+            return None;
+        }
+    }
+    // Image attachment metadata can precede the user's actual request.
+    while text.starts_with("<image ") {
+        let end = text.find("</image>")? + "</image>".len();
+        text = text[end..].trim();
+    }
+    (!text.is_empty()).then(|| title_from_prompt(text.to_owned()))
+}
+
+/// Read provider names in batches, once per scan, rather than once per rollout.
+/// SQLite is already used by the workspace; read-only access recovers names
+/// without depending on a running provider process or scanning transcript bodies.
+fn provider_titles(home: &Path) -> HashMap<String, String> {
+    let mut titles = HashMap::new();
+    let mut explicit = HashMap::new();
+    let mut databases = fs::read_dir(home)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_file()))
+        .filter_map(|entry| {
+            let name = entry.file_name();
+            let version = name
+                .to_str()?
+                .strip_prefix("state_")?
+                .strip_suffix(".sqlite")?
+                .parse::<u32>()
+                .ok()?;
+            Some((version, entry.path()))
+        })
+        .collect::<Vec<_>>();
+    databases.sort_by_key(|(version, _)| std::cmp::Reverse(*version));
+    for (_, path) in databases.into_iter().take(16) {
+        let Ok(connection) = rusqlite::Connection::open_with_flags(
+            path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        ) else {
+            continue;
+        };
+        let _ = connection.busy_timeout(std::time::Duration::from_millis(20));
+        let columns = connection
+            .prepare("PRAGMA table_info(threads)")
+            .ok()
+            .and_then(|mut statement| {
+                Some(
+                    statement
+                        .query_map([], |row| row.get::<_, String>(1))
+                        .ok()?
+                        .filter_map(Result::ok)
+                        .collect::<HashSet<_>>(),
+                )
+            })
+            .unwrap_or_default();
+        if !columns.contains("id") {
+            continue;
+        }
+        let field = |name: &str| if columns.contains(name) { name } else { "NULL" }.to_owned();
+        let query = format!(
+            "SELECT id, {}, {}, {} FROM threads LIMIT 100000",
+            field("name"),
+            field("title"),
+            field("first_user_message")
+        );
+        let Ok(mut statement) = connection.prepare(&query) else {
+            continue;
+        };
+        let Ok(rows) = statement.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+            ))
+        }) else {
+            continue;
+        };
+        for (id, name, title, prompt) in rows.flatten() {
+            if let Some(name) = name.as_deref().and_then(useful_prompt) {
+                explicit.entry(id.clone()).or_insert(name);
+            }
+            if let Some(title) = title
+                .as_deref()
+                .and_then(useful_prompt)
+                .or_else(|| prompt.as_deref().and_then(useful_prompt))
+            {
+                titles.entry(id).or_insert(title);
+            }
+        }
+    }
+    let index_path = home.join("session_index.jsonl");
+    if fs::symlink_metadata(&index_path).is_ok_and(|metadata| metadata.is_file())
+        && let Ok(mut file) = File::open(index_path)
+    {
+        let end = file.seek(SeekFrom::End(0)).unwrap_or(0);
+        let start = end.saturating_sub(16 << 20);
+        if file.seek(SeekFrom::Start(start)).is_ok() {
+            let mut lines = BufReader::new(file.take(16 << 20)).lines();
+            if start > 0 {
+                lines.next();
+            }
+            for line in lines.map_while(Result::ok) {
+                let Ok(value) = serde_json::from_str::<Value>(&line) else {
+                    continue;
+                };
+                if let (Some(id), Some(title)) = (
+                    value.get("id").and_then(Value::as_str),
+                    value
+                        .get("thread_name")
+                        .and_then(Value::as_str)
+                        .and_then(useful_prompt),
+                ) {
+                    titles.insert(id.to_owned(), title);
+                }
+            }
+        }
+    }
+    titles.extend(explicit);
+    titles
 }
 
 fn folder_name(path: &str) -> &str {
@@ -520,9 +788,10 @@ mod tests {
             serde_json::json!({ "claudeCode": {} })
         );
         assert_eq!(params["entry"]["transcriptPath"], entry.transcript_path);
-        assert!(params["initialPrompt"].as_str().is_some_and(|prompt| {
-            prompt.contains("historical conversation has just been resumed")
-        }));
+        assert!(
+            params["initialPrompt"].is_null(),
+            "opening history must not send a message"
+        );
 
         client.shutdown().await;
         server.join().unwrap();
@@ -540,9 +809,156 @@ mod tests {
             created_at: None,
             cwd_exists: false,
         };
-        assert!(matches_query(&entry, "hpal"));
-        assert!(matches_query(&entry, "diri"));
-        assert!(!matches_query(&entry, "zebra"));
+        let mut search = HistorySearch::default();
+        search.rebuild(&[entry]);
+        assert_eq!(search.rank("hpal"), [0]);
+        assert_eq!(search.rank("diri"), [0]);
+        assert_eq!(search.rank("claude tmp history"), [0]);
+        assert!(search.rank("zebra").is_empty());
+    }
+
+    #[test]
+    fn history_skips_injected_context_and_reads_response_item_prompts() {
+        let temp = TempDir::new().unwrap();
+        let roots = fixture_roots(&temp);
+        let day = roots.codex.join("2026/09/05");
+        fs::create_dir_all(&day).unwrap();
+        let path = day.join("rollout-thread.jsonl");
+        let records = [
+            serde_json::json!({"type":"session_meta","payload":{"id":"thread","cwd":"/tmp"}}),
+            serde_json::json!({"type":"event_msg","payload":{"type":"user_message","message":"The following is the Codex agent history whose request activated this agent."}}),
+            serde_json::json!({"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"# AGENTS.md instructions for /tmp\n<INSTRUCTIONS>rules</INSTRUCTIONS>"}]}}),
+            serde_json::json!({"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Fix conversation search performance"}]}}),
+        ];
+        fs::write(
+            path,
+            records.iter().map(|r| format!("{r}\n")).collect::<String>(),
+        )
+        .unwrap();
+        let entries = scan(&roots, &HashSet::new());
+        assert_eq!(
+            entries[0].title.as_deref(),
+            Some("Fix conversation search performance")
+        );
+    }
+
+    #[test]
+    fn history_scan_large_transcripts_benchmark() {
+        let temp = TempDir::new().unwrap();
+        let roots = fixture_roots(&temp);
+        let day = roots.codex.join("2026/09/05");
+        fs::create_dir_all(&day).unwrap();
+        for index in 0..64 {
+            let mut file = File::create(day.join(format!("rollout-{index}.jsonl"))).unwrap();
+            writeln!(file, "{}", serde_json::json!({"type":"session_meta","payload":{"id":format!("thread-{index}"),"cwd":"/tmp"}})).unwrap();
+            writeln!(file, "{}", serde_json::json!({"type":"event_msg","payload":{"type":"user_message","message":"Fix search"}})).unwrap();
+            file.set_len(8 << 20).unwrap();
+        }
+        let mut scanner = HistoryScanner::default();
+        let started = std::time::Instant::now();
+        assert_eq!(scanner.scan(&roots, &HashSet::new()).len(), 64);
+        eprintln!("64 x 8 MiB history scan: {:?}", started.elapsed());
+        let started = std::time::Instant::now();
+        assert_eq!(scanner.scan(&roots, &HashSet::new()).len(), 64);
+        eprintln!("64 x 8 MiB cached scan: {:?}", started.elapsed());
+    }
+
+    #[test]
+    fn cached_history_refreshes_names_folders_and_deleted_transcripts() {
+        let temp = TempDir::new().unwrap();
+        let roots = fixture_roots(&temp);
+        let day = roots.codex.join("2026/09/05");
+        let cwd = temp.path().join("project");
+        fs::create_dir_all(&day).unwrap();
+        fs::create_dir(&cwd).unwrap();
+        let path = day.join("rollout-thread.jsonl");
+        fs::write(&path, format!("{}\n{}\n", serde_json::json!({"type":"session_meta","payload":{"id":"thread","cwd":cwd}}), serde_json::json!({"type":"event_msg","payload":{"type":"user_message","message":"Fallback prompt"}}))).unwrap();
+        let connection = rusqlite::Connection::open(temp.path().join("state_5.sqlite")).unwrap();
+        connection.execute_batch("CREATE TABLE threads (id TEXT, name TEXT, title TEXT); INSERT INTO threads VALUES ('thread', NULL, 'Database title');").unwrap();
+        let mut scanner = HistoryScanner::default();
+        assert_eq!(
+            scanner.scan(&roots, &HashSet::new())[0].title.as_deref(),
+            Some("Database title")
+        );
+        fs::write(
+            temp.path().join("session_index.jsonl"),
+            "{\"id\":\"thread\",\"thread_name\":\"Indexed title\"}\n",
+        )
+        .unwrap();
+        assert_eq!(
+            scanner.scan(&roots, &HashSet::new())[0].title.as_deref(),
+            Some("Indexed title")
+        );
+        connection
+            .execute_batch("UPDATE threads SET name = 'My custom title';")
+            .unwrap();
+        assert_eq!(
+            scanner.scan(&roots, &HashSet::new())[0].title.as_deref(),
+            Some("My custom title")
+        );
+        assert!(
+            scanner
+                .scan(&roots, &HashSet::from(["thread".to_owned()]))
+                .is_empty()
+        );
+        fs::remove_dir(cwd).unwrap();
+        assert!(!scanner.scan(&roots, &HashSet::new())[0].cwd_exists);
+        fs::remove_file(path).unwrap();
+        assert!(scanner.scan(&roots, &HashSet::new()).is_empty());
+        assert!(scanner.files.is_empty());
+    }
+
+    #[test]
+    fn claude_cwd_before_user_prompt_and_custom_title() {
+        let temp = TempDir::new().unwrap();
+        let roots = fixture_roots(&temp);
+        let project = roots.claude.join("project");
+        fs::create_dir_all(&project).unwrap();
+        let path = project.join("12345678-1234-1234-1234-123456789abc.jsonl");
+        fs::write(&path, "{\"type\":\"system\",\"cwd\":\"/tmp\"}\n{\"type\":\"user\",\"message\":{\"content\":\"Actual request\"}}\n").unwrap();
+        let mut scanner = HistoryScanner::default();
+        assert_eq!(
+            scanner.scan(&roots, &HashSet::new())[0].title.as_deref(),
+            Some("Actual request")
+        );
+        let mut file = fs::OpenOptions::new().append(true).open(path).unwrap();
+        writeln!(file, "{{\"type\":\"custom-title\",\"customTitle\":\"My title\"}}\n{{\"type\":\"ai-title\",\"aiTitle\":\"Generated later\"}}").unwrap();
+        assert_eq!(
+            scanner.scan(&roots, &HashSet::new())[0].title.as_deref(),
+            Some("My title")
+        );
+    }
+
+    #[test]
+    #[ignore = "read-only benchmark of local history; prints only counts and timings"]
+    fn history_real_store_benchmark() {
+        let mut scanner = HistoryScanner::default();
+        for label in ["cold", "warm"] {
+            let start = std::time::Instant::now();
+            let entries = scanner.scan(&HistoryRoots::current_user(), &HashSet::new());
+            eprintln!(
+                "{label}: {} conversations in {:?}; {} named",
+                entries.len(),
+                start.elapsed(),
+                entries.iter().filter(|e| e.title.is_some()).count()
+            );
+            let mut search = HistorySearch::default();
+            search.rebuild(&entries);
+            let start = std::time::Instant::now();
+            for query in [
+                "d",
+                "di",
+                "diri",
+                "codex search",
+                "claude",
+                "fix",
+                "terminal",
+                "!codex",
+            ] {
+                let _ = search.rank(query);
+            }
+            eprintln!("8 ranked searches: {:?}", start.elapsed());
+        }
     }
 
     /// Explicit live acceptance check for T14. It is ignored by the normal

--- a/diri/crates/diri-app/src/store/mod.rs
+++ b/diri/crates/diri-app/src/store/mod.rs
@@ -1438,7 +1438,7 @@ impl SessionStore {
         self.focus_session(id);
     }
 
-    fn apply_spawn_result(&mut self, id: SessionId) {
+    pub(crate) fn apply_spawn_result(&mut self, id: SessionId) {
         // session.updated and the spawn response travel on separate channels,
         // so either can arrive first. focus_session handles both orderings:
         // if the record is already present it grants terminal residency now;

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -26,8 +26,9 @@ use diri_ui::{
 use gpui::{
     Animation, AnimationExt, AnyElement, App, Bounds, BoxShadow, ClickEvent, Context, CursorStyle,
     FocusHandle, Focusable, FontWeight, IntoElement, KeyDownEvent, MouseButton, PathPromptOptions,
-    Pixels, Render, Rgba, ScrollHandle, SharedString, Task, TextRun, Window, canvas, deferred, div,
-    ease_out_quint, font, point, prelude::*, px, rgba,
+    Pixels, Render, Rgba, ScrollHandle, ScrollStrategy, SharedString, Task, TextRun,
+    UniformListScrollHandle, Window, canvas, deferred, div, ease_out_quint, font, point,
+    prelude::*, px, rgba, uniform_list,
 };
 use tokio::runtime::Runtime;
 
@@ -39,7 +40,6 @@ const SETTINGS_CONTENT_MAX_WIDTH: f32 = 760.0;
 const SETTINGS_TRANSITION_DURATION: Duration = Duration::from_millis(190);
 const SETTINGS_SECTION_GAP: f32 = 16.0;
 const SETTINGS_ROW_HEIGHT: f32 = 50.0;
-const RESULT_LIMIT: usize = 200;
 const HOST_FIELD_HORIZONTAL_PADDING: f32 = 10.0;
 /// Reinstall success is confirmation, not persistent host state. Errors stay
 /// actionable and first-time setup keeps its "Use by default" action.
@@ -258,6 +258,11 @@ pub struct UtilitySurfaces {
     history_highlight: usize,
     history_loading: bool,
     history_error: Option<String>,
+    history_scanner: Option<crate::history::HistoryScanner>,
+    history_search: crate::history::HistorySearch,
+    history_matches: Vec<usize>,
+    history_scroll: UniformListScrollHandle,
+    history_resuming: Option<String>,
     worktrees: WorktreesSheet,
     settings_tab: SettingsTab,
     usage: crate::usage::UsageSnapshot,
@@ -377,6 +382,11 @@ impl UtilitySurfaces {
             history_highlight: 0,
             history_loading: false,
             history_error: None,
+            history_scanner: Some(crate::history::HistoryScanner::default()),
+            history_search: crate::history::HistorySearch::default(),
+            history_matches: Vec::new(),
+            history_scroll: UniformListScrollHandle::new(),
+            history_resuming: None,
             worktrees: WorktreesSheet::default(),
             settings_tab,
             usage: crate::usage::UsageSnapshot::default(),
@@ -422,37 +432,41 @@ impl UtilitySurfaces {
         self.surface = Surface::History;
         self.history_query.clear();
         self.history_highlight = 0;
+        self.history_scroll = UniformListScrollHandle::new();
+        self.filter_history();
+        self.history_error = None;
+        cx.notify();
+        self.refresh_history(cx);
+    }
+
+    fn refresh_history(&mut self, cx: &mut Context<Self>) {
+        // Reopening uses the last result immediately and shares any in-flight
+        // scan. History is local data: a disconnected Engine must not delay it.
+        let Some(mut scanner) = self.history_scanner.take() else {
+            return;
+        };
         self.history_loading = true;
         self.history_error = None;
         cx.notify();
 
         let roots = crate::history::HistoryRoots::current_user();
-        let client = Arc::clone(self.store_runtime.client());
+        let tracked = self
+            .store
+            .read()
+            .expect("session store lock poisoned")
+            .sessions()
+            .values()
+            .filter_map(|session| session.agent_session_id.clone())
+            .collect();
         let runtime = Arc::clone(&self.runtime);
         cx.spawn(async move |this, cx| {
             let task = runtime.spawn(async move {
-                let tracked = if client
-                    .wait_until_connected(Duration::from_secs(5))
-                    .await
-                    .is_ok()
-                {
-                    client
-                        .sessions()
-                        .await
-                        .map(|result| {
-                            result
-                                .sessions
-                                .into_iter()
-                                .filter_map(|session| session.agent_session_id)
-                                .collect()
-                        })
-                        .unwrap_or_default()
-                } else {
-                    HashSet::new()
-                };
-                tokio::task::spawn_blocking(move || crate::history::scan(&roots, &tracked))
-                    .await
-                    .map_err(|error| error.to_string())
+                tokio::task::spawn_blocking(move || {
+                    let entries = scanner.scan(&roots, &tracked);
+                    (scanner, entries)
+                })
+                .await
+                .map_err(|error| error.to_string())
             });
             let result = task
                 .await
@@ -461,11 +475,34 @@ impl UtilitySurfaces {
             let _ = this.update(cx, |this, cx| {
                 this.history_loading = false;
                 match result {
-                    Ok(entries) => {
+                    Ok((scanner, mut entries)) => {
+                        // A session can become tracked while the disk scan is
+                        // running. Reconcile against the current store as well.
+                        let tracked = this
+                            .store
+                            .read()
+                            .expect("session store lock poisoned")
+                            .sessions()
+                            .values()
+                            .filter_map(|session| session.agent_session_id.clone())
+                            .collect::<HashSet<_>>();
+                        entries.retain(|entry| !tracked.contains(&entry.id));
+                        let selected_id = this.highlighted_history().map(|entry| entry.id.clone());
+                        this.history_scanner = Some(scanner);
                         this.activity = format!("{} past conversations found", entries.len());
                         this.history = entries;
+                        this.history_search.rebuild(&this.history);
+                        this.filter_history();
+                        if let Some(index) = this.history_matches.iter().position(|index| {
+                            Some(&this.history[*index].id) == selected_id.as_ref()
+                        }) {
+                            this.history_highlight = index;
+                        }
                     }
-                    Err(error) => this.history_error = Some(error),
+                    Err(error) => {
+                        this.history_scanner = Some(crate::history::HistoryScanner::default());
+                        this.history_error = Some(error);
+                    }
                 }
                 cx.notify();
             });
@@ -508,15 +545,39 @@ impl UtilitySurfaces {
     }
 
     fn resume_history(&mut self, entry: HistoryEntry, cx: &mut Context<Self>) {
+        if self.history_resuming.is_some() {
+            return;
+        }
+        let existing = self
+            .store
+            .read()
+            .expect("session store lock poisoned")
+            .sessions()
+            .values()
+            .find(|session| {
+                session.agent_session_id.as_deref() == Some(&entry.id) && session.kind == entry.kind
+            })
+            .map(|session| session.id.clone());
+        if let Some(id) = existing {
+            self.store
+                .write()
+                .expect("session store lock poisoned")
+                .select(id);
+            self.surface = Surface::None;
+            cx.notify();
+            return;
+        }
         if !entry.cwd_exists || !Path::new(&entry.cwd).is_dir() {
             self.history_error = Some("The conversation folder is no longer available".to_owned());
             cx.notify();
             return;
         }
-        self.history_loading = true;
+        self.history_resuming = Some(entry.id.clone());
         self.history_error = None;
+        cx.notify();
         let client = Arc::clone(self.store_runtime.client());
         let runtime = Arc::clone(&self.runtime);
+        let conversation_id = entry.id.clone();
         cx.spawn(async move |this, cx| {
             let task = runtime.spawn(async move {
                 client.wait_until_connected(Duration::from_secs(5)).await?;
@@ -527,10 +588,19 @@ impl UtilitySurfaces {
                 Err(error) => Err(error.to_string()),
             };
             let _ = this.update(cx, |this, cx| {
-                this.history_loading = false;
+                this.history_resuming = None;
                 match result {
                     Ok(id) => {
-                        this.surface = Surface::None;
+                        this.history.retain(|entry| entry.id != conversation_id);
+                        this.history_search.rebuild(&this.history);
+                        this.filter_history();
+                        this.store
+                            .write()
+                            .expect("session store lock poisoned")
+                            .apply_spawn_result(id.clone());
+                        if this.surface == Surface::History {
+                            this.surface = Surface::None;
+                        }
                         this.activity = format!("Resumed conversation in session {id}");
                     }
                     Err(error) => this.history_error = Some(error),
@@ -995,25 +1065,31 @@ impl UtilitySurfaces {
         true
     }
 
-    fn visible_history(&self) -> Vec<HistoryEntry> {
-        self.history
-            .iter()
-            .filter(|entry| crate::history::matches_query(entry, self.history_query.text()))
-            .take(RESULT_LIMIT)
-            .cloned()
-            .collect()
+    fn filter_history(&mut self) {
+        self.history_matches = self.history_search.rank(self.history_query.text());
+        self.history_highlight = self
+            .history_highlight
+            .min(self.history_matches.len().saturating_sub(1));
+    }
+
+    fn highlighted_history(&self) -> Option<&HistoryEntry> {
+        self.history_matches
+            .get(self.history_highlight)
+            .and_then(|index| self.history.get(*index))
     }
 
     fn move_history(&mut self, delta: isize, cx: &mut Context<Self>) {
         if self.surface != Surface::History {
             return;
         }
-        let count = self.visible_history().len();
+        let count = self.history_matches.len();
         if count == 0 {
             return;
         }
         self.history_highlight =
             (self.history_highlight as isize + delta).rem_euclid(count as isize) as usize;
+        self.history_scroll
+            .scroll_to_item(self.history_highlight, ScrollStrategy::Nearest);
         cx.notify();
     }
 
@@ -1021,7 +1097,7 @@ impl UtilitySurfaces {
         if self.surface != Surface::History {
             return;
         }
-        if let Some(entry) = self.visible_history().get(self.history_highlight).cloned() {
+        if let Some(entry) = self.highlighted_history().cloned() {
             self.resume_history(entry, cx);
         }
     }
@@ -1488,143 +1564,204 @@ impl UtilitySurfaces {
             };
             if changed {
                 self.history_highlight = 0;
+                self.filter_history();
+                self.history_scroll.scroll_to_item(0, ScrollStrategy::Top);
             }
             cx.notify();
         }
     }
 
-    fn render_history(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        let colors = self.colors();
-        let entries = self.visible_history();
-        let empty = entries.is_empty() && !self.history_loading;
-        let rows = entries.into_iter().enumerate().map(|(index, entry)| {
-            let selected = index == self.history_highlight;
-            let resumable = entry.cwd_exists;
-            let folder = folder_name(&entry.cwd).to_owned();
-            let parent = relative_parent(&entry.cwd);
-            let title = entry
-                .title
-                .clone()
-                .unwrap_or_else(|| "Untitled conversation".to_owned());
-            let age = relative_time(entry.last_active_at.0);
-            let agent = ui_agent(&entry.kind);
-            div()
-                .id(("history-row", index))
-                .h(px(46.0))
-                .px(px(10.0))
-                .rounded(px(Radius::ROW))
-                .flex()
-                .items_center()
-                .gap(px(9.0))
-                .opacity(if resumable { 1.0 } else { 0.45 })
-                .bg(Fill::selected(colors, selected))
-                .cursor_pointer()
-                .hover(move |style| style.bg(Fill::hover(colors, true)))
-                .on_click(cx.listener(move |this, _, _, cx| {
-                    if resumable {
+    fn render_history_row(&self, index: usize, cx: &mut Context<Self>) -> AnyElement {
+        let colors = self.settings_colors();
+        let entry = self.history[self.history_matches[index]].clone();
+        let selected = index == self.history_highlight;
+        let resumable = entry.cwd_exists;
+        let opening = self.history_resuming.as_deref() == Some(&entry.id);
+        let busy = self.history_resuming.is_some();
+        let folder = folder_name(&entry.cwd).to_owned();
+        let parent = relative_parent(&entry.cwd);
+        let title = entry
+            .title
+            .clone()
+            .unwrap_or_else(|| "Untitled conversation".to_owned());
+        let age = relative_time(entry.last_active_at.0);
+        let agent = ui_agent(&entry.kind);
+        div()
+            .h(px(56.0))
+            .px(px(8.0))
+            .py(px(2.0))
+            .child(
+                div()
+                    .id(("history-row", index))
+                    .debug_selector(move || format!("history-row-{index}"))
+                    .h_full()
+                    .px(px(10.0))
+                    .rounded(px(Radius::CARD))
+                    .flex()
+                    .items_center()
+                    .gap(px(9.0))
+                    .bg(Fill::selected(colors, selected))
+                    .when(resumable && !busy, |row| row.cursor_pointer())
+                    .when(!resumable, |row| {
+                        row.cursor(CursorStyle::OperationNotAllowed)
+                    })
+                    .hover(move |style| {
+                        style.bg(if selected {
+                            Fill::selected(colors, true)
+                        } else {
+                            Fill::hover(colors, true)
+                        })
+                    })
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        this.history_highlight = index;
                         this.resume_history(entry.clone(), cx);
-                    }
-                }))
-                .child(AgentLogo::new(agent, 18.0, colors))
-                .child(
-                    div()
-                        .flex()
-                        .flex_col()
-                        .flex_1()
-                        .min_w(px(0.0))
-                        .gap(px(2.0))
-                        .child(
-                            div()
-                                .text_size(px(13.0))
-                                .text_color(colors.primary)
-                                .overflow_hidden()
-                                .child(title),
-                        )
-                        .child(
-                            div()
-                                .flex()
-                                .gap(px(5.0))
-                                .text_size(px(11.0))
-                                .child(div().text_color(colors.secondary).child(folder))
-                                .child(div().text_color(colors.tertiary).child(parent)),
-                        ),
-                )
-                .child(chip(
-                    if !resumable {
-                        "folder gone".to_owned()
-                    } else if selected {
-                        "↵ resume".to_owned()
-                    } else {
-                        age
-                    },
-                    colors,
-                ))
-        });
+                    }))
+                    .child(AgentLogo::new(agent, 24.0, colors))
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .flex_1()
+                            .min_w(px(0.0))
+                            .gap(px(2.0))
+                            .child(
+                                div()
+                                    .text_size(px(13.0))
+                                    .font_weight(if selected {
+                                        FontWeight::MEDIUM
+                                    } else {
+                                        FontWeight::NORMAL
+                                    })
+                                    .text_color(colors.primary)
+                                    .truncate()
+                                    .child(title),
+                            )
+                            .child(
+                                div()
+                                    .flex()
+                                    .overflow_hidden()
+                                    .gap(px(5.0))
+                                    .text_size(px(11.0))
+                                    .child(div().text_color(colors.secondary).child(folder))
+                                    .child(
+                                        div().text_color(colors.tertiary).truncate().child(parent),
+                                    ),
+                            ),
+                    )
+                    .child(
+                        div()
+                            .flex_none()
+                            .text_size(px(11.0))
+                            .text_color(colors.secondary)
+                            .child(if opening {
+                                "Opening…".to_owned()
+                            } else if !resumable {
+                                "Folder unavailable".to_owned()
+                            } else {
+                                age
+                            }),
+                    ),
+            )
+            .into_any_element()
+    }
+
+    fn render_history(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let colors = self.settings_colors();
+        let count = self.history_matches.len();
+        let entity = cx.entity();
+        let selected = self.highlighted_history();
+        let status = if self.history_resuming.is_some() {
+            "Opening conversation…".to_owned()
+        } else if self.history_loading {
+            "Updating history…".to_owned()
+        } else if self.history_query.is_empty() {
+            format!("{count} conversations · Recent first")
+        } else {
+            format!("{count} matches · Best match first")
+        };
 
         FloatingSurface::new(
-            self.colors(),
+            colors,
             div()
-                .w(px(560.0))
-                .max_h(px(440.0))
+                .id("conversation-history")
+                .debug_selector(|| "conversation-history".into())
+                .w(px(620.0))
+                .max_w_full()
                 .flex()
                 .flex_col()
                 .child(
+                    div().px(px(18.0)).pt(px(14.0)).pb(px(10.0)).flex().items_center().justify_between()
+                        .child(div().text_size(px(13.0)).font_weight(FontWeight::SEMIBOLD).child("Past conversations"))
+                        .child(div().id("close-history").cursor_pointer().rounded(px(Radius::ROW))
+                            .px(px(7.0)).py(px(4.0)).text_size(px(11.0)).text_color(colors.secondary)
+                            .hover(move |style| style.bg(Fill::hover(colors, true)))
+                            .on_click(cx.listener(|this, _, _, cx| this.close_surface(cx)))
+                            .child("esc")),
+                )
+                .child(div().px(px(12.0)).pb(px(10.0)).child(
                     div()
-                        .h(px(48.0))
-                        .px(px(16.0))
+                        .h(px(40.0))
+                        .px(px(12.0))
+                        .rounded(px(Radius::CARD))
+                        .bg(Fill::subtle(colors))
+                        .border_1().border_color(colors.primary.alpha(0.10))
                         .flex()
                         .items_center()
                         .gap(px(10.0))
-                        .text_size(px(15.0))
+                        .text_size(px(13.0))
                         .child(sf_symbol("magnifyingglass", 13.0, colors.tertiary))
                         .child(
                             div()
                                 .flex_1()
+                                .min_w(px(0.0))
+                                .overflow_hidden()
                                 .text_color(if self.history_query.is_empty() {
                                     colors.tertiary
                                 } else {
                                     colors.primary
                                 })
                                 .child(if self.history_query.is_empty() {
-                                    div().child("Search past conversations…").into_any_element()
+                                    div().child("Search by title, project, or agent…").into_any_element()
                                 } else {
                                     query_label(&self.history_query)
                                 }),
                         )
-                        .child(chip("esc".to_owned(), colors)),
-                )
+                        .when(!self.history_query.is_empty(), |view| view.child(
+                            div().id("clear-history-search").cursor_pointer().text_color(colors.secondary)
+                                .on_click(cx.listener(|this, _, _, cx| {
+                                    this.history_query.clear(); this.history_highlight = 0;
+                                    this.filter_history(); this.history_scroll.scroll_to_item(0, ScrollStrategy::Top); cx.notify();
+                                })).child(sf_symbol("xmark.circle.fill", 13.0, colors.tertiary))
+                        )),
+                ))
+                .child(div().px(px(18.0)).pb(px(8.0)).flex().items_center().justify_between()
+                    .child(div().text_size(px(11.0)).text_color(colors.secondary).child(status))
+                    .when(!self.history_loading, |view| view.child(div().id("refresh-history").cursor_pointer()
+                        .text_size(px(11.0)).text_color(colors.secondary)
+                        .on_click(cx.listener(|this, _, _, cx| this.refresh_history(cx))).child("Refresh"))))
+                .when_some(self.history_error.clone(), |view, error| view.child(
+                    div().px(px(18.0)).py(px(8.0)).text_size(px(12.0)).text_color(Ink::DANGER).child(error)))
+                .child(div().h(px(336.0)).when(count > 0, |view| view.child(
+                    uniform_list("history-results", count, move |range, _, cx| {
+                        entity.update(cx, |this, cx| range.map(|index| this.render_history_row(index, cx)).collect())
+                    }).track_scroll(&self.history_scroll).size_full()
+                )).when(count == 0, |view| view.child(
+                    div().size_full().flex().flex_col().items_center().justify_center().gap(px(10.0))
+                        .child(sf_symbol("magnifyingglass", 24.0, colors.tertiary))
+                        .child(div().text_size(px(13.0)).text_color(colors.primary).child(
+                            if self.history_loading { "Finding your conversations…" } else if self.history_query.is_empty() { "Your next conversation starts here" } else { "No matching conversations" }))
+                        .child(div().text_size(px(12.0)).text_color(colors.secondary).child(
+                            if self.history_query.is_empty() { "Past Claude and Codex chats appear here automatically." } else { "Try a project name, agent, or a few words from the title." }))
+                )))
                 .child(HairlineDivider::horizontal(colors))
-                .child(
-                    div()
-                        .id("history-results")
-                        .max_h(px(380.0))
-                        .overflow_y_scroll()
-                        .p(px(6.0))
-                        .flex()
-                        .flex_col()
-                        .gap(px(1.0))
-                        .when(self.history_loading, |view| {
-                            view.child(empty_label(
-                                "Scanning Claude and Codex transcripts…",
-                                colors,
-                            ))
-                        })
-                        .when_some(self.history_error.clone(), |view, error| {
-                            view.child(empty_label(&error, colors))
-                        })
-                        .when(empty, |view| {
-                            view.child(empty_label(
-                                if self.history_query.is_empty() {
-                                    "Past Claude and Codex conversations will appear here."
-                                } else {
-                                    "No conversations match. Try a different search."
-                                },
-                                colors,
-                            ))
-                        })
-                        .children(rows),
-                ),
-        )
+                .child(div().px(px(18.0)).py(px(10.0)).h(px(88.0)).flex().flex_col().justify_between().gap(px(5.0))
+                    .child(div().text_size(px(12.0)).text_color(colors.primary).max_h(px(36.0)).overflow_hidden()
+                        .child(selected.and_then(|entry| entry.title.clone()).unwrap_or_else(|| "Pick up where you left off".to_owned())))
+                    .child(div().flex().items_center().justify_between().gap(px(12.0))
+                        .child(div().min_w(px(0.0)).flex_1().text_size(px(11.0)).text_color(colors.secondary).truncate()
+                            .child(selected.map(|entry| entry.cwd.clone()).unwrap_or_else(|| "Search all your local conversations".to_owned())))
+                        .child(div().flex_none().text_size(px(11.0)).text_color(colors.secondary).child("↑ ↓ navigate    ↵ open"))))
+        ).radius(Radius::FLOATING_MENU)
     }
 
     fn render_worktrees(&self, cx: &mut Context<Self>) -> impl IntoElement {
@@ -5970,6 +6107,174 @@ mod tests {
                     .cached(StyleRefinement::default().absolute().inset_0()),
             )
         }
+    }
+
+    fn seed_history(surfaces: &mut UtilitySurfaces) {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64()
+            * 1000.0;
+        let titles = [
+            "Make conversation search fast and useful",
+            "Polish sidebar navigation and rounded popovers",
+            "Keep remote sessions alive after reconnecting",
+            "Fix terminal rendering when switching projects",
+            "Add keyboard shortcuts for quick navigation",
+            "Explore a simpler onboarding flow",
+            "A longer conversation title about investigating search results across multiple projects and keeping useful names visible",
+        ];
+        surfaces.surface = Surface::History;
+        surfaces.history = (0..640)
+            .map(|index| HistoryEntry {
+                id: format!("conversation-{index}"),
+                kind: if index % 2 == 0 {
+                    ProtoAgentKind::CODEX
+                } else {
+                    ProtoAgentKind::CLAUDE_CODE
+                },
+                cwd: if index == 4 {
+                    "/work/old-worktree".to_owned()
+                } else {
+                    "/work/diri".to_owned()
+                },
+                title: Some(titles[index % titles.len()].to_owned()),
+                transcript_path: String::new(),
+                last_active_at: diri_proto::DateMillis(now - index as f64 * 3600000.0),
+                created_at: None,
+                cwd_exists: index != 4,
+            })
+            .collect();
+        surfaces.history_search.rebuild(&surfaces.history);
+        surfaces.filter_history();
+    }
+
+    #[cfg(target_os = "macos")]
+    #[gpui::test]
+    fn history_virtualizes_results_and_keeps_keyboard_selection_visible(cx: &mut TestAppContext) {
+        let (view, cx) = cx.add_window_view(|window, cx| {
+            let runtime = Arc::new(StoreRuntime::inert());
+            let tokio = Arc::new(
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap(),
+            );
+            let surfaces = cx.new(|cx| {
+                let mut surfaces =
+                    UtilitySurfaces::new(runtime, tokio, crate::updates::inert(), window, cx);
+                seed_history(&mut surfaces);
+                surfaces.focus.focus(window, cx);
+                surfaces
+            });
+            CachedOverlayHarness { surfaces }
+        });
+        cx.simulate_resize(size(px(800.0), px(700.0)));
+        cx.run_until_parked();
+        assert!(cx.debug_bounds("history-row-0").is_some());
+        assert!(
+            cx.debug_bounds("history-row-639").is_none(),
+            "offscreen rows must not be rendered"
+        );
+        let surfaces = view.read_with(cx, |view, _| view.surfaces.clone());
+        surfaces.update(cx, |surfaces, cx| surfaces.move_history(-1, cx));
+        cx.run_until_parked();
+        let row = cx
+            .debug_bounds("history-row-639")
+            .expect("keyboard selection scrolled into view");
+        let dialog = cx.debug_bounds("conversation-history").unwrap();
+        assert!(row.top() >= dialog.top() && row.bottom() <= dialog.bottom());
+        cx.simulate_keystrokes("s e a r c h");
+        cx.run_until_parked();
+        surfaces.read_with(cx, |surfaces, _| {
+            assert_eq!(surfaces.history_query.text(), "search");
+            assert_eq!(surfaces.history_highlight, 0);
+            assert!(surfaces.history_matches.len() < 640);
+        });
+        surfaces.update(cx, |surfaces, cx| {
+            surfaces.history_query.clear();
+            surfaces.history_query.insert("zzzzzz");
+            surfaces.filter_history();
+            cx.notify();
+        });
+        cx.run_until_parked();
+        let empty_dialog = cx.debug_bounds("conversation-history").unwrap();
+        assert_eq!(
+            empty_dialog.size.width, dialog.size.width,
+            "empty results preserve dialog width"
+        );
+        surfaces.update(cx, |surfaces, cx| {
+            surfaces.history_resuming = Some("already-opening".to_owned());
+            let entry = surfaces.history[0].clone();
+            surfaces.resume_history(entry, cx);
+            assert_eq!(
+                surfaces.history_resuming.as_deref(),
+                Some("already-opening")
+            );
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "renders deterministic history UI without a live daemon"]
+    fn render_history_preview_screenshot() {
+        let output =
+            PathBuf::from(std::env::var_os("DIRI_VISUAL_OUTPUT").expect("set DIRI_VISUAL_OUTPUT"));
+        let platform = gpui_platform::current_platform(true);
+        let mut cx = HeadlessAppContext::with_platform(
+            platform.text_system(),
+            Arc::new(diri_ui::IconAssets),
+            gpui_platform::current_headless_renderer,
+        );
+        cx.update(|cx| {
+            crate::fonts::init(cx);
+            cx.set_reduce_motion(true);
+        });
+        let narrow = std::env::var_os("DIRI_VISUAL_NARROW").is_some();
+        let window = cx
+            .open_window(
+                size(px(if narrow { 680.0 } else { 1000.0 }), px(720.0)),
+                move |window, cx| {
+                    let surfaces = cx.new(|cx| {
+                        let runtime = Arc::new(StoreRuntime::inert());
+                        let tokio = Arc::new(
+                            tokio::runtime::Builder::new_current_thread()
+                                .enable_all()
+                                .build()
+                                .unwrap(),
+                        );
+                        let mut surfaces = UtilitySurfaces::new(
+                            runtime,
+                            tokio,
+                            crate::updates::inert(),
+                            window,
+                            cx,
+                        );
+                        seed_history(&mut surfaces);
+                        if std::env::var_os("DIRI_VISUAL_LIGHT").is_some() {
+                            surfaces.prefs.terminal_theme = TermTheme::DIRIJOR_LIGHT.id.to_owned();
+                        }
+                        if let Ok(query) = std::env::var("DIRI_VISUAL_QUERY") {
+                            surfaces.history_query.insert(&query);
+                            surfaces.filter_history();
+                        }
+                        if std::env::var_os("DIRI_VISUAL_OPENING").is_some() {
+                            surfaces.history_resuming = Some(surfaces.history[0].id.clone());
+                        }
+                        surfaces
+                    });
+                    cx.new(|_| CachedOverlayHarness { surfaces })
+                },
+            )
+            .unwrap();
+        cx.run_until_parked();
+        cx.update_window(window.into(), |_, window, _| window.refresh())
+            .unwrap();
+        cx.run_until_parked();
+        cx.capture_screenshot(window.into())
+            .unwrap()
+            .save(output)
+            .unwrap();
     }
 
     /// Regenerates the issue/PR screenshot without Screen Recording access or


### PR DESCRIPTION
Past-conversation search displayed injected Codex history as titles, reread large transcripts on every open, and sent an unsolicited prompt when resuming. This change recovers provider-saved names and useful user prompts, streams and caches transcript discovery, and opens conversations without sending a message.

The dialog follows main's rounded popover styling, ranks matches across titles, paths, agents, and conversation IDs, virtualizes results without the old 200/500-entry cutoffs, and keeps keyboard selection visible. Resume focuses the recovered session and prevents duplicate launches while opening.

Reuses the workspace's existing SQLite dependency for read-only, batched provider-title lookup. Transcript files are never modified.

Validation: workspace tests, strict Clippy, formatting, and release build passed. Headless visual checks cover dark/light appearances, narrow width, long titles, empty results, and opening state. Regression tests cover unsolicited resume input, context filtering, provider-name precedence, cache invalidation, and keyboard virtualization.

The 64 × 8 MiB fixture scan improved from 125 ms to about 5 ms; cached scans took about 0.7 ms. A read-only debug benchmark of 794 local conversations measured 0.97 s cold, 76 ms warm, and approximately 9 ms per ranked search.
