### PR TITLE
Show provider plan limits and session context in the account menu

### DIFF
--- a/diri/crates/diri-app/src/launcher.rs
+++ b/diri/crates/diri-app/src/launcher.rs
@@ -3871,6 +3871,7 @@ mod tests {
         Arc::new(AppServices {
             store,
             usage_tx,
+            usage_limits_refresh: tokio::sync::mpsc::channel(1).0,
             updates: crate::updates::inert(),
             tokio,
             dev_build: None,
@@ -4010,6 +4011,7 @@ mod tests {
         let services = Arc::new(AppServices {
             store,
             usage_tx,
+            usage_limits_refresh: tokio::sync::mpsc::channel(1).0,
             updates: crate::updates::inert(),
             tokio,
             dev_build: None,
@@ -4062,6 +4064,7 @@ mod tests {
         let services = Arc::new(AppServices {
             store: Arc::clone(&store),
             usage_tx,
+            usage_limits_refresh: tokio::sync::mpsc::channel(1).0,
             updates: crate::updates::inert(),
             tokio,
             dev_build: None,
@@ -4730,6 +4733,7 @@ mod tests {
         let services = Arc::new(AppServices {
             store: runtime,
             usage_tx,
+            usage_limits_refresh: tokio::sync::mpsc::channel(1).0,
             updates: crate::updates::inert(),
             tokio,
             dev_build: None,
@@ -5012,6 +5016,7 @@ mod tests {
         let services = Arc::new(AppServices {
             store: Arc::clone(&runtime),
             usage_tx,
+            usage_limits_refresh: tokio::sync::mpsc::channel(1).0,
             updates: crate::updates::inert(),
             tokio,
             dev_build: None,

--- a/diri/crates/diri-app/src/main.rs
+++ b/diri/crates/diri-app/src/main.rs
@@ -158,6 +158,7 @@ pub(crate) struct AppServices {
     // StoreRuntime drops/aborts its client tasks before the executor is dropped.
     pub(crate) store: Arc<StoreRuntime>,
     pub(crate) usage_tx: tokio::sync::watch::Sender<UsageSnapshot>,
+    pub(crate) usage_limits_refresh: tokio::sync::mpsc::Sender<()>,
     pub(crate) updates: UpdateHandle,
     pub(crate) dev_build: Option<DevBuildIdentity>,
     #[cfg(unix)]
@@ -321,6 +322,37 @@ fn main() {
             }
         });
     }
+    let (usage_limits_refresh, mut limits_requests) = tokio::sync::mpsc::channel(1);
+    if !preview && std::env::var_os("DIRI_SETTINGS_PREVIEW").is_none() {
+        let usage_tx = usage_tx.clone();
+        let client = Arc::clone(&client);
+        let home = std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/nonexistent"));
+        tokio.spawn(async move {
+            let mut last_request: Option<std::time::Instant> = None;
+            while limits_requests.recv().await.is_some() {
+                if last_request.is_some_and(|last| last.elapsed() < Duration::from_secs(10)) {
+                    continue;
+                }
+                last_request = Some(std::time::Instant::now());
+                // Read credentials only after opening the account menu or
+                // explicitly refreshing it. Never during startup/preview.
+                if client
+                    .wait_until_connected(Duration::from_secs(5))
+                    .await
+                    .is_err()
+                {
+                    continue;
+                }
+                let Ok(accounts) = client.account_profiles().await else {
+                    continue;
+                };
+                let limits = usage::limits::refresh(&home, &accounts).await;
+                usage_tx.send_modify(|snapshot| snapshot.limits = limits);
+            }
+        });
+    }
     let updates = if preview {
         updates::inert()
     } else {
@@ -340,6 +372,7 @@ fn main() {
     let services = Arc::new(AppServices {
         store: store_runtime,
         usage_tx,
+        usage_limits_refresh,
         updates,
         dev_build,
         #[cfg(unix)]
@@ -459,7 +492,11 @@ async fn publish_usage_refresh(
     .await
     .ok()?;
     let snapshot = merge_fleet_usage(snapshot, home).await;
-    usage_tx.send_replace(snapshot);
+    usage_tx.send_modify(|current| {
+        let limits = std::mem::take(&mut current.limits);
+        *current = snapshot;
+        current.limits = limits;
+    });
     Some(store)
 }
 

--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -307,6 +307,9 @@ impl RootView {
             .detach();
         }
         cx.subscribe_in(&sidebar, window, |this, _, event, window, cx| {
+            if matches!(event, SidebarEvent::RefreshUsageLimits) {
+                let _ = this.services.usage_limits_refresh.try_send(());
+            }
             if let SidebarEvent::ContinueAccount(id) = event
                 && let Some(surfaces) = &this.utility_surfaces
             {

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -118,6 +118,7 @@ enum HorizontalFocusAction {
 
 #[derive(Clone, Debug)]
 pub(crate) enum SidebarEvent {
+    RefreshUsageLimits,
     ContinueAccount(SessionId),
     VisibilityChanged,
     WidthChanged,
@@ -238,6 +239,9 @@ pub struct Sidebar {
     focus_handle: FocusHandle,
     hover_generation: u64,
     usage: Option<UsageSnapshot>,
+    account_context: Option<crate::transcript::ContextUsage>,
+    account_context_session: Option<SessionId>,
+    account_context_task: Option<Task<()>>,
     update: UpdateState,
     /// When visibility last flipped, so a held ⌘B cannot outrun the slide.
     last_toggle: Option<Instant>,
@@ -317,7 +321,13 @@ impl Sidebar {
                 loop {
                     match changes.recv().await {
                         Ok(()) | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
-                            if this.update(cx, |_, cx| cx.notify()).is_err() {
+                            if this
+                                .update(cx, |this, cx| {
+                                    this.refresh_account_context(false, cx);
+                                    cx.notify();
+                                })
+                                .is_err()
+                            {
                                 return;
                             }
                         }
@@ -342,6 +352,9 @@ impl Sidebar {
             focus_handle: cx.focus_handle(),
             hover_generation: 0,
             usage: None,
+            account_context: None,
+            account_context_session: None,
+            account_context_task: None,
             update: UpdateState::default(),
             last_toggle: None,
             preview,
@@ -398,8 +411,74 @@ impl Sidebar {
     }
 
     pub fn set_usage(&mut self, snapshot: UsageSnapshot, cx: &mut Context<Self>) {
+        let now = crate::usage::Clock::read(&crate::usage::SystemClock).unix_seconds;
+        if !self.preview
+            && self.ui.popover == Some(Popover::Account)
+            && snapshot
+                .limits
+                .iter()
+                .all(|limits| now - limits.checked_at >= 180)
+        {
+            cx.emit(SidebarEvent::RefreshUsageLimits);
+        }
         self.usage = Some(snapshot);
+        self.refresh_account_context(true, cx);
         cx.notify();
+    }
+
+    fn refresh_account_context(&mut self, force: bool, cx: &mut Context<Self>) {
+        if self.preview || self.ui.popover != Some(Popover::Account) {
+            return;
+        }
+        let session = self
+            .store
+            .read()
+            .expect("session store lock poisoned")
+            .selected_session()
+            .cloned();
+        let id = session.as_ref().map(|session| session.id.clone());
+        if !force && self.account_context_session == id {
+            return;
+        }
+        self.account_context_task = None;
+        if self.account_context_session != id {
+            self.account_context = None;
+        }
+        self.account_context_session = id.clone();
+        let Some(session) = session.filter(|session| session.host.is_none()) else {
+            self.account_context = None;
+            return;
+        };
+        let Some((path, agent_id)) = session.transcript_path.zip(session.agent_session_id) else {
+            self.account_context = None;
+            return;
+        };
+        let home = std::env::var_os("HOME")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| std::path::PathBuf::from("/nonexistent"));
+        self.account_context_task = Some(cx.spawn(async move |this, cx| {
+            let context = cx
+                .background_spawn(async move {
+                    crate::transcript::load(
+                        &home,
+                        std::path::Path::new(&path),
+                        &session.kind,
+                        &agent_id,
+                        &session.cwd,
+                        None,
+                    )
+                    .ok()
+                    .flatten()
+                    .and_then(|snapshot| snapshot.document.context_usage)
+                })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                if this.account_context_session == id {
+                    this.account_context = context;
+                    cx.notify();
+                }
+            });
+        }));
     }
 
     pub fn pending_close_copy(&self) -> Option<(String, String)> {
@@ -2821,6 +2900,10 @@ impl Sidebar {
                         } else {
                             Some(Popover::Account)
                         };
+                        this.refresh_account_context(true, cx);
+                        if !this.preview && this.ui.popover == Some(Popover::Account) {
+                            cx.emit(SidebarEvent::RefreshUsageLimits);
+                        }
                         cx.notify();
                     }))
                     .child(account_avatar(&account_label, 20.0, colors))
@@ -2886,7 +2969,7 @@ impl Sidebar {
         self.popover_shell_at(
             point(px(12.0), px(top)),
             Anchor::TopLeft,
-            244.0,
+            276.0,
             child,
             colors,
             cx,
@@ -2905,7 +2988,7 @@ impl Sidebar {
         self.popover_shell_at(
             point(px(12.0), px(footer_top)),
             Anchor::BottomLeft,
-            244.0,
+            276.0,
             child,
             colors,
             cx,
@@ -2965,7 +3048,8 @@ impl Sidebar {
                                     // GPUI has no per-element backdrop blur.
                                     // Preserve the material without leaving
                                     // terminal text legible through the menu.
-                                    .surface_opacity(0.975),
+                                    .surface_opacity(0.975)
+                                    .animate_entry(!self.preview),
                                 ),
                         ),
                 )
@@ -3798,14 +3882,40 @@ impl Sidebar {
          * animate independently: this is a frequent, keyboard-adjacent menu.
          * ───────────────────────────────────────────────────────── */
         let account_label = local_account_label(self.preview);
-        let mut usage = div().flex().flex_col().py(px(3.0));
+        let context = if self.preview {
+            Some(crate::transcript::ContextUsage {
+                tokens: 17_800,
+                window: 258_400,
+            })
+        } else {
+            let store = self.store.read().expect("session store lock poisoned");
+            (store.selected_session_id() == self.account_context_session.as_ref())
+                .then_some(self.account_context)
+                .flatten()
+        };
+        let limits = if self.preview {
+            crate::usage::limits::preview()
+        } else {
+            self.usage
+                .as_ref()
+                .map_or_else(Vec::new, |usage| usage.limits.clone())
+        };
+        let mut usage = div().flex().flex_col().py(px(3.0)).child(
+            div()
+                .px(px(14.0))
+                .pt(px(3.0))
+                .pb(px(2.0))
+                .text_size(px(Typo::META.size))
+                .text_color(colors.tertiary)
+                .child("Usage cost · estimates included"),
+        );
         if self.preview {
             usage = usage
                 .child(usage_menu_row(
                     "account-usage-session",
                     "clock",
-                    "Session",
-                    "resets in 2h 14m",
+                    "5h block",
+                    "estimated",
                     "$2.31",
                     colors,
                 ))
@@ -3830,12 +3940,8 @@ impl Sidebar {
                 .child(usage_menu_row(
                     "account-usage-session",
                     "clock",
-                    "Session",
-                    snapshot
-                        .session_remaining_seconds
-                        .map(|seconds| format!("resets in {}", compact_duration(seconds)))
-                        .as_deref()
-                        .unwrap_or("idle"),
+                    "5h block",
+                    "estimated",
                     &snapshot
                         .session_cost
                         .map(UsageFormat::money)
@@ -3888,6 +3994,10 @@ impl Sidebar {
         let content = div()
             .id("account-menu")
             .debug_selector(|| "account-menu".into())
+            .max_h(px(
+                (f32::from(window.viewport_size().height) - 64.0).max(200.0)
+            ))
+            .overflow_y_scroll()
             .flex()
             .flex_col()
             .child(
@@ -3932,6 +4042,12 @@ impl Sidebar {
                             .child("This Mac"),
                     ),
             )
+            .child(menu_divider(colors))
+            .when_some(context, |menu, context| {
+                menu.child(account_context_menu(context, colors))
+                    .child(menu_divider(colors))
+            })
+            .child(account_limits_menu(&limits, colors, cx))
             .child(menu_divider(colors))
             .child(usage)
             .child(menu_divider(colors))
@@ -5767,6 +5883,216 @@ fn account_avatar(label: &str, size: f32, colors: SemanticColors) -> AnyElement 
         .into_any_element()
 }
 
+fn account_context_menu(
+    context: crate::transcript::ContextUsage,
+    colors: SemanticColors,
+) -> AnyElement {
+    let percent = (context.tokens as f64 / context.window as f64 * 100.0).clamp(0.0, 100.0);
+    div()
+        .id("account-context-window")
+        .debug_selector(|| "account-context-window".into())
+        .flex_none()
+        .px(px(14.0))
+        .py(px(8.0))
+        .flex()
+        .flex_col()
+        .gap(px(5.0))
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .gap(px(6.0))
+                .child(
+                    div()
+                        .flex_1()
+                        .text_size(px(Typo::ROW.size))
+                        .text_color(colors.primary)
+                        .child("Context window"),
+                )
+                .child(
+                    div()
+                        .text_size(px(Typo::META.size))
+                        .text_color(colors.secondary)
+                        .child(format!("{percent:.0}%")),
+                ),
+        )
+        .child(
+            div()
+                .h(px(3.0))
+                .w_full()
+                .rounded_full()
+                .bg(colors.primary.alpha(0.09))
+                .child(
+                    div()
+                        .h_full()
+                        .w(gpui::relative(percent as f32 / 100.0))
+                        .rounded_full()
+                        .bg(Palette::GEMINI_BLUE),
+                ),
+        )
+        .child(
+            div()
+                .text_size(px(10.0))
+                .text_color(colors.tertiary)
+                .child(format!(
+                    "{} / {} · selected session",
+                    UsageFormat::tokens(context.tokens),
+                    UsageFormat::tokens(context.window)
+                )),
+        )
+        .into_any_element()
+}
+
+/// Subscription quotas are provider facts, separate from cost estimates below.
+fn account_limits_menu(
+    limits: &[crate::usage::limits::AccountLimits],
+    colors: SemanticColors,
+    cx: &mut Context<Sidebar>,
+) -> AnyElement {
+    let now = crate::usage::Clock::read(&crate::usage::SystemClock).unix_seconds;
+    let mut content = div()
+        .id("account-plan-limits")
+        .debug_selector(|| "account-plan-limits".into())
+        .flex_none()
+        .px(px(14.0))
+        .py(px(8.0))
+        .flex()
+        .flex_col()
+        .gap(px(8.0))
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .justify_between()
+                .child(
+                    div()
+                        .text_size(px(Typo::META.size))
+                        .text_color(colors.secondary)
+                        .child("Plan limits"),
+                )
+                .child(
+                    div()
+                        .id("account-refresh-limits")
+                        .cursor_pointer()
+                        .rounded(px(4.0))
+                        .p(px(2.0))
+                        .hover(move |row| row.bg(colors.primary.alpha(0.06)))
+                        .child(sf_symbol(
+                            "arrow.triangle.2.circlepath",
+                            11.0,
+                            colors.secondary,
+                        ))
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            if !this.preview {
+                                cx.emit(SidebarEvent::RefreshUsageLimits);
+                            }
+                        })),
+                ),
+        );
+    if limits.is_empty() {
+        return content
+            .child(
+                div()
+                    .text_size(px(Typo::META.size))
+                    .text_color(colors.tertiary)
+                    .child("Checking provider limits…"),
+            )
+            .into_any_element();
+    }
+    for account in limits {
+        let mut provider = div().flex().flex_col().gap(px(7.0)).child(
+            div()
+                .text_size(px(Typo::META.size))
+                .text_color(colors.secondary)
+                .child(format!("{} · {}", account.provider, account.account)),
+        );
+        for limit in &account.windows {
+            let expired = limit.resets_at.is_some_and(|reset| reset <= now);
+            let stale = expired || account.error.is_some() || now - account.checked_at > 360;
+            let reset = match limit.resets_at {
+                Some(reset) if reset > now => {
+                    let seconds = reset - now;
+                    if seconds >= 86_400 {
+                        format!(
+                            "Resets in {}d {}h",
+                            seconds / 86_400,
+                            seconds % 86_400 / 3_600
+                        )
+                    } else {
+                        format!("Resets in {}", compact_duration(seconds))
+                    }
+                }
+                Some(_) => "Awaiting refresh".into(),
+                None => "Reset time unavailable".into(),
+            };
+            provider = provider.child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap(px(4.0))
+                    .child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .gap(px(8.0))
+                            .child(
+                                div()
+                                    .flex_1()
+                                    .text_size(px(Typo::ROW.size))
+                                    .text_color(colors.primary)
+                                    .child(limit.label.clone()),
+                            )
+                            .child(
+                                div()
+                                    .flex_none()
+                                    .text_size(px(Typo::META.size))
+                                    .text_color(colors.secondary)
+                                    .child(format!(
+                                        "{:.0}%{}",
+                                        limit.used_percent,
+                                        if stale { " · last" } else { "" }
+                                    )),
+                            ),
+                    )
+                    .child(
+                        div()
+                            .h(px(3.0))
+                            .w_full()
+                            .rounded_full()
+                            .bg(colors.primary.alpha(0.09))
+                            .child(
+                                div()
+                                    .h_full()
+                                    .w(gpui::relative(limit.used_percent as f32 / 100.0))
+                                    .rounded_full()
+                                    .bg(if stale {
+                                        colors.tertiary
+                                    } else {
+                                        Palette::GEMINI_BLUE
+                                    }),
+                            ),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(10.0))
+                            .text_color(colors.tertiary)
+                            .child(reset),
+                    ),
+            );
+        }
+        if let Some(error) = account.error {
+            provider = provider.child(
+                div()
+                    .text_size(px(Typo::META.size))
+                    .text_color(colors.tertiary)
+                    .child(error),
+            );
+        }
+        content = content.child(provider);
+    }
+    content.into_any_element()
+}
+
 fn usage_menu_row(
     id: &'static str,
     icon: &'static str,
@@ -6837,6 +7163,8 @@ mod tests {
         });
 
         assert!(cx.debug_bounds("account-menu").is_some());
+        assert!(cx.debug_bounds("account-context-window").is_some());
+        assert!(cx.debug_bounds("account-plan-limits").is_some());
         assert!(cx.debug_bounds("account-usage-session").is_some());
         assert!(cx.debug_bounds("account-usage-today").is_some());
         assert!(cx.debug_bounds("account-usage-month").is_some());

--- a/diri/crates/diri-app/src/transcript.rs
+++ b/diri/crates/diri-app/src/transcript.rs
@@ -33,6 +33,14 @@ pub struct TranscriptTurn {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct TranscriptDocument {
     pub turns: Vec<TranscriptTurn>,
+    pub context_usage: Option<ContextUsage>,
+}
+
+/// Last request occupancy reported by the provider, never cumulative spend.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ContextUsage {
+    pub tokens: i64,
+    pub window: i64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -114,11 +122,21 @@ pub fn load(
     }
 
     let mut turns = Vec::new();
+    let mut context_usage = None;
     for (index, line) in reader.lines().enumerate() {
         let Ok(line) = line else { continue };
         let Ok(record) = serde_json::from_str::<Value>(&line) else {
             continue;
         };
+        if kind.id() == AgentKind::CODEX_ID {
+            if let Some(usage) = codex_context_usage(&record) {
+                context_usage = Some(usage);
+            } else if record.pointer("/payload/type").and_then(Value::as_str)
+                == Some("context_compacted")
+            {
+                context_usage = None;
+            }
+        }
         let parsed = match kind.id() {
             AgentKind::CLAUDE_CODE_ID => claude_turn(&record),
             AgentKind::CODEX_ID => codex_turn(&record),
@@ -145,7 +163,10 @@ pub fn load(
         }
     }
     Ok(Some(TranscriptSnapshot {
-        document: TranscriptDocument { turns },
+        document: TranscriptDocument {
+            turns,
+            context_usage,
+        },
         version,
     }))
 }
@@ -234,6 +255,18 @@ fn validate_opened_identity(
         ));
     }
     Ok(())
+}
+
+fn codex_context_usage(record: &Value) -> Option<ContextUsage> {
+    if record.get("type").and_then(Value::as_str) != Some("event_msg")
+        || record.pointer("/payload/type").and_then(Value::as_str) != Some("token_count")
+    {
+        return None;
+    }
+    let info = record.pointer("/payload/info")?;
+    let tokens = info.pointer("/last_token_usage/total_tokens")?.as_i64()?;
+    let window = info.get("model_context_window")?.as_i64()?;
+    (tokens >= 0 && window > 0).then_some(ContextUsage { tokens, window })
 }
 
 fn claude_turn(record: &Value) -> Option<(&'static str, String)> {
@@ -339,6 +372,25 @@ mod tests {
         )
         .unwrap();
         (file, path)
+    }
+
+    #[test]
+    fn context_uses_last_request_instead_of_cumulative_billing() {
+        let record = serde_json::json!({"type":"event_msg", "payload":{"type":"token_count", "info":{
+            "total_token_usage":{"total_tokens":9_000_000},
+            "last_token_usage":{"total_tokens":17_800},
+            "model_context_window":258_400
+        }}});
+        assert_eq!(
+            codex_context_usage(&record),
+            Some(ContextUsage {
+                tokens: 17_800,
+                window: 258_400
+            })
+        );
+        let mut missing_window = record;
+        missing_window["payload"]["info"]["model_context_window"] = serde_json::Value::Null;
+        assert_eq!(codex_context_usage(&missing_window), None);
     }
 
     #[test]

--- a/diri/crates/diri-app/src/usage/limits.rs
+++ b/diri/crates/diri-app/src/usage/limits.rs
@@ -1,0 +1,449 @@
+//! Provider-reported subscription windows. These are independent of transcript
+//! cost estimates and context occupancy. Credentials stay in provider storage;
+//! only parsed percentages, reset times and account labels reach the UI.
+use std::{
+    path::{Path, PathBuf},
+    process::Stdio,
+    time::Duration,
+};
+
+use diri_proto::AgentAccountCatalog;
+use serde_json::Value;
+use tokio::{io::AsyncWriteExt, process::Command};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct LimitWindow {
+    pub label: String,
+    pub used_percent: f64,
+    pub resets_at: Option<i64>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AccountLimits {
+    pub provider: &'static str,
+    pub account: String,
+    pub windows: Vec<LimitWindow>,
+    pub checked_at: i64,
+    pub error: Option<&'static str>,
+}
+
+struct AccountSource {
+    provider: &'static str,
+    label: String,
+    directory: PathBuf,
+    #[cfg(target_os = "macos")]
+    keychain: Option<String>,
+}
+
+fn sources(home: &Path, accounts: &AgentAccountCatalog) -> Vec<AccountSource> {
+    [
+        ("claude-code", "Claude", ".claude", "CLAUDE_CONFIG_DIR"),
+        ("codex", "Codex", ".codex", "CODEX_HOME"),
+    ]
+    .into_iter()
+    .map(|(agent, provider, directory, variable)| {
+        let profile = accounts
+            .profiles
+            .iter()
+            .find(|p| p.agent == agent && p.host.is_none() && p.is_default);
+        let config = profile.map(|p| PathBuf::from(&p.config_home)).or_else(|| {
+            std::env::var_os(variable)
+                .filter(|p| !p.is_empty())
+                .map(PathBuf::from)
+        });
+        let config = config.map(|path| {
+            path.to_str()
+                .and_then(|path| path.strip_prefix("~/"))
+                .map_or_else(|| path.clone(), |relative| home.join(relative))
+        });
+        // Explicit profiles scrub ambient credential overrides at launch.
+        // Otherwise mirror Claude's credential-store override, including its
+        // empty-string pin to the default store.
+        let config = if agent == "claude-code" && profile.is_none() {
+            match std::env::var_os("CLAUDE_SECURESTORAGE_CONFIG_DIR") {
+                Some(value) => (!value.is_empty()).then(|| PathBuf::from(value)),
+                None => config,
+            }
+        } else {
+            config
+        };
+        #[cfg(target_os = "macos")]
+        let keychain = (agent == "claude-code").then(|| {
+            config.as_ref().map_or_else(
+                || "Claude Code-credentials".into(),
+                |path| {
+                    use sha2::{Digest, Sha256};
+                    let digest = Sha256::digest(path.to_string_lossy().as_bytes());
+                    format!(
+                        "Claude Code-credentials-{:02x}{:02x}{:02x}{:02x}",
+                        digest[0], digest[1], digest[2], digest[3]
+                    )
+                },
+            )
+        });
+        AccountSource {
+            provider,
+            label: profile.map_or_else(|| "CLI account".into(), |p| p.label.clone()),
+            #[cfg(target_os = "macos")]
+            keychain,
+            directory: config.unwrap_or_else(|| home.join(directory)),
+        }
+    })
+    .collect()
+}
+
+pub(crate) async fn refresh(home: &Path, accounts: &AgentAccountCatalog) -> Vec<AccountLimits> {
+    let mut result = Vec::new();
+    for source in sources(home, accounts) {
+        let now = super::Clock::read(&super::SystemClock).unix_seconds;
+        let fetched = fetch(&source).await;
+        let (windows, error) = match fetched {
+            Ok(windows) => (windows, None),
+            // A sign-in can change at the same path. Never reuse another
+            // account's last percentages when its replacement fails to load.
+            Err(error) => (Vec::new(), Some(error)),
+        };
+        result.push(AccountLimits {
+            provider: source.provider,
+            account: source.label,
+            windows,
+            checked_at: now,
+            error,
+        });
+    }
+    result
+}
+
+async fn fetch(source: &AccountSource) -> Result<Vec<LimitWindow>, &'static str> {
+    let (url, mut headers) = if source.provider == "Claude" {
+        let value = claude_credentials(source)
+            .await
+            .ok_or("Sign in to Claude to see limits")?;
+        let token = value
+            .pointer("/claudeAiOauth/accessToken")
+            .and_then(Value::as_str)
+            .ok_or("Claude subscription sign-in unavailable")?;
+        (
+            "https://api.anthropic.com/api/oauth/usage",
+            vec![
+                format!("Authorization: Bearer {token}"),
+                "anthropic-beta: oauth-2025-04-20".into(),
+                "User-Agent: claude-code/2.1.0".into(),
+            ],
+        )
+    } else {
+        let value = read_json(&source.directory.join("auth.json"))
+            .await
+            .ok_or("Sign in to Codex to see limits")?;
+        let token = value
+            .pointer("/tokens/access_token")
+            .and_then(Value::as_str)
+            .ok_or("Codex subscription sign-in unavailable")?;
+        let mut headers = vec![
+            format!("Authorization: Bearer {token}"),
+            "User-Agent: diri".into(),
+        ];
+        if let Some(account) = value.pointer("/tokens/account_id").and_then(Value::as_str) {
+            headers.push(format!("ChatGPT-Account-Id: {account}"));
+        }
+        ("https://chatgpt.com/backend-api/wham/usage", headers)
+    };
+    headers.push("Accept: application/json".into());
+    let body = http_get(url, &headers).await?;
+    let windows = if source.provider == "Claude" {
+        parse_claude(&body)
+    } else {
+        parse_codex(&body)
+    };
+    if windows.is_empty() {
+        Err("No subscription limits reported")
+    } else {
+        Ok(windows)
+    }
+}
+
+async fn read_json(path: &Path) -> Option<Value> {
+    let path = path.to_owned();
+    tokio::task::spawn_blocking(move || {
+        use std::io::Read;
+        #[cfg(unix)]
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut options = std::fs::OpenOptions::new();
+        options.read(true);
+        #[cfg(unix)]
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+        let file = options.open(path).ok()?;
+        if !file.metadata().ok()?.is_file() {
+            return None;
+        }
+        let mut bytes = Vec::new();
+        file.take(1_048_577).read_to_end(&mut bytes).ok()?;
+        if bytes.len() > 1_048_576 {
+            return None;
+        }
+        serde_json::from_slice(&bytes).ok()
+    })
+    .await
+    .ok()
+    .flatten()
+}
+
+async fn claude_credentials(source: &AccountSource) -> Option<Value> {
+    #[cfg(target_os = "macos")]
+    if let Some(service) = &source.keychain {
+        let mut command = Command::new("/usr/bin/security");
+        command
+            .args(["find-generic-password", "-s", service, "-w"])
+            .stdin(Stdio::null())
+            .stderr(Stdio::null())
+            .kill_on_drop(true);
+        if let Ok(Ok(output)) = tokio::time::timeout(Duration::from_secs(8), command.output()).await
+            && output.status.success()
+            && let Ok(value) = serde_json::from_slice(&output.stdout)
+        {
+            return Some(value);
+        }
+    }
+    read_json(&source.directory.join(".credentials.json")).await
+}
+
+/// Disable curl's user config, redirects and diagnostics. Authorization travels
+/// via stdin, never process arguments, temp files, logs or error strings.
+async fn http_get(url: &str, headers: &[String]) -> Result<Value, &'static str> {
+    let mut config = String::new();
+    for header in headers {
+        if header.chars().any(char::is_control) {
+            return Err("Invalid sign-in credentials");
+        }
+        config.push_str("header = \"");
+        config.push_str(&header.replace('\\', "\\\\").replace('"', "\\\""));
+        config.push_str("\"\n");
+    }
+    let mut child = Command::new("/usr/bin/curl")
+        .args([
+            "-q",
+            "--silent",
+            "--proto",
+            "=https",
+            "--max-time",
+            "10",
+            "--max-filesize",
+            "1048576",
+            "--write-out",
+            "\n%{http_code}",
+            "--config",
+            "-",
+            url,
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|_| "Could not refresh limits")?;
+    let mut stdin = child.stdin.take().ok_or("Could not refresh limits")?;
+    stdin
+        .write_all(config.as_bytes())
+        .await
+        .map_err(|_| "Could not refresh limits")?;
+    drop(stdin);
+    let output = tokio::time::timeout(Duration::from_secs(12), child.wait_with_output())
+        .await
+        .map_err(|_| "Limits refresh timed out")?
+        .map_err(|_| "Could not refresh limits")?;
+    if !output.status.success() {
+        return Err("Could not refresh limits");
+    }
+    let raw = std::str::from_utf8(&output.stdout).map_err(|_| "Invalid usage response")?;
+    let (body, status) = raw.rsplit_once('\n').ok_or("Invalid usage response")?;
+    match status {
+        "200" => serde_json::from_str(body).map_err(|_| "Invalid usage response"),
+        "401" | "403" => Err("Sign in again to refresh limits"),
+        "429" => Err("Refresh limited; retrying shortly"),
+        _ => Err("Could not refresh limits"),
+    }
+}
+
+fn window(label: String, percent: Option<f64>, resets: Option<&Value>) -> Option<LimitWindow> {
+    let percent = percent.filter(|value| value.is_finite())?;
+    Some(LimitWindow {
+        label,
+        used_percent: percent.clamp(0.0, 100.0),
+        resets_at: resets.and_then(|v| {
+            v.as_i64()
+                .or_else(|| v.as_str().and_then(super::timestamp::parse_timestamp))
+        }),
+    })
+}
+
+fn parse_claude(body: &Value) -> Vec<LimitWindow> {
+    let modern: Vec<_> = body
+        .get("limits")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| {
+            let label = match entry.get("kind")?.as_str()? {
+                "session" => "5-hour limit".into(),
+                "weekly_all" => "Weekly limit".into(),
+                "weekly_scoped" => format!(
+                    "Weekly · {}",
+                    entry
+                        .pointer("/scope/model/display_name")
+                        .and_then(Value::as_str)
+                        .unwrap_or("model")
+                ),
+                _ => return None,
+            };
+            window(
+                label,
+                entry.get("percent").and_then(Value::as_f64),
+                entry.get("resets_at"),
+            )
+        })
+        .collect();
+    if !modern.is_empty() {
+        return modern;
+    }
+    [
+        ("five_hour", "5-hour limit"),
+        ("seven_day", "Weekly limit"),
+        ("seven_day_opus", "Weekly · Opus"),
+        ("seven_day_sonnet", "Weekly · Sonnet"),
+    ]
+    .into_iter()
+    .filter_map(|(key, label)| {
+        let entry = body.get(key)?;
+        window(
+            label.into(),
+            entry.get("utilization").and_then(Value::as_f64),
+            entry.get("resets_at"),
+        )
+    })
+    .collect()
+}
+
+fn parse_codex(body: &Value) -> Vec<LimitWindow> {
+    let mut result = Vec::new();
+    let mut add = |rate: &Value, scope: Option<&str>| {
+        for key in ["primary_window", "secondary_window"] {
+            let Some(entry) = rate.get(key) else {
+                continue;
+            };
+            let label = match entry.get("limit_window_seconds").and_then(Value::as_i64) {
+                Some(604_800) => "Weekly limit".into(),
+                Some(seconds) if seconds >= 86_400 => format!("{}-day limit", seconds / 86_400),
+                Some(seconds) if seconds >= 3_600 => format!("{}-hour limit", seconds / 3_600),
+                Some(seconds) if seconds > 0 => format!("{}-minute limit", seconds / 60),
+                _ => if key == "primary_window" {
+                    "Session limit"
+                } else {
+                    "Weekly limit"
+                }
+                .into(),
+            };
+            let label = scope.map_or_else(|| label.clone(), |scope| format!("{label} · {scope}"));
+            if let Some(window) = window(
+                label,
+                entry.get("used_percent").and_then(Value::as_f64),
+                entry.get("reset_at"),
+            ) {
+                result.push(window);
+            }
+        }
+    };
+    if let Some(rate) = body.get("rate_limit") {
+        add(rate, None);
+    }
+    for entry in body
+        .get("additional_rate_limits")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        if let Some(rate) = entry.get("rate_limit") {
+            add(rate, entry.get("limit_name").and_then(Value::as_str));
+        }
+    }
+    result
+}
+
+/// Design fixture; never mixed into the live account snapshot.
+pub(crate) fn preview() -> Vec<AccountLimits> {
+    vec![AccountLimits {
+        provider: "Claude",
+        account: "CLI account".into(),
+        windows: vec![
+            LimitWindow {
+                label: "5-hour limit".into(),
+                used_percent: 37.0,
+                resets_at: Some(super::Clock::read(&super::SystemClock).unix_seconds + 8_040),
+            },
+            LimitWindow {
+                label: "Weekly limit".into(),
+                used_percent: 68.0,
+                resets_at: Some(super::Clock::read(&super::SystemClock).unix_seconds + 172_800),
+            },
+        ],
+        checked_at: super::Clock::read(&super::SystemClock).unix_seconds,
+        error: None,
+    }]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn limits_resolve_local_default_profiles_without_other_account_fallback() {
+        let profile = |id: &str, agent: &str, host: Option<&str>, directory: &str| {
+            diri_proto::AgentAccountProfile {
+                id: id.into(),
+                label: id.into(),
+                agent: agent.into(),
+                host: host.map(str::to_owned),
+                config_home: directory.into(),
+                is_default: true,
+            }
+        };
+        let catalog = AgentAccountCatalog {
+            profiles: vec![
+                profile("remote", "claude-code", Some("server"), "/remote/claude"),
+                profile("work", "claude-code", None, "~/accounts/work-claude"),
+                profile("personal", "codex", None, "/accounts/codex"),
+            ],
+        };
+        let resolved = sources(Path::new("/local/home"), &catalog);
+        assert_eq!(
+            resolved[0].directory,
+            Path::new("/local/home/accounts/work-claude")
+        );
+        assert_eq!(resolved[0].label, "work");
+        assert_eq!(resolved[1].directory, Path::new("/accounts/codex"));
+        #[cfg(target_os = "macos")]
+        assert_ne!(
+            resolved[0].keychain.as_deref(),
+            Some("Claude Code-credentials")
+        );
+    }
+
+    #[test]
+    fn provider_windows_keep_real_percentages_and_reset_times() {
+        let legacy = parse_claude(
+            &json!({"five_hour":{"utilization":37,"resets_at":"2026-09-05T12:00:00Z"},"seven_day":null}),
+        );
+        let modern = parse_claude(
+            &json!({"limits":[{"kind":"session","percent":37,"resets_at":"2026-09-05T12:00:00Z"}]}),
+        );
+        assert_eq!(legacy, modern);
+        assert_eq!(legacy[0].used_percent, 37.0);
+        let codex = parse_codex(
+            &json!({"rate_limit":{"primary_window":{"used_percent":42,"limit_window_seconds":18000,"reset_at":1788609600},"secondary_window":{"used_percent":0,"limit_window_seconds":604800,"reset_at":1789214400}}}),
+        );
+        assert_eq!(codex[0].resets_at, legacy[0].resets_at);
+        assert_eq!(codex[1].label, "Weekly limit");
+        assert_eq!(codex[1].used_percent, 0.0);
+        assert!(parse_codex(&json!({"rate_limit":null})).is_empty());
+    }
+}

--- a/diri/crates/diri-app/src/usage/mod.rs
+++ b/diri/crates/diri-app/src/usage/mod.rs
@@ -1,11 +1,13 @@
 //! Incremental, daemon-free usage accounting for Claude Code and Codex transcripts.
 //!
 //! Costs are computed locally from the transcripts on disk; nothing is sent
-//! anywhere and no provider API is queried.
+//! anywhere. The separate limits reader queries provider-reported subscription
+//! windows without deriving quota percentages from these estimates.
 
 mod cache;
 pub mod dashboard;
 mod fleet;
+pub(crate) mod limits;
 mod model;
 mod parser;
 mod pricing;

--- a/diri/crates/diri-app/src/usage/model.rs
+++ b/diri/crates/diri-app/src/usage/model.rs
@@ -59,6 +59,8 @@ pub struct UsageSnapshot {
     pub session_ends_at: Option<i64>,
     pub session_remaining_seconds: Option<i64>,
     pub updated_at: i64,
+    /// Default local account quotas; never inferred from transcript costs.
+    pub limits: Vec<super::limits::AccountLimits>,
     /// Local transcript history; fleet summaries do not provide this detail.
     pub history: std::sync::Arc<super::dashboard::UsageHistory>,
 }


### PR DESCRIPTION
Show provider-reported Claude and Codex subscription windows in the bottom-left account menu: percentages, progress bars and reset times, labeled by the default local account profile. Keep cost totals in a separate estimates section and stop presenting Diri's inferred five-hour cost block as a provider quota reset.

Selected local Codex sessions also show a separate context gauge when the validated transcript reports last-request tokens and model capacity. Missing/unsupported context is omitted; cumulative billed tokens are never used as context occupancy.

Limits refresh on opening the menu or pressing refresh. While visible, existing usage activity can request refreshed quotas after three minutes. A bounded request channel coalesces refreshes; startup, preview, and an unused menu never read credentials or query providers. Credential files are bounded regular-file reads off-thread; scoped Claude Keychain entries and Codex account IDs follow local default profiles. Requests use fixed provider HTTPS URLs, no redirects, timeouts, and credentials passed through stdin rather than process arguments. Errors clear percentages instead of retaining another sign-in's quotas. Old/expired readings are labeled as last observed.

Validation: two provider schema/account-routing fixtures, one context arithmetic fixture, the existing account-menu interaction test, fixture-only macOS screenshot review, `cargo fmt --all -- --check`, and `cargo clippy -p diri-app --all-targets -- -D warnings` passed. The screenshot fixture now captures the settled menu instead of its entry fade. Live authenticated provider calls were not exercised in this environment; the parsers cover Waku's observed endpoint shapes. These provider endpoints are not a guaranteed public API, so failures remain explicit and do not affect session execution.

Independent of #174, which fixes repeated Codex usage events inflating cost estimates.

Combined verification with #174, #175, #176, #177 and #179 on main `1c56e5f`: workspace formatting, clippy with warnings denied, all 1,304 tests (24 opt-in tests ignored), and the release workspace build passed in an isolated worktree. Native browser and visual fixtures were checked separately as described above. Merge #177 first for its shared Linux-only lint correction to the existing macOS fixture helper. The separate iPhone CI job still fails before compilation because the runner selects Xcode older than 26.

