### PR TITLE
Fix repeated Codex usage inflating token and cost totals

### DIFF
--- a/diri/crates/diri-app/src/usage/cache.rs
+++ b/diri/crates/diri-app/src/usage/cache.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use super::model::UsageHourAgg;
 
-pub(crate) const CACHE_VERSION: u32 = 3;
+pub(crate) const CACHE_VERSION: u32 = 4;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct UsageFileEntry {
@@ -21,6 +21,7 @@ pub(crate) struct UsageFileEntry {
     pub hours: BTreeMap<i64, UsageHourAgg>,
     pub details: super::dashboard::ModelHours,
     pub model: Option<String>,
+    pub codex_total: Option<super::parser::CodexTotal>,
 }
 
 impl UsageFileEntry {
@@ -35,6 +36,7 @@ impl UsageFileEntry {
             hours: BTreeMap::new(),
             details: BTreeMap::new(),
             model: None,
+            codex_total: None,
         }
     }
 }

--- a/diri/crates/diri-app/src/usage/parser.rs
+++ b/diri/crates/diri-app/src/usage/parser.rs
@@ -104,6 +104,15 @@ pub(crate) fn parse_claude(
     Ok(consumed)
 }
 
+/// Cumulative counters identify a re-emitted usage event without confusing it
+/// with a separate request that happens to have the same token counts.
+#[derive(Clone, Copy, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub(crate) struct CodexTotal {
+    input_tokens: i64,
+    cached_input_tokens: i64,
+    output_tokens: i64,
+}
+
 pub(crate) fn parse_codex(
     path: &Path,
     offset: u64,
@@ -111,6 +120,7 @@ pub(crate) fn parse_codex(
     hours: &mut BTreeMap<i64, UsageHourAgg>,
     details: &mut super::dashboard::ModelHours,
     model: &mut Option<String>,
+    previous_total: &mut Option<CodexTotal>,
 ) -> io::Result<u64> {
     let Some((data, consumed)) = read_complete_lines(path, offset)? else {
         return Ok(0);
@@ -161,6 +171,26 @@ pub(crate) fn parse_codex(
         let Some(timestamp) = parse_timestamp(timestamp) else {
             continue;
         };
+        // Update even outside retention, so a recent re-emission of old usage
+        // cannot become new spend. Persist across incremental scans.
+        if let Some(total) = payload
+            .pointer("/info/total_token_usage")
+            .filter(|total| total.is_object())
+        {
+            let current = CodexTotal {
+                input_tokens: integer(total.get("input_tokens")),
+                cached_input_tokens: integer(total.get("cached_input_tokens")),
+                output_tokens: integer(total.get("output_tokens")),
+            };
+            if previous_total.as_ref() == Some(&current) {
+                continue;
+            }
+            *previous_total = Some(current);
+        } else {
+            // Old rollouts have only per-request usage. Equal-sized requests
+            // are legitimate; don't deduplicate by token counts alone.
+            *previous_total = None;
+        }
         let hour = timestamp / 3_600;
         if hour < cutoff_hour {
             continue;

--- a/diri/crates/diri-app/src/usage/store.rs
+++ b/diri/crates/diri-app/src/usage/store.rs
@@ -358,6 +358,7 @@ fn scan(
                 &mut live.hours,
                 &mut live.details,
                 &mut live.model,
+                &mut live.codex_total,
             ),
         };
         let Ok(consumed) = parsed else {

--- a/diri/crates/diri-app/src/usage/tests.rs
+++ b/diri/crates/diri-app/src/usage/tests.rs
@@ -667,3 +667,39 @@ fn dashboard_ranges_zero_fill_and_rebuild_old_caches_for_ninety_days() {
         "2024-02-29"
     );
 }
+
+#[test]
+fn codex_repeated_usage_is_not_billed_again_after_cache_reload() {
+    let fixture = Fixture::new();
+    let path = fixture.codex.join("rollout.jsonl");
+    let event = |total: i64| json!({"timestamp":"2026-07-22T09:05:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":total,"cached_input_tokens":0,"output_tokens":total / 10},"last_token_usage":{"input_tokens":100,"cached_input_tokens":0,"output_tokens":10}}}});
+    write_lines(
+        &path,
+        &[
+            json!({"type":"turn_context","payload":{"model":"gpt-5.4"}}),
+            event(100),
+        ],
+    );
+    let make_store = || {
+        fixture.store(
+            "2026-07-22T10:00:00Z",
+            "2026-07-22T00:00:00Z",
+            "2026-07-01T00:00:00Z",
+        )
+    };
+    let first = make_store().refresh();
+    append(&path, &line_bytes(&event(100)));
+    let mut reloaded = make_store();
+    let repeated = reloaded.refresh();
+    assert_eq!(
+        repeated.codex.today, first.codex.today,
+        "re-emitted cumulative counters are not a second request"
+    );
+    append(&path, &line_bytes(&event(200)));
+    let second_request = reloaded.refresh();
+    assert_eq!(
+        second_request.codex.today.total_tokens(),
+        220,
+        "equal-sized real requests must both count when cumulative usage advances"
+    );
+}


### PR DESCRIPTION
Codex can re-emit the same token usage at stream boundaries. Diri counted each copy as another request, inflating token and estimated cost totals, including after restarting the app. Persist the last cumulative counters per rollout and skip unchanged totals while still counting separate equal-sized requests. Bump the usage cache version so existing totals rebuild once.

Validation: the new incremental append/cache reload regression failed before the fix (220 tokens instead of 110), then all 11 usage tests passed. `cargo fmt --all` completed.

Waku also suppresses repeated events, using the last request's token signature. Cumulative counters distinguish a duplicate from two legitimate requests with identical counts. Rollouts without cumulative counters retain previous behavior because counts alone cannot prove duplication.

The comparison also surfaced different pricing assumptions: Waku's model-rate parser falls back to full input pricing when a cached-input rate is missing; Diri uses family-based API-equivalent estimates with discounted cache reads. A $5/M full-input rate versus a $0.50/M cache-read estimate yields a tenfold difference on cached tokens. The screenshots also compare a 90-day dashboard with a calendar-month menu. This PR fixes verified duplicate accounting without asserting either estimate matches provider billing or subscription usage.

Combined verification with #174, #175, #176, #177 and #179 on main `1c56e5f`: workspace formatting, clippy with warnings denied, all 1,304 tests (24 opt-in tests ignored), and the release workspace build passed in an isolated worktree. Native browser and visual fixtures were checked separately as described above. Merge #177 first for its shared Linux-only lint correction to the existing macOS fixture helper. The separate iPhone CI job still fails before compilation because the runner selects Xcode older than 26.

