### PR TITLE
Add tabbed workspace panel with native browser and shell

### DIFF
--- a/diri/Cargo.lock
+++ b/diri/Cargo.lock
@@ -1557,7 +1557,9 @@ dependencies = [
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
  "objc2-user-notifications",
+ "objc2-web-kit",
  "qrcode",
+ "raw-window-handle",
  "rusqlite",
  "serde",
  "serde_json",
@@ -4217,6 +4219,20 @@ dependencies = [
  "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-location",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-web-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
  "objc2-foundation 0.3.2",
 ]
 

--- a/diri/Cargo.toml
+++ b/diri/Cargo.toml
@@ -47,6 +47,7 @@ getrandom = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 regex = "1"
+raw-window-handle = "0.6.2"
 rusqlite = { version = "0.40.1", features = ["bundled"] }
 sha2 = "0.11"
 tempfile = "3"

--- a/diri/crates/diri-app/Cargo.toml
+++ b/diri/crates/diri-app/Cargo.toml
@@ -31,6 +31,7 @@ background-app = false
 [dependencies]
 diri-web = { path = "../diri-web" }
 qrcode = { version = "0.14", default-features = false }
+raw-window-handle.workspace = true
 diri-client.workspace = true
 diri-proto.workspace = true
 diri-term.workspace = true
@@ -109,6 +110,8 @@ objc2-foundation = { version = "=0.3.2", default-features = false, features = [
     "NSAttributedString",
     "NSBundle",
     "NSDictionary",
+    "NSDate",
+    "NSRunLoop",
     "NSError",
     "NSGeometry",
     "NSNotification",
@@ -131,4 +134,13 @@ objc2-user-notifications = { version = "=0.3.2", default-features = false, featu
     "UNNotificationTrigger",
     "UNUserNotificationCenter",
     "block2",
+] }
+objc2-web-kit = { version = "=0.3.2", default-features = false, features = [
+    "objc2-app-kit",
+    "objc2-core-foundation",
+    "block2",
+    "WKNavigation",
+    "WKNavigationDelegate",
+    "WKWebView",
+    "WKWebViewConfiguration",
 ] }

--- a/diri/crates/diri-app/src/inspector.rs
+++ b/diri/crates/diri-app/src/inspector.rs
@@ -22,7 +22,7 @@ use gpui::{
     Animation, AnimationExt, AnyElement, App, Context, DragMoveEvent, Entity, EventEmitter,
     FocusHandle, Focusable, FontWeight, KeyDownEvent, ListHorizontalSizingBehavior, MouseButton,
     Render, ScrollStrategy, SharedString, StatefulInteractiveElement, Task,
-    UniformListScrollHandle, Window, div, ease_out_quint, point, prelude::*, px, rgba,
+    UniformListScrollHandle, Window, deferred, div, ease_out_quint, point, prelude::*, px, rgba,
     uniform_list,
 };
 
@@ -39,6 +39,7 @@ use crate::query_editor::{self, ClipboardEdit, Edit, QueryEditor};
 use crate::quote::{Quote, QuoteSource};
 use crate::review_prompt::{ReviewEvidence, ReviewLayer, ReviewPrompt};
 use crate::store::{InspectorTab, StoreRuntime};
+use crate::terminal_pane::TerminalPane;
 use crate::transcript::{TranscriptDocument, TranscriptVersion, load as load_transcript};
 
 const DIFF_ROW_HEIGHT: f32 = 20.0;
@@ -71,13 +72,38 @@ struct ScrollbarMetrics {
     thumb_top: f32,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub enum InspectorEvent {
     Close,
+    WorkspaceChanged(WorkspaceSurface),
+    WorkspaceClosed(WorkspaceSurface),
+    RequestTerminal,
+    Browser(BrowserAction),
+}
+
+#[derive(Clone, Debug)]
+pub enum BrowserAction {
+    Navigate(String),
+    Back,
+    Forward,
+    Reload,
+    OpenExternal(String),
+}
+
+/// The native WebKit view owns navigation. This compact projection lets the
+/// GPUI chrome accurately reflect redirects, in-page links, and history.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BrowserState {
+    pub url: Option<String>,
+    pub title: Option<String>,
+    pub can_go_back: bool,
+    pub can_go_forward: bool,
+    pub is_loading: bool,
+    pub error: Option<String>,
 }
 
 impl InspectorTab {
-    const ALL: [Self; 4] = [Self::Info, Self::Changes, Self::Code, Self::Artifacts];
+    const DETAILS: [Self; 2] = [Self::Info, Self::Artifacts];
 
     const fn label(self) -> &'static str {
         match self {
@@ -103,6 +129,47 @@ impl InspectorTab {
             Self::Changes => "INSPECTOR_TAB_CHANGES",
             Self::Code => "INSPECTOR_TAB_CODE",
             Self::Artifacts => "INSPECTOR_TAB_ARTIFACTS",
+        }
+    }
+}
+
+/// A workspace surface is deliberately separate from `InspectorTab`: the
+/// latter is persisted user state for the existing agent details views.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WorkspaceSurface {
+    Details,
+    Browser,
+    Terminal,
+    Files,
+    Review,
+}
+
+impl WorkspaceSurface {
+    const CATALOG: [Self; 5] = [
+        Self::Browser,
+        Self::Terminal,
+        Self::Files,
+        Self::Review,
+        Self::Details,
+    ];
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Details => "Details",
+            Self::Browser => "Browser",
+            Self::Terminal => "Terminal",
+            Self::Files => "Files",
+            Self::Review => "Review",
+        }
+    }
+
+    const fn icon(self) -> &'static str {
+        match self {
+            Self::Details => "square.stack.3d.up",
+            Self::Browser => "network",
+            Self::Terminal => "terminal",
+            Self::Files => "folder",
+            Self::Review => "checklist",
         }
     }
 }
@@ -171,12 +238,20 @@ pub struct WorkbenchInspector {
     _tokio_owner: Arc<tokio::runtime::Runtime>,
     tokio: tokio::runtime::Handle,
     code_viewer: Entity<CodeViewer>,
+    terminal_surface: Option<Entity<TerminalPane>>,
     markdown_cache: HashMap<String, Arc<MarkdownDocument>>,
     focus: FocusHandle,
     visible: bool,
     selected_tab: InspectorTab,
+    details_tab: InspectorTab,
+    workspace_tabs: Vec<WorkspaceSurface>,
+    workspace_selected: Option<WorkspaceSurface>,
+    workspace_chooser_open: bool,
     tab_direction: f32,
     tab_transition_generation: u64,
+    browser_query: QueryEditor,
+    browser_address_focused: bool,
+    browser_state: BrowserState,
     context: Option<DiffContext>,
     state: LoadState,
     review_state: ReviewLoadState,
@@ -256,17 +331,38 @@ impl WorkbenchInspector {
                 }
             }
         });
