### PR TITLE
Add searchable Skills catalogue in Settings

### DIFF
--- a/diri/README.md
+++ b/diri/README.md
@@ -154,6 +154,15 @@ Removing the file leaves the app in local-only mode. Tailscale IPv4 addresses
 and MagicDNS names work like any other SSH destination when OpenSSH can resolve
 them; Diri neither requires nor configures Tailscale for Remote Holder sessions.
 
+## Skills
+
+**Settings → Skills** lists skills found in shared and provider skill directories
+on this Mac, the selected local session's project, and Claude/Codex plugin caches.
+Search by name, description, or provider; filter by Personal, Project, or Plugins;
+open a skill to read or copy its instructions and reveal its source file. Refresh
+after adding or removing skills. Cached plugin versions are labeled separately;
+the catalogue does not activate skills or change provider configuration.
+
 ## Agent preferences
 
 The default agent is stored in

--- a/diri/crates/diri-app/src/main.rs
+++ b/diri/crates/diri-app/src/main.rs
@@ -40,6 +40,8 @@ pub mod seam;
 mod session_surfaces;
 pub mod settings;
 pub mod sidebar;
+mod skills_catalog;
+mod skills_page;
 pub mod sounds;
 mod status_debug;
 mod surface_shell;

--- a/diri/crates/diri-app/src/settings.rs
+++ b/diri/crates/diri-app/src/settings.rs
@@ -44,6 +44,7 @@ pub enum SettingsTab {
     #[default]
     General,
     Agents,
+    Skills,
     Accounts,
     Shortcuts,
     Terminal,
@@ -54,9 +55,10 @@ pub enum SettingsTab {
 }
 
 impl SettingsTab {
-    pub const ALL: [Self; 9] = [
+    pub const ALL: [Self; 10] = [
         Self::General,
         Self::Agents,
+        Self::Skills,
         Self::Accounts,
         Self::Shortcuts,
         Self::Terminal,
@@ -70,6 +72,7 @@ impl SettingsTab {
         match self {
             Self::General => "General",
             Self::Agents => "Agents",
+            Self::Skills => "Skills",
             Self::Accounts => "Accounts",
             Self::Shortcuts => "Shortcuts",
             Self::Terminal => "Appearance",
@@ -84,6 +87,7 @@ impl SettingsTab {
         match self {
             Self::General => "Startup, sessions, and updates",
             Self::Agents => "Installed CLIs and quick create",
+            Self::Skills => "Browse local and project skills",
             Self::Accounts => "Profiles for work and personal accounts",
             Self::Shortcuts => "Keyboard commands and bindings",
             Self::Terminal => "Themes and terminal type",
@@ -100,6 +104,7 @@ impl SettingsTab {
         match self {
             Self::General
             | Self::Agents
+            | Self::Skills
             | Self::Accounts
             | Self::Shortcuts
             | Self::Terminal
@@ -112,6 +117,7 @@ impl SettingsTab {
         match self {
             Self::General => "gearshape",
             Self::Agents => "sparkles",
+            Self::Skills => "doc.text",
             Self::Accounts => "account.circle",
             Self::Shortcuts => "keyboard",
             Self::Terminal => "terminal",

--- a/diri/crates/diri-app/src/skills_catalog.rs
+++ b/diri/crates/diri-app/src/skills_catalog.rs
@@ -1,0 +1,471 @@
+//! Bounded, read-only discovery of local SKILL.md files. This catalogue never
+//! installs, activates, or executes a skill; provider configuration owns that.
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+
+const MAX_FILE_BYTES: u64 = 128 * 1024;
+const MAX_ENTRIES: usize = 2_000;
+const MAX_DIRECTORIES: usize = 10_000;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum Scope {
+    #[default]
+    All,
+    Personal,
+    Project,
+    Plugins,
+}
+
+impl Scope {
+    pub const ALL: [Self; 4] = [Self::All, Self::Personal, Self::Project, Self::Plugins];
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::All => "All",
+            Self::Personal => "Personal",
+            Self::Project => "Project",
+            Self::Plugins => "Plugins",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SkillRoot {
+    pub path: PathBuf,
+    pub source: String,
+    pub scope: Scope,
+}
+
+#[derive(Clone, Debug)]
+pub struct Skill {
+    pub name: String,
+    pub description: String,
+    pub path: PathBuf,
+    pub sources: BTreeSet<String>,
+    pub scopes: Vec<Scope>,
+}
+
+impl Skill {
+    pub fn matches(&self, query: &str, scope: Scope) -> bool {
+        if scope != Scope::All && !self.scopes.contains(&scope) {
+            return false;
+        }
+        let haystack = format!(
+            "{} {} {}",
+            self.name,
+            self.description,
+            self.sources.iter().cloned().collect::<Vec<_>>().join(" ")
+        )
+        .to_lowercase();
+        query
+            .split_whitespace()
+            .all(|word| haystack.contains(&word.to_lowercase()))
+    }
+
+    pub fn source_label(&self) -> String {
+        self.sources.iter().cloned().collect::<Vec<_>>().join(" · ")
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Catalog {
+    pub skills: Vec<Skill>,
+    pub unreadable: usize,
+    pub limited: bool,
+}
+
+pub fn roots(home: &Path, project: Option<&Path>) -> Vec<SkillRoot> {
+    let providers = [
+        (".agents/skills", "Shared"),
+        (".claude/skills", "Claude"),
+        (".codex/skills", "Codex"),
+        (".cursor/skills", "Cursor"),
+        (".gemini/skills", "Gemini"),
+        (".opencode/skills", "OpenCode"),
+        (".pi/agent/skills", "Pi"),
+    ];
+    let mut roots = Vec::new();
+    for (relative, source) in providers {
+        roots.push(SkillRoot {
+            path: home.join(relative),
+            source: source.into(),
+            scope: Scope::Personal,
+        });
+        if let Some(project) = project {
+            roots.push(SkillRoot {
+                path: project.join(relative),
+                source: format!("Project · {source}"),
+                scope: Scope::Project,
+            });
+        }
+    }
+    roots.push(SkillRoot {
+        path: home.join(".config/opencode/skills"),
+        source: "OpenCode".into(),
+        scope: Scope::Personal,
+    });
+    for (variable, source) in [("CODEX_HOME", "Codex"), ("CLAUDE_CONFIG_DIR", "Claude")] {
+        if let Some(path) = std::env::var_os(variable).filter(|path| !path.is_empty()) {
+            roots.push(SkillRoot {
+                path: PathBuf::from(path).join("skills"),
+                source: source.into(),
+                scope: Scope::Personal,
+            });
+        }
+    }
+    // Inspect only the known cache layout: publisher/plugin/version/skills.
+    // Never walk node_modules, plugin scripts, repositories, or skill resources.
+    // Cached versions are identified as such, not claimed to be enabled.
+    for provider in [".codex", ".claude"] {
+        for publisher in directories(&home.join(provider).join("plugins/cache"), 128) {
+            for plugin in directories(&publisher, 128) {
+                for version in directories(&plugin, 32) {
+                    roots.push(SkillRoot {
+                        path: version.join("skills"),
+                        source: format!(
+                            "{} plugin cache · {} · {}",
+                            provider.trim_start_matches('.'),
+                            basename(&plugin),
+                            basename(&version)
+                        ),
+                        scope: Scope::Plugins,
+                    });
+                }
+            }
+        }
+    }
+    roots
+}
+
+fn basename(path: &Path) -> String {
+    path.file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn directories(path: &Path, limit: usize) -> Vec<PathBuf> {
+    let Ok(entries) = fs::read_dir(path) else {
+        return Vec::new();
+    };
+    let mut paths: Vec<_> = entries
+        .take(limit)
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_dir()))
+        .map(|entry| entry.path())
+        .collect();
+    paths.sort();
+    paths
+}
+
+pub fn scan(roots: &[SkillRoot]) -> Catalog {
+    let mut catalog = Catalog::default();
+    let mut skills = BTreeMap::<PathBuf, Skill>::new();
+    let mut remaining = MAX_DIRECTORIES;
+    for root in roots {
+        let Ok(canonical_root) = fs::canonicalize(&root.path) else {
+            continue;
+        };
+        let mut visited = HashSet::new();
+        let mut pending = vec![(root.path.clone(), 0)];
+        while let Some((directory, depth)) = pending.pop() {
+            if remaining == 0 || skills.len() >= MAX_ENTRIES {
+                catalog.limited = true;
+                break;
+            }
+            remaining -= 1;
+            let canonical = match fs::canonicalize(&directory) {
+                Ok(path) => path,
+                Err(error) => {
+                    if error.kind() != io::ErrorKind::NotFound {
+                        catalog.unreadable += 1;
+                    }
+                    continue;
+                }
+            };
+            if !visited.insert(canonical.clone()) {
+                continue;
+            }
+            let path = canonical.join("SKILL.md");
+            match read(&path) {
+                Ok(text) => {
+                    let (name, description) = metadata(&text, &basename(&canonical));
+                    let skill = skills.entry(path.clone()).or_insert_with(|| Skill {
+                        name,
+                        description,
+                        path,
+                        sources: BTreeSet::new(),
+                        scopes: Vec::new(),
+                    });
+                    skill.sources.insert(root.source.clone());
+                    if !skill.scopes.contains(&root.scope) {
+                        skill.scopes.push(root.scope);
+                    }
+                    // A skill's supporting directories are not other skills.
+                    continue;
+                }
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(_) => {
+                    catalog.unreadable += 1;
+                    continue;
+                }
+            }
+            // Linked individual skills are common installations. Read their
+            // SKILL.md above, but never traverse an external linked directory.
+            if !canonical.starts_with(&canonical_root) {
+                continue;
+            }
+            if depth >= 5 {
+                catalog.limited = true;
+                continue;
+            }
+            match fs::read_dir(&canonical) {
+                Ok(entries) => {
+                    let mut children = Vec::new();
+                    for entry in entries.take(remaining.min(MAX_ENTRIES)) {
+                        let Ok(entry) = entry else {
+                            catalog.unreadable += 1;
+                            continue;
+                        };
+                        let name = entry.file_name();
+                        if matches!(
+                            name.to_str(),
+                            Some("node_modules" | ".git" | "references" | "scripts" | "assets")
+                        ) {
+                            continue;
+                        }
+                        if entry
+                            .file_type()
+                            .is_ok_and(|kind| kind.is_dir() || kind.is_symlink())
+                        {
+                            children.push((entry.path(), depth + 1));
+                        }
+                    }
+                    children.sort();
+                    pending.extend(children.into_iter().rev());
+                }
+                Err(_) => catalog.unreadable += 1,
+            }
+        }
+    }
+    catalog.skills = skills.into_values().collect();
+    catalog.skills.sort_by(|a, b| {
+        a.name
+            .to_lowercase()
+            .cmp(&b.name.to_lowercase())
+            .then_with(|| a.path.cmp(&b.path))
+    });
+    catalog
+}
+
+pub fn read(path: &Path) -> io::Result<String> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NONBLOCK);
+    }
+    let file: File = options.open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata.len() > MAX_FILE_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Skill must be a regular UTF-8 file smaller than 128 KiB",
+        ));
+    }
+    let mut text = String::new();
+    file.take(MAX_FILE_BYTES + 1).read_to_string(&mut text)?;
+    if text.len() as u64 > MAX_FILE_BYTES {
+        return Err(io::Error::other("Skill is too large"));
+    }
+    Ok(text)
+}
+
+/// Extract display metadata without interpreting YAML tags or executing any
+/// skill instructions. Plain, quoted and folded/literal descriptions are
+/// supported; missing metadata falls back to the directory name.
+fn metadata(text: &str, fallback: &str) -> (String, String) {
+    let mut lines = text.trim_start_matches('\u{feff}').lines();
+    if lines.next().map(str::trim) != Some("---") {
+        return (fallback.into(), String::new());
+    }
+    let mut name = fallback.to_owned();
+    let mut description = String::new();
+    let mut field = "";
+    for line in lines {
+        if matches!(line.trim(), "---" | "...") {
+            break;
+        }
+        if line.starts_with(char::is_whitespace) && field == "description" {
+            if !description.is_empty() {
+                description.push(' ');
+            }
+            description.push_str(line.trim());
+            continue;
+        }
+        field = "";
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        let value = value.trim();
+        match key {
+            "name" if !value.is_empty() => name = scalar(value),
+            "description" => {
+                field = "description";
+                description = if matches!(value, ">" | ">-" | ">+" | "|" | "|-" | "|+") {
+                    String::new()
+                } else {
+                    scalar(value)
+                };
+            }
+            _ => {}
+        }
+    }
+    let description = scalar(&description);
+    (
+        name.chars().filter(|c| !c.is_control()).take(160).collect(),
+        description
+            .chars()
+            .filter(|c| !c.is_control())
+            .take(2_000)
+            .collect(),
+    )
+}
+
+fn scalar(value: &str) -> String {
+    if value.starts_with('"')
+        && let Ok(value) = serde_json::from_str::<String>(value)
+    {
+        return value;
+    }
+    if let Some(value) = value
+        .strip_prefix('\'')
+        .and_then(|value| value.strip_suffix('\''))
+    {
+        return value.replace("''", "'");
+    }
+    value.to_owned()
+}
+
+pub fn body(text: &str) -> &str {
+    let text = text.trim_start_matches('\u{feff}');
+    if text.lines().next().map(str::trim) != Some("---") {
+        return text;
+    }
+    let mut offset = text.find('\n').map_or(text.len(), |index| index + 1);
+    for line in text[offset..].split_inclusive('\n') {
+        offset += line.len();
+        if matches!(line.trim(), "---" | "...") {
+            return &text[offset..];
+        }
+    }
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn folded_descriptions_quotes_and_body_remain_readable() {
+        let text = "---\r\nname: 'User''s skill'\r\ndescription: >-\r\n  Find useful files\r\n  across a project.\r\n---\r\n# Instructions\r\n";
+        assert_eq!(
+            metadata(text, "fallback"),
+            (
+                "User's skill".into(),
+                "Find useful files across a project.".into()
+            )
+        );
+        assert_eq!(body(text), "# Instructions\r\n");
+    }
+
+    #[test]
+    fn scan_merges_shared_sources_and_keeps_same_name_different_files() {
+        let temp = tempfile::tempdir().unwrap();
+        for folder in ["shared/one", "project/one"] {
+            fs::create_dir_all(temp.path().join(folder)).unwrap();
+            fs::write(
+                temp.path().join(folder).join("SKILL.md"),
+                "---\nname: design\ndescription: interface polish\n---\nHello",
+            )
+            .unwrap();
+        }
+        let roots = [
+            SkillRoot {
+                path: temp.path().join("shared"),
+                source: "Claude".into(),
+                scope: Scope::Personal,
+            },
+            SkillRoot {
+                path: temp.path().join("shared"),
+                source: "Codex".into(),
+                scope: Scope::Personal,
+            },
+            SkillRoot {
+                path: temp.path().join("project"),
+                source: "Project".into(),
+                scope: Scope::Project,
+            },
+        ];
+        let catalog = scan(&roots);
+        assert_eq!(catalog.skills.len(), 2);
+        assert!(catalog.skills.iter().any(|skill| skill.sources.len() == 2));
+        assert_eq!(
+            catalog
+                .skills
+                .iter()
+                .filter(|skill| skill.matches("design polish", Scope::Project))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn scan_bounds_files_and_does_not_walk_supporting_resources() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(temp.path().join("one/references/nested")).unwrap();
+        fs::write(temp.path().join("one/SKILL.md"), "# My skill").unwrap();
+        fs::write(
+            temp.path().join("one/references/nested/SKILL.md"),
+            "Not a skill",
+        )
+        .unwrap();
+        fs::create_dir_all(temp.path().join("large")).unwrap();
+        File::create(temp.path().join("large/SKILL.md"))
+            .unwrap()
+            .set_len(MAX_FILE_BYTES + 1)
+            .unwrap();
+        let catalog = scan(&[SkillRoot {
+            path: temp.path().into(),
+            source: "Test".into(),
+            scope: Scope::Personal,
+        }]);
+        assert_eq!(catalog.skills.len(), 1);
+        assert_eq!(catalog.unreadable, 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn linked_skills_are_read_without_traversing_external_trees() {
+        use std::os::unix::fs::symlink;
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("skills");
+        fs::create_dir_all(&root).unwrap();
+        let external = temp.path().join("external");
+        fs::create_dir_all(external.join("nested")).unwrap();
+        fs::write(external.join("nested/SKILL.md"), "# Shared skill").unwrap();
+        symlink(&external, root.join("escape")).unwrap();
+        let roots = [SkillRoot {
+            path: root.clone(),
+            source: "Test".into(),
+            scope: Scope::Personal,
+        }];
+        assert!(scan(&roots).skills.is_empty());
+        symlink(external.join("nested"), root.join("installed")).unwrap();
+        assert_eq!(scan(&roots).skills.len(), 1);
+    }
+}

--- a/diri/crates/diri-app/src/skills_page.rs
+++ b/diri/crates/diri-app/src/skills_page.rs
@@ -1,0 +1,652 @@
+//! Searchable local skill catalogue, with all disk work outside rendering.
+
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
+
+use diri_ui::{Icon, IconName, IconSize, SemanticColors};
+use gpui::{
+    AnyElement, ClipboardItem, Context, FocusHandle, FontWeight, KeyDownEvent, Render,
+    ScrollHandle, ScrollStrategy, Task, UniformListScrollHandle, Window, div, prelude::*, px,
+    uniform_list,
+};
+
+use crate::markdown::MarkdownDocument;
+use crate::query_editor::{self, ClipboardEdit, Edit, QueryEditor};
+use crate::skills_catalog::{self, Catalog, Scope};
+use crate::store::SessionStore;
+
+pub struct SkillsPage {
+    store: Arc<RwLock<SessionStore>>,
+    focus: FocusHandle,
+    keyboard_target: usize,
+    query: QueryEditor,
+    scope: Scope,
+    catalog: Catalog,
+    matches: Vec<usize>,
+    highlighted: usize,
+    project: Option<PathBuf>,
+    loaded: bool,
+    loading: bool,
+    generation: u64,
+    scan_task: Option<Task<()>>,
+    selected: Option<usize>,
+    document: Option<MarkdownDocument>,
+    instructions: Option<String>,
+    detail_error: Option<String>,
+    detail_task: Option<Task<()>>,
+    list_scroll: UniformListScrollHandle,
+    detail_scroll: ScrollHandle,
+}
+
+impl SkillsPage {
+    #[cfg(test)]
+    pub(crate) fn seed_preview(&mut self, detail: bool) {
+        self.catalog.skills = [
+            ("Interface craftsmanship", "Design and refine interfaces with careful typography, layout, color, and interaction.", "Shared", Scope::Personal),
+            ("PostgreSQL", "Review queries, diagnose slow connections, and improve database performance.", "Project · Claude", Scope::Project),
+            ("Release checklist", "Prepare release notes and verify the steps required before publishing a new version.", "Project · Codex", Scope::Project),
+            ("Spreadsheets", "Create, analyze, and verify workbooks, charts, and financial models.", "Codex plugin cache", Scope::Plugins),
+        ].into_iter().map(|(name, description, source, scope)| skills_catalog::Skill {
+            name: name.into(), description: description.into(), path: PathBuf::from(format!("/Users/example/.agents/skills/{}/SKILL.md", name.to_lowercase().replace(' ', "-"))),
+            sources: [source.to_owned()].into_iter().collect(), scopes: vec![scope],
+        }).collect();
+        self.loaded = true;
+        self.loading = false;
+        self.refilter();
+        if detail {
+            self.selected = Some(0);
+            self.document = Some(MarkdownDocument::parse(
+                "# Interface craftsmanship\n\nTreat interface quality as a system of related decisions.\n\n## Review by impact\n\n- Make the primary action obvious.\n- Give repeated elements consistent spacing.\n- Keep keyboard focus visible.\n\n## Verification\n\nInspect realistic content in both light and dark appearances.",
+            ));
+            self.instructions = self.document.as_ref().map(MarkdownDocument::plain_text);
+        }
+    }
+
+    pub fn new(store: Arc<RwLock<SessionStore>>, cx: &mut Context<Self>) -> Self {
+        Self {
+            store,
+            focus: cx.focus_handle(),
+            keyboard_target: 0,
+            query: QueryEditor::default(),
+            scope: Scope::All,
+            catalog: Catalog::default(),
+            matches: Vec::new(),
+            highlighted: 0,
+            project: None,
+            loaded: false,
+            loading: false,
+            generation: 0,
+            scan_task: None,
+            selected: None,
+            document: None,
+            instructions: None,
+            detail_error: None,
+            detail_task: None,
+            list_scroll: UniformListScrollHandle::new(),
+            detail_scroll: ScrollHandle::new(),
+        }
+    }
+
+    pub fn open(&mut self, project: Option<PathBuf>, cx: &mut Context<Self>) {
+        if !self.loaded || self.project != project {
+            self.project = project;
+            self.refresh(cx);
+        }
+    }
+
+    fn refresh(&mut self, cx: &mut Context<Self>) {
+        self.generation = self.generation.wrapping_add(1);
+        let generation = self.generation;
+        self.loading = true;
+        self.selected = None;
+        self.document = None;
+        self.instructions = None;
+        self.detail_task = None;
+        let home = std::env::var_os("HOME").map(PathBuf::from);
+        let project = self.project.clone();
+        self.scan_task = Some(cx.spawn(async move |this, cx| {
+            let catalog = cx
+                .background_executor()
+                .spawn(async move {
+                    home.map(|home| {
+                        skills_catalog::scan(&skills_catalog::roots(&home, project.as_deref()))
+                    })
+                })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                if this.generation != generation {
+                    return;
+                }
+                this.loading = false;
+                this.loaded = true;
+                this.catalog = catalog.unwrap_or_else(|| Catalog {
+                    unreadable: 1,
+                    ..Catalog::default()
+                });
+                this.refilter();
+                cx.notify();
+            });
+        }));
+        cx.notify();
+    }
+
+    fn refilter(&mut self) {
+        self.matches = self
+            .catalog
+            .skills
+            .iter()
+            .enumerate()
+            .filter(|(_, skill)| skill.matches(self.query.text(), self.scope))
+            .map(|(index, _)| index)
+            .collect();
+        self.highlighted = 0;
+        self.list_scroll.scroll_to_item(0, ScrollStrategy::Top);
+    }
+
+    fn select_scope(&mut self, scope: Scope, cx: &mut Context<Self>) {
+        self.scope = scope;
+        self.refilter();
+        cx.notify();
+    }
+
+    fn open_skill(&mut self, index: usize, cx: &mut Context<Self>) {
+        let Some(skill) = self.catalog.skills.get(index) else {
+            return;
+        };
+        let path = skill.path.clone();
+        self.selected = Some(index);
+        self.document = None;
+        self.instructions = None;
+        self.detail_error = None;
+        self.keyboard_target = 0;
+        self.detail_scroll.set_offset(gpui::point(px(0.0), px(0.0)));
+        let generation = self.generation;
+        self.detail_task = Some(cx.spawn(async move |this, cx| {
+            let result = cx.background_executor().spawn(async move {
+                skills_catalog::read(&path).map(|text| {
+                    let instructions = skills_catalog::body(&text).to_owned();
+                    (MarkdownDocument::parse(&instructions), instructions)
+                })
+            }).await;
+            let _ = this.update(cx, |this, cx| {
+                if this.generation != generation || this.selected != Some(index) { return; }
+                match result {
+                    Ok((document, instructions)) => {
+                        this.document = Some(document);
+                        this.instructions = Some(instructions);
+                    }
+                    Err(_) => this.detail_error = Some("This skill could not be read. Refresh the catalogue if it was moved or removed.".into()),
+                }
+                cx.notify();
+            });
+        }));
+        cx.notify();
+    }
+
+    fn back(&mut self, cx: &mut Context<Self>) {
+        self.selected = None;
+        self.document = None;
+        self.instructions = None;
+        self.detail_task = None;
+        self.keyboard_target = 6;
+        cx.notify();
+    }
+
+    pub(crate) fn handle_key(&mut self, event: &KeyDownEvent, cx: &mut Context<Self>) -> bool {
+        let key = &event.keystroke;
+        let handled = match key.key.as_str() {
+            "tab" => {
+                let count = if self.selected.is_some() { 3 } else { 7 };
+                self.keyboard_target = (self.keyboard_target
+                    + if key.modifiers.shift { count - 1 } else { 1 })
+                    % count;
+                true
+            }
+            "escape" if self.selected.is_some() => {
+                self.back(cx);
+                true
+            }
+            "escape" if !self.query.is_empty() => {
+                self.query.clear();
+                self.refilter();
+                true
+            }
+            "enter" | "space" if self.selected.is_some() => {
+                match self.keyboard_target {
+                    0 => self.back(cx),
+                    1 => {
+                        if let Some(instructions) = &self.instructions {
+                            cx.write_to_clipboard(ClipboardItem::new_string(instructions.clone()));
+                        }
+                    }
+                    _ => {
+                        if let Some(index) = self.selected {
+                            cx.reveal_path(&self.catalog.skills[index].path);
+                        }
+                    }
+                }
+                true
+            }
+            "up" | "down" if self.selected.is_none() && self.keyboard_target == 6 => {
+                if key.key == "up" {
+                    self.highlighted = self.highlighted.saturating_sub(1);
+                } else {
+                    self.highlighted =
+                        (self.highlighted + 1).min(self.matches.len().saturating_sub(1));
+                }
+                self.list_scroll
+                    .scroll_to_item(self.highlighted, ScrollStrategy::Center);
+                true
+            }
+            "enter" | "space"
+                if self.selected.is_none() && (key.key == "enter" || self.keyboard_target > 0) =>
+            {
+                match self.keyboard_target {
+                    1..=4 => self.select_scope(Scope::ALL[self.keyboard_target - 1], cx),
+                    5 => self.refresh(cx),
+                    _ => {
+                        if let Some(&index) = self.matches.get(self.highlighted) {
+                            self.open_skill(index, cx);
+                        }
+                    }
+                }
+                true
+            }
+            _ if self.selected.is_none() && self.keyboard_target == 0 => {
+                if let Some(edit) = query_editor::edit_for(key) {
+                    match edit {
+                        Edit::Local(local) => {
+                            self.query.apply(local);
+                        }
+                        Edit::Clipboard(ClipboardEdit::Copy) => {
+                            query_editor::copy_selection(&self.query, cx)
+                        }
+                        Edit::Clipboard(ClipboardEdit::Cut) => {
+                            query_editor::cut_selection(&mut self.query, cx);
+                        }
+                        Edit::Clipboard(ClipboardEdit::Paste) => {
+                            if let Some(text) =
+                                cx.read_from_clipboard().and_then(|item| item.text())
+                            {
+                                self.query.insert(&text);
+                            }
+                        }
+                    }
+                    self.refilter();
+                    true
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        };
+        if handled {
+            cx.stop_propagation();
+            cx.notify();
+        }
+        handled
+    }
+
+    fn colors(&self) -> SemanticColors {
+        crate::app_theme::colors(
+            &self
+                .store
+                .read()
+                .expect("session store lock poisoned")
+                .preferences()
+                .terminal_theme,
+        )
+    }
+
+    fn button(
+        &self,
+        id: &'static str,
+        label: &'static str,
+        target: usize,
+        colors: SemanticColors,
+    ) -> gpui::Stateful<gpui::Div> {
+        div()
+            .id(id)
+            .role(gpui::Role::Button)
+            .aria_label(label)
+            .px(px(10.0))
+            .h(px(30.0))
+            .flex()
+            .items_center()
+            .rounded(px(7.0))
+            .border_1()
+            .border_color(if self.keyboard_target == target {
+                colors.primary.alpha(0.28)
+            } else {
+                colors.primary.alpha(0.08)
+            })
+            .text_size(px(12.0))
+            .text_color(colors.secondary)
+            .cursor_pointer()
+            .hover(move |style| style.bg(colors.primary.alpha(0.07)))
+            .active(move |style| style.bg(colors.primary.alpha(0.11)))
+            .child(label)
+    }
+}
+
+impl Render for SkillsPage {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let colors = self.colors();
+        let body_height = (f32::from(window.viewport_size().height) - 330.0).max(180.0);
+        let mut page = div()
+            .id("skills-catalog")
+            .track_focus(&self.focus)
+            .on_key_down(cx.listener(|this, event, _, cx| {
+                this.handle_key(event, cx);
+            }))
+            .on_mouse_down(
+                gpui::MouseButton::Left,
+                cx.listener(|this, _, window, cx| this.focus.focus(window, cx)),
+            )
+            .px(px(24.0))
+            .pt(px(18.0))
+            .pb(px(24.0))
+            .flex()
+            .flex_col()
+            .gap(px(16.0))
+            .text_color(colors.primary)
+            .child(
+                div()
+                    .text_size(px(20.0))
+                    .font_weight(FontWeight::SEMIBOLD)
+                    .child("Skills"),
+            );
+        if let Some(index) = self.selected {
+            let skill = &self.catalog.skills[index];
+            let path = skill.path.clone();
+            let controls = div()
+                .flex()
+                .gap(px(8.0))
+                .child(
+                    self.button("skills-back", "Back to skills", 0, colors)
+                        .on_click(cx.listener(|this, _, _, cx| this.back(cx))),
+                )
+                .child(
+                    self.button("skills-copy", "Copy instructions", 1, colors)
+                        .when(self.document.is_none(), |button| button.opacity(0.45))
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            if let Some(instructions) = &this.instructions {
+                                cx.write_to_clipboard(ClipboardItem::new_string(
+                                    instructions.clone(),
+                                ));
+                            }
+                        })),
+                )
+                .child(
+                    self.button("skills-reveal", "Show file", 2, colors)
+                        .on_click(move |_, _, cx| cx.reveal_path(&path)),
+                );
+            page = page.child(controls).child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap(px(6.0))
+                    .child(
+                        div()
+                            .text_size(px(18.0))
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .child(skill.name.clone()),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(12.0))
+                            .text_color(colors.secondary)
+                            .child(skill.description.clone()),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(12.0))
+                            .text_color(colors.secondary)
+                            .child(skill.source_label()),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(11.0))
+                            .text_color(colors.tertiary)
+                            .child(skill.path.to_string_lossy().into_owned()),
+                    ),
+            );
+            let content: AnyElement = if let Some(document) = &self.document {
+                crate::markdown_view::render_markdown(document, colors)
+            } else {
+                div()
+                    .text_size(px(13.0))
+                    .text_color(colors.secondary)
+                    .child(
+                        self.detail_error
+                            .clone()
+                            .unwrap_or_else(|| "Reading skill…".into()),
+                    )
+                    .into_any_element()
+            };
+            return page.child(
+                div()
+                    .id("skill-instructions")
+                    .h(px(body_height))
+                    .overflow_y_scroll()
+                    .track_scroll(&self.detail_scroll)
+                    .child(content),
+            );
+        }
+        page = page.child(
+            div()
+                .text_size(px(13.0))
+                .text_color(colors.secondary)
+                .child("Browse skills on this Mac and in the current local project."),
+        );
+        let search_label = if self.query.is_empty() && self.keyboard_target != 0 {
+            div()
+                .text_color(colors.tertiary)
+                .child("Search skills…")
+                .into_any_element()
+        } else {
+            crate::navigation::query_label(&self.query)
+        };
+        page = page.child(
+            div()
+                .id("skills-search")
+                .role(gpui::Role::TextInput)
+                .aria_label("Search skills")
+                .h(px(36.0))
+                .px(px(10.0))
+                .flex()
+                .items_center()
+                .gap(px(8.0))
+                .rounded(px(8.0))
+                .border_1()
+                .border_color(colors.primary.alpha(if self.keyboard_target == 0 {
+                    0.25
+                } else {
+                    0.1
+                }))
+                .bg(colors.primary.alpha(0.025))
+                .text_size(px(13.0))
+                .child(Icon::new(
+                    IconName::Search,
+                    IconSize::REGULAR,
+                    colors.secondary,
+                ))
+                .child(search_label)
+                .on_click(cx.listener(|this, _, window, cx| {
+                    this.keyboard_target = 0;
+                    this.focus.focus(window, cx);
+                    cx.notify();
+                })),
+        );
+        let mut filters = div().flex().flex_wrap().gap(px(5.0));
+        for (index, scope) in Scope::ALL.into_iter().enumerate() {
+            filters = filters.child(
+                self.button(
+                    match scope {
+                        Scope::All => "skills-all",
+                        Scope::Personal => "skills-personal",
+                        Scope::Project => "skills-project",
+                        Scope::Plugins => "skills-plugins",
+                    },
+                    scope.label(),
+                    index + 1,
+                    colors,
+                )
+                .when(self.scope == scope, |button| {
+                    button
+                        .bg(colors.primary.alpha(0.08))
+                        .text_color(colors.primary)
+                })
+                .on_click(cx.listener(move |this, _, _, cx| {
+                    this.keyboard_target = index + 1;
+                    this.select_scope(scope, cx);
+                })),
+            );
+        }
+        page = page.child(
+            div()
+                .flex()
+                .flex_wrap()
+                .justify_between()
+                .gap(px(8.0))
+                .child(filters)
+                .child(
+                    self.button(
+                        "skills-refresh",
+                        if self.loading {
+                            "Refreshing…"
+                        } else {
+                            "Refresh"
+                        },
+                        5,
+                        colors,
+                    )
+                    .on_click(cx.listener(|this, _, _, cx| {
+                        this.keyboard_target = 5;
+                        this.refresh(cx);
+                    })),
+                ),
+        );
+        let message = if self.loading && !self.loaded {
+            "Looking for skills…".to_owned()
+        } else if self.matches.is_empty() && self.scope == Scope::Project && self.project.is_none()
+        {
+            "Select a local project to browse its skills.".into()
+        } else if self.matches.is_empty() && (!self.query.is_empty() || self.scope != Scope::All) {
+            "No skills match these filters.".into()
+        } else if self.matches.is_empty() {
+            "No skills found. Add a SKILL.md folder to your agent’s skills directory, then refresh."
+                .into()
+        } else {
+            format!("{} skills", self.matches.len())
+        };
+        page = page.child(
+            div()
+                .text_size(px(12.0))
+                .text_color(colors.secondary)
+                .child(message),
+        );
+        if !self.matches.is_empty() {
+            let entity = cx.entity();
+            page = page.child(
+                uniform_list("skills-list", self.matches.len(), move |range, _, cx| {
+                    entity.update(cx, |this, cx| {
+                        let colors = this.colors();
+                        range
+                            .map(|row| {
+                                let index = this.matches[row];
+                                let skill = &this.catalog.skills[index];
+                                div()
+                                    .id(("skill", index))
+                                    .role(gpui::Role::Button)
+                                    .aria_label(format!(
+                                        "Open skill {}. {}",
+                                        skill.name, skill.description
+                                    ))
+                                    .w_full()
+                                    .h(px(82.0))
+                                    .px(px(12.0))
+                                    .py(px(10.0))
+                                    .flex()
+                                    .flex_col()
+                                    .gap(px(4.0))
+                                    .rounded(px(8.0))
+                                    .cursor_pointer()
+                                    .when(
+                                        this.keyboard_target == 6 && row == this.highlighted,
+                                        |item| item.bg(colors.primary.alpha(0.08)),
+                                    )
+                                    .hover(move |style| style.bg(colors.primary.alpha(0.05)))
+                                    .child(
+                                        div()
+                                            .flex()
+                                            .justify_between()
+                                            .gap(px(12.0))
+                                            .child(
+                                                div()
+                                                    .min_w(px(0.0))
+                                                    .truncate()
+                                                    .text_size(px(13.0))
+                                                    .font_weight(FontWeight::MEDIUM)
+                                                    .child(skill.name.clone()),
+                                            )
+                                            .child(
+                                                div()
+                                                    .max_w(px(220.0))
+                                                    .truncate()
+                                                    .text_size(px(11.0))
+                                                    .text_color(colors.tertiary)
+                                                    .child(skill.source_label()),
+                                            ),
+                                    )
+                                    .child(
+                                        div()
+                                            .truncate()
+                                            .text_size(px(12.0))
+                                            .text_color(colors.secondary)
+                                            .child(if skill.description.is_empty() {
+                                                "Open to read instructions".into()
+                                            } else {
+                                                skill.description.clone()
+                                            }),
+                                    )
+                                    .child(
+                                        div()
+                                            .truncate()
+                                            .text_size(px(10.0))
+                                            .text_color(colors.tertiary)
+                                            .child(skill.path.to_string_lossy().into_owned()),
+                                    )
+                                    .on_click(cx.listener(move |this, _, _, cx| {
+                                        this.highlighted = row;
+                                        this.open_skill(index, cx);
+                                    }))
+                            })
+                            .collect()
+                    })
+                })
+                .h(px(body_height))
+                .track_scroll(&self.list_scroll),
+            );
+        }
+        if self.catalog.unreadable > 0 || self.catalog.limited {
+            page = page.child(
+                div()
+                    .text_size(px(12.0))
+                    .text_color(colors.secondary)
+                    .child(format!(
+                        "{} files or folders could not be read.{}",
+                        self.catalog.unreadable,
+                        if self.catalog.limited {
+                            " Discovery reached its size limit."
+                        } else {
+                            ""
+                        }
+                    )),
+            );
+        }
+        page.child(div().text_size(px(11.0)).text_color(colors.tertiary).child(
+            "Plugin entries include cached versions. Each agent controls which skills are active.",
+        ))
+    }
+}

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -253,6 +253,7 @@ impl HostEditor {
 }
 
 pub struct UtilitySurfaces {
+    skills: gpui::Entity<crate::skills_page::SkillsPage>,
     accounts: AccountsState,
     phone_access: Option<crate::phone_access::PhoneAccess>,
     phone_loading: bool,
@@ -332,6 +333,7 @@ impl UtilitySurfaces {
         let settings_tab = match settings_preview.as_deref() {
             Some("terminal" | "appearance") => SettingsTab::Terminal,
             Some("agents") => SettingsTab::Agents,
+            Some("skills") => SettingsTab::Skills,
             Some("accounts") => SettingsTab::Accounts,
             Some("shortcuts") => SettingsTab::Shortcuts,
             Some("resources") => SettingsTab::Resources,
@@ -377,8 +379,21 @@ impl UtilitySurfaces {
                 }
             })
         };
+        let skills =
+            cx.new(|cx| crate::skills_page::SkillsPage::new(Arc::clone(&store_runtime.store), cx));
+        if settings_tab == SettingsTab::Skills {
+            let project = store_runtime
+                .store
+                .read()
+                .expect("session store lock poisoned")
+                .selected_session()
+                .filter(|session| session.host.is_none())
+                .map(|session| PathBuf::from(&session.cwd));
+            skills.update(cx, |skills, cx| skills.open(project, cx));
+        }
         Self {
             focus,
+            skills,
             accounts: AccountsState::default(),
             phone_access: None,
             phone_loading: false,
@@ -1159,6 +1174,9 @@ impl UtilitySurfaces {
         self.shortcut_search.clear();
         self.shortcut_search_active = false;
         self.shortcut_editor = None;
+        if self.settings_tab == SettingsTab::Skills {
+            self.refresh_skills(cx);
+        }
         cx.notify();
     }
 
@@ -1231,6 +1249,9 @@ impl UtilitySurfaces {
             self.settings_scroll.set_offset(point(px(0.0), px(0.0)));
         }
         self.settings_tab = tab;
+        if tab == SettingsTab::Skills {
+            self.refresh_skills(cx);
+        }
         if tab == SettingsTab::Accounts {
             self.refresh_accounts(cx);
         }
@@ -1249,6 +1270,18 @@ impl UtilitySurfaces {
                 .request_agent_catalog(self.agents_host.clone(), false);
         }
         cx.notify();
+    }
+
+    fn refresh_skills(&mut self, cx: &mut Context<Self>) {
+        let project = self
+            .store
+            .read()
+            .expect("session store lock poisoned")
+            .selected_session()
+            .filter(|session| session.host.is_none())
+            .map(|session| PathBuf::from(&session.cwd));
+        self.skills
+            .update(cx, |skills, cx| skills.open(project, cx));
     }
 
     fn begin_shortcut_edit(
@@ -1546,6 +1579,14 @@ impl UtilitySurfaces {
         }
         if self.handle_settings_search_key(event, cx) {
             cx.stop_propagation();
+            return;
+        }
+        if self.surface == Surface::Settings
+            && self.settings_tab == SettingsTab::Skills
+            && self
+                .skills
+                .update(cx, |skills, cx| skills.handle_key(event, cx))
+        {
             return;
         }
         let key = &event.keystroke;
@@ -2204,6 +2245,7 @@ impl UtilitySurfaces {
         let pane = match self.settings_tab {
             SettingsTab::General => self.general_settings(cx).into_any_element(),
             SettingsTab::Agents => self.agents_settings(cx).into_any_element(),
+            SettingsTab::Skills => self.skills.clone().into_any_element(),
             SettingsTab::Accounts => self.accounts_settings(cx).into_any_element(),
             SettingsTab::Shortcuts => self.shortcuts_settings(cx).into_any_element(),
             SettingsTab::Terminal => self.terminal_settings(cx).into_any_element(),
@@ -5408,6 +5450,9 @@ fn settings_tab_matches(tab: SettingsTab, query: &str) -> bool {
         SettingsTab::Agents => {
             "agents codex claude cursor gemini executable installed command line quick create default"
         }
+        SettingsTab::Skills => {
+            "skills catalogue catalog instructions personal project plugins search SKILL.md"
+        }
         SettingsTab::Accounts => {
             "accounts profiles work personal login authentication codex claude default config home"
         }
@@ -6463,6 +6508,7 @@ mod tests {
             Ok("shortcuts") => SettingsTab::Shortcuts,
             Ok("general") => SettingsTab::General,
             Ok("agents") => SettingsTab::Agents,
+            Ok("skills") => SettingsTab::Skills,
             Ok("accounts") => SettingsTab::Accounts,
             Ok("terminal") => SettingsTab::Terminal,
             Ok("resources") => SettingsTab::Resources,
@@ -6772,6 +6818,14 @@ mod tests {
 
         fn open_at(tab: SettingsTab, window: &mut Window, cx: &mut Context<Self>) -> Self {
             let runtime = Arc::new(StoreRuntime::inert());
+            if std::env::var_os("DIRI_VISUAL_LIGHT").is_some() {
+                runtime
+                    .store
+                    .write()
+                    .expect("preview store")
+                    .update_preferences(|prefs| prefs.terminal_theme = "dirijor-light".into())
+                    .expect("preview theme");
+            }
             let tokio = Arc::new(
                 tokio::runtime::Builder::new_current_thread()
                     .enable_all()
@@ -6796,6 +6850,11 @@ mod tests {
                 );
                 surfaces.open_settings(cx);
                 surfaces.settings_tab = tab;
+                if tab == SettingsTab::Skills {
+                    surfaces.skills.update(cx, |skills, _| {
+                        skills.seed_preview(std::env::var_os("DIRI_VISUAL_SKILL_DETAIL").is_some())
+                    });
+                }
                 if tab == SettingsTab::Accounts {
                     surfaces.seed_account_preview(
                         std::env::var_os("DIRI_VISUAL_ACCOUNT_EDITOR").is_some(),

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -6270,6 +6270,7 @@ mod tests {
         }
     }
 
+    #[cfg(target_os = "macos")]
     fn seed_history(surfaces: &mut UtilitySurfaces) {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)


### PR DESCRIPTION
Adds Settings → Skills so users can find and read skill instructions without hunting through provider folders. The catalogue supports search, Personal/Project/Plugins filters, keyboard navigation, a Markdown detail reader, copying instructions, revealing the source file, and refresh.

Discovery runs off the UI thread, merges shared directory aliases, bounds reads/traversal, and preserves distinct same-name skills. It covers shared and provider directories, the selected local project's directories, and labeled Claude/Codex plugin-cache versions; it does not claim cached skills are enabled or change provider configuration. No new dependencies.

Validation: four focused discovery/metadata tests, including linked skill containment; `cargo check -p diri-app`; `cargo clippy -p diri-app --all-targets -- -D warnings`; formatting; native deterministic dark catalogue and light detail screenshots inspected. Full remote/PTY suites are outside this UI-only change.

Combined verification with #174, #175, #176, #177 and #179 on main `1c56e5f`: workspace formatting, clippy with warnings denied, all 1,304 tests (24 opt-in tests ignored), and the release workspace build passed in an isolated worktree. Native browser and visual fixtures were checked separately as described above. Merge #177 first for its shared Linux-only lint correction to the existing macOS fixture helper. The separate iPhone CI job still fails before compilation because the runner selects Xcode older than 26.

