### PR TITLE
Add flexible terminal splits with persistent pane layouts

### DIFF
--- a/diri/SPLITS.md
+++ b/diri/SPLITS.md
@@ -1,0 +1,31 @@
+# Terminal panes
+
+A desktop workspace can show up to eight sessions in nested right/below splits.
+Each pane controls its own existing Engine session. Selecting a session in the
+sidebar restores its saved workspace and focuses that pane.
+
+- **⌘D** creates a terminal to the right of the focused pane.
+- **⌥⌘D** creates a terminal below it. New terminals inherit that session's
+  directory and host.
+- **Add Existing Session to Split**, in the command palette, opens the session
+  picker. Choose Right or Below, then an existing agent or terminal. Moving a
+  session from another split workspace removes its old pane first.
+- **⇧⌥⌘← / → / ↑ / ↓** moves focus in that direction. **⌥⌘Tab** cycles through
+  panes. Clicking a terminal also selects its session for the inspector and
+  attention state.
+- Drag a divider to resize either branch; double-click it to reset that split
+  to equal sizes. Nested ratios are saved when the drag ends.
+- **⌘W**, **Close Pane**, or the pane's × removes that pane while keeping the
+  session running. Reopen it from the sidebar or the existing-session picker.
+  The sidebar's session-close action still ends/removes the session.
+- **⌘J** keeps its auxiliary-terminal workflow. An auxiliary already visible
+  when splitting becomes part of the layout; hiding it keeps its shell alive.
+
+The picker supports Up/Down and Enter, Left/Right to choose the split direction,
+and Escape to dismiss it. Shortcuts can be changed in Settings → Shortcuts.
+
+Layouts are versioned desktop preferences, bounded to 64 saved workspaces. A
+restart restores session identities and split ratios after the Engine session
+list arrives. Missing/archived sessions are pruned and empty branches collapse.
+The existing Holder owns every process; no transport or Helper changes are
+needed, and a session has at most one mounted terminal attachment owner.