+        let initial_surface = match selected_tab {
+            InspectorTab::Changes => WorkspaceSurface::Review,
+            InspectorTab::Code => WorkspaceSurface::Files,
+            InspectorTab::Info | InspectorTab::Artifacts => WorkspaceSurface::Details,
+        };
+        let mut workspace_tabs = vec![WorkspaceSurface::Details];
+        if initial_surface != WorkspaceSurface::Details {
+            workspace_tabs.push(initial_surface);
+        }
         Self {
             runtime,
             _tokio_owner: tokio_owner,
             tokio,
             code_viewer,
+            terminal_surface: None,
             markdown_cache: HashMap::new(),
             focus,
             visible: false,
             selected_tab,
+            details_tab: if selected_tab == InspectorTab::Artifacts {
+                InspectorTab::Artifacts
+            } else {
+                InspectorTab::Info
+            },
+            workspace_tabs,
+            workspace_selected: Some(initial_surface),
+            workspace_chooser_open: false,
             tab_direction: 1.0,
             tab_transition_generation: 0,
+            browser_query: QueryEditor::default(),
+            browser_address_focused: false,
+            browser_state: BrowserState::default(),
             context: None,
             state: LoadState::NoSession,
             review_state: ReviewLoadState::NoSession,
@@ -320,6 +416,9 @@ impl WorkbenchInspector {
             // settled read of the working tree — what stays tab-gated is the
             // *periodic* poll below, not this edge-triggered refresh.
             self.refresh(true, cx);
+            if self.is_terminal_tab() {
+                cx.emit(InspectorEvent::RequestTerminal);
+            }
         } else {
             self.comparison_menu_open = false;
             self.files_open = false;
@@ -331,6 +430,58 @@ impl WorkbenchInspector {
         cx.notify();
     }
 
+    pub fn set_terminal_surface(
+        &mut self,
+        terminal: Option<Entity<TerminalPane>>,
+        cx: &mut Context<Self>,
+    ) {
+        self.terminal_surface = terminal;
+        cx.notify();
+    }
+
+    #[must_use]
+    pub fn is_terminal_tab(&self) -> bool {
+        self.workspace_selected == Some(WorkspaceSurface::Terminal)
+    }
+
+    #[must_use]
+    #[cfg(target_os = "macos")]
+    pub fn is_browser_tab(&self) -> bool {
+        self.workspace_selected == Some(WorkspaceSurface::Browser)
+    }
+
+    #[must_use]
+    #[cfg(target_os = "macos")]
+    pub fn blocks_native_browser(&self) -> bool {
+        self.workspace_chooser_open
+            || self.comparison_menu_open
+            || self.files_open
+            || self.status_evidence_open
+            || self.ask_draft.is_some()
+            || self.commit_open
+    }
+
+    #[must_use]
+    pub fn workspace_needs_terminal(&self) -> bool {
+        self.workspace_tabs.contains(&WorkspaceSurface::Terminal)
+    }
+
+    #[cfg(target_os = "macos")]
+    pub fn set_browser_state(&mut self, state: BrowserState, cx: &mut Context<Self>) {
+        if self.browser_state == state {
+            return;
+        }
+        let update_address = !self.browser_address_focused;
+        self.browser_state = state;
+        if update_address {
+            self.browser_query.clear();
+            if let Some(url) = self.browser_state.url.as_deref() {
+                self.browser_query.insert(url);
+            }
+        }
+        cx.notify();
+    }
+
     #[must_use]
     pub fn is_focused(&self, window: &Window) -> bool {
         self.focus.is_focused(window)
@@ -339,18 +490,28 @@ impl WorkbenchInspector {
     /// Returns the selection owned by the inspector's active surface.
     #[must_use]
     pub fn quote_selection(&self) -> Option<Quote> {
-        match self.selected_tab {
-            InspectorTab::Changes => {
+        match self.workspace_selected {
+            Some(WorkspaceSurface::Review) => {
                 let LoadState::Ready(snapshot) = &self.state else {
                     return None;
                 };
                 let session_id = self.context.as_ref()?.id.clone();
                 self.diff_selection.quote(snapshot, session_id)
             }
-            InspectorTab::Info | InspectorTab::Artifacts => {
-                self.selected_turn.as_ref().map(|turn| turn.quote.clone())
-            }
-            InspectorTab::Code => None,
+            Some(WorkspaceSurface::Details) => match self.selected_tab {
+                InspectorTab::Info | InspectorTab::Artifacts => {
+                    self.selected_turn.as_ref().map(|turn| turn.quote.clone())
+                }
+                InspectorTab::Changes => {
+                    let LoadState::Ready(snapshot) = &self.state else {
+                        return None;
+                    };
+                    let session_id = self.context.as_ref()?.id.clone();
+                    self.diff_selection.quote(snapshot, session_id)
+                }
+                InspectorTab::Code => None,
+            },
+            _ => None,
         }
     }
 
@@ -394,7 +555,10 @@ impl WorkbenchInspector {
     }
 
     fn reconcile_diff_polling(&mut self, cx: &mut Context<Self>) {
-        let should_poll = self.visible && self.selected_tab == InspectorTab::Changes;
+        let should_poll = self.visible
+            && (self.workspace_selected == Some(WorkspaceSurface::Review)
+                || (self.workspace_selected == Some(WorkspaceSurface::Details)
+                    && self.selected_tab == InspectorTab::Changes));
         if !should_poll {
             // Dropping a GPUI Task cancels its timer/future. Info and Artifacts
             // therefore perform no periodic Git work and have no idle wakeup.
@@ -409,7 +573,11 @@ impl WorkbenchInspector {
                 cx.background_executor().timer(REFRESH_INTERVAL).await;
                 if this
                     .update(cx, |this, cx| {
-                        if this.visible && this.selected_tab == InspectorTab::Changes {
+                        if this.visible
+                            && (this.workspace_selected == Some(WorkspaceSurface::Review)
+                                || (this.workspace_selected == Some(WorkspaceSurface::Details)
+                                    && this.selected_tab == InspectorTab::Changes))
+                        {
                             this.refresh(false, cx);
                         }
                     })
@@ -475,6 +643,9 @@ impl WorkbenchInspector {
         // no Git calls because `reconcile_diff_polling` installs no timer.
         if self.selected_context() != self.context {
             self.refresh(true, cx);
+            if self.is_terminal_tab() {
+                cx.emit(InspectorEvent::RequestTerminal);
+            }
         } else {
             // Info and Artifacts are projections of the live session record,
             // so same-session store changes repaint and schedule one bounded
@@ -487,6 +658,18 @@ impl WorkbenchInspector {
     }
 
     fn select_tab(&mut self, tab: InspectorTab, cx: &mut Context<Self>) {
+        if tab == InspectorTab::Changes {
+            self.select_workspace(WorkspaceSurface::Review, cx);
+            return;
+        }
+        if tab == InspectorTab::Code {
+            self.select_workspace(WorkspaceSurface::Files, cx);
+            return;
+        }
+        self.details_tab = tab;
+        if self.workspace_selected != Some(WorkspaceSurface::Details) {
+            self.select_workspace(WorkspaceSurface::Details, cx);
+        }
         if self.selected_tab == tab {
             return;
         }
@@ -520,6 +703,73 @@ impl WorkbenchInspector {
             self.refresh_transcript(&context, false, cx);
         }
         self.reconcile_diff_polling(cx);
+        cx.notify();
+    }
+
+    pub(crate) fn select_workspace(&mut self, surface: WorkspaceSurface, cx: &mut Context<Self>) {
+        self.workspace_chooser_open = false;
+        if !self.workspace_tabs.contains(&surface) {
+            self.workspace_tabs.push(surface);
+        }
+        if self.workspace_selected == Some(surface) {
+            cx.notify();
+            return;
+        }
+        self.tab_transition_generation = self.tab_transition_generation.wrapping_add(1);
+        self.workspace_selected = Some(surface);
+        self.comparison_menu_open = false;
+        self.files_open = false;
+        self.status_evidence_open = false;
+        self.commit_open = false;
+        self.ask_draft = None;
+        self.browser_address_focused = false;
+        let preference_tab = match surface {
+            WorkspaceSurface::Files => Some(InspectorTab::Code),
+            WorkspaceSurface::Review => Some(InspectorTab::Changes),
+            WorkspaceSurface::Details => Some(self.details_tab),
+            WorkspaceSurface::Browser | WorkspaceSurface::Terminal => None,
+        };
+        if let Some(tab) = preference_tab {
+            self.selected_tab = tab;
+            let _ = self
+                .runtime
+                .store
+                .write()
+                .expect("session store lock poisoned")
+                .update_preferences(|prefs| prefs.inspector_tab = tab);
+        }
+        if surface == WorkspaceSurface::Review {
+            self.refresh(true, cx);
+        }
+        if surface == WorkspaceSurface::Terminal {
+            cx.emit(InspectorEvent::RequestTerminal);
+        }
+        if surface == WorkspaceSurface::Details
+            && self.details_tab == InspectorTab::Info
+            && let Some(context) = self.context.clone()
+        {
+            self.refresh_transcript(&context, false, cx);
+        }
+        self.reconcile_diff_polling(cx);
+        cx.emit(InspectorEvent::WorkspaceChanged(surface));
+        cx.notify();
+    }
+
+    fn close_workspace(&mut self, surface: WorkspaceSurface, cx: &mut Context<Self>) {
+        let Some(index) = self.workspace_tabs.iter().position(|tab| *tab == surface) else {
+            return;
+        };
+        self.workspace_tabs.remove(index);
+        self.workspace_chooser_open = false;
+        if self.workspace_selected == Some(surface) {
+            let next = self.workspace_tabs.get(index.saturating_sub(1)).copied();
+            self.workspace_selected = None;
+            if let Some(selected) = next {
+                self.select_workspace(selected, cx);
+            }
+        }
+        self.reconcile_diff_polling(cx);
+        cx.emit(InspectorEvent::WorkspaceClosed(surface));
         cx.notify();
     }
 
@@ -942,7 +1192,7 @@ impl WorkbenchInspector {
             .items_center()
             .gap(px(2.0));
 
-        for tab in InspectorTab::ALL {
+        for tab in InspectorTab::DETAILS {
             let count = match tab {
                 InspectorTab::Info => None,
                 InspectorTab::Changes => changes_count,
@@ -1022,6 +1272,226 @@ impl WorkbenchInspector {
             .items_center()
             .gap(px(Metrics::TOOLBAR_COMPACT_GAP))
             .child(tabs)
+    }
+
+    fn render_surface_chooser(&self, colors: SemanticColors, cx: &mut Context<Self>) -> AnyElement {
+        let choices = [
+            (WorkspaceSurface::Browser, "Open a local app or URL"),
+            (
+                WorkspaceSurface::Terminal,
+                "Start a shell in this workspace",
+            ),
+            (WorkspaceSurface::Files, "Browse workspace files"),
+            (WorkspaceSurface::Review, "Review file changes"),
+        ];
+        let mut cards = div().w_full().flex().flex_col().gap(px(8.0));
+        for pair in choices.chunks_exact(2) {
+            let mut row = div().w_full().flex().gap(px(8.0));
+            for &(surface, description) in pair {
+                row = row.child(
+                    div()
+                        .id(SharedString::from(format!(
+                            "workspace-open-{}",
+                            surface.label()
+                        )))
+                        .min_w(px(115.0))
+                        .flex_1()
+                        .p(px(14.0))
+                        .flex()
+                        .flex_col()
+                        .gap(px(7.0))
+                        .rounded(px(Radius::CARD))
+                        .border_1()
+                        .border_color(colors.primary.alpha(0.12))
+                        .bg(colors.primary.alpha(0.025))
+                        .cursor_pointer()
+                        .hover(move |card| {
+                            card.bg(colors.primary.alpha(0.055))
+                                .border_color(colors.primary.alpha(0.22))
+                        })
+                        .child(sf_symbol(surface.icon(), 17.0, colors.secondary))
+                        .child(
+                            div()
+                                .mt(px(8.0))
+                                .text_size(px(12.0))
+                                .font_weight(FontWeight::MEDIUM)
+                                .child(surface.label()),
+                        )
+                        .child(
+                            div()
+                                .text_size(px(11.0))
+                                .text_color(colors.tertiary)
+                                .child(description),
+                        )
+                        .on_click(
+                            cx.listener(move |this, _, _, cx| this.select_workspace(surface, cx)),
+                        ),
+                );
+            }
+            cards = cards.child(row);
+        }
+        div()
+            .size_full()
+            .p(px(20.0))
+            .flex()
+            .flex_col()
+            .justify_center()
+            .items_center()
+            .gap(px(10.0))
+            .child(
+                div()
+                    .text_size(px(14.0))
+                    .font_weight(FontWeight::MEDIUM)
+                    .child("Open a surface"),
+            )
+            .child(
+                div()
+                    .mb(px(14.0))
+                    .text_size(px(11.0))
+                    .text_color(colors.tertiary)
+                    .child("Choose what to show in the right panel"),
+            )
+            .child(cards)
+            .into_any_element()
+    }
+
+    fn render_workspace_header(
+        &self,
+        colors: SemanticColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let selected = self.workspace_selected;
+        let mut tabs = div()
+            .id("workspace-surface-tabs")
+            .overflow_x_scroll()
+            .min_w(px(0.0))
+            .flex_1()
+            .flex()
+            .items_center()
+            .gap(px(3.0));
+
+        for surface in self.workspace_tabs.iter().copied() {
+            let active = selected == Some(surface);
+            let label = if surface == WorkspaceSurface::Browser {
+                self.browser_state
+                    .title
+                    .clone()
+                    .filter(|title| !title.is_empty())
+                    .unwrap_or_else(|| surface.label().into())
+            } else {
+                surface.label().into()
+            };
+            tabs = tabs.child(
+                div()
+                    .id(SharedString::from(format!(
+                        "workspace-tab-{}",
+                        surface.label()
+                    )))
+                    .h(px(29.0))
+                    .flex_none()
+                    .max_w(px(160.0))
+                    .min_w(px(0.0))
+                    .px(px(7.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(5.0))
+                    .rounded(px(Radius::BADGE))
+                    .bg(if active {
+                        colors.primary.alpha(0.09)
+                    } else {
+                        colors.primary.alpha(0.0)
+                    })
+                    .text_color(if active {
+                        colors.primary
+                    } else {
+                        colors.secondary
+                    })
+                    .cursor_pointer()
+                    .hover(move |tab| {
+                        tab.bg(colors.primary.alpha(if active { 0.12 } else { 0.055 }))
+                    })
+                    .child(sf_symbol(
+                        surface.icon(),
+                        10.5,
+                        if active {
+                            colors.primary
+                        } else {
+                            colors.tertiary
+                        },
+                    ))
+                    .child(
+                        div()
+                            .truncate()
+                            .text_size(px(11.0))
+                            .font_weight(if active {
+                                FontWeight::SEMIBOLD
+                            } else {
+                                FontWeight::MEDIUM
+                            })
+                            .child(label),
+                    )
+                    .child(
+                        div()
+                            .id(SharedString::from(format!(
+                                "close-workspace-{}",
+                                surface.label()
+                            )))
+                            .size(px(16.0))
+                            .flex_none()
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .rounded_full()
+                            .text_color(colors.tertiary)
+                            .hover(move |button| {
+                                button
+                                    .bg(colors.primary.alpha(0.09))
+                                    .text_color(colors.secondary)
+                            })
+                            .on_click(cx.listener(move |this, _, _, cx| {
+                                this.close_workspace(surface, cx);
+                                cx.stop_propagation();
+                            }))
+                            .child(sf_symbol("xmark", 8.5, colors.tertiary)),
+                    )
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        this.select_workspace(surface, cx);
+                        cx.stop_propagation();
+                    })),
+            );
+        }
+
+        let mut header = div()
+            .id("workspace-surface-header")
+            .relative()
+            .h(px(Metrics::TITLE_BAR))
+            .flex_none()
+            .pl(px(8.0))
+            .pr(px(Metrics::TOOLBAR_EDGE_INSET))
+            .flex()
+            .items_center()
+            .gap(px(4.0))
+            .border_b_1()
+            .border_color(colors.primary.alpha(0.065))
+            .child(tabs)
+            .child(
+                div()
+                    .id("workspace-add-surface")
+                    .size(px(Metrics::TOOLBAR_CONTROL_SIZE))
+                    .flex_none()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .rounded(px(Radius::BADGE))
+                    .cursor_pointer()
+                    .hover(move |button| button.bg(Fill::subtle(colors)))
+                    .child(sf_symbol("plus", 13.0, colors.secondary))
+                    .on_click(cx.listener(|this, _, _, cx| {
+                        this.workspace_chooser_open = !this.workspace_chooser_open;
+                        cx.notify();
+                        cx.stop_propagation();
+                    })),
+            )
             .child(
                 div()
                     .id("close-inspector")
@@ -1044,7 +1514,271 @@ impl WorkbenchInspector {
                         cx.emit(InspectorEvent::Close);
                         cx.stop_propagation();
                     })),
+            );
+
+        if self.workspace_chooser_open {
+            let mut catalog = div()
+                .id("workspace-surface-catalog")
+                .absolute()
+                .top(px(Metrics::TITLE_BAR - 2.0))
+                .right(px(35.0))
+                .w(px(196.0))
+                .p(px(5.0))
+                .flex()
+                .flex_col()
+                .gap(px(2.0))
+                .rounded(px(Radius::CARD))
+                .bg(colors.sidebar_surface())
+                .border_1()
+                .border_color(colors.primary.alpha(0.14))
+                .shadow_lg();
+            for surface in WorkspaceSurface::CATALOG {
+                let opened = self.workspace_tabs.contains(&surface);
+                catalog = catalog.child(
+                    div()
+                        .id(SharedString::from(format!(
+                            "workspace-catalog-{}",
+                            surface.label()
+                        )))
+                        .h(px(32.0))
+                        .px(px(8.0))
+                        .flex()
+                        .items_center()
+                        .gap(px(8.0))
+                        .rounded(px(Radius::BADGE))
+                        .cursor_pointer()
+                        .hover(move |row| row.bg(colors.primary.alpha(0.07)))
+                        .child(sf_symbol(surface.icon(), 11.0, colors.secondary))
+                        .child(
+                            div()
+                                .flex_1()
+                                .text_size(px(11.5))
+                                .text_color(colors.primary)
+                                .child(surface.label()),
+                        )
+                        .when(opened, |row| {
+                            row.child(sf_symbol("checkmark", 10.0, colors.tertiary))
+                        })
+                        .on_click(cx.listener(move |this, _, _, cx| {
+                            this.select_workspace(surface, cx);
+                            cx.stop_propagation();
+                        })),
+                );
+            }
+            header = header.child(deferred(catalog.occlude()));
+        }
+        header.into_any_element()
+    }
+
+    fn browser_url(&self) -> Option<String> {
+        let typed = self.browser_query.text().trim();
+        if typed.is_empty() {
+            return None;
+        }
+        crate::agent_catalog::normal_web_url(typed).or_else(|| {
+            let candidate = url::Url::parse(&format!("https://{typed}")).ok()?;
+            let local = candidate.host_str().is_some_and(|host| {
+                host == "localhost"
+                    || host == "[::1]"
+                    || host
+                        .parse::<std::net::IpAddr>()
+                        .is_ok_and(|ip| ip.is_loopback())
+            });
+            crate::agent_catalog::normal_web_url(&format!(
+                "{}://{typed}",
+                if local { "http" } else { "https" }
+            ))
+        })
+    }
+
+    fn navigate_browser(&mut self, cx: &mut Context<Self>) {
+        let Some(url) = self.browser_url() else {
+            return;
+        };
+        self.browser_query.clear();
+        self.browser_query.insert(&url);
+        self.browser_address_focused = false;
+        cx.emit(InspectorEvent::Browser(BrowserAction::Navigate(url)));
+        cx.notify();
+    }
+
+    fn apply_browser_edit(&mut self, event: &KeyDownEvent, cx: &mut Context<Self>) {
+        match event.keystroke.key.as_str() {
+            "escape" => self.browser_address_focused = false,
+            "enter" => self.navigate_browser(cx),
+            _ => match query_editor::edit_for(&event.keystroke) {
+                Some(Edit::Local(edit)) => {
+                    self.browser_query.apply(edit);
+                }
+                Some(Edit::Clipboard(ClipboardEdit::Copy)) => {
+                    query_editor::copy_selection(&self.browser_query, cx);
+                }
+                Some(Edit::Clipboard(ClipboardEdit::Cut)) => {
+                    query_editor::cut_selection(&mut self.browser_query, cx);
+                }
+                Some(Edit::Clipboard(ClipboardEdit::Paste)) => {
+                    if let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) {
+                        self.browser_query.insert(&text);
+                    }
+                }
+                None => return,
+            },
+        }
+        cx.notify();
+    }
+
+    fn render_browser(&self, colors: SemanticColors, cx: &mut Context<Self>) -> AnyElement {
+        let has_url = self.browser_state.url.is_some() || self.browser_url().is_some();
+        let nav_button = |id: &'static str,
+                          symbol: &'static str,
+                          action: BrowserAction,
+                          enabled: bool,
+                          cx: &mut Context<Self>| {
+            div()
+                .id(id)
+                .size(px(26.0))
+                .flex_none()
+                .flex()
+                .items_center()
+                .justify_center()
+                .rounded(px(Radius::BADGE))
+                .text_color(if enabled {
+                    colors.secondary
+                } else {
+                    colors.primary.alpha(0.24)
+                })
+                .when(enabled, |button| {
+                    button
+                        .cursor_pointer()
+                        .hover(move |button| button.bg(colors.primary.alpha(0.07)))
+                        .on_click(cx.listener(move |_this, _, _, cx| {
+                            cx.emit(InspectorEvent::Browser(action.clone()));
+                            cx.stop_propagation();
+                        }))
+                })
+                .child(sf_symbol_weighted(
+                    symbol,
+                    10.5,
+                    SymbolWeight::Semibold,
+                    if enabled {
+                        colors.secondary
+                    } else {
+                        colors.primary.alpha(0.24)
+                    },
+                ))
+        };
+        let url_label = if self.browser_query.is_empty() {
+            div()
+                .text_color(colors.tertiary)
+                .child("Enter a URL or local preview address")
+                .into_any_element()
+        } else {
+            crate::navigation::query_label(&self.browser_query)
+        };
+        div()
+            .id("workspace-browser")
+            .relative()
+            .size_full()
+            .flex()
+            .flex_col()
+            .child(
+                div()
+                    .h(px(42.0))
+                    .flex_none()
+                    .px(px(9.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(3.0))
+                    .border_b_1()
+                    .border_color(colors.primary.alpha(0.065))
+                    .child(nav_button("browser-back", "chevron.left", BrowserAction::Back, self.browser_state.can_go_back, cx))
+                    .child(nav_button("browser-forward", "chevron.right", BrowserAction::Forward, self.browser_state.can_go_forward, cx))
+                    .child(nav_button("browser-reload", "arrow.triangle.2.circlepath", BrowserAction::Reload, has_url, cx))
+                    .child(
+                        div()
+                            .id("browser-address")
+                            .min_w(px(0.0))
+                            .flex_1()
+                            .h(px(28.0))
+                            .px(px(9.0))
+                            .flex()
+                            .items_center()
+                            .rounded(px(Radius::BADGE))
+                            .bg(colors.primary.alpha(0.045))
+                            .border_1()
+                            .border_color(if self.browser_address_focused { rgba(0x4f83f1cc) } else { colors.primary.alpha(0.075) })
+                            .text_size(px(10.5))
+                            .text_color(colors.primary)
+                            .cursor_text()
+                            .on_mouse_down(MouseButton::Left, cx.listener(|this, _, window, cx| {
+                                this.browser_address_focused = true;
+                                window.focus(&this.focus, cx);
+                                cx.notify();
+                                cx.stop_propagation();
+                            }))
+                            .child(url_label),
+                    )
+                    .child(
+                        div()
+                            .id("browser-open-external")
+                            .size(px(26.0))
+                            .flex_none()
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .rounded(px(Radius::BADGE))
+                            .text_color(if has_url { colors.secondary } else { colors.primary.alpha(0.24) })
+                            .when(has_url, |button| button.cursor_pointer().hover(move |button| button.bg(colors.primary.alpha(0.07)))
+                                .on_click(cx.listener(|this, _, _, cx| {
+                                    if let Some(url) = this.browser_state.url.clone().or_else(|| this.browser_url()) {
+                                        cx.emit(InspectorEvent::Browser(BrowserAction::OpenExternal(url)));
+                                    }
+                                    cx.stop_propagation();
+                                })))
+                            .child(sf_symbol("link", 10.5, if has_url { colors.secondary } else { colors.primary.alpha(0.24) })),
+                    ),
             )
+            .child(
+                div()
+                    .id("workspace-browser-loading-space")
+                    .min_h(px(0.0))
+                    .flex_1()
+                    .flex()
+                    .flex_col()
+                    .items_center()
+                    .justify_center()
+                    .gap(px(8.0))
+                    .text_center()
+                    .text_color(colors.tertiary)
+                    .when(!has_url, |body| body
+                        .child(sf_symbol("network", 26.0, colors.tertiary))
+                        .child(div().text_size(px(13.0)).font_weight(FontWeight::MEDIUM).text_color(colors.secondary).child("Open a page"))
+                        .child(div().max_w(px(230.0)).text_size(px(11.0)).line_height(px(17.0)).child("Browse a local preview or any secure web address without leaving the workspace.")))
+                    .when_some(self.browser_state.error.clone(), |body, error| body.child(div().max_w(px(260.0)).text_size(px(12.0)).child(error)))
+                    .when(self.browser_state.is_loading, |body| body.child(div().text_size(px(10.0)).child("Loading…"))),
+            )
+            .into_any_element()
+    }
+
+    fn render_terminal(&self, colors: SemanticColors) -> AnyElement {
+        self.terminal_surface.clone().map_or_else(
+            || {
+                self.render_message(
+                    colors,
+                    "terminal",
+                    "Select a session",
+                    "A shell follows the active agent here.",
+                )
+                .into_any_element()
+            },
+            |terminal| {
+                div()
+                    .id("workspace-terminal")
+                    .size_full()
+                    .child(terminal)
+                    .into_any_element()
+            },
+        )
     }
 
     fn render_info(
@@ -2614,6 +3348,13 @@ impl WorkbenchInspector {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.workspace_selected == Some(WorkspaceSurface::Browser)
+            && self.browser_address_focused
+        {
+            self.apply_browser_edit(event, cx);
+            cx.stop_propagation();
+            return;
+        }
         if self.ask_draft.is_some() {
             match event.keystroke.key.as_str() {
                 "escape" => {
@@ -2651,7 +3392,11 @@ impl WorkbenchInspector {
             cx.stop_propagation();
             return;
         }
-        if !self.commit_open && self.selected_tab == InspectorTab::Changes {
+        if !self.commit_open
+            && (self.workspace_selected == Some(WorkspaceSurface::Review)
+                || (self.workspace_selected == Some(WorkspaceSurface::Details)
+                    && self.selected_tab == InspectorTab::Changes))
+        {
             let moved = match event.keystroke.key.as_str() {
                 "up" => match &self.state {
                     LoadState::Ready(snapshot) => {
@@ -3241,18 +3986,46 @@ impl Render for WorkbenchInspector {
             crate::app_theme::sidebar_colors(&store.preferences().terminal_theme)
         };
         let session = self.selected_session();
-        let body = match self.selected_tab {
-            InspectorTab::Info => self.render_info(session.as_ref(), colors, cx),
-            InspectorTab::Artifacts => self.render_artifacts(session.as_ref(), colors, cx),
-            InspectorTab::Changes => self.render_changes(colors, window, cx),
-            InspectorTab::Code => self.code_viewer.clone().into_any_element(),
+        let body = match self.workspace_selected {
+            Some(WorkspaceSurface::Details) => {
+                let detail = match self.selected_tab {
+                    InspectorTab::Info => self.render_info(session.as_ref(), colors, cx),
+                    InspectorTab::Artifacts => self.render_artifacts(session.as_ref(), colors, cx),
+                    InspectorTab::Changes => self.render_changes(colors, window, cx),
+                    InspectorTab::Code => self.code_viewer.clone().into_any_element(),
+                };
+                div()
+                    .id("workspace-details")
+                    .size_full()
+                    .flex()
+                    .flex_col()
+                    .child(self.render_header(session.as_ref(), colors, cx))
+                    .child(
+                        div()
+                            .min_h(px(0.0))
+                            .flex_1()
+                            .overflow_hidden()
+                            .child(detail),
+                    )
+                    .into_any_element()
+            }
+            Some(WorkspaceSurface::Browser) => self.render_browser(colors, cx),
+            Some(WorkspaceSurface::Terminal) => self.render_terminal(colors),
+            Some(WorkspaceSurface::Files) => self.code_viewer.clone().into_any_element(),
+            Some(WorkspaceSurface::Review) => self.render_changes(colors, window, cx),
+            None => self.render_surface_chooser(colors, cx),
         };
         let transition_id = SharedString::from(format!(
             "inspector-tab-transition-{}",
             self.tab_transition_generation
         ));
         let direction = self.tab_direction;
-        let ask_composer = self.render_ask_composer(colors, cx);
+        let ask_composer = matches!(
+            self.workspace_selected,
+            Some(WorkspaceSurface::Details | WorkspaceSurface::Review)
+        )
+        .then(|| self.render_ask_composer(colors, cx))
+        .flatten();
         let body = div().relative().size_full().child(body);
         let body = if cx.reduce_motion() {
             body.into_any_element()
@@ -3277,7 +4050,7 @@ impl Render for WorkbenchInspector {
             .on_key_down(cx.listener(Self::handle_key_down))
             .bg(colors.sidebar_surface())
             .text_color(colors.primary)
-            .child(self.render_header(session.as_ref(), colors, cx))
+            .child(self.render_workspace_header(colors, cx))
             .child(div().min_h(px(0.0)).flex_1().overflow_hidden().child(body))
             .when_some(ask_composer, |panel, composer| panel.child(composer))
     }
@@ -5051,11 +5824,90 @@ mod tests {
         }
     }
 
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "writes the isolated workspace-panel screenshot"]
+    fn render_workspace_preview_screenshot() {
+        let output = std::env::var_os("DIRI_VISUAL_OUTPUT")
+            .map(PathBuf::from)
+            .expect("output path");
+        let platform = gpui_platform::current_platform(true);
+        let mut cx = gpui::HeadlessAppContext::with_platform(
+            platform.text_system(),
+            Arc::new(diri_ui::IconAssets),
+            gpui_platform::current_headless_renderer,
+        );
+        cx.update(|cx| crate::fonts::init(cx));
+        let window = cx
+            .open_window(gpui::size(px(440.0), px(700.0)), |_, cx| {
+                let runtime = Arc::new(StoreRuntime::inert());
+                let tokio = Arc::new(
+                    tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                        .unwrap(),
+                );
+                cx.new(|cx| {
+                    let mut inspector = WorkbenchInspector::new(runtime, tokio, cx);
+                    inspector.workspace_tabs.clear();
+                    inspector.workspace_selected = None;
+                    if std::env::var_os("DIRI_VISUAL_BROWSER").is_some() {
+                        inspector.select_workspace(WorkspaceSurface::Review, cx);
+                        inspector.select_workspace(WorkspaceSurface::Browser, cx);
+                    }
+                    inspector
+                })
+            })
+            .expect("headless window");
+        cx.run_until_parked();
+        cx.update_window(window.into(), |_, window, _| window.refresh())
+            .unwrap();
+        cx.run_until_parked();
+        cx.capture_screenshot(window.into())
+            .expect("screenshot")
+            .save(output)
+            .expect("save");
+    }
+
     #[test]
     fn inspector_tabs_have_stable_spatial_order() {
         assert!(InspectorTab::Info.index() < InspectorTab::Changes.index());
         assert!(InspectorTab::Changes.index() < InspectorTab::Code.index());
         assert!(InspectorTab::Code.index() < InspectorTab::Artifacts.index());
+    }
+
+    #[gpui::test]
+    fn workspace_surfaces_are_closable_without_rewriting_inspector_preferences(
+        cx: &mut TestAppContext,
+    ) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        let tokio = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime"),
+        );
+        let inspector = cx.new(|cx| WorkbenchInspector::new(runtime.clone(), tokio, cx));
+
+        inspector.update(cx, |inspector, cx| {
+            inspector.select_workspace(WorkspaceSurface::Browser, cx);
+            inspector.close_workspace(WorkspaceSurface::Browser, cx);
+            inspector.close_workspace(WorkspaceSurface::Details, cx);
+        });
+
+        inspector.read_with(cx, |inspector, _| {
+            assert!(inspector.workspace_tabs.is_empty());
+            assert_eq!(inspector.workspace_selected, None);
+        });
+        assert_eq!(
+            runtime
+                .store
+                .read()
+                .expect("session store lock poisoned")
+                .preferences()
+                .inspector_tab,
+            InspectorTab::Info
+        );
     }
 
     #[gpui::test]
@@ -5476,26 +6328,22 @@ mod tests {
         cx.run_until_parked();
 
         let info = cx.debug_bounds("INSPECTOR_TAB_INFO").expect("Info tab");
-        let changes = cx
-            .debug_bounds("INSPECTOR_TAB_CHANGES")
-            .expect("Changes tab");
-        let code = cx.debug_bounds("INSPECTOR_TAB_CODE").expect("Code tab");
         let artifacts = cx
             .debug_bounds("INSPECTOR_TAB_ARTIFACTS")
             .expect("Artifacts tab");
         let close = cx.debug_bounds("INSPECTOR_CLOSE").expect("close button");
-
-        assert!(info.right() <= changes.left());
-        assert!(changes.right() <= code.left());
-        assert!(code.right() <= artifacts.left());
-        assert!(artifacts.right() <= close.left());
+        assert!(info.right() <= artifacts.left());
+        assert!(artifacts.right() <= px(300.0));
         assert!(close.right() <= px(300.0));
-
-        cx.simulate_click(changes.center(), Modifiers::none());
+        assert!(cx.debug_bounds("INSPECTOR_TAB_CHANGES").is_none());
+        assert!(cx.debug_bounds("INSPECTOR_TAB_CODE").is_none());
         let inspector = harness.read_with(cx, |harness, _| harness.inspector.clone());
+        inspector.update(cx, |inspector, cx| {
+            inspector.select_tab(InspectorTab::Changes, cx)
+        });
         assert_eq!(
-            inspector.read_with(cx, |inspector, _| inspector.selected_tab),
-            InspectorTab::Changes
+            inspector.read_with(cx, |inspector, _| inspector.workspace_selected),
+            Some(WorkspaceSurface::Review)
         );
         cx.run_until_parked();
 
@@ -5513,6 +6361,13 @@ mod tests {
             DiffLayer::Working
         );
 
+        inspector.update(cx, |inspector, cx| {
+            inspector.select_workspace(WorkspaceSurface::Details, cx)
+        });
+        cx.run_until_parked();
+        let artifacts = cx
+            .debug_bounds("INSPECTOR_TAB_ARTIFACTS")
+            .expect("Artifacts tab restored");
         cx.simulate_click(artifacts.center(), Modifiers::none());
         assert_eq!(
             inspector.read_with(cx, |inspector, _| inspector.selected_tab),

--- a/diri/crates/diri-app/src/macos/browser.rs
+++ b/diri/crates/diri-app/src/macos/browser.rs
@@ -1,0 +1,452 @@
+//! Native WebKit backing for the workspace Browser surface.
+//!
+//! GPUI does not expose an arbitrary native-child-view primitive. This owner
+//! bridges that small platform seam with typed `objc2` WebKit/AppKit bindings;
+//! it owns the child view, converts coordinates once, and tears the child down
+//! before releasing it. Navigation stays in WebKit, while the GPUI toolbar
+//! receives a compact state projection.
+
+use objc2::rc::Retained;
+use objc2::runtime::ProtocolObject;
+use objc2::{DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send};
+use objc2_app_kit::NSView;
+use objc2_foundation::{
+    NSError, NSObject, NSObjectProtocol, NSPoint, NSRect, NSSize, NSString, NSURL, NSURLRequest,
+};
+use objc2_web_kit::{WKNavigation, WKNavigationDelegate, WKWebView, WKWebViewConfiguration};
+use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+use std::cell::RefCell;
+
+use crate::inspector::BrowserState;
+
+/// Top-left frame coordinates in GPUI points.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct BrowserFrame {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+}
+
+/// A lazily-attached, single-tab WebKit view.
+pub struct NativeBrowser {
+    web_view: Option<objc2::rc::Retained<WKWebView>>,
+    /// Non-owning: AppKit owns the GPUI root view for the window lifetime.
+    parent: Option<*const NSView>,
+    pending_url: Option<String>,
+    delegate: Option<Retained<BrowserDelegate>>,
+    events: tokio::sync::mpsc::Sender<()>,
+}
+
+impl NativeBrowser {
+    pub fn new() -> (Self, tokio::sync::mpsc::Receiver<()>) {
+        let (events, receiver) = tokio::sync::mpsc::channel(1);
+        (
+            Self {
+                web_view: None,
+                parent: None,
+                pending_url: None,
+                delegate: None,
+                events,
+            },
+            receiver,
+        )
+    }
+
+    pub fn has_page(&self) -> bool {
+        self.pending_url.is_some()
+    }
+
+    pub fn sync(&mut self, window: &impl HasWindowHandle, visible: bool, frame: BrowserFrame) {
+        if !visible
+            || !self.has_page()
+            || self.error().is_some()
+            || frame.width <= 1.0
+            || frame.height <= 1.0
+        {
+            self.hide();
+            return;
+        }
+        let Some(parent) = parent_view(window) else {
+            self.hide();
+            return;
+        };
+        let Some(view) = self.ensure_view(parent) else {
+            return;
+        };
+        // GPUI lays out from the top. AppKit views are usually bottom-left,
+        // but a flipped host view uses the same origin and must not be flipped
+        // a second time.
+        let parent = unsafe { &*parent };
+        let bounds = parent.bounds();
+        let y = if parent.isFlipped() {
+            f64::from(frame.y)
+        } else {
+            (bounds.size.height - f64::from(frame.y + frame.height)).max(0.0)
+        };
+        view.setFrame(NSRect::new(
+            NSPoint::new(f64::from(frame.x), y),
+            NSSize::new(f64::from(frame.width), f64::from(frame.height)),
+        ));
+        view.setHidden(false);
+    }
+
+    pub fn load(&mut self, url: String) {
+        if request_for(&url).is_none() {
+            return;
+        }
+        if let Some(delegate) = &self.delegate {
+            *delegate.ivars().error.borrow_mut() = None;
+        }
+        self.pending_url = Some(url.clone());
+        if let (Some(view), Some(request)) = (&self.web_view, request_for(&url)) {
+            unsafe { view.loadRequest(&request) };
+        }
+    }
+
+    pub fn go_back(&self) {
+        if let Some(view) = &self.web_view {
+            unsafe { view.goBack() };
+        }
+    }
+
+    pub fn go_forward(&self) {
+        if let Some(view) = &self.web_view {
+            unsafe { view.goForward() };
+        }
+    }
+
+    pub fn reload(&self) {
+        if let Some(delegate) = &self.delegate {
+            *delegate.ivars().error.borrow_mut() = None;
+        }
+        if let Some(view) = &self.web_view {
+            unsafe { view.reload() };
+        }
+    }
+
+    pub fn state(&self) -> BrowserState {
+        let Some(view) = &self.web_view else {
+            return BrowserState {
+                url: self.pending_url.clone(),
+                ..BrowserState::default()
+            };
+        };
+        BrowserState {
+            url: unsafe { view.URL() }
+                .and_then(|url| url.absoluteString())
+                .map(|value| value.to_string()),
+            title: unsafe { view.title() }.map(|value| value.to_string()),
+            can_go_back: unsafe { view.canGoBack() },
+            can_go_forward: unsafe { view.canGoForward() },
+            is_loading: unsafe { view.isLoading() },
+            error: self.error(),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.detach();
+        self.pending_url = None;
+        let _ = self.events.try_send(());
+    }
+
+    fn error(&self) -> Option<String> {
+        self.delegate
+            .as_ref()
+            .and_then(|delegate| delegate.ivars().error.borrow().clone())
+    }
+
+    pub fn hide(&mut self) {
+        if let Some(view) = &self.web_view {
+            view.setHidden(true);
+        }
+    }
+
+    fn ensure_view(&mut self, parent: *const NSView) -> Option<&WKWebView> {
+        if self.parent != Some(parent) {
+            self.detach();
+            self.parent = Some(parent);
+        }
+        if self.web_view.is_none() {
+            let mtm = MainThreadMarker::new()?;
+            let configuration = unsafe { WKWebViewConfiguration::new(mtm) };
+            let view = unsafe {
+                WKWebView::initWithFrame_configuration(
+                    mtm.alloc(),
+                    NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(1.0, 1.0)),
+                    &configuration,
+                )
+            };
+            let delegate = BrowserDelegate::new(mtm, self.events.clone());
+            unsafe {
+                view.setNavigationDelegate(Some(ProtocolObject::from_ref(&*delegate)));
+            }
+            self.delegate = Some(delegate);
+            // The parent receives its own retain. `self` retains the child so
+            // it is valid until `detach` removes it, including a host change.
+            unsafe { (&*parent).addSubview(&view) };
+            self.web_view = Some(view);
+            if let Some(url) = self.pending_url.clone() {
+                self.load(url);
+            }
+        }
+        self.web_view.as_deref()
+    }
+
+    fn detach(&mut self) {
+        if let Some(view) = self.web_view.take() {
+            // Remove while our retain still exists. The old parent also holds
+            // the view, so dropping first could otherwise leave an overlay.
+            unsafe {
+                view.setNavigationDelegate(None);
+                view.stopLoading();
+            }
+            view.removeFromSuperview();
+        }
+        self.delegate = None;
+        self.parent = None;
+    }
+}
+
+impl Drop for NativeBrowser {
+    fn drop(&mut self) {
+        self.detach();
+    }
+}
+
+fn parent_view(window: &impl HasWindowHandle) -> Option<*const NSView> {
+    let handle = window.window_handle().ok()?;
+    let RawWindowHandle::AppKit(handle) = handle.as_raw() else {
+        return None;
+    };
+    Some(handle.ns_view.as_ptr().cast())
+}
+
+fn request_for(url: &str) -> Option<objc2::rc::Retained<NSURLRequest>> {
+    let string = NSString::from_str(url);
+    let url = NSURL::URLWithString(&string)?;
+    Some(NSURLRequest::requestWithURL(&url))
+}
+
+struct BrowserDelegateIvars {
+    events: tokio::sync::mpsc::Sender<()>,
+    error: RefCell<Option<String>>,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[thread_kind = MainThreadOnly]
+    #[name = "DiriWorkspaceBrowserDelegate"]
+    #[ivars = BrowserDelegateIvars]
+    struct BrowserDelegate;
+
+    unsafe impl NSObjectProtocol for BrowserDelegate {}
+    unsafe impl WKNavigationDelegate for BrowserDelegate {
+        #[unsafe(method(webView:didStartProvisionalNavigation:))]
+        fn started(&self, _view: &WKWebView, _navigation: Option<&WKNavigation>) {
+            *self.ivars().error.borrow_mut() = None;
+            self.changed();
+        }
+        #[unsafe(method(webView:didCommitNavigation:))]
+        fn committed(&self, _view: &WKWebView, _navigation: Option<&WKNavigation>) {
+            self.changed();
+        }
+        #[unsafe(method(webView:didFinishNavigation:))]
+        fn finished(&self, _view: &WKWebView, _navigation: Option<&WKNavigation>) {
+            self.changed();
+        }
+        #[unsafe(method(webView:didReceiveServerRedirectForProvisionalNavigation:))]
+        fn redirected(&self, _view: &WKWebView, _navigation: Option<&WKNavigation>) {
+            self.changed();
+        }
+        #[unsafe(method(webView:didFailProvisionalNavigation:withError:))]
+        fn provisional_failed(
+            &self,
+            _view: &WKWebView,
+            _navigation: Option<&WKNavigation>,
+            error: &NSError,
+        ) {
+            self.failed(error);
+        }
+        #[unsafe(method(webView:didFailNavigation:withError:))]
+        fn failed_navigation(
+            &self,
+            _view: &WKWebView,
+            _navigation: Option<&WKNavigation>,
+            error: &NSError,
+        ) {
+            self.failed(error);
+        }
+        #[unsafe(method(webViewWebContentProcessDidTerminate:))]
+        fn terminated(&self, _view: &WKWebView) {
+            *self.ivars().error.borrow_mut() =
+                Some("This page stopped responding. Reload to continue.".into());
+            self.changed();
+        }
+    }
+);
+
+impl BrowserDelegate {
+    fn new(mtm: MainThreadMarker, events: tokio::sync::mpsc::Sender<()>) -> Retained<Self> {
+        let this = mtm.alloc().set_ivars(BrowserDelegateIvars {
+            events,
+            error: RefCell::new(None),
+        });
+        unsafe { msg_send![super(this), init] }
+    }
+    fn changed(&self) {
+        let _ = self.ivars().events.try_send(());
+    }
+    fn failed(&self, error: &NSError) {
+        // NSURLErrorCancelled is an ordinary superseded navigation.
+        if error.code() != -999 {
+            *self.ivars().error.borrow_mut() =
+                Some("This page could not be loaded. Check the address or try again.".into());
+            self.changed();
+        }
+    }
+}
+
+/// Opt-in native integration fixture. Runs before any app services start and
+/// uses only an ephemeral loopback server; never connects to a Diri daemon.
+#[cfg(debug_assertions)]
+pub fn smoke_test() {
+    use objc2_app_kit::{NSApplication, NSBackingStoreType, NSWindow, NSWindowStyleMask};
+    use objc2_foundation::{NSDate, NSRunLoop};
+    use raw_window_handle::{AppKitWindowHandle, HandleError, WindowHandle};
+    use std::io::{Read, Write};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+    use std::time::{Duration, Instant};
+
+    struct Host(Retained<NSView>);
+    impl HasWindowHandle for Host {
+        fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
+            let handle = AppKitWindowHandle::new(std::ptr::NonNull::from(&*self.0).cast());
+            Ok(unsafe { WindowHandle::borrow_raw(RawWindowHandle::AppKit(handle)) })
+        }
+    }
+    fn until(mut condition: impl FnMut() -> bool) {
+        let deadline = Instant::now() + Duration::from_secs(15);
+        while !condition() {
+            assert!(
+                Instant::now() < deadline,
+                "native browser fixture timed out"
+            );
+            NSRunLoop::currentRunLoop().runUntilDate(&NSDate::dateWithTimeIntervalSinceNow(0.01));
+        }
+    }
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("fixture listener");
+    listener.set_nonblocking(true).unwrap();
+    let address = listener.local_addr().unwrap();
+    let stopping = Arc::new(AtomicBool::new(false));
+    let stop = stopping.clone();
+    let server = std::thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(60);
+        while !stop.load(Ordering::Relaxed) && Instant::now() < deadline {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let _ = stream.set_read_timeout(Some(Duration::from_secs(1)));
+                let mut request = [0; 4096];
+                let count = stream.read(&mut request).unwrap_or(0);
+                let request = String::from_utf8_lossy(&request[..count]);
+                let (title, body) = if request.starts_with("GET /two ") {
+                    ("Fixture Two", "<h1>Second fixture page</h1>")
+                } else {
+                    (
+                        "Fixture One",
+                        "<h1>Native browser fixture</h1><a id='next' href='/two'>Next page</a>",
+                    )
+                };
+                let html = format!("<!doctype html><title>{title}</title>{body}");
+                let _ = write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    html.len(),
+                    html
+                );
+            } else {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+        }
+    });
+    let mtm = MainThreadMarker::new().expect("fixture must run on the main thread");
+    let app = NSApplication::sharedApplication(mtm);
+    app.finishLaunching();
+    let window = unsafe {
+        NSWindow::initWithContentRect_styleMask_backing_defer(
+            mtm.alloc(),
+            NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(640.0, 480.0)),
+            NSWindowStyleMask::Titled,
+            NSBackingStoreType::Buffered,
+            false,
+        )
+    };
+    unsafe {
+        window.setReleasedWhenClosed(false);
+    }
+    window.makeKeyAndOrderFront(None);
+    let host = Host(window.contentView().expect("fixture content view"));
+    let (mut browser, mut events) = NativeBrowser::new();
+    let frame = BrowserFrame {
+        x: 0.0,
+        y: 0.0,
+        width: 640.0,
+        height: 480.0,
+    };
+    browser.sync(&host, true, frame);
+    assert!(
+        browser.web_view.is_none(),
+        "blank surface must not cover its prompt"
+    );
+    browser.load(format!("http://{address}/one"));
+    browser.sync(&host, true, frame);
+    until(|| {
+        browser.state().title.as_deref() == Some("Fixture One") && !browser.state().is_loading
+    });
+    assert!(
+        events.try_recv().is_ok(),
+        "native navigation must notify the toolbar"
+    );
+    let view = browser.web_view.as_ref().unwrap().clone();
+    unsafe {
+        view.evaluateJavaScript_completionHandler(
+            &NSString::from_str("document.getElementById('next').click()"),
+            None,
+        );
+    }
+    until(|| {
+        browser.state().title.as_deref() == Some("Fixture Two") && !browser.state().is_loading
+    });
+    assert!(browser.state().url.unwrap().ends_with("/two"));
+    assert!(browser.state().can_go_back);
+    browser.go_back();
+    until(|| {
+        browser.state().title.as_deref() == Some("Fixture One") && !browser.state().is_loading
+    });
+    assert!(browser.state().can_go_forward);
+    browser.go_forward();
+    until(|| {
+        browser.state().title.as_deref() == Some("Fixture Two") && !browser.state().is_loading
+    });
+    browser.sync(&host, false, frame);
+    assert!(view.isHidden());
+    browser.sync(&host, true, frame);
+    assert!(!view.isHidden());
+    browser.clear();
+    assert!(unsafe { view.superview() }.is_none());
+    assert!(!browser.has_page());
+    stopping.store(true, Ordering::Relaxed);
+    server.join().expect("fixture server cleanup");
+    browser.load(format!("http://{address}/unavailable"));
+    browser.sync(&host, true, frame);
+    until(|| browser.state().error.is_some());
+    browser.sync(&host, true, frame);
+    assert!(browser.web_view.as_ref().unwrap().isHidden());
+    browser.clear();
+    window.close();
+    println!(
+        "Native browser fixture passed: DOM load, link navigation, history, event delivery, hide/show, close, load failure."
+    );
+}

--- a/diri/crates/diri-app/src/macos/mod.rs
+++ b/diri/crates/diri-app/src/macos/mod.rs
@@ -1,4 +1,5 @@
 pub mod brand_raster;
+pub mod browser;
 pub mod menu_bar;
 pub mod notifier;
 

--- a/diri/crates/diri-app/src/main.rs
+++ b/diri/crates/diri-app/src/main.rs
@@ -168,6 +168,11 @@ pub(crate) struct AppServices {
 }
 
 fn main() {
+    #[cfg(all(target_os = "macos", debug_assertions))]
+    if std::env::var_os("DIRI_NATIVE_BROWSER_SMOKE").is_some() {
+        macos::browser::smoke_test();
+        return;
+    }
     if std::env::var_os("DIRI_PROBE_SYMBOLS").is_some() {
         icons::probe();
         return;

--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -25,8 +25,10 @@ use crate::commands::{
 };
 use crate::external_drop::ExternalDropAction;
 use crate::icons::{SymbolWeight, sf_symbol, sf_symbol_weighted};
-use crate::inspector::{InspectorEvent, WorkbenchInspector};
+use crate::inspector::{BrowserAction, InspectorEvent, WorkbenchInspector};
 use crate::launcher::{LauncherEvent, LauncherOverlay};
+#[cfg(target_os = "macos")]
+use crate::macos::browser::{BrowserFrame, NativeBrowser};
 use crate::navigation::NavigationOverlay;
 use crate::notifications::{InAppBanner, NotificationSound};
 use crate::quote::Quote;
@@ -174,6 +176,8 @@ pub struct RootView {
     utility_surfaces: Option<Entity<UtilitySurfaces>>,
     launcher: Entity<LauncherOverlay>,
     inspector: Option<Entity<WorkbenchInspector>>,
+    #[cfg(target_os = "macos")]
+    browser: NativeBrowser,
     services: Arc<AppServices>,
     focus: FocusHandle,
     resize_origin: Option<(f32, f32)>,
@@ -224,6 +228,8 @@ pub struct RootView {
     _service_events: Task<()>,
     _surface_sync: Option<Task<()>>,
     _workbench_sync: Task<()>,
+    #[cfg(target_os = "macos")]
+    _browser_state_sync: Task<()>,
 }
 
 impl Focusable for RootView {
@@ -456,11 +462,51 @@ impl RootView {
         )
         .detach();
         if let Some(inspector) = &inspector {
-            cx.subscribe(inspector, |this, _, event, cx| {
-                if matches!(event, InspectorEvent::Close) {
-                    this.set_inspector_open(false, cx);
-                }
-            })
+            cx.subscribe_in(
+                inspector,
+                window,
+                |this, _, event, window, cx| match event {
+                    InspectorEvent::Close => this.set_inspector_open(false, cx),
+                    InspectorEvent::WorkspaceChanged(surface) => {
+                        if let Some(terminal) = &this.auxiliary_terminal
+                            && *surface == crate::inspector::WorkspaceSurface::Terminal
+                        {
+                            terminal.update(cx, |terminal, cx| terminal.focus(window, cx));
+                        }
+                        cx.notify();
+                    }
+                    InspectorEvent::RequestTerminal => {
+                        this.ensure_auxiliary_terminal(window, cx);
+                    }
+                    InspectorEvent::WorkspaceClosed(surface) => {
+                        #[cfg(target_os = "macos")]
+                        if *surface == crate::inspector::WorkspaceSurface::Browser {
+                            this.browser.clear();
+                        }
+                        if *surface == crate::inspector::WorkspaceSurface::Terminal {
+                            this.hide_auxiliary_terminal(window, cx);
+                        }
+                        cx.notify();
+                    }
+                    InspectorEvent::Browser(action) => {
+                        #[cfg(target_os = "macos")]
+                        match action {
+                            BrowserAction::Navigate(url) => this.browser.load(url.clone()),
+                            BrowserAction::Back => this.browser.go_back(),
+                            BrowserAction::Forward => this.browser.go_forward(),
+                            BrowserAction::Reload => this.browser.reload(),
+                            BrowserAction::OpenExternal(url) => cx.open_url(url),
+                        }
+                        #[cfg(not(target_os = "macos"))]
+                        if let BrowserAction::Navigate(url) | BrowserAction::OpenExternal(url) =
+                            action
+                        {
+                            cx.open_url(url);
+                        }
+                        cx.notify();
+                    }
+                },
+            )
             .detach();
         }
 
@@ -692,6 +738,26 @@ impl RootView {
             0.0
         };
         let inspector_seam = if inspector_open { inspector_width } else { 0.0 };
+        #[cfg(target_os = "macos")]
+        let (browser, mut browser_events) = NativeBrowser::new();
+        #[cfg(target_os = "macos")]
+        let browser_state_sync = cx.spawn_in(window, async move |this, cx| {
+            while browser_events.recv().await.is_some() {
+                if this
+                    .update_in(cx, |this, _window, cx| {
+                        if let Some(inspector) = this.inspector.clone() {
+                            let state = this.browser.state();
+                            inspector
+                                .update(cx, |inspector, cx| inspector.set_browser_state(state, cx));
+                            cx.notify();
+                        }
+                    })
+                    .is_err()
+                {
+                    return;
+                }
+            }
+        });
         let mut root = Self {
             sidebar,
             terminal,
@@ -700,6 +766,8 @@ impl RootView {
             utility_surfaces,
             launcher,
             inspector,
+            #[cfg(target_os = "macos")]
+            browser,
             services,
             focus: cx.focus_handle(),
             resize_origin: None,
@@ -737,6 +805,8 @@ impl RootView {
             _service_events: service_events,
             _surface_sync: surface_sync,
             _workbench_sync: workbench_sync,
+            #[cfg(target_os = "macos")]
+            _browser_state_sync: browser_state_sync,
         };
         root.sync_auxiliary_terminal(window, cx);
         if !preview {
@@ -1330,7 +1400,29 @@ impl RootView {
         if self.preview {
             return false;
         }
+        if let Some(inspector) = &self.inspector
+            && inspector.read(cx).workspace_needs_terminal()
+        {
+            inspector.update(cx, |inspector, cx| {
+                inspector.select_workspace(crate::inspector::WorkspaceSurface::Terminal, cx);
+            });
+            self.reveal_inspector(cx);
+            return self.ensure_auxiliary_terminal(window, cx);
+        }
         self.sync_auxiliary_terminal(window, cx);
+        if self.auxiliary_terminal.is_some() {
+            self.hide_auxiliary_terminal(window, cx);
+            true
+        } else {
+            self.ensure_auxiliary_terminal(window, cx)
+        }
+    }
+
+    /// Tab activation is idempotent: it never toggles an already-open shell.
+    fn ensure_auxiliary_terminal(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
+        if self.preview {
+            return false;
+        }
         let selected = self
             .services
             .store
@@ -1342,23 +1434,11 @@ impl RootView {
         let Some(parent) = selected else {
             return false;
         };
-        if self.auxiliary_parent.as_ref() == Some(&parent) && self.auxiliary_terminal.is_some() {
-            self.collapsed_auxiliary_parents.insert(parent);
-            self.auxiliary_terminal = None;
-            self.auxiliary_id = None;
-            self.auxiliary_parent = None;
-            if let Some(primary) = &self.terminal {
-                primary.update(cx, |terminal, cx| terminal.focus(window, cx));
-            }
-            cx.notify();
+        self.collapsed_auxiliary_parents.remove(&parent);
+        self.sync_auxiliary_terminal(window, cx);
+        if let Some(terminal) = &self.auxiliary_terminal {
+            terminal.update(cx, |terminal, cx| terminal.focus(window, cx));
             return true;
-        }
-        if self.collapsed_auxiliary_parents.remove(&parent) {
-            self.sync_auxiliary_terminal(window, cx);
-            if let Some(terminal) = &self.auxiliary_terminal {
-                terminal.update(cx, |terminal, cx| terminal.focus(window, cx));
-                return true;
-            }
         }
         if self.auxiliary_spawn_parent.as_ref() == Some(&parent) {
             return true;
@@ -1375,6 +1455,32 @@ impl RootView {
             cx.notify();
         }
         spawned
+    }
+
+    /// Hide the pane without starting or stopping the Engine-owned child shell.
+    fn hide_auxiliary_terminal(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(parent) = self
+            .services
+            .store
+            .store
+            .read()
+            .expect("session store lock poisoned")
+            .selected_session_id()
+            .cloned()
+        {
+            self.collapsed_auxiliary_parents.insert(parent);
+        }
+        self.auxiliary_terminal = None;
+        self.auxiliary_id = None;
+        self.auxiliary_parent = None;
+        self.auxiliary_spawn_parent = None;
+        if let Some(inspector) = &self.inspector {
+            inspector.update(cx, |inspector, cx| inspector.set_terminal_surface(None, cx));
+        }
+        if let Some(primary) = &self.terminal {
+            primary.update(cx, |terminal, cx| terminal.focus(window, cx));
+        }
+        cx.notify();
     }
 
     /// Reconciles the UI-owned pane entity with the daemon-owned child shell.
@@ -1407,6 +1513,9 @@ impl RootView {
             self.auxiliary_terminal = None;
             self.auxiliary_id = None;
             self.auxiliary_parent = None;
+            if let Some(inspector) = &self.inspector {
+                inspector.update(cx, |inspector, cx| inspector.set_terminal_surface(None, cx));
+            }
             return;
         }
 
@@ -1439,6 +1548,12 @@ impl RootView {
             self.auxiliary_parent = Some(parent);
             self.auxiliary_terminal = Some(terminal.clone());
             self.auxiliary_spawn_parent = None;
+            if let Some(inspector) = &self.inspector {
+                let terminal = terminal.clone();
+                inspector.update(cx, |inspector, cx| {
+                    inspector.set_terminal_surface(Some(terminal), cx)
+                });
+            }
             if should_focus {
                 terminal.update(cx, |terminal, cx| terminal.focus(window, cx));
             }
@@ -1461,6 +1576,9 @@ impl RootView {
         self.auxiliary_id = None;
         self.auxiliary_parent = None;
         self.auxiliary_spawn_parent = None;
+        if let Some(inspector) = &self.inspector {
+            inspector.update(cx, |inspector, cx| inspector.set_terminal_surface(None, cx));
+        }
         if had_auxiliary_state {
             cx.notify();
         }
@@ -1642,6 +1760,21 @@ impl RootView {
                     .w(px(9.0))
                     .h_full()
                     .cursor(CursorStyle::ResizeLeftRight)
+                    .group("sidebar-resize")
+                    .child(
+                        div()
+                            .absolute()
+                            .left(px(3.5))
+                            .top_0()
+                            .w(px(2.0))
+                            .h_full()
+                            .bg(if self.resize_origin.is_some() {
+                                rgba(0x4f83f1ff)
+                            } else {
+                                rgba(0x4f83f100)
+                            })
+                            .group_hover("sidebar-resize", |line| line.bg(rgba(0x4f83f1ff))),
+                    )
                     .occlude()
                     .on_drag(DraggedSidebarEdge, |edge, _, _, cx| {
                         cx.stop_propagation();
@@ -1652,6 +1785,7 @@ impl RootView {
                         cx.listener(|this, event: &gpui::MouseDownEvent, _, cx| {
                             let width = this.sidebar.read(cx).width();
                             this.resize_origin = Some((f32::from(event.position.x), width));
+                            cx.notify();
                             cx.stop_propagation();
                         }),
                     )
@@ -1691,6 +1825,21 @@ impl RootView {
                     .h(px(9.0))
                     .w_full()
                     .cursor(CursorStyle::ResizeUpDown)
+                    .group("terminal-resize")
+                    .child(
+                        div()
+                            .absolute()
+                            .top(px(3.5))
+                            .left_0()
+                            .h(px(2.0))
+                            .w_full()
+                            .bg(if self.terminal_resize_origin.is_some() {
+                                rgba(0x4f83f1ff)
+                            } else {
+                                rgba(0x4f83f100)
+                            })
+                            .group_hover("terminal-resize", |line| line.bg(rgba(0x4f83f1ff))),
+                    )
                     .occlude()
                     .on_drag(DraggedTerminalEdge, |edge, _, _, cx| {
                         cx.stop_propagation();
@@ -1705,6 +1854,7 @@ impl RootView {
                                 .primary;
                             this.terminal_resize_origin =
                                 Some((f32::from(event.position.y), primary));
+                            cx.notify();
                             cx.stop_propagation();
                         }),
                     )
@@ -1828,6 +1978,21 @@ impl RootView {
                     .w(px(9.0))
                     .h_full()
                     .cursor(CursorStyle::ResizeLeftRight)
+                    .group("inspector-resize")
+                    .child(
+                        div()
+                            .absolute()
+                            .left(px(3.5))
+                            .top_0()
+                            .w(px(2.0))
+                            .h_full()
+                            .bg(if self.inspector_resize_origin.is_some() {
+                                rgba(0x4f83f1ff)
+                            } else {
+                                rgba(0x4f83f100)
+                            })
+                            .group_hover("inspector-resize", |line| line.bg(rgba(0x4f83f1ff))),
+                    )
                     .occlude()
                     .on_drag(DraggedInspectorEdge, |edge, _, _, cx| {
                         cx.stop_propagation();
@@ -1838,6 +2003,7 @@ impl RootView {
                         cx.listener(|this, event: &gpui::MouseDownEvent, _, cx| {
                             this.inspector_resize_origin =
                                 Some((f32::from(event.position.x), this.inspector_width));
+                            cx.notify();
                             cx.stop_propagation();
                         }),
                     )
@@ -1957,10 +2123,20 @@ impl RootView {
             .expect("session store lock poisoned")
             .selected_session_id()
             .cloned();
-        let split_open = self.auxiliary_terminal.is_some()
-            || selected
+        let terminal_in_workspace_panel = inspector_seam > 0.5
+            && self
+                .inspector
                 .as_ref()
-                .is_some_and(|id| self.auxiliary_spawn_parent.as_ref() == Some(id));
+                .is_some_and(|inspector| inspector.read(cx).is_terminal_tab());
+        let workspace_owns_terminal = self
+            .inspector
+            .as_ref()
+            .is_some_and(|inspector| inspector.read(cx).workspace_needs_terminal());
+        let split_open = !workspace_owns_terminal
+            && (self.auxiliary_terminal.is_some()
+                || selected
+                    .as_ref()
+                    .is_some_and(|id| self.auxiliary_spawn_parent.as_ref() == Some(id)));
         let mut card = div()
             .relative()
             .flex_1()
@@ -1990,6 +2166,21 @@ impl RootView {
             .rounded_bl(px(Radius::CARD))
             .border_1()
             .border_color(terminal.primary.alpha(0.10));
+
+        if terminal_in_workspace_panel && let Some(auxiliary) = &self.auxiliary_terminal {
+            auxiliary.update(cx, |terminal, cx| {
+                terminal.set_shell_chrome(visible_sidebar, true, cx);
+                terminal.set_viewport(
+                    TerminalViewport {
+                        x: sidebar_width + card_width,
+                        y: Metrics::TITLE_BAR,
+                        width: inspector_width,
+                        height: card_height.max(0.0),
+                    },
+                    cx,
+                );
+            });
+        }
 
         if self.preview && self.preview_scenario != PreviewScenario::Empty {
             card = card.child(self.preview_workbench(terminal));
@@ -2718,6 +2909,52 @@ impl Render for RootView {
         self.inspector_seam = advance_seam(&mut self.inspector_slide, inspector_width, now, window);
         let seam = self.sidebar_seam;
         let inspector_seam = self.inspector_seam;
+        #[cfg(target_os = "macos")]
+        {
+            let utility_open = self
+                .utility_surfaces
+                .as_ref()
+                .is_some_and(|surfaces| surfaces.read(cx).is_open());
+            let navigation_open = self
+                .navigation
+                .as_ref()
+                .is_some_and(|navigation| navigation.read(cx).is_open());
+            let inspector_blocks_browser = self
+                .inspector
+                .as_ref()
+                .is_some_and(|inspector| inspector.read(cx).blocks_native_browser());
+            let browser_active = self.browser.has_page()
+                && self.resize_origin.is_none()
+                && self.inspector_resize_origin.is_none()
+                && !launcher_open
+                && !utility_open
+                && !navigation_open
+                && !self.arrow_surface_visible()
+                && self.quote_target_picker.is_none()
+                && self.sidebar.read(cx).pending_close_copy().is_none()
+                && !inspector_blocks_browser
+                && self.inspector_open
+                && inspector_seam >= inspector_panel_width - 0.5
+                && self
+                    .inspector
+                    .as_ref()
+                    .is_some_and(|inspector| inspector.read(cx).is_browser_tab());
+            let height = f32::from(window.inner_window_bounds().get_bounds().size.height);
+            self.browser.sync(
+                window,
+                browser_active,
+                BrowserFrame {
+                    x: window_width - inspector_panel_width,
+                    y: recovery_height + Metrics::TITLE_BAR + 42.0,
+                    width: inspector_panel_width,
+                    height: (height - recovery_height - Metrics::TITLE_BAR - 42.0).max(0.0),
+                },
+            );
+            let state = self.browser.state();
+            if let Some(inspector) = &self.inspector {
+                inspector.update(cx, |inspector, cx| inspector.set_browser_state(state, cx));
+            }
+        }
         let mut key_context = KeyContext::new_with_defaults();
         key_context.add(APP_CONTEXT);
         key_context.add(SESSION_NAVIGATION_CONTEXT);


### PR DESCRIPTION
The right panel now keeps Details, Browser, Terminal, Files, and Review in closable tabs. The plus menu opens a surface, and an empty panel presents a compact two-column chooser. Details retains Info and Artifacts; existing file/review commands select their corresponding workspace tab.

Browser embeds a lazily created WebKit view on macOS with an editable address, back/forward, reload, page title, and open-in-browser action. Loopback addresses default to HTTP. Navigation delegate events update the toolbar without idle polling, failed loads show a recoverable message, and the native child hides for overlays, panel transitions, and resizing. Closing its tab removes the child. Other platforms open entered URLs in the system browser.

Terminal uses the existing session-owned auxiliary shell while keeping the primary agent visible. Activating it is idempotent, switching sessions resolves that session's shell, and switching away does not relocate the shell into the bottom drawer. The existing terminal command activates an owned tab; without one it retains its drawer behavior. Sidebar, panel, and split resizers use a two-point blue hover/drag guide inside the existing nine-point hit area.

The only new production dependency is the typed objc2 WebKit binding plus the standard raw-window-handle interface, keeping the native child-view ownership/teardown seam small and avoiding handwritten Objective-C ABI calls. Engine/Holder transport and persisted InspectorTab meanings remain intact.

Validation:
- `cargo clippy -p diri-app --all-targets -- -D warnings`, formatting and diff checks passed.
- Two focused inspector tests passed: minimum-width routing/Artifacts behavior and closable surface/preferences behavior.
- Opt-in debug-only native fixture (`DIRI_NATIVE_BROWSER_SMOKE=1 target/debug/diri`) passed using an isolated NSWindow and ephemeral loopback HTML server: actual DOM load, HTML link navigation, URL/title, back/forward history, delegate events, hide/show, child removal, and failed-load feedback. It exits before any app services start and never connects to a Diri daemon.
- Isolated headless chooser and Browser-toolbar screenshots generated and visually reviewed. Embedded page content was verified by the native fixture, since headless GPUI screenshots cannot capture native child views.

Embedded browsing is currently macOS-only; workspace tabs and external URL opening remain cross-platform. No real remote host or live sessions were used for verification.

Combined verification with #174, #175, #176, #177 and #179 on main `1c56e5f`: workspace formatting, clippy with warnings denied, all 1,304 tests (24 opt-in tests ignored), and the release workspace build passed in an isolated worktree. Native browser and visual fixtures were checked separately as described above. Merge #177 first for its shared Linux-only lint correction to the existing macOS fixture helper. The separate iPhone CI job still fails before compilation because the runner selects Xcode older than 26.