--- a/diri/crates/diri-app/src/commands.rs
+++ b/diri/crates/diri-app/src/commands.rs
@@ -41,6 +41,15 @@ actions!(
         FocusSidebar,
         ToggleInspector,
         ToggleAuxiliaryTerminal,
+        SplitRight,
+        SplitBelow,
+        AddExistingPane,
+        FocusNextPane,
+        FocusPaneLeft,
+        FocusPaneRight,
+        FocusPaneUp,
+        FocusPaneDown,
+        ClosePane,
         QuoteSelection,
         QuoteSelectionToSession,
         ArchiveSelectedSession,
@@ -105,6 +114,15 @@ pub enum CommandId {
     FocusSidebar,
     ToggleInspector,
     ToggleAuxiliaryTerminal,
+    SplitRight,
+    SplitBelow,
+    AddExistingPane,
+    FocusNextPane,
+    FocusPaneLeft,
+    FocusPaneRight,
+    FocusPaneUp,
+    FocusPaneDown,
+    ClosePane,
     QuoteSelection,
     QuoteSelectionToSession,
     ArchiveSelectedSession,
@@ -368,6 +386,96 @@ pub const COMMANDS: &[CommandSpec] = &[
         Some("cmd-j"),
         Some("⌘J"),
         Some(APP_CONTEXT)
+    ),
+    spec!(
+        SplitRight,
+        "split-right",
+        Some("cmd-d"),
+        Some("⌘D"),
+        Some(APP_CONTEXT),
+        "Split Right",
+        "rectangle.split.2x1",
+        "pane split terminal focus workspace"
+    ),
+    spec!(
+        SplitBelow,
+        "split-below",
+        Some("cmd-alt-d"),
+        Some("⌥⌘D"),
+        Some(APP_CONTEXT),
+        "Split Below",
+        "rectangle.split.2x1",
+        "pane split terminal focus workspace"
+    ),
+    spec!(
+        AddExistingPane,
+        "add-existing-pane",
+        None,
+        None,
+        Some(APP_CONTEXT),
+        "Add Existing Session to Split",
+        "rectangle.split.2x1",
+        "pane split terminal focus workspace"
+    ),
+    spec!(
+        FocusNextPane,
+        "focus-next-pane",
+        Some("cmd-alt-tab"),
+        Some("⌥⌘⇥"),
+        Some(APP_CONTEXT),
+        "Focus Next Pane",
+        "rectangle.split.2x1",
+        "pane split terminal focus workspace"
+    ),
+    spec!(
+        FocusPaneLeft,
+        "focus-pane-left",
+        Some("cmd-alt-shift-left"),
+        Some("⇧⌥⌘←"),
+        Some(APP_CONTEXT),
+        "Focus Pane Left",
+        "rectangle.split.2x1",
+        "pane split terminal focus workspace"
+    ),
+    spec!(
+        FocusPaneRight,
+        "focus-pane-right",
+        Some("cmd-alt-shift-right"),
+        Some("⇧⌥⌘→"),
+        Some(APP_CONTEXT),
+        "Focus Pane Right",
+        "rectangle.split.2x1",
+        "pane split terminal focus workspace"
+    ),
+    spec!(
+        FocusPaneUp,
+        "focus-pane-up",
+        Some("cmd-alt-shift-up"),
+        Some("⇧⌥⌘↑"),
+        Some(APP_CONTEXT),
+        "Focus Pane Up",
+        "rectangle.split.2x1",
+        "pane split terminal focus workspace"
+    ),
+    spec!(
+        FocusPaneDown,
+        "focus-pane-down",
+        Some("cmd-alt-shift-down"),
+        Some("⇧⌥⌘↓"),
+        Some(APP_CONTEXT),
+        "Focus Pane Down",
+        "rectangle.split.2x1",
+        "pane split terminal focus workspace"
+    ),
+    spec!(
+        ClosePane,
+        "close-pane",
+        None,
+        None,
+        Some(APP_CONTEXT),
+        "Close Pane",
+        "rectangle.split.2x1",
+        "pane split terminal focus workspace"
     ),
     spec!(
         QuoteSelection,
@@ -720,6 +828,15 @@ impl CommandSpec {
             CommandId::ToggleAuxiliaryTerminal => {
                 KeyBinding::new(key, ToggleAuxiliaryTerminal, context)
             }
+            CommandId::SplitRight => KeyBinding::new(key, SplitRight, context),
+            CommandId::SplitBelow => KeyBinding::new(key, SplitBelow, context),
+            CommandId::AddExistingPane => KeyBinding::new(key, AddExistingPane, context),
+            CommandId::FocusNextPane => KeyBinding::new(key, FocusNextPane, context),
+            CommandId::FocusPaneLeft => KeyBinding::new(key, FocusPaneLeft, context),
+            CommandId::FocusPaneRight => KeyBinding::new(key, FocusPaneRight, context),
+            CommandId::FocusPaneUp => KeyBinding::new(key, FocusPaneUp, context),
+            CommandId::FocusPaneDown => KeyBinding::new(key, FocusPaneDown, context),
+            CommandId::ClosePane => KeyBinding::new(key, ClosePane, context),
             CommandId::QuoteSelection => KeyBinding::new(key, QuoteSelection, context),
             CommandId::QuoteSelectionToSession => {
                 KeyBinding::new(key, QuoteSelectionToSession, context)
@@ -1055,6 +1172,51 @@ impl CommandId {
                 description: "Show or hide the session inspector",
                 category: Workspace,
             },
+            Self::SplitRight => ShortcutMetadata {
+                title: "Split Right",
+                description: "Create a terminal to the right of the focused pane",
+                category: Workspace,
+            },
+            Self::SplitBelow => ShortcutMetadata {
+                title: "Split Below",
+                description: "Create a terminal below the focused pane",
+                category: Workspace,
+            },
+            Self::AddExistingPane => ShortcutMetadata {
+                title: "Add Existing Session to Split",
+                description: "Choose an existing session for this split workspace",
+                category: Workspace,
+            },
+            Self::FocusNextPane => ShortcutMetadata {
+                title: "Focus Next Pane",
+                description: "Move focus to the next terminal pane",
+                category: Workspace,
+            },
+            Self::FocusPaneLeft => ShortcutMetadata {
+                title: "Focus Pane Left",
+                description: "Move focus to the terminal pane on the left",
+                category: Workspace,
+            },
+            Self::FocusPaneRight => ShortcutMetadata {
+                title: "Focus Pane Right",
+                description: "Move focus to the terminal pane on the right",
+                category: Workspace,
+            },
+            Self::FocusPaneUp => ShortcutMetadata {
+                title: "Focus Pane Up",
+                description: "Move focus to the terminal pane above",
+                category: Workspace,
+            },
+            Self::FocusPaneDown => ShortcutMetadata {
+                title: "Focus Pane Down",
+                description: "Move focus to the terminal pane below",
+                category: Workspace,
+            },
+            Self::ClosePane => ShortcutMetadata {
+                title: "Close Pane",
+                description: "Remove the focused pane and keep its session running",
+                category: Workspace,
+            },
             Self::ToggleAuxiliaryTerminal => ShortcutMetadata {
                 title: "Toggle auxiliary terminal",
                 description: "Show or hide the lower terminal pane",
@@ -1160,6 +1322,16 @@ impl CommandId {
             Self::FocusSidebar => Box::new(FocusSidebar),
             Self::ToggleInspector => Box::new(ToggleInspector),
             Self::ToggleAuxiliaryTerminal => Box::new(ToggleAuxiliaryTerminal),
+            Self::SplitRight => Box::new(SplitRight),
+            Self::SplitBelow => Box::new(SplitBelow),
+            Self::AddExistingPane => Box::new(AddExistingPane),
+            Self::FocusNextPane => Box::new(FocusNextPane),
+            Self::FocusPaneLeft => Box::new(FocusPaneLeft),
+            Self::FocusPaneRight => Box::new(FocusPaneRight),
+            Self::FocusPaneUp => Box::new(FocusPaneUp),
+            Self::FocusPaneDown => Box::new(FocusPaneDown),
+            Self::ClosePane => Box::new(ClosePane),
+
             Self::QuoteSelection => Box::new(QuoteSelection),
             Self::QuoteSelectionToSession => Box::new(QuoteSelectionToSession),
             Self::ArchiveSelectedSession => Box::new(ArchiveSelectedSession),
@@ -1257,6 +1429,27 @@ mod tests {
         let picker = command(CommandId::QuoteSelectionToSession);
         assert_eq!(picker.keystroke, Some("cmd-alt-shift-c"));
         assert!(picker.palette.is_some());
+    }
+
+    #[test]
+    fn pane_shortcuts_do_not_shadow_session_navigation_or_other_defaults() {
+        for id in [
+            CommandId::SplitRight,
+            CommandId::SplitBelow,
+            CommandId::FocusNextPane,
+            CommandId::FocusPaneLeft,
+            CommandId::FocusPaneRight,
+            CommandId::FocusPaneUp,
+            CommandId::FocusPaneDown,
+        ] {
+            let spec = command(id);
+            let key = spec.keystroke.unwrap();
+            assert!(
+                !COMMANDS.iter().any(|other| other.id != id
+                    && (other.keystroke == Some(key) || other.alternate_keystrokes.contains(&key))),
+                "{key} shadows another command"
+            );
+        }
     }
 
     #[test]

--- a/diri/crates/diri-app/src/main.rs
+++ b/diri/crates/diri-app/src/main.rs
@@ -42,6 +42,8 @@ mod session_surfaces;
 pub mod settings;
 pub mod sidebar;
 pub mod sounds;
+mod split_layout;
+mod split_workbench;
 mod status_debug;
 mod surface_shell;
 pub mod switcher;

--- a/diri/crates/diri-app/src/notification_panel.rs
+++ b/diri/crates/diri-app/src/notification_panel.rs
@@ -12,6 +12,9 @@ impl RootView {
         }
         if self.notification_panel_open {
             self.notification_focus.focus(window, cx);
+        } else if self.split_workbench.read(cx).active_for_selection() {
+            self.split_workbench
+                .update(cx, |splits, cx| splits.focus_selected(window, cx));
         } else if let Some(terminal) = &self.terminal {
             terminal.update(cx, |terminal, cx| terminal.focus(window, cx));
         }
@@ -100,9 +103,17 @@ impl RootView {
         }
         cx.activate(true);
         window.activate_window();
-        if let Some(terminal) = &self.terminal {
+        // Native clicks can arrive before the store-change subscription has
+        // mounted the saved workspace. Transfer attachment ownership first,
+        // then focus the exact pane selected by the notification.
+        self.sync_auxiliary_terminal(window, cx);
+        if self.split_workbench.read(cx).active_for_selection() {
+            self.split_workbench
+                .update(cx, |splits, cx| splits.focus_selected(window, cx));
+        } else if let Some(terminal) = &self.terminal {
             terminal.update(cx, |terminal, cx| terminal.focus(window, cx));
         }
+        self.services.store.publish_local_change();
         cx.notify();
     }
 

--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -13,15 +13,16 @@ use gpui::{
 
 use crate::AppServices;
 use crate::commands::{
-    self, APP_CONTEXT, ArchiveSelectedSession, CheckForUpdates, CloseSession, CommandId,
-    DelegateSelectedSession, FocusSidebar, MoveSelectedSessionDown, MoveSelectedSessionUp,
+    self, APP_CONTEXT, AddExistingPane, ArchiveSelectedSession, CheckForUpdates, ClosePane,
+    CloseSession, CommandId, DelegateSelectedSession, FocusNextPane, FocusPaneDown, FocusPaneLeft,
+    FocusPaneRight, FocusPaneUp, FocusSidebar, MoveSelectedSessionDown, MoveSelectedSessionUp,
     NewCodexSession, NewDefaultSession, NewTerminal, OpenLauncher, OpenSettings, OpenWorktrees,
     QuoteSelection, QuoteSelectionToSession, RenameSelectedSession, ReopenSession,
     SESSION_NAVIGATION_CONTEXT, SelectLastSession, SelectNextAttentionSession, SelectNextSession,
     SelectPreviousSession, SelectSession1, SelectSession2, SelectSession3, SelectSession4,
-    SelectSession5, SelectSession6, SelectSession7, SelectSession8, ToggleAuxiliaryTerminal,
-    ToggleCommandPalette, ToggleHistory, ToggleInspector, ToggleOverview, ToggleQuickOpen,
-    ToggleSidebar,
+    SelectSession5, SelectSession6, SelectSession7, SelectSession8, SplitBelow, SplitRight,
+    ToggleAuxiliaryTerminal, ToggleCommandPalette, ToggleHistory, ToggleInspector, ToggleOverview,
+    ToggleQuickOpen, ToggleSidebar,
 };
 use crate::external_drop::ExternalDropAction;
 use crate::icons::{SymbolWeight, sf_symbol, sf_symbol_weighted};
@@ -35,6 +36,8 @@ use crate::seam::{SeamSlide, toggle_has_settled};
 use crate::session_surfaces::SessionSurfaces;
 use crate::sidebar::{PreviewScenario, Sidebar, SidebarEvent};
 use crate::sounds::{self, PlatformPlayer, SoundGate, StatusSound};
+use crate::split_layout::{Direction, Rect, SplitAxis};
+use crate::split_workbench::SplitWorkbench;
 use crate::store::SpawnOptions;
 use crate::surface_shell::UtilitySurfaces;
 use crate::terminal_pane::{TerminalPane, TerminalPaneEvent, TerminalViewport};
@@ -145,6 +148,7 @@ enum QuoteSurface {
     #[default]
     PrimaryTerminal,
     AuxiliaryTerminal,
+    SplitTerminal,
     Inspector,
 }
 
@@ -192,6 +196,7 @@ pub struct RootView {
     auxiliary_spawn_parent: Option<SessionId>,
     collapsed_auxiliary_parents: HashSet<SessionId>,
     workbench_layout: WorkbenchLayout,
+    split_workbench: Entity<SplitWorkbench>,
     terminal_resize_origin: Option<(f32, f32)>,
     terminal_available_height: f32,
     inspector_open: bool,
@@ -289,31 +294,18 @@ impl RootView {
         }
         if let Some(terminal) = &terminal {
             let terminal = terminal.clone();
-            cx.defer_in(window, move |_, window, cx| {
-                terminal.update(cx, |terminal, cx| terminal.focus(window, cx));
+            cx.defer_in(window, move |this, window, cx| {
+                if this.split_workbench.read(cx).active_for_selection() {
+                    this.split_workbench
+                        .update(cx, |splits, cx| splits.focus_selected(window, cx));
+                } else {
+                    terminal.update(cx, |terminal, cx| terminal.focus(window, cx));
+                }
             });
         }
         if let Some(terminal) = &terminal {
-            cx.subscribe_in(terminal, window, |this, _, event, window, cx| match event {
-                TerminalPaneEvent::ContinueAccount(id) => {
-                    if let Some(surfaces) = &this.utility_surfaces {
-                        surfaces.update(cx, |surfaces, cx| {
-                            surfaces.open_account_continuation(id.clone(), window, cx)
-                        });
-                    }
-                }
-                TerminalPaneEvent::OpenFileReference { reference, cwd, .. } => {
-                    let inspector = this.inspector.clone();
-                    this.reveal_inspector(cx);
-                    if let Some(inspector) = inspector {
-                        inspector.update(cx, |inspector, cx| {
-                            inspector.open_file_reference(cwd.clone(), reference.clone(), cx);
-                        });
-                    }
-                }
-                TerminalPaneEvent::ExternalDropFeedback { message } => {
-                    this.show_quote_feedback("Dropped files", message.clone(), cx);
-                }
+            cx.subscribe_in(terminal, window, |this, _, event, window, cx| {
+                this.handle_terminal_event(event, window, cx)
             })
             .detach();
         }
@@ -371,12 +363,20 @@ impl RootView {
                 if let Some(terminal) = &this.terminal {
                     terminal.update(cx, |terminal, cx| terminal.focus(window, cx));
                     this.sync_auxiliary_terminal(window, cx);
+                    if this.split_workbench.read(cx).active_for_selection() {
+                        this.split_workbench
+                            .update(cx, |splits, cx| splits.focus_selected(window, cx));
+                    }
                 }
             }
             if matches!(event, SidebarEvent::FocusTerminal) {
                 if let Some(terminal) = &this.terminal {
                     terminal.update(cx, |terminal, cx| terminal.focus(window, cx));
                     this.sync_auxiliary_terminal(window, cx);
+                    if this.split_workbench.read(cx).active_for_selection() {
+                        this.split_workbench
+                            .update(cx, |splits, cx| splits.focus_selected(window, cx));
+                    }
                 } else {
                     window.focus(&this.focus, cx);
                 }
@@ -455,7 +455,10 @@ impl RootView {
                         surfaces.open_agent_settings(host.clone(), cx);
                     });
                 }
-                if let Some(terminal) = &this.terminal {
+                if this.split_workbench.read(cx).active_for_selection() {
+                    this.split_workbench
+                        .update(cx, |splits, cx| splits.focus_selected(window, cx));
+                } else if let Some(terminal) = &this.terminal {
                     terminal.update(cx, |terminal, cx| terminal.focus(window, cx));
                 } else {
                     window.focus(&this.focus, cx);
@@ -751,6 +754,21 @@ impl RootView {
             0.0
         };
         let inspector_seam = if inspector_open { inspector_width } else { 0.0 };
+        let split_workbench = cx.new(|cx| {
+            SplitWorkbench::new(
+                Arc::clone(&services.store),
+                Arc::clone(&services.tokio),
+                terminal.clone(),
+                navigation.clone(),
+                utility_surfaces.clone(),
+                cx,
+            )
+        });
+        cx.subscribe_in(&split_workbench, window, |this, _, event, window, cx| {
+            this.handle_terminal_event(event, window, cx)
+        })
+        .detach();
+        let split_observer = cx.observe(&split_workbench, |_, _, cx| cx.notify());
         let mut root = Self {
             sidebar,
             terminal,
@@ -770,6 +788,7 @@ impl RootView {
             auxiliary_spawn_parent: None,
             collapsed_auxiliary_parents: HashSet::new(),
             workbench_layout,
+            split_workbench,
             terminal_resize_origin: None,
             terminal_available_height: 0.0,
             inspector_open,
@@ -802,7 +821,10 @@ impl RootView {
             menu_bar,
             #[cfg(target_os = "macos")]
             notifier,
-            _subscriptions: std::iter::once(activation).chain(bounds_observer).collect(),
+            _subscriptions: std::iter::once(activation)
+                .chain(bounds_observer)
+                .chain(std::iter::once(split_observer))
+                .collect(),
             _service_events: service_events,
             _surface_sync: surface_sync,
             _workbench_sync: workbench_sync,
@@ -849,6 +871,35 @@ impl RootView {
         }));
     }
 
+    fn handle_terminal_event(
+        &mut self,
+        event: &TerminalPaneEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        match event {
+            TerminalPaneEvent::ContinueAccount(id) => {
+                if let Some(surfaces) = &self.utility_surfaces {
+                    surfaces.update(cx, |surfaces, cx| {
+                        surfaces.open_account_continuation(id.clone(), window, cx)
+                    });
+                }
+            }
+            TerminalPaneEvent::OpenFileReference { reference, cwd, .. } => {
+                let inspector = self.inspector.clone();
+                self.reveal_inspector(cx);
+                if let Some(inspector) = inspector {
+                    inspector.update(cx, |inspector, cx| {
+                        inspector.open_file_reference(cwd.clone(), reference.clone(), cx);
+                    });
+                }
+            }
+            TerminalPaneEvent::ExternalDropFeedback { message } => {
+                self.show_quote_feedback("Dropped files", message.clone(), cx);
+            }
+        }
+    }
+
     fn colors(&self) -> SemanticColors {
         let store = self
             .services
@@ -885,6 +936,14 @@ impl RootView {
     }
 
     fn focused_quote_surface(&self, window: &Window, cx: &App) -> Option<QuoteSurface> {
+        if self
+            .split_workbench
+            .read(cx)
+            .focused_terminal(window, cx)
+            .is_some()
+        {
+            return Some(QuoteSurface::SplitTerminal);
+        }
         if let Some(auxiliary) = &self.auxiliary_terminal
             && auxiliary.read(cx).is_focused(window)
         {
@@ -905,6 +964,7 @@ impl RootView {
 
     fn quote_from_surface(&self, surface: QuoteSurface, cx: &App) -> Option<Quote> {
         match surface {
+            QuoteSurface::SplitTerminal => self.split_workbench.read(cx).quote_selection(cx),
             QuoteSurface::PrimaryTerminal => self
                 .terminal
                 .as_ref()
@@ -932,7 +992,13 @@ impl RootView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if surface == QuoteSurface::SplitTerminal {
+            self.split_workbench
+                .update(cx, |splits, cx| splits.focus_selected(window, cx));
+            return;
+        }
         let handle = match surface {
+            QuoteSurface::SplitTerminal => None,
             QuoteSurface::PrimaryTerminal => self
                 .terminal
                 .as_ref()
@@ -1285,6 +1351,46 @@ impl RootView {
             CommandId::ToggleAuxiliaryTerminal => {
                 self.open_auxiliary_terminal(window, cx);
             }
+            CommandId::SplitRight | CommandId::SplitBelow => {
+                let axis = if command == CommandId::SplitRight {
+                    SplitAxis::Right
+                } else {
+                    SplitAxis::Below
+                };
+                if let Some(auxiliary) = self.auxiliary_id.clone() {
+                    self.split_workbench
+                        .update(cx, |splits, _| splits.include_auxiliary(auxiliary));
+                }
+                self.split_workbench
+                    .update(cx, |splits, cx| splits.spawn(axis, window, cx));
+            }
+            CommandId::AddExistingPane => {
+                self.split_workbench.update(cx, |splits, cx| {
+                    splits.open_picker(SplitAxis::Right, window, cx)
+                });
+            }
+            CommandId::FocusNextPane => {
+                self.split_workbench
+                    .update(cx, |splits, cx| splits.focus_next(window, cx));
+            }
+            CommandId::FocusPaneLeft
+            | CommandId::FocusPaneRight
+            | CommandId::FocusPaneUp
+            | CommandId::FocusPaneDown => {
+                let direction = match command {
+                    CommandId::FocusPaneLeft => Direction::Left,
+                    CommandId::FocusPaneRight => Direction::Right,
+                    CommandId::FocusPaneUp => Direction::Up,
+                    _ => Direction::Down,
+                };
+                self.split_workbench.update(cx, |splits, cx| {
+                    splits.focus_direction(direction, window, cx)
+                });
+            }
+            CommandId::ClosePane => {
+                self.split_workbench
+                    .update(cx, |splits, cx| splits.close_selected(window, cx));
+            }
             CommandId::QuoteSelection => self.quote_selection(false, window, cx),
             CommandId::QuoteSelectionToSession => self.quote_selection(true, window, cx),
             CommandId::ArchiveSelectedSession => {
@@ -1404,6 +1510,11 @@ impl RootView {
             return false;
         }
         self.sync_auxiliary_terminal(window, cx);
+        if self.split_workbench.read(cx).active_for_selection() {
+            self.split_workbench
+                .update(cx, |splits, cx| splits.toggle_auxiliary(window, cx));
+            return true;
+        }
         let selected = self
             .services
             .store
@@ -1426,7 +1537,11 @@ impl RootView {
             cx.notify();
             return true;
         }
-        if self.collapsed_auxiliary_parents.remove(&parent) {
+        if self.collapsed_auxiliary_parents.remove(&parent)
+            || self
+                .split_workbench
+                .update(cx, |splits, _| splits.show_auxiliary_for(&parent))
+        {
             self.sync_auxiliary_terminal(window, cx);
             if let Some(terminal) = &self.auxiliary_terminal {
                 terminal.update(cx, |terminal, cx| terminal.focus(window, cx));
@@ -1457,6 +1572,23 @@ impl RootView {
         if self.preview {
             return;
         }
+        if self.split_workbench.read(cx).active_for_selection() {
+            if let Some(terminal) = &self.terminal {
+                terminal.update(cx, |terminal, cx| terminal.set_suspended(true, cx));
+            }
+            self.auxiliary_terminal = None;
+            self.auxiliary_id = None;
+            self.auxiliary_parent = None;
+        }
+        self.split_workbench
+            .update(cx, |splits, cx| splits.sync(window, cx));
+        let split_active = self.split_workbench.read(cx).active_for_selection();
+        if let Some(terminal) = &self.terminal {
+            terminal.update(cx, |terminal, cx| terminal.set_suspended(split_active, cx));
+        }
+        if split_active {
+            return;
+        }
         let (selected, auxiliary, spawn_failed) = {
             let store = self
                 .services
@@ -1471,10 +1603,10 @@ impl RootView {
             (selected, auxiliary, store.last_action_error().is_some())
         };
 
-        if selected
-            .as_ref()
-            .is_some_and(|parent| self.collapsed_auxiliary_parents.contains(parent))
-        {
+        if selected.as_ref().is_some_and(|parent| {
+            self.collapsed_auxiliary_parents.contains(parent)
+                || self.split_workbench.read(cx).auxiliary_hidden_for(parent)
+        }) {
             // Collapsing a pane is UI-only: keep its daemon shell alive so
             // the next ⌘J restores the same scrollback and process state.
             self.auxiliary_terminal = None;
@@ -1560,6 +1692,11 @@ impl RootView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.split_workbench.read(cx).active_for_selection() {
+            self.split_workbench
+                .update(cx, |splits, cx| splits.close_selected(window, cx));
+            return;
+        }
         if self
             .auxiliary_terminal
             .as_ref()
@@ -2066,6 +2203,20 @@ impl RootView {
 
         if self.preview && self.preview_scenario != PreviewScenario::Empty {
             card = card.child(self.preview_workbench(terminal));
+        } else if self.split_workbench.read(cx).active_for_selection() {
+            self.split_workbench.update(cx, |splits, _| {
+                splits.set_viewport(
+                    Rect {
+                        x: sidebar_width,
+                        y: 0.0,
+                        width: card_width,
+                        height: card_height,
+                    },
+                    visible_sidebar,
+                    self.inspector_open,
+                )
+            });
+            card = card.child(self.split_workbench.clone());
         } else if split_open {
             let available_height = (card_height - 1.0).max(0.0);
             self.terminal_available_height = available_height;
@@ -2177,6 +2328,16 @@ impl RootView {
             card = card.child(primary.clone());
         }
 
+        if !self.split_workbench.read(cx).active_for_selection()
+            && self.split_workbench.read(cx).has_overlay()
+        {
+            card = card.child(
+                div()
+                    .absolute()
+                    .inset_0()
+                    .child(self.split_workbench.clone()),
+            );
+        }
         card.child(card_outline).into_any_element()
     }
 
@@ -2922,6 +3083,33 @@ impl Render for RootView {
                     this.run_command(CommandId::ToggleAuxiliaryTerminal, window, cx);
                 }),
             )
+            .on_action(cx.listener(|this, _: &SplitRight, window, cx| {
+                this.run_command(CommandId::SplitRight, window, cx);
+            }))
+            .on_action(cx.listener(|this, _: &SplitBelow, window, cx| {
+                this.run_command(CommandId::SplitBelow, window, cx);
+            }))
+            .on_action(cx.listener(|this, _: &AddExistingPane, window, cx| {
+                this.run_command(CommandId::AddExistingPane, window, cx);
+            }))
+            .on_action(cx.listener(|this, _: &FocusNextPane, window, cx| {
+                this.run_command(CommandId::FocusNextPane, window, cx);
+            }))
+            .on_action(cx.listener(|this, _: &FocusPaneLeft, window, cx| {
+                this.run_command(CommandId::FocusPaneLeft, window, cx);
+            }))
+            .on_action(cx.listener(|this, _: &FocusPaneRight, window, cx| {
+                this.run_command(CommandId::FocusPaneRight, window, cx);
+            }))
+            .on_action(cx.listener(|this, _: &FocusPaneUp, window, cx| {
+                this.run_command(CommandId::FocusPaneUp, window, cx);
+            }))
+            .on_action(cx.listener(|this, _: &FocusPaneDown, window, cx| {
+                this.run_command(CommandId::FocusPaneDown, window, cx);
+            }))
+            .on_action(cx.listener(|this, _: &ClosePane, window, cx| {
+                this.run_command(CommandId::ClosePane, window, cx);
+            }))
             .on_action(cx.listener(|this, _: &QuoteSelection, window, cx| {
                 this.run_command(CommandId::QuoteSelection, window, cx);
             }))

--- a/diri/crates/diri-app/src/split_layout.rs
+++ b/diri/crates/diri-app/src/split_layout.rs
@@ -1,0 +1,462 @@
+//! App-owned split intent. Leaves are session identities, never processes or attachments.
+use std::collections::HashSet;
+
+use diri_proto::SessionId;
+use serde::{Deserialize, Serialize};
+
+pub const MAX_PANES: usize = 8;
+const MAX_LAYOUTS: usize = 64;
+pub const DIVIDER: f32 = 5.0;
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SplitAxis {
+    Right,
+    Below,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum SplitNode {
+    Session {
+        id: SessionId,
+    },
+    Split {
+        axis: SplitAxis,
+        fraction: f32,
+        first: Box<Self>,
+        second: Box<Self>,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Rect {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Divider {
+    pub path: Vec<bool>,
+    pub axis: SplitAxis,
+    pub rect: Rect,
+    pub parent: Rect,
+}
+
+impl SplitNode {
+    pub fn session(id: SessionId) -> Self {
+        Self::Session { id }
+    }
+
+    pub fn ids(&self) -> Vec<SessionId> {
+        let mut ids = Vec::new();
+        self.collect_ids(&mut ids);
+        ids
+    }
+
+    fn collect_ids(&self, ids: &mut Vec<SessionId>) {
+        match self {
+            Self::Session { id } => ids.push(id.clone()),
+            Self::Split { first, second, .. } => {
+                first.collect_ids(ids);
+                second.collect_ids(ids);
+            }
+        }
+    }
+
+    pub fn contains(&self, candidate: &SessionId) -> bool {
+        match self {
+            Self::Session { id } => id == candidate,
+            Self::Split { first, second, .. } => {
+                first.contains(candidate) || second.contains(candidate)
+            }
+        }
+    }
+
+    fn split(&mut self, target: &SessionId, new_id: SessionId, axis: SplitAxis) -> bool {
+        match self {
+            Self::Session { id } if id == target => {
+                *self = Self::Split {
+                    axis,
+                    fraction: 0.5,
+                    first: Box::new(self.clone()),
+                    second: Box::new(Self::session(new_id)),
+                };
+                true
+            }
+            Self::Session { .. } => false,
+            Self::Split { first, second, .. } => {
+                first.split(target, new_id.clone(), axis) || second.split(target, new_id, axis)
+            }
+        }
+    }
+
+    fn retain(self, keep: &impl Fn(&SessionId) -> bool) -> Option<Self> {
+        match self {
+            Self::Session { ref id } => keep(id).then_some(self),
+            Self::Split {
+                axis,
+                fraction,
+                first,
+                second,
+            } => match (first.retain(keep), second.retain(keep)) {
+                (Some(first), Some(second)) => Some(Self::Split {
+                    axis,
+                    fraction: normalized_fraction(fraction),
+                    first: Box::new(first),
+                    second: Box::new(second),
+                }),
+                (first, second) => first.or(second),
+            },
+        }
+    }
+
+    pub fn geometry(&self, rect: Rect) -> (Vec<(SessionId, Rect)>, Vec<Divider>) {
+        let mut panes = Vec::new();
+        let mut dividers = Vec::new();
+        self.place(rect, &mut Vec::new(), &mut panes, &mut dividers);
+        (panes, dividers)
+    }
+
+    fn place(
+        &self,
+        rect: Rect,
+        path: &mut Vec<bool>,
+        panes: &mut Vec<(SessionId, Rect)>,
+        dividers: &mut Vec<Divider>,
+    ) {
+        match self {
+            Self::Session { id } => panes.push((id.clone(), rect)),
+            Self::Split {
+                axis,
+                fraction,
+                first,
+                second,
+            } => {
+                let total = match axis {
+                    SplitAxis::Right => rect.width,
+                    SplitAxis::Below => rect.height,
+                };
+                let seam = DIVIDER.min(total.max(0.0));
+                let available = (total - seam).max(0.0);
+                // At small sizes both children shrink proportionally instead of overflowing.
+                let minimum = match axis {
+                    SplitAxis::Right => 160.0_f32,
+                    SplitAxis::Below => 100.0,
+                }
+                .min(available / 2.0);
+                let a = (available * normalized_fraction(*fraction))
+                    .clamp(minimum, available - minimum);
+                let (first_rect, second_rect, divider_rect) = match axis {
+                    SplitAxis::Right => (
+                        Rect { width: a, ..rect },
+                        Rect {
+                            x: rect.x + a + seam,
+                            width: available - a,
+                            ..rect
+                        },
+                        Rect {
+                            x: rect.x + a,
+                            width: seam,
+                            ..rect
+                        },
+                    ),
+                    SplitAxis::Below => (
+                        Rect { height: a, ..rect },
+                        Rect {
+                            y: rect.y + a + seam,
+                            height: available - a,
+                            ..rect
+                        },
+                        Rect {
+                            y: rect.y + a,
+                            height: seam,
+                            ..rect
+                        },
+                    ),
+                };
+                dividers.push(Divider {
+                    path: path.clone(),
+                    axis: *axis,
+                    rect: divider_rect,
+                    parent: rect,
+                });
+                path.push(false);
+                first.place(first_rect, path, panes, dividers);
+                path.pop();
+                path.push(true);
+                second.place(second_rect, path, panes, dividers);
+                path.pop();
+            }
+        }
+    }
+
+    pub fn resize(&mut self, path: &[bool], fraction: f32) -> bool {
+        let Self::Split {
+            first,
+            second,
+            fraction: saved,
+            ..
+        } = self
+        else {
+            return false;
+        };
+        match path.split_first() {
+            None => {
+                *saved = normalized_fraction(fraction);
+                true
+            }
+            Some((false, rest)) => first.resize(rest, fraction),
+            Some((true, rest)) => second.resize(rest, fraction),
+        }
+    }
+
+    pub fn neighbor(&self, id: &SessionId, direction: Direction, rect: Rect) -> Option<SessionId> {
+        let (panes, _) = self.geometry(rect);
+        let (_, source) = panes.iter().find(|(candidate, _)| candidate == id)?;
+        let sx = source.x + source.width / 2.0;
+        let sy = source.y + source.height / 2.0;
+        panes
+            .iter()
+            .filter(|(candidate, _)| candidate != id)
+            .filter_map(|(candidate, r)| {
+                let dx = r.x + r.width / 2.0 - sx;
+                let dy = r.y + r.height / 2.0 - sy;
+                let (forward, cross) = match direction {
+                    Direction::Left => (-dx, dy.abs()),
+                    Direction::Right => (dx, dy.abs()),
+                    Direction::Up => (-dy, dx.abs()),
+                    Direction::Down => (dy, dx.abs()),
+                };
+                (forward > 0.5).then_some((candidate, forward + cross * 2.0))
+            })
+            .min_by(|a, b| a.1.total_cmp(&b.1))
+            .map(|(id, _)| id.clone())
+    }
+}
+
+fn normalized_fraction(value: f32) -> f32 {
+    if value.is_finite() {
+        value.clamp(0.1, 0.9)
+    } else {
+        0.5
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum Direction {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SplitLayouts {
+    pub version: u32,
+    pub layouts: Vec<SplitNode>,
+    #[serde(default)]
+    pub hidden_auxiliary_parents: Vec<SessionId>,
+}
+
+impl Default for SplitLayouts {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            layouts: Vec::new(),
+            hidden_auxiliary_parents: Vec::new(),
+        }
+    }
+}
+
+impl SplitLayouts {
+    pub fn containing(&self, id: &SessionId) -> Option<&SplitNode> {
+        self.layouts.iter().find(|layout| layout.contains(id))
+    }
+    pub fn containing_mut(&mut self, id: &SessionId) -> Option<&mut SplitNode> {
+        self.layouts.iter_mut().find(|layout| layout.contains(id))
+    }
+
+    pub fn split(&mut self, target: SessionId, new_id: SessionId, axis: SplitAxis) -> bool {
+        if target == new_id
+            || self
+                .containing(&target)
+                .is_some_and(|tree| tree.ids().len() >= MAX_PANES || tree.contains(&new_id))
+        {
+            return false;
+        }
+        if self.containing(&target).is_none() && self.layouts.len() >= MAX_LAYOUTS {
+            return false;
+        }
+        // Moving an existing session between workspaces never creates two controllers.
+        self.close(&new_id);
+        if let Some(layout) = self.containing_mut(&target) {
+            return layout.split(&target, new_id, axis);
+        }
+        if self.layouts.len() >= MAX_LAYOUTS {
+            return false;
+        }
+        let mut layout = SplitNode::session(target.clone());
+        layout.split(&target, new_id, axis);
+        self.layouts.push(layout);
+        true
+    }
+
+    pub fn close(&mut self, id: &SessionId) -> Option<SessionId> {
+        let index = self.layouts.iter().position(|layout| layout.contains(id))?;
+        let layout = self
+            .layouts
+            .remove(index)
+            .retain(&|candidate| candidate != id)?;
+        let ids = layout.ids();
+        if ids.len() > 1 {
+            self.layouts.insert(index, layout);
+        }
+        ids.first().cloned()
+    }
+
+    /// Call only once the authoritative session list has hydrated. Empty startup
+    /// caches must not erase layouts awaiting their saved sessions.
+    pub fn reconcile(&mut self, exists: impl Fn(&SessionId) -> bool) {
+        let mut seen = HashSet::new();
+        if self.version != 1 {
+            *self = Self::default();
+            return;
+        }
+        self.hidden_auxiliary_parents.retain(|id| exists(id));
+        self.hidden_auxiliary_parents.truncate(MAX_LAYOUTS);
+        self.layouts = std::mem::take(&mut self.layouts)
+            .into_iter()
+            .take(MAX_LAYOUTS)
+            .filter_map(|tree| {
+                let ids = tree.ids();
+                if ids.len() > MAX_PANES
+                    || ids.iter().any(|id| seen.contains(id))
+                    || ids.iter().collect::<HashSet<_>>().len() != ids.len()
+                {
+                    return None;
+                }
+                let tree = tree.retain(&exists)?;
+                let ids = tree.ids();
+                if ids.len() < 2 {
+                    return None;
+                }
+                seen.extend(ids);
+                Some(tree)
+            })
+            .collect();
+    }
+}
+
+pub fn deserialize_split_layouts<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<SplitLayouts, D::Error> {
+    let value = serde_json::Value::deserialize(deserializer)?;
+    let mut layouts: SplitLayouts = serde_json::from_value(value).unwrap_or_default();
+    layouts.reconcile(|_| true);
+    Ok(layouts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn id(value: &str) -> SessionId {
+        SessionId::new(value)
+    }
+    fn nested() -> SplitLayouts {
+        let mut layouts = SplitLayouts::default();
+        assert!(layouts.split(id("a"), id("b"), SplitAxis::Right));
+        assert!(layouts.split(id("b"), id("c"), SplitAxis::Below));
+        layouts
+    }
+    #[test]
+    fn nested_splits_preserve_identity_and_fill_the_viewport() {
+        let layouts = nested();
+        let tree = layouts.containing(&id("a")).unwrap();
+        let (panes, dividers) = tree.geometry(Rect {
+            width: 805.0,
+            height: 605.0,
+            ..Rect::default()
+        });
+        assert_eq!(panes[0].1.width, 400.0);
+        assert_eq!(panes[1].1.height, 300.0);
+        assert_eq!(panes[2].1.y, 305.0);
+        assert_eq!(dividers.len(), 2);
+        assert_eq!(
+            tree.neighbor(
+                &id("c"),
+                Direction::Up,
+                Rect {
+                    width: 805.0,
+                    height: 605.0,
+                    ..Rect::default()
+                }
+            ),
+            Some(id("b"))
+        );
+    }
+    #[test]
+    fn closing_collapses_only_the_affected_branch() {
+        let mut layouts = nested();
+        assert_eq!(layouts.close(&id("b")), Some(id("a")));
+        assert_eq!(
+            layouts.containing(&id("a")).unwrap().ids(),
+            vec![id("a"), id("c")]
+        );
+        assert_eq!(layouts.close(&id("a")), Some(id("c")));
+        assert!(layouts.layouts.is_empty());
+    }
+    #[test]
+    fn persistence_reconciles_deleted_sessions_and_unknown_versions() {
+        let layouts = nested();
+        let mut restored: SplitLayouts =
+            serde_json::from_str(&serde_json::to_string(&layouts).unwrap()).unwrap();
+        restored.reconcile(|id| id.0 != "b");
+        assert_eq!(restored.layouts[0].ids(), vec![id("a"), id("c")]);
+        restored.version = 99;
+        restored.reconcile(|_| true);
+        assert!(restored.layouts.is_empty());
+    }
+    #[test]
+    fn duplicates_and_limits_do_not_change_layout() {
+        let mut layouts = nested();
+        let before = layouts.clone();
+        assert!(!layouts.split(id("a"), id("c"), SplitAxis::Right));
+        assert_eq!(layouts, before);
+        for i in 3..MAX_PANES {
+            assert!(layouts.split(id("a"), id(&i.to_string()), SplitAxis::Right));
+        }
+        assert!(!layouts.split(id("a"), id("overflow"), SplitAxis::Below));
+        let duplicate = layouts.layouts[0].clone();
+        layouts.layouts.push(duplicate);
+        layouts.reconcile(|_| true);
+        assert_eq!(layouts.layouts.len(), 1);
+    }
+    #[test]
+    fn resizing_nested_branch_does_not_move_its_sibling() {
+        let mut layouts = nested();
+        let tree = layouts.containing_mut(&id("a")).unwrap();
+        assert!(tree.resize(&[true], 0.7));
+        let (panes, _) = tree.geometry(Rect {
+            width: 805.0,
+            height: 605.0,
+            ..Rect::default()
+        });
+        assert_eq!(panes[0].1.width, 400.0);
+        assert_eq!(panes[1].1.height, 420.0);
+        tree.resize(&[], f32::NAN);
+        let (panes, _) = tree.geometry(Rect {
+            width: 2.0,
+            height: 2.0,
+            ..Rect::default()
+        });
+        assert!(
+            panes
+                .iter()
+                .all(|(_, rect)| rect.width >= 0.0 && rect.height >= 0.0)
+        );
+    }
+}

--- a/diri/crates/diri-app/src/split_workbench.rs
+++ b/diri/crates/diri-app/src/split_workbench.rs
@@ -1,0 +1,1144 @@
+//! Desktop split views. Closing a pane drops its attachment, never its session.
+use std::{collections::HashMap, sync::Arc};
+
+use diri_proto::{AgentKind, SessionId, SessionSpawnParams};
+use gpui::{
+    AnyElement, App, Context, CursorStyle, DragMoveEvent, Entity, EventEmitter, FocusHandle,
+    KeyDownEvent, MouseButton, Render, ScrollHandle, SharedString, Window, div, prelude::*, px,
+};
+
+use crate::{
+    icons::sf_symbol,
+    navigation::NavigationOverlay,
+    quote::Quote,
+    split_layout::{Direction, Divider, MAX_PANES, Rect, SplitAxis, SplitLayouts},
+    store::StoreRuntime,
+    surface_shell::UtilitySurfaces,
+    terminal_pane::{TerminalPane, TerminalPaneEvent, TerminalViewport},
+};
+
+#[derive(Clone)]
+struct DraggedDivider(Divider);
+impl Render for DraggedDivider {
+    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+        gpui::Empty
+    }
+}
+
+pub struct SplitWorkbench {
+    runtime: Arc<StoreRuntime>,
+    tokio: Arc<tokio::runtime::Runtime>,
+    fallback: Option<Entity<TerminalPane>>,
+    focus: FocusHandle,
+    picker_index: usize,
+    picker_scroll: ScrollHandle,
+    focus_pending: bool,
+    resize_active: bool,
+    layouts: SplitLayouts,
+    panes: HashMap<SessionId, Entity<TerminalPane>>,
+    selected: Option<SessionId>,
+    viewport: Rect,
+    navigation: Option<Entity<NavigationOverlay>>,
+    utilities: Option<Entity<UtilitySurfaces>>,
+    sidebar_visible: bool,
+    inspector_open: bool,
+    pending: bool,
+    auxiliary_pending: Option<SessionId>,
+    picker: Option<SplitAxis>,
+    error: Option<String>,
+}
+
+impl EventEmitter<TerminalPaneEvent> for SplitWorkbench {}
+
+impl SplitWorkbench {
+    pub fn new(
+        runtime: Arc<StoreRuntime>,
+        tokio: Arc<tokio::runtime::Runtime>,
+        fallback: Option<Entity<TerminalPane>>,
+        navigation: Option<Entity<NavigationOverlay>>,
+        utilities: Option<Entity<UtilitySurfaces>>,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let layouts = runtime
+            .store
+            .read()
+            .expect("session store lock poisoned")
+            .preferences()
+            .split_layouts
+            .clone();
+        Self {
+            runtime,
+            tokio,
+            fallback,
+            focus: cx.focus_handle(),
+            picker_index: 0,
+            picker_scroll: ScrollHandle::new(),
+            focus_pending: false,
+            resize_active: false,
+            layouts,
+            panes: HashMap::new(),
+            selected: None,
+            viewport: Rect::default(),
+            navigation,
+            utilities,
+            sidebar_visible: true,
+            inspector_open: false,
+            pending: false,
+            auxiliary_pending: None,
+            picker: None,
+            error: None,
+        }
+    }
+
+    pub fn active_for_selection(&self) -> bool {
+        let store = self
+            .runtime
+            .store
+            .read()
+            .expect("session store lock poisoned");
+        store
+            .selected_session_id()
+            .is_some_and(|id| self.layouts.containing(id).is_some())
+    }
+
+    pub fn sync(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(target) = self.auxiliary_pending.clone() {
+            let (auxiliary, failed) = {
+                let store = self
+                    .runtime
+                    .store
+                    .read()
+                    .expect("session store lock poisoned");
+                (
+                    store.auxiliary_terminal_for(&target),
+                    store.last_action_error().is_some(),
+                )
+            };
+            if let Some(auxiliary) = auxiliary {
+                self.auxiliary_pending = None;
+                if self
+                    .layouts
+                    .split(target.clone(), auxiliary.id.clone(), SplitAxis::Below)
+                {
+                    self.persist();
+                    if self
+                        .runtime
+                        .store
+                        .read()
+                        .expect("session store lock poisoned")
+                        .selected_session_id()
+                        == Some(&target)
+                    {
+                        self.select(auxiliary.id.clone(), window, cx);
+                    }
+                }
+            } else if failed {
+                self.auxiliary_pending = None;
+            }
+        }
+
+        let (selected, live, connected) = {
+            let store = self
+                .runtime
+                .store
+                .read()
+                .expect("session store lock poisoned");
+            (
+                store.selected_session_id().cloned(),
+                store
+                    .sessions()
+                    .values()
+                    .filter(|session| !session.is_archived())
+                    .map(|session| session.id.clone())
+                    .collect::<std::collections::HashSet<_>>(),
+                store.has_hydrated_sessions(),
+            )
+        };
+        if connected {
+            let before = self.layouts.clone();
+            self.layouts.reconcile(|id| live.contains(id));
+            if self.layouts != before {
+                self.persist();
+            }
+        }
+        let changed_selection = self.selected != selected;
+        self.selected = selected;
+        let ids = self
+            .selected
+            .as_ref()
+            .and_then(|id| self.layouts.containing(id))
+            .map(|tree| tree.ids())
+            .unwrap_or_default();
+        // Drop old owners before making any new attachments.
+        self.panes.retain(|id, _| ids.contains(id));
+        for id in ids {
+            if self.panes.contains_key(&id) {
+                continue;
+            }
+            let terminal = cx.new(|cx| {
+                TerminalPane::new_fixed(
+                    Arc::clone(&self.runtime),
+                    Arc::clone(&self.tokio),
+                    id.clone(),
+                    window,
+                    cx,
+                )
+            });
+            terminal.update(cx, |terminal, _| {
+                terminal.set_select_on_focus();
+                if let (Some(nav), Some(utilities)) = (&self.navigation, &self.utilities) {
+                    terminal.set_shell_entities(nav.clone(), utilities.clone());
+                }
+            });
+            cx.subscribe(&terminal, |_, _, event: &TerminalPaneEvent, cx| {
+                cx.emit(event.clone())
+            })
+            .detach();
+            self.panes.insert(id, terminal);
+        }
+        if changed_selection || self.focus_pending {
+            self.focus_selected(window, cx);
+            self.focus_pending = false;
+        }
+        cx.notify();
+    }
+
+    fn persist(&self) {
+        self.runtime
+            .store
+            .write()
+            .expect("session store lock poisoned")
+            .remember_split_layouts(self.layouts.clone());
+    }
+
+    pub fn set_viewport(&mut self, viewport: Rect, sidebar_visible: bool, inspector_open: bool) {
+        self.viewport = viewport;
+        self.sidebar_visible = sidebar_visible;
+        self.inspector_open = inspector_open;
+    }
+
+    pub fn focused_terminal(&self, window: &Window, cx: &App) -> Option<&Entity<TerminalPane>> {
+        self.panes
+            .values()
+            .find(|pane| pane.read(cx).is_focused(window))
+    }
+
+    pub fn quote_selection(&self, cx: &App) -> Option<Quote> {
+        self.selected
+            .as_ref()
+            .and_then(|id| self.panes.get(id))
+            .and_then(|pane| pane.read(cx).quote_selection())
+    }
+
+    pub fn focus_selected(&self, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(terminal) = self.selected.as_ref().and_then(|id| self.panes.get(id)) {
+            terminal.update(cx, |terminal, cx| terminal.focus(window, cx));
+        } else if let Some(terminal) = &self.fallback {
+            terminal.update(cx, |terminal, cx| terminal.focus(window, cx));
+        }
+    }
+
+    fn select(&mut self, id: SessionId, window: &mut Window, cx: &mut Context<Self>) {
+        self.runtime
+            .store
+            .write()
+            .expect("session store lock poisoned")
+            .select(id.clone());
+        self.focus_pending = !self.panes.contains_key(&id);
+        self.selected = Some(id);
+        self.focus_selected(window, cx);
+        self.runtime.publish_local_change();
+        cx.notify();
+    }
+
+    pub fn focus_direction(
+        &mut self,
+        direction: Direction,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(selected) = &self.selected else {
+            return;
+        };
+        if let Some(next) = self
+            .layouts
+            .containing(selected)
+            .and_then(|tree| tree.neighbor(selected, direction, self.viewport))
+        {
+            self.select(next, window, cx);
+        }
+    }
+
+    pub fn focus_next(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(selected) = &self.selected else {
+            return;
+        };
+        if let Some(tree) = self.layouts.containing(selected) {
+            let ids = tree.ids();
+            let index = ids.iter().position(|id| id == selected).unwrap_or_default();
+            self.select(ids[(index + 1) % ids.len()].clone(), window, cx);
+        }
+    }
+
+    pub fn close_selected(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
+        let Some(selected) = self.selected.clone() else {
+            return false;
+        };
+        self.close(&selected, window, cx)
+    }
+
+    fn close(&mut self, id: &SessionId, window: &mut Window, cx: &mut Context<Self>) -> bool {
+        let Some(next) = self.layouts.close(id) else {
+            return false;
+        };
+        self.panes.remove(id);
+        let parent = self
+            .runtime
+            .store
+            .read()
+            .expect("session store lock poisoned")
+            .sessions()
+            .get(id)
+            .filter(|session| crate::store::is_auxiliary_terminal(session))
+            .and_then(|session| session.parent.clone());
+        if let Some(parent) = parent
+            && !self.layouts.hidden_auxiliary_parents.contains(&parent)
+        {
+            self.layouts.hidden_auxiliary_parents.push(parent);
+            if self.layouts.hidden_auxiliary_parents.len() > 64 {
+                self.layouts.hidden_auxiliary_parents.remove(0);
+            }
+        }
+        self.persist();
+        self.select(next, window, cx);
+        // A two-pane workspace collapses to the following terminal. Focus it
+        // again after sync drops the old fixed entity.
+        self.focus_pending = true;
+        true
+    }
+
+    pub fn auxiliary_hidden_for(&self, parent: &SessionId) -> bool {
+        self.layouts.hidden_auxiliary_parents.contains(parent)
+    }
+
+    pub fn show_auxiliary_for(&mut self, parent: &SessionId) -> bool {
+        let hidden = self.auxiliary_hidden_for(parent);
+        if hidden {
+            self.layouts
+                .hidden_auxiliary_parents
+                .retain(|id| id != parent);
+            self.persist();
+        }
+        hidden
+    }
+
+    pub fn include_auxiliary(&mut self, auxiliary: SessionId) {
+        let target = self
+            .runtime
+            .store
+            .read()
+            .expect("session store lock poisoned")
+            .selected_session_id()
+            .cloned();
+        if let Some(target) = target
+            && self.layouts.split(target, auxiliary, SplitAxis::Below)
+        {
+            self.persist();
+            self.runtime.publish_local_change();
+        }
+    }
+
+    pub fn toggle_auxiliary(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(selected) = self.selected.clone() else {
+            return;
+        };
+        let (target, auxiliary) = {
+            let store = self
+                .runtime
+                .store
+                .read()
+                .expect("session store lock poisoned");
+            let target = store
+                .sessions()
+                .get(&selected)
+                .filter(|session| crate::store::is_auxiliary_terminal(session))
+                .and_then(|session| session.parent.clone())
+                .unwrap_or(selected);
+            let auxiliary = store.auxiliary_terminal_for(&target);
+            (target, auxiliary)
+        };
+        if let Some(auxiliary) = auxiliary {
+            self.show_auxiliary_for(&target);
+            if self
+                .layouts
+                .containing(&target)
+                .is_some_and(|tree| tree.contains(&auxiliary.id))
+            {
+                self.close(&auxiliary.id, window, cx);
+            } else if self
+                .layouts
+                .split(target, auxiliary.id.clone(), SplitAxis::Below)
+            {
+                self.persist();
+                self.select(auxiliary.id.clone(), window, cx);
+            }
+        } else if self.auxiliary_pending.is_none()
+            && self
+                .layouts
+                .containing(&target)
+                .is_none_or(|tree| tree.ids().len() < MAX_PANES)
+            && self
+                .runtime
+                .store
+                .write()
+                .expect("session store lock poisoned")
+                .spawn_auxiliary_terminal(target.clone())
+        {
+            self.auxiliary_pending = Some(target);
+        }
+        cx.notify();
+    }
+
+    pub fn has_overlay(&self) -> bool {
+        self.picker.is_some() || self.error.is_some() || self.pending
+    }
+
+    pub fn open_picker(&mut self, axis: SplitAxis, window: &mut Window, cx: &mut Context<Self>) {
+        self.picker = Some(axis);
+        self.picker_index = 0;
+        self.picker_scroll.scroll_to_item(0);
+        window.focus(&self.focus, cx);
+        self.error = None;
+        cx.notify();
+    }
+
+    pub fn add_existing(
+        &mut self,
+        id: SessionId,
+        axis: SplitAxis,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.pending {
+            return;
+        }
+        let target = self
+            .runtime
+            .store
+            .read()
+            .expect("session store lock poisoned")
+            .selected_session_id()
+            .cloned();
+        if let Some(target) = target {
+            if self.layouts.split(target, id.clone(), axis) {
+                self.persist();
+                self.picker = None;
+                self.select(id, window, cx);
+            } else {
+                self.error = Some(format!(
+                    "A workspace can contain up to {MAX_PANES} distinct panes."
+                ));
+                cx.notify();
+            }
+        }
+    }
+
+    pub fn spawn(&mut self, axis: SplitAxis, window: &mut Window, cx: &mut Context<Self>) {
+        if self.pending {
+            return;
+        }
+        let session = self
+            .runtime
+            .store
+            .read()
+            .expect("session store lock poisoned")
+            .selected_session()
+            .cloned();
+        let Some(session) = session else {
+            return;
+        };
+        let target = session.id.clone();
+        if self
+            .layouts
+            .containing(&target)
+            .is_some_and(|tree| tree.ids().len() >= MAX_PANES)
+        {
+            self.error = Some(format!("This workspace already has {MAX_PANES} panes."));
+            cx.notify();
+            return;
+        }
+        let params = SessionSpawnParams {
+            kind: AgentKind::SHELL,
+            cwd: session.cwd.clone(),
+            new_worktree: None,
+            worktree_branch: None,
+            worktree_base: None,
+            title: Some("Split terminal".to_owned()),
+            initial_prompt: None,
+            parent: None,
+            initial_cols: None,
+            initial_rows: None,
+            host: session.host.clone(),
+            account_profile_id: None,
+            same_repo_as: None,
+        };
+        let client = Arc::clone(self.runtime.client());
+        let spawn = self.tokio.spawn(async move {
+            let id = client
+                .spawn(params)
+                .await
+                .map_err(|error| format!("Could not open terminal: {error}"))?;
+            let sessions = client.sessions().await.map_err(|error| {
+                format!(
+                    "Terminal created; could not load its pane: {error}. Open it from the sidebar."
+                )
+            })?;
+            sessions
+                .sessions
+                .into_iter()
+                .find(|session| session.id == id)
+                .ok_or_else(|| "Terminal created; its session is no longer available.".to_owned())
+        });
+        self.pending = true;
+        self.error = None;
+        cx.notify();
+        cx.spawn_in(window, async move |this, cx| {
+            let result = spawn.await;
+            let _ = this.update_in(cx, |this, window, cx| {
+                this.pending = false;
+                match result {
+                    Ok(Ok(record)) => {
+                        let id = record.id.clone();
+                        let mut store = this.runtime.store.write().expect("session store lock poisoned");
+                        if !store.sessions().contains_key(&id) { store.upsert_session(record); }
+                        let still_selected = store.selected_session_id() == Some(&target);
+                        let target_exists = store.sessions().contains_key(&target);
+                        drop(store);
+                        if target_exists && this.layouts.split(target, id.clone(), axis) {
+                            this.persist();
+                            if still_selected { this.select(id, window, cx); }
+                            this.picker = None;
+                        } else {
+                            this.error = Some("Terminal created. Open it from the sidebar; the original pane changed while it was opening.".to_owned());
+                        }
+                        this.runtime.publish_local_change();
+                    }
+                    Ok(Err(error)) => this.error = Some(error),
+                    Err(_) => this.error = Some("Could not open terminal. Try again.".to_owned()),
+                }
+                cx.notify();
+            });
+        }).detach();
+    }
+
+    fn divider(&self, divider: Divider, cx: &mut Context<Self>) -> AnyElement {
+        let colors = {
+            let store = self
+                .runtime
+                .store
+                .read()
+                .expect("session store lock poisoned");
+            crate::app_theme::colors(&store.preferences().terminal_theme)
+        };
+        let reset_path = divider.path.clone();
+        let drag = DraggedDivider(divider.clone());
+        div()
+            .id(SharedString::from(format!(
+                "split-divider-{:?}",
+                divider.path
+            )))
+            .absolute()
+            .left(px(divider.rect.x))
+            .top(px(divider.rect.y))
+            .w(px(divider.rect.width))
+            .h(px(divider.rect.height))
+            .cursor(match divider.axis {
+                SplitAxis::Right => CursorStyle::ResizeLeftRight,
+                SplitAxis::Below => CursorStyle::ResizeUpDown,
+            })
+            .bg(colors.primary.alpha(0.05))
+            .hover(|s| s.bg(colors.primary.alpha(0.20)))
+            .on_drag(drag, |drag, _, _, cx| {
+                cx.stop_propagation();
+                cx.new(|_| drag.clone())
+            })
+            .on_mouse_up(
+                MouseButton::Left,
+                cx.listener(move |this, event: &gpui::MouseUpEvent, _, cx| {
+                    if event.click_count == 2
+                        && let Some(tree) = this
+                            .selected
+                            .as_ref()
+                            .and_then(|id| this.layouts.containing_mut(id))
+                    {
+                        tree.resize(&reset_path, 0.5);
+                    }
+                    this.persist();
+                    cx.notify();
+                }),
+            )
+            .into_any_element()
+    }
+
+    fn picker_sessions(&self) -> Vec<Arc<diri_proto::SessionRecord>> {
+        let store = self
+            .runtime
+            .store
+            .read()
+            .expect("session store lock poisoned");
+        let selected = store.selected_session_id();
+        let mut sessions: Vec<_> = store
+            .sessions()
+            .values()
+            .filter(|session| {
+                !session.is_archived()
+                    && selected != Some(&session.id)
+                    && !selected
+                        .and_then(|id| self.layouts.containing(id))
+                        .is_some_and(|tree| tree.contains(&session.id))
+            })
+            .cloned()
+            .collect();
+        sessions.sort_by(|a, b| a.title.cmp(&b.title).then(a.id.0.cmp(&b.id.0)));
+        sessions
+    }
+
+    fn picker_key(&mut self, event: &KeyDownEvent, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(axis) = self.picker else {
+            return;
+        };
+        let sessions = self.picker_sessions();
+        match event.keystroke.key.as_str() {
+            "escape" => {
+                self.picker = None;
+                self.error = None;
+                self.focus_selected(window, cx);
+            }
+            "up" => self.picker_index = self.picker_index.saturating_sub(1),
+            "down" => self.picker_index = (self.picker_index + 1).min(sessions.len()),
+            "left" => self.picker = Some(SplitAxis::Right),
+            "right" => self.picker = Some(SplitAxis::Below),
+            "enter" if self.picker_index == 0 => self.spawn(axis, window, cx),
+            "enter" => {
+                if let Some(session) = sessions.get(self.picker_index - 1) {
+                    self.add_existing(session.id.clone(), axis, window, cx);
+                }
+            }
+            _ => return,
+        }
+        if self.picker_index > 0 {
+            self.picker_scroll.scroll_to_item(self.picker_index - 1);
+        }
+        cx.stop_propagation();
+        cx.notify();
+    }
+
+    fn picker(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
+        let axis = self.picker?;
+        let store = self
+            .runtime
+            .store
+            .read()
+            .expect("session store lock poisoned");
+        let colors = crate::app_theme::colors(&store.preferences().terminal_theme);
+        drop(store);
+        let sessions = self.picker_sessions();
+        Some(
+            div()
+                .absolute()
+                .inset_0()
+                .bg(colors.background.alpha(0.65))
+                .flex()
+                .items_center()
+                .justify_center()
+                .occlude()
+                .child(
+                    div()
+                        .w(px(360.0))
+                        .max_h(px(460.0))
+                        .p(px(14.0))
+                        .rounded(px(12.0))
+                        .bg(colors.background)
+                        .border_1()
+                        .border_color(colors.primary.alpha(0.15))
+                        .shadow_lg()
+                        .flex()
+                        .flex_col()
+                        .gap(px(8.0))
+                        .child(
+                            div()
+                                .flex()
+                                .items_center()
+                                .justify_between()
+                                .child("Add a pane")
+                                .child(
+                                    div()
+                                        .id("dismiss-split-picker")
+                                        .cursor_pointer()
+                                        .p(px(6.0))
+                                        .child(sf_symbol("xmark", 11.0, colors.secondary))
+                                        .on_click(cx.listener(|this, _, window, cx| {
+                                            this.picker = None;
+                                            this.error = None;
+                                            this.focus_selected(window, cx);
+                                            cx.notify();
+                                        })),
+                                ),
+                        )
+                        .child(
+                            div().flex().gap(px(6.0)).children(
+                                [(SplitAxis::Right, "Right"), (SplitAxis::Below, "Below")]
+                                    .into_iter()
+                                    .map(|(candidate, label)| {
+                                        div()
+                                            .id(SharedString::from(format!("split-axis-{label}")))
+                                            .px(px(12.0))
+                                            .py(px(6.0))
+                                            .rounded(px(5.0))
+                                            .cursor_pointer()
+                                            .bg(colors.primary.alpha(if axis == candidate {
+                                                0.14
+                                            } else {
+                                                0.04
+                                            }))
+                                            .text_size(px(12.0))
+                                            .child(label)
+                                            .on_click(cx.listener(move |this, _, _, cx| {
+                                                this.picker = Some(candidate);
+                                                cx.notify();
+                                            }))
+                                    }),
+                            ),
+                        )
+                        .child(
+                            div()
+                                .id("split-new-shell")
+                                .when(self.picker_index == 0, |row| {
+                                    row.bg(colors.primary.alpha(0.1))
+                                })
+                                .p(px(10.0))
+                                .rounded(px(6.0))
+                                .cursor_pointer()
+                                .hover(|s| s.bg(colors.primary.alpha(0.08)))
+                                .child(if self.pending {
+                                    "Opening terminal…"
+                                } else {
+                                    "New terminal in this directory"
+                                })
+                                .on_click(cx.listener(move |this, _, window, cx| {
+                                    this.spawn(axis, window, cx)
+                                })),
+                        )
+                        .child(
+                            div()
+                                .text_size(px(11.0))
+                                .text_color(colors.secondary)
+                                .child("Or choose an existing session"),
+                        )
+                        .child(
+                            div()
+                                .id("split-session-options")
+                                .track_scroll(&self.picker_scroll)
+                                .overflow_y_scroll()
+                                .min_h_0()
+                                .children(sessions.into_iter().enumerate().map(
+                                    |(index, session)| {
+                                        let id = session.id.clone();
+                                        div()
+                                            .id(SharedString::from(format!(
+                                                "split-existing-{}",
+                                                id.0
+                                            )))
+                                            .when(self.picker_index == index + 1, |row| {
+                                                row.bg(colors.primary.alpha(0.1))
+                                            })
+                                            .p(px(10.0))
+                                            .rounded(px(6.0))
+                                            .cursor_pointer()
+                                            .hover(|s| s.bg(colors.primary.alpha(0.08)))
+                                            .child(
+                                                div()
+                                                    .text_size(px(12.0))
+                                                    .text_ellipsis()
+                                                    .child(session.title.clone()),
+                                            )
+                                            .child(
+                                                div()
+                                                    .text_size(px(10.0))
+                                                    .text_color(colors.secondary)
+                                                    .text_ellipsis()
+                                                    .child(session.cwd.clone()),
+                                            )
+                                            .on_click(cx.listener(move |this, _, window, cx| {
+                                                this.add_existing(id.clone(), axis, window, cx)
+                                            }))
+                                    },
+                                )),
+                        )
+                        .children(self.error.as_ref().map(|error| {
+                            div()
+                                .text_size(px(12.0))
+                                .text_color(colors.secondary)
+                                .child(error.clone())
+                        })),
+                )
+                .into_any_element(),
+        )
+    }
+}
+
+impl Render for SplitWorkbench {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let colors = {
+            let store = self
+                .runtime
+                .store
+                .read()
+                .expect("session store lock poisoned");
+            crate::app_theme::colors(&store.preferences().terminal_theme)
+        };
+        let tree = self
+            .selected
+            .as_ref()
+            .and_then(|id| self.layouts.containing(id));
+        let (panes, dividers) = tree
+            .map(|tree| {
+                tree.geometry(Rect {
+                    width: self.viewport.width,
+                    height: self.viewport.height,
+                    ..Rect::default()
+                })
+            })
+            .unwrap_or_default();
+        let mut surface = div()
+            .id("split-workbench")
+            .track_focus(&self.focus)
+            .on_key_down(cx.listener(Self::picker_key))
+            .relative()
+            .size_full()
+            .overflow_hidden()
+            .on_drag_move(
+                cx.listener(|this, event: &DragMoveEvent<DraggedDivider>, _, cx| {
+                    let divider = &event.drag(cx).0;
+                    let (position, start, available) = match divider.axis {
+                        SplitAxis::Right => (
+                            f32::from(event.event.position.x) - this.viewport.x,
+                            divider.parent.x,
+                            divider.parent.width - crate::split_layout::DIVIDER,
+                        ),
+                        SplitAxis::Below => (
+                            f32::from(event.event.position.y) - this.viewport.y,
+                            divider.parent.y,
+                            divider.parent.height - crate::split_layout::DIVIDER,
+                        ),
+                    };
+                    if available > 0.0
+                        && let Some(tree) = this
+                            .selected
+                            .as_ref()
+                            .and_then(|id| this.layouts.containing_mut(id))
+                    {
+                        tree.resize(&divider.path, (position - start) / available);
+                        this.resize_active = true;
+                        cx.notify();
+                    }
+                }),
+            )
+            .on_mouse_up(
+                MouseButton::Left,
+                cx.listener(|this, _, _, _| {
+                    if this.resize_active {
+                        this.resize_active = false;
+                        this.persist();
+                    }
+                }),
+            )
+            .on_mouse_up_out(
+                MouseButton::Left,
+                cx.listener(|this, _, _, _| {
+                    if this.resize_active {
+                        this.resize_active = false;
+                        this.persist();
+                    }
+                }),
+            );
+        for (index, (id, rect)) in panes.into_iter().enumerate() {
+            let Some(terminal) = self.panes.get(&id) else {
+                continue;
+            };
+            terminal.update(cx, |terminal, cx| {
+                terminal.set_workbench_primary(index == 0);
+                terminal.set_shell_chrome(self.sidebar_visible, self.inspector_open, cx);
+                terminal.set_viewport(
+                    TerminalViewport {
+                        x: self.viewport.x + rect.x,
+                        y: self.viewport.y + rect.y,
+                        width: rect.width,
+                        height: rect.height,
+                    },
+                    cx,
+                );
+            });
+            let close_id = id.clone();
+            let debug_id = id.clone();
+            let active = self.selected.as_ref() == Some(&id);
+            surface =
+                surface.child(
+                    div()
+                        .id(SharedString::from(format!("split-pane-{}", id.0)))
+                        .debug_selector(move || format!("SPLIT_PANE_{}", debug_id.0))
+                        .absolute()
+                        .left(px(rect.x))
+                        .top(px(rect.y))
+                        .w(px(rect.width))
+                        .h(px(rect.height))
+                        .overflow_hidden()
+                        .child(terminal.clone())
+                        .child(div().absolute().left_0().top_0().w(px(3.0)).h(px(42.0)).bg(
+                            if active {
+                                colors.primary.alpha(0.7)
+                            } else {
+                                colors.primary.alpha(0.12)
+                            },
+                        ))
+                        .child(
+                            div()
+                                .id(SharedString::from(format!("split-pane-controls-{}", id.0)))
+                                .absolute()
+                                .right(px(6.0))
+                                .top(px(7.0))
+                                .flex()
+                                .items_center()
+                                .gap(px(2.0))
+                                .bg(colors.background)
+                                .child(
+                                    div()
+                                        .text_size(px(10.0))
+                                        .text_color(colors.secondary)
+                                        .px(px(4.0))
+                                        .child(format!("{}", index + 1)),
+                                )
+                                .child(
+                                    div()
+                                        .id(SharedString::from(format!("split-add-{}", id.0)))
+                                        .size(px(26.0))
+                                        .flex()
+                                        .items_center()
+                                        .justify_center()
+                                        .rounded(px(4.0))
+                                        .cursor_pointer()
+                                        .hover(|s| s.bg(colors.primary.alpha(0.1)))
+                                        .child(sf_symbol("plus", 11.0, colors.secondary))
+                                        .on_click(cx.listener(move |this, _, window, cx| {
+                                            this.select(id.clone(), window, cx);
+                                            this.open_picker(SplitAxis::Right, window, cx);
+                                        })),
+                                )
+                                .child(
+                                    div()
+                                        .id(SharedString::from(format!(
+                                            "split-close-{}",
+                                            close_id.0
+                                        )))
+                                        .size(px(26.0))
+                                        .flex()
+                                        .items_center()
+                                        .justify_center()
+                                        .rounded(px(4.0))
+                                        .cursor_pointer()
+                                        .hover(|s| s.bg(colors.primary.alpha(0.1)))
+                                        .child(sf_symbol("xmark", 10.0, colors.secondary))
+                                        .on_click(cx.listener(move |this, _, window, cx| {
+                                            this.close(&close_id, window, cx);
+                                        })),
+                                ),
+                        ),
+                );
+        }
+        surface = surface.children(
+            dividers
+                .into_iter()
+                .map(|divider| self.divider(divider, cx)),
+        );
+        if self.picker.is_none() && (self.pending || self.error.is_some()) {
+            surface = surface.child(
+                div()
+                    .absolute()
+                    .bottom(px(16.0))
+                    .left(px(16.0))
+                    .right(px(16.0))
+                    .p(px(12.0))
+                    .rounded(px(8.0))
+                    .bg(colors.background)
+                    .border_1()
+                    .border_color(colors.primary.alpha(0.16))
+                    .flex()
+                    .items_center()
+                    .gap(px(8.0))
+                    .child(
+                        div().flex_1().text_size(px(12.0)).child(
+                            self.error
+                                .clone()
+                                .unwrap_or_else(|| "Opening terminal…".to_owned()),
+                        ),
+                    )
+                    .when(self.error.is_some(), |row| {
+                        row.child(
+                            div()
+                                .id("dismiss-split-error")
+                                .cursor_pointer()
+                                .p(px(6.0))
+                                .child(sf_symbol("xmark", 11.0, colors.secondary))
+                                .on_click(cx.listener(|this, _, _, cx| {
+                                    this.error = None;
+                                    cx.notify();
+                                })),
+                        )
+                    }),
+            );
+        }
+        if let Some(picker) = self.picker(cx) {
+            surface = surface.child(picker);
+        }
+        surface
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use diri_proto::{SessionListResult, SessionRecord};
+    use gpui::{TestAppContext, size};
+
+    fn session(id: &str) -> SessionRecord {
+        let envelope: serde_json::Value = serde_json::from_str(include_str!(
+            "../../diri-proto/tests/fixtures/session_list_response.json"
+        ))
+        .unwrap();
+        let list: SessionListResult = serde_json::from_value(envelope["ok"].clone()).unwrap();
+        let mut session = list.sessions[0].clone();
+        session.id = SessionId::new(id);
+        session
+    }
+
+    fn runtime() -> Arc<tokio::runtime::Runtime> {
+        Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap(),
+        )
+    }
+
+    #[gpui::test]
+    fn pane_navigation_keeps_entities_and_close_keeps_engine_sessions(cx: &mut TestAppContext) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        let a = session("a");
+        let b = session("b");
+        let c = session("c");
+        {
+            let mut store = runtime.store.write().unwrap();
+            store.hydrate(SessionListResult {
+                sessions: vec![a.clone(), b.clone(), c.clone()],
+                projects: vec![],
+            });
+            store.select(a.id.clone());
+        }
+        let shared = runtime.clone();
+        let tokio = self::runtime();
+        let (view, cx) = cx.add_window_view(move |window, cx| {
+            let mut view = SplitWorkbench::new(shared, tokio, None, None, None, cx);
+            view.layouts
+                .split(SessionId::new("a"), SessionId::new("b"), SplitAxis::Right);
+            view.layouts
+                .split(SessionId::new("b"), SessionId::new("c"), SplitAxis::Below);
+            view.set_viewport(
+                Rect {
+                    width: 805.0,
+                    height: 605.0,
+                    ..Rect::default()
+                },
+                true,
+                false,
+            );
+            view.sync(window, cx);
+            view
+        });
+        cx.simulate_resize(size(px(805.0), px(605.0)));
+        let first_bounds = cx.debug_bounds("SPLIT_PANE_a").expect("first pane renders");
+        let third_bounds = cx
+            .debug_bounds("SPLIT_PANE_c")
+            .expect("nested pane renders");
+        assert_eq!(first_bounds.size.width, px(400.0));
+        assert_eq!(third_bounds.size.height, px(300.0));
+        assert_eq!(third_bounds.origin.y, px(305.0));
+        view.update_in(cx, |view, window, cx| {
+            assert_eq!(view.panes.len(), 3);
+            let entities: HashMap<_, _> = view
+                .panes
+                .iter()
+                .map(|(id, pane)| (id.clone(), pane.entity_id()))
+                .collect();
+            view.focus_direction(Direction::Right, window, cx);
+            assert_eq!(view.selected, Some(b.id.clone()));
+            assert!(view.panes[&b.id].read(cx).is_focused(window));
+            assert_eq!(
+                runtime.store.read().unwrap().selected_session_id(),
+                Some(&b.id)
+            );
+            view.sync(window, cx);
+            assert!(
+                view.panes
+                    .iter()
+                    .all(|(id, pane)| entities[id] == pane.entity_id())
+            );
+            assert!(view.close_selected(window, cx));
+            view.sync(window, cx);
+            assert_eq!(view.panes.len(), 2);
+            assert!(
+                runtime.store.read().unwrap().sessions().contains_key(&b.id),
+                "closing a pane must never remove its Engine session"
+            );
+            assert!(view.close_selected(window, cx));
+            view.sync(window, cx);
+            assert!(view.panes.is_empty());
+            assert_eq!(runtime.store.read().unwrap().sessions().len(), 3);
+        });
+    }
+
+    #[gpui::test]
+    fn pending_hydration_keeps_layout_and_picker_does_not_steal_terminal_keys(
+        cx: &mut TestAppContext,
+    ) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        let shared = runtime.clone();
+        let tokio = self::runtime();
+        let (view, cx) = cx.add_window_view(move |window, cx| {
+            let mut view = SplitWorkbench::new(shared, tokio, None, None, None, cx);
+            view.layouts
+                .split(SessionId::new("a"), SessionId::new("b"), SplitAxis::Right);
+            view.sync(window, cx);
+            assert_eq!(view.layouts.layouts.len(), 1);
+            view
+        });
+        runtime.store.write().unwrap().hydrate(SessionListResult {
+            sessions: vec![session("a"), session("b")],
+            projects: vec![],
+        });
+        runtime.store.write().unwrap().select(SessionId::new("a"));
+        view.update_in(cx, |view, window, cx| {
+            view.sync(window, cx);
+            assert_eq!(view.panes.len(), 2);
+            view.open_picker(SplitAxis::Right, window, cx);
+            assert!(view.focus.is_focused(window));
+            let event = KeyDownEvent {
+                keystroke: gpui::Keystroke::parse("escape").unwrap(),
+                is_held: false,
+                prefer_character_input: false,
+            };
+            view.picker_key(&event, window, cx);
+            assert!(view.picker.is_none());
+            assert!(view.panes[&SessionId::new("a")].read(cx).is_focused(window));
+        });
+    }
+}

--- a/diri/crates/diri-app/src/store/mod.rs
+++ b/diri/crates/diri-app/src/store/mod.rs
@@ -942,6 +942,13 @@ impl SessionStore {
         self.repo_targets.insert(key, target);
     }
 
+    pub fn remember_split_layouts(&mut self, layouts: crate::split_layout::SplitLayouts) {
+        self.prefs.split_layouts = layouts;
+        if let Err(error) = self.persist_preferences() {
+            eprintln!("diri: could not remember terminal panes: {error}");
+        }
+    }
+
     pub fn preferences(&self) -> &Prefs {
         &self.prefs
     }

--- a/diri/crates/diri-app/src/store/prefs.rs
+++ b/diri/crates/diri-app/src/store/prefs.rs
@@ -121,6 +121,12 @@ pub struct Prefs {
     /// Fraction of the terminal workbench reserved for the primary pane when
     /// the lower terminal is open.
     pub workbench_primary_fraction: f32,
+    /// Versioned desktop pane layout; sessions remain Engine-owned.
+    #[serde(
+        default,
+        deserialize_with = "crate::split_layout::deserialize_split_layouts"
+    )]
+    pub split_layouts: crate::split_layout::SplitLayouts,
     /// Newline-separated roots, matching the Swift settings text field.
     pub quick_open_roots: String,
     pub sidebar_project_order: Vec<ProjectId>,
@@ -168,6 +174,7 @@ impl Default for Prefs {
             inspector_width: 440.0,
             inspector_tab: InspectorTab::Info,
             workbench_primary_fraction: crate::workbench::DEFAULT_PRIMARY_FRACTION,
+            split_layouts: crate::split_layout::SplitLayouts::default(),
             quick_open_roots: String::new(),
             sidebar_project_order: Vec::new(),
             sidebar_session_order: Vec::new(),

--- a/diri/crates/diri-app/src/terminal_pane.rs
+++ b/diri/crates/diri-app/src/terminal_pane.rs
@@ -874,6 +874,9 @@ pub struct TerminalPane {
     reflow_holds: HashMap<SessionId, ReflowHold>,
     started_at: Instant,
     session_source: SessionSource,
+    suspended: bool,
+    select_on_focus: bool,
+    workbench_primary: bool,
     /// Last selection observed by the primary pane. Spawn responses select the
     /// daemon-created id asynchronously, so this transition is also the
     /// reliable point at which keyboard focus can leave the picker.
@@ -1000,6 +1003,9 @@ impl TerminalPane {
             started_at: Instant::now(),
             session_source,
             observed_selected_id,
+            suspended: false,
+            select_on_focus: false,
+            workbench_primary: false,
             viewport: None,
             sidebar_visible: true,
             inspector_open: false,
@@ -1020,14 +1026,22 @@ impl TerminalPane {
             .store
             .read()
             .expect("session store lock poisoned");
-        let resident_ids: HashSet<_> = match &self.session_source {
-            SessionSource::FollowSelection => {
-                store.terminal_residency().resident().cloned().collect()
+        let owned_by_split = matches!(self.session_source, SessionSource::FollowSelection)
+            && store
+                .selected_session_id()
+                .is_some_and(|id| store.preferences().split_layouts.containing(id).is_some());
+        let resident_ids: HashSet<_> = if self.suspended || owned_by_split {
+            HashSet::new()
+        } else {
+            match &self.session_source {
+                SessionSource::FollowSelection => {
+                    store.terminal_residency().resident().cloned().collect()
+                }
+                SessionSource::Fixed(id) if store.sessions().contains_key(id) => {
+                    HashSet::from([id.clone()])
+                }
+                SessionSource::Fixed(_) => HashSet::new(),
             }
-            SessionSource::Fixed(id) if store.sessions().contains_key(id) => {
-                HashSet::from([id.clone()])
-            }
-            SessionSource::Fixed(_) => HashSet::new(),
         };
         // A parked grid for a session the store no longer lists is dead
         // weight; one for a session that just became resident is superseded
@@ -1134,7 +1148,17 @@ impl TerminalPane {
         // successful spawns select their daemon-assigned id on the async store
         // path. Following the selection here covers both RPC/event orderings
         // and avoids trying to focus a terminal before its id exists.
-        if selection_changed && selected_id.is_some() {
+        let owned_by_split = selected_id.as_ref().is_some_and(|id| {
+            self.runtime
+                .store
+                .read()
+                .expect("session store lock poisoned")
+                .preferences()
+                .split_layouts
+                .containing(id)
+                .is_some()
+        });
+        if selection_changed && selected_id.is_some() && !self.suspended && !owned_by_split {
             window.focus(&self.focus, cx);
         }
         cx.notify();
@@ -1159,6 +1183,29 @@ impl TerminalPane {
 
     pub fn focus(&self, window: &mut Window, cx: &mut Context<Self>) {
         window.focus(&self.focus, cx);
+    }
+
+    /// Transfers attachment ownership to/from a fixed-pane workbench. Suspended
+    /// panes never attach in response to selection or store changes.
+    pub fn set_suspended(&mut self, suspended: bool, cx: &mut Context<Self>) {
+        if self.suspended != suspended {
+            self.suspended = suspended;
+            if suspended {
+                self.pending_resizes.clear();
+                self.resize_flush = None;
+                self.resize_flush_armed = false;
+            }
+            self.reconcile_residency();
+            cx.notify();
+        }
+    }
+
+    pub fn set_workbench_primary(&mut self, primary: bool) {
+        self.workbench_primary = primary;
+    }
+
+    pub fn set_select_on_focus(&mut self) {
+        self.select_on_focus = true;
     }
 
     pub fn set_viewport(&mut self, viewport: TerminalViewport, cx: &mut Context<Self>) {
@@ -2603,7 +2650,8 @@ impl TerminalPane {
                 .host_display_name(host)
         });
         let kind = ui_agent_kind(session.effective_kind());
-        let shell_controls = matches!(self.session_source, SessionSource::FollowSelection);
+        let shell_controls =
+            matches!(self.session_source, SessionSource::FollowSelection) || self.workbench_primary;
         let show_sidebar = shell_controls && !self.sidebar_visible;
         let sidebar_reveal = show_sidebar.then(|| self.render_sidebar_reveal_control(colors, cx));
         let inspector_open = self.inspector_open;
@@ -2647,6 +2695,7 @@ impl TerminalPane {
             .h(px(Metrics::TITLE_BAR))
             .flex_none()
             .px(px(Metrics::TOOLBAR_EDGE_INSET))
+            .when(self.select_on_focus, |header| header.pr(px(86.0)))
             .flex()
             .items_center()
             .justify_between()
@@ -2871,12 +2920,13 @@ impl TerminalPane {
                 MouseButton::Left,
                 cx.listener(move |this, event: &gpui::MouseDownEvent, window, cx| {
                     window.focus(&this.focus, cx);
-                    if follows_selection {
+                    if follows_selection || this.select_on_focus {
                         this.runtime
                             .store
                             .write()
                             .expect("session store lock poisoned")
                             .select(id_for_focus.clone());
+                        this.runtime.publish_local_change();
                     }
                     this.handle_pointer_down(event, window, cx);
                 }),
@@ -5131,6 +5181,58 @@ mod tests {
             cx.debug_bounds("show-sidebar").is_some(),
             "collapsing the sidebar must leave a way to reveal it"
         );
+    }
+
+    #[gpui::test]
+    fn split_workbench_exclusively_owns_attachments_until_it_is_unmounted(cx: &mut TestAppContext) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        let tokio = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap(),
+        );
+        let first = fixture_session();
+        let mut second = first.clone();
+        second.id = SessionId::new("second-pane");
+        {
+            let mut store = runtime.store.write().unwrap();
+            store.upsert_session(first.clone());
+            store.upsert_session(second.clone());
+            store.select(first.id.clone());
+            let mut layouts = crate::split_layout::SplitLayouts::default();
+            layouts.split(
+                first.id.clone(),
+                second.id.clone(),
+                crate::split_layout::SplitAxis::Right,
+            );
+            store.remember_split_layouts(layouts);
+        }
+        let shared = runtime.clone();
+        let (pane, cx) =
+            cx.add_window_view(move |window, cx| TerminalPane::new(shared, tokio, window, cx));
+        pane.update_in(cx, |pane, window, cx| {
+            assert!(
+                pane.residents.is_empty(),
+                "the hidden following pane must not acquire a second controller on startup"
+            );
+            pane.set_suspended(true, cx);
+            runtime.store.write().unwrap().select(second.id.clone());
+            pane.reconcile_store_change(window, cx);
+            assert!(pane.residents.is_empty());
+            runtime
+                .store
+                .write()
+                .unwrap()
+                .remember_split_layouts(crate::split_layout::SplitLayouts::default());
+            pane.reconcile_store_change(window, cx);
+            assert!(
+                pane.residents.is_empty(),
+                "wait for the old fixed panes to drop before reacquiring their sessions"
+            );
+            pane.set_suspended(false, cx);
+            assert!(pane.residents.contains_key(&second.id));
+        });
     }
 
     #[gpui::test]


### PR DESCRIPTION
## Why

Diri only supported one agent plus a lower auxiliary terminal. This adds nested terminal workspaces so agents and shells can remain visible side by side, with notification clicks and the inspector following the focused pane.

Stacked on [notification lifecycle PR #181](https://github.com/cristicretu/diri/pull/181), with base `fix/notification-lifecycle` at `87e0268`.

## What changed

- Right/below splits, up to eight panes per workspace; create a shell in the focused session's host/directory or choose an existing session.
- Directional/cyclic focus, visible active-pane marker, draggable dividers, equal-size reset, and saved layout restoration.
- Pane close preserves the Engine session. Moving a session between workspaces transfers its pane without creating a second attachment owner. The auxiliary-terminal workflow, terminal selection quoting, file references, and account continuation remain available.
- Versioned preferences bound saved workspaces to 64 and prune missing sessions after hydration. No Holder/protocol changes or new dependencies.
- Notification navigation mounts the saved workspace before focusing the correct pane. Shortcuts and behavior are documented in `diri/SPLITS.md`.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`: 1,300 passed, 22 ignored before stacking; notification base is independently verified. `cargo test -p diri-app` after stacking: 534 passed, 11 ignored.
- `cargo build --workspace --release`
- Final rebase onto notification commit `e840791`: format check and all 10 targeted split tests pass. The final notification base independently passed `./scripts/check.sh` (1,310 passed, 22 ignored) and the release build; the replay-boundary change is confined to the Engine/parser. Subsequently rebased onto `87e0268`, a parent-only platform guard for notification controls; split code is unchanged.
- Deterministic GPUI tests verify nested geometry, focus/selection routing, stable pane entities, session preservation after pane close, pending-hydration restoration, and exclusive attachment ownership. Pure tests cover serialization, pruning, bounds, duplicate identities, and resizing.

Draft pending native visual/drag review and screenshot: the isolated test app launched, but native UI automation stalled for roughly 15 minutes while reading its window. The temporary app and Engine were stopped. No personal sessions or preferences were used.

- [ ] `./scripts/check.sh` passes, or I explained why a check is not applicable. The four Rust workspace gates above were run; release/dependency scripts are unchanged.
- [x] Existing session lifetime remains Engine/Holder-owned; layout restoration and attachment ownership have regression coverage.
- [x] Security/privacy impact considered: no SSH changes, new endpoints, services, credentials, or dependencies.
- [x] User-visible behavior is documented.
- [ ] UI screenshot or short recording (native automation limitation above).
