### PR TITLE
Fix agent notifications and add a persistent inbox

### DIFF
--- a/diri/REMOTE_PORT.md
+++ b/diri/REMOTE_PORT.md
@@ -799,6 +799,18 @@ The completed acceptance scenario is:
 5. Continue interacting with the same Agent process.
 ```
 
+## Terminal notification ingestion
+
+The local Engine optionally extracts bounded OSC 9, OSC 777 and textual OSC 99
+notifications from the existing live raw-output stream. It emits a local
+`session.notification` event; the app owns notification history, read state,
+macOS delivery and navigation. Notifications do not change execution status.
+The Holder does not enable notification extraction, store notification objects,
+run hooks, or interpret actions. No Helper protocol or capability changes are
+required. Replayed output must not redeliver notifications. Alerts produced
+while the Engine is disconnected are not recovered from replay; reliable
+offline notification delivery remains an independent enhancement.
+
 ## Deferred enhancements
 
 The following are independent product enhancements, not unfinished remote

--- a/diri/crates/diri-app/Cargo.toml
+++ b/diri/crates/diri-app/Cargo.toml
@@ -66,6 +66,7 @@ objc2 = "=0.6.4"
 objc2-app-kit = { version = "=0.3.2", default-features = false, features = [
     "NSAppearance",
     "NSApplication",
+    "NSDockTile",
     "NSAttributedString",
     "NSBezierPath",
     "NSBitmapImageRep",
@@ -128,6 +129,7 @@ objc2-user-notifications = { version = "=0.3.2", default-features = false, featu
     "UNNotificationRequest",
     "UNNotificationResponse",
     "UNNotificationSound",
+    "UNNotificationSettings",
     "UNNotificationTrigger",
     "UNUserNotificationCenter",
     "block2",

--- a/diri/crates/diri-app/src/commands.rs
+++ b/diri/crates/diri-app/src/commands.rs
@@ -33,6 +33,7 @@ actions!(
         ToggleCommandPalette,
         ToggleQuickOpen,
         ToggleHistory,
+        ToggleNotifications,
         ToggleOverview,
         OpenWorktrees,
         OpenSettings,
@@ -96,6 +97,7 @@ pub enum CommandId {
     ToggleCommandPalette,
     ToggleQuickOpen,
     ToggleHistory,
+    ToggleNotifications,
     ToggleOverview,
     OpenWorktrees,
     OpenSettings,
@@ -419,6 +421,16 @@ pub const COMMANDS: &[CommandSpec] = &[
         Some(APP_CONTEXT)
     ),
     spec!(
+        ToggleNotifications,
+        "toggle-notifications",
+        Some("cmd-shift-i"),
+        Some("⇧⌘I"),
+        Some(APP_CONTEXT),
+        "Notifications",
+        "bell",
+        "inbox unread alerts attention"
+    ),
+    spec!(
         CheckForUpdates,
         "check-for-updates",
         None,
@@ -698,6 +710,7 @@ impl CommandSpec {
             CommandId::ToggleCommandPalette => KeyBinding::new(key, ToggleCommandPalette, context),
             CommandId::ToggleQuickOpen => KeyBinding::new(key, ToggleQuickOpen, context),
             CommandId::ToggleHistory => KeyBinding::new(key, ToggleHistory, context),
+            CommandId::ToggleNotifications => KeyBinding::new(key, ToggleNotifications, context),
             CommandId::ToggleOverview => KeyBinding::new(key, ToggleOverview, context),
             CommandId::OpenWorktrees => KeyBinding::new(key, OpenWorktrees, context),
             CommandId::OpenSettings => KeyBinding::new(key, OpenSettings, context),
@@ -935,6 +948,11 @@ impl CommandId {
                 description: "Hand off work from the selected session",
                 category: Sessions,
             },
+            Self::ToggleNotifications => ShortcutMetadata {
+                title: "Notifications",
+                description: "Open the unread notification inbox",
+                category: Navigation,
+            },
             Self::SelectNextAttentionSession => ShortcutMetadata {
                 title: "Next session needing attention",
                 description: "Jump to the next session waiting for you",
@@ -1134,6 +1152,7 @@ impl CommandId {
             Self::ToggleCommandPalette => Box::new(ToggleCommandPalette),
             Self::ToggleQuickOpen => Box::new(ToggleQuickOpen),
             Self::ToggleHistory => Box::new(ToggleHistory),
+            Self::ToggleNotifications => Box::new(ToggleNotifications),
             Self::ToggleOverview => Box::new(ToggleOverview),
             Self::OpenWorktrees => Box::new(OpenWorktrees),
             Self::OpenSettings => Box::new(OpenSettings),

--- a/diri/crates/diri-app/src/macos/menu_bar.rs
+++ b/diri/crates/diri-app/src/macos/menu_bar.rs
@@ -513,9 +513,23 @@ impl NativeMenuBar {
         let (model, selected, attention, theme_id) = {
             let mut store = self.store.write().expect("session store lock poisoned");
             let projection = store.menu_bar_projection();
-            let model = build_inbox(&projection, &collapsed);
+            let mut model = build_inbox(&projection, &collapsed);
+            for row in &mut model.rows {
+                if let InboxRow::Session(session) = row
+                    && store
+                        .notifications()
+                        .session_unread(&SessionId::new(session.session_id.clone()))
+                    && session.trailing != Some(TrailingStatus::NeedsYou)
+                {
+                    session.trailing = Some(TrailingStatus::Unread);
+                }
+            }
             let selected = store.selected_session_id().cloned();
-            let attention = store.global_attention();
+            let mut attention = store.global_attention();
+            if store.notifications().unread_count() != 0 && attention != AttentionLevel::NeedsInput
+            {
+                attention = AttentionLevel::DoneUnseen;
+            }
             let theme_id = store.preferences().terminal_theme.clone();
             (model, selected, attention, theme_id)
         };
@@ -1050,6 +1064,11 @@ fn trailing_label(session: &InboxSessionRow, theme: &MenuTheme) -> Option<Traili
             width: 36.0,
             color: rgba_ns(Ink::FRESH.r, Ink::FRESH.g, Ink::FRESH.b, 1.0),
         }),
+        TrailingStatus::Unread => Some(TrailingLabel {
+            text: "unread",
+            width: 48.0,
+            color: rgba_ns(Ink::FRESH.r, Ink::FRESH.g, Ink::FRESH.b, 1.0),
+        }),
         TrailingStatus::Zzz => Some(TrailingLabel {
             text: "Zzz",
             width: 28.0,
@@ -1128,7 +1147,9 @@ fn glyph_tint(session: &InboxSessionRow, theme: &MenuTheme) -> Retained<NSColor>
         Some(TrailingStatus::NeedsYou) => {
             rgba_ns(Ink::ATTENTION.r, Ink::ATTENTION.g, Ink::ATTENTION.b, 1.0)
         }
-        Some(TrailingStatus::Done) => rgba_ns(Ink::FRESH.r, Ink::FRESH.g, Ink::FRESH.b, 1.0),
+        Some(TrailingStatus::Done | TrailingStatus::Unread) => {
+            rgba_ns(Ink::FRESH.r, Ink::FRESH.g, Ink::FRESH.b, 1.0)
+        }
         Some(TrailingStatus::Zzz) => theme.primary_alpha(0.36),
         None if session.working => match session.agent_id.as_str() {
             AgentKind::CLAUDE_CODE_ID => {

--- a/diri/crates/diri-app/src/macos/notifier.rs
+++ b/diri/crates/diri-app/src/macos/notifier.rs
@@ -1,228 +1,284 @@
-//! `UNUserNotificationCenter` bridge for actionable agent notifications.
-//!
-//! The center is deliberately inert for a raw
-//! `cargo run`; UserNotifications aborts when no application bundle exists.
-
-use std::cell::Cell;
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+//! macOS delivery and navigation. A notification is a route to a session,
+//! never a delayed permission keystroke into an arbitrary terminal prompt.
+use std::cell::{Cell, RefCell};
+use std::collections::BTreeMap;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 
 use block2::RcBlock;
 use objc2::rc::Retained;
-use objc2::runtime::{AnyObject, Bool, ProtocolObject};
+use objc2::runtime::{Bool, ProtocolObject};
 use objc2::{AnyThread, DefinedClass, define_class, msg_send};
-use objc2_foundation::{
-    NSArray, NSBundle, NSDictionary, NSError, NSObject, NSObjectProtocol, NSSet, NSString,
-};
+use objc2_foundation::{NSArray, NSBundle, NSError, NSObject, NSObjectProtocol, NSSet, NSString};
 use objc2_user_notifications::{
     UNAuthorizationOptions, UNMutableNotificationContent, UNNotification, UNNotificationAction,
     UNNotificationActionOptions, UNNotificationCategory, UNNotificationCategoryOptions,
-    UNNotificationPresentationOptions, UNNotificationRequest, UNNotificationResponse,
-    UNNotificationSound, UNUserNotificationCenter, UNUserNotificationCenterDelegate,
+    UNNotificationDismissActionIdentifier, UNNotificationPresentationOptions,
+    UNNotificationRequest, UNNotificationResponse, UNNotificationSound, UNUserNotificationCenter,
+    UNUserNotificationCenterDelegate,
 };
 use tokio::sync::mpsc;
 
-use crate::notifications::{
-    APPROVE_ACTION_ID, ActionData, DENY_ACTION_ID, NotificationRequest as DiriNotification,
-    PERMISSION_CATEGORY_ID, SendTextCommand, command_for_action,
-};
+use crate::notifications::{NotificationRequest as DiriNotification, OPEN_ACTION_ID};
 
-const ACTION_DATA_KEY: &str = "diriActionData";
+#[derive(Clone, Debug)]
+pub enum NativeNotificationEvent {
+    Open {
+        session_id: String,
+        notification_id: String,
+    },
+    Read(String),
+    Health(String),
+}
 
 pub struct NativeNotifier {
     inner: Option<NativeNotifierInner>,
+    badge_count: Cell<Option<usize>>,
 }
-
 struct NativeNotifierInner {
     center: Retained<UNUserNotificationCenter>,
-    // `delegate` is weak on UNUserNotificationCenter.
     _delegate: Retained<NotificationDelegate>,
-    actions: Arc<Mutex<HashMap<String, ActionData>>>,
+    sender: mpsc::UnboundedSender<NativeNotificationEvent>,
     authorization_requested: Cell<bool>,
+    pending: RefCell<BTreeMap<String, Arc<AtomicBool>>>,
 }
 
 impl NativeNotifier {
-    #[must_use]
-    pub fn new(action_sender: mpsc::UnboundedSender<SendTextCommand>) -> Self {
-        let inner = NativeNotifierInner::new(action_sender);
-        Self { inner }
+    pub fn new(sender: mpsc::UnboundedSender<NativeNotificationEvent>) -> Self {
+        let inner = NSBundle::mainBundle().bundleIdentifier().map(|_| {
+            let center = UNUserNotificationCenter::currentNotificationCenter();
+            let delegate = NotificationDelegate::new(sender.clone());
+            center.setDelegate(Some(ProtocolObject::from_ref(&*delegate)));
+            let open = UNNotificationAction::actionWithIdentifier_title_options(
+                &NSString::from_str(OPEN_ACTION_ID),
+                &NSString::from_str("Open session"),
+                UNNotificationActionOptions::Foreground,
+            );
+            let category =
+                UNNotificationCategory::categoryWithIdentifier_actions_intentIdentifiers_options(
+                    &NSString::from_str("diri-session"),
+                    &NSArray::from_retained_slice(&[open]),
+                    &NSArray::new(),
+                    UNNotificationCategoryOptions::CustomDismissAction,
+                );
+            center.setNotificationCategories(&NSSet::from_retained_slice(&[category]));
+            NativeNotifierInner {
+                center,
+                _delegate: delegate,
+                sender: sender.clone(),
+                authorization_requested: Cell::new(false),
+                pending: RefCell::new(BTreeMap::new()),
+            }
+        });
+        if inner.is_none() {
+            let _ = sender.send(NativeNotificationEvent::Health(
+                "Mac alerts require the packaged Diri app. Your inbox still works.".into(),
+            ));
+        }
+        Self {
+            inner,
+            badge_count: Cell::new(None),
+        }
+    }
+
+    pub fn set_badge(&self, count: usize) {
+        if self.badge_count.replace(Some(count)) == Some(count) {
+            return;
+        }
+        if let Some(main) = objc2::MainThreadMarker::new() {
+            let label = (count != 0).then(|| NSString::from_str(&count.to_string()));
+            objc2_app_kit::NSApplication::sharedApplication(main)
+                .dockTile()
+                .setBadgeLabel(label.as_deref());
+        }
+    }
+
+    pub fn refresh_health(&self) {
+        let Some(inner) = &self.inner else {
+            return;
+        };
+        let sender = inner.sender.clone();
+        let completion = RcBlock::new(
+            move |settings: std::ptr::NonNull<objc2_user_notifications::UNNotificationSettings>| {
+                // SAFETY: the notification center supplies a valid settings object for the callback.
+                let settings = unsafe { settings.as_ref() };
+                use objc2_user_notifications::UNAuthorizationStatus as Status;
+                let message = match settings.authorizationStatus() {
+                    Status::Denied => {
+                        "Mac alerts are disabled. Enable Diri in System Settings → Notifications."
+                    }
+                    Status::NotDetermined => {
+                        "Use Test alert to enable Mac alerts. Your inbox already works."
+                    }
+                    _ => {
+                        "Mac alerts are enabled. Focus mode and System Settings can silence delivery."
+                    }
+                };
+                let _ = sender.send(NativeNotificationEvent::Health(message.into()));
+            },
+        );
+        inner
+            .center
+            .getNotificationSettingsWithCompletionHandler(&completion);
+    }
+
+    pub fn dismiss(&self, identifiers: &[String]) {
+        if let Some(inner) = &self.inner {
+            for id in identifiers {
+                if let Some(active) = inner.pending.borrow_mut().remove(id) {
+                    active.store(false, Ordering::SeqCst);
+                }
+            }
+            let ids = NSArray::from_retained_slice(
+                &identifiers
+                    .iter()
+                    .map(|id| NSString::from_str(id))
+                    .collect::<Vec<_>>(),
+            );
+            inner
+                .center
+                .removePendingNotificationRequestsWithIdentifiers(&ids);
+            inner
+                .center
+                .removeDeliveredNotificationsWithIdentifiers(&ids);
+        }
     }
 
     pub fn post(&self, notification: &DiriNotification) {
-        if let Some(inner) = &self.inner {
-            inner.post(notification);
+        let Some(inner) = &self.inner else { return };
+        let active = Arc::new(AtomicBool::new(true));
+        {
+            let mut pending = inner.pending.borrow_mut();
+            if pending.len() >= 200
+                && let Some((_, oldest)) = pending.pop_first()
+            {
+                oldest.store(false, Ordering::SeqCst);
+            }
+            if let Some(previous) = pending.insert(notification.identifier.clone(), active.clone())
+            {
+                previous.store(false, Ordering::SeqCst);
+            }
         }
-    }
-}
-
-impl NativeNotifierInner {
-    fn new(action_sender: mpsc::UnboundedSender<SendTextCommand>) -> Option<Self> {
-        // UserNotifications throws an Objective-C exception outside an app bundle.
-        NSBundle::mainBundle().bundleIdentifier()?;
-
-        let center = UNUserNotificationCenter::currentNotificationCenter();
-        let actions = Arc::new(Mutex::new(HashMap::new()));
-        let delegate = NotificationDelegate::new(action_sender, Arc::clone(&actions));
-        center.setDelegate(Some(ProtocolObject::from_ref(&*delegate)));
-        register_permission_category(&center);
-
-        Some(Self {
-            center,
-            _delegate: delegate,
-            actions,
-            authorization_requested: Cell::new(false),
-        })
-    }
-
-    fn request_authorization(&self) {
-        if self.authorization_requested.replace(true) {
-            return;
-        }
-        let completion = RcBlock::new(|_granted: Bool, _error: *mut NSError| {});
-        self.center
-            .requestAuthorizationWithOptions_completionHandler(
-                UNAuthorizationOptions::Alert | UNAuthorizationOptions::Sound,
-                &completion,
-            );
-    }
-
-    fn post(&self, notification: &DiriNotification) {
-        self.request_authorization();
-        if let Some(action_data) = &notification.action_data {
-            self.actions
-                .lock()
-                .expect("notification action map poisoned")
-                .insert(notification.identifier.clone(), action_data.clone());
-        }
-
         let content = UNMutableNotificationContent::new();
         content.setTitle(&NSString::from_str(&notification.title));
         content.setBody(&NSString::from_str(&notification.body));
-        if let Some(thread) = &notification.thread_identifier {
-            content.setThreadIdentifier(&NSString::from_str(thread));
-        }
-        if notification.action_data.is_some() {
-            content.setCategoryIdentifier(&NSString::from_str(PERMISSION_CATEGORY_ID));
-        }
-        if let Some(action_data) = &notification.action_data
-            && let Ok(json) = serde_json::to_string(action_data)
-        {
-            let key = NSString::from_str(ACTION_DATA_KEY);
-            let value = NSString::from_str(&json);
-            let typed = NSDictionary::from_slices(&[&*key], &[&*value]);
-            // SAFETY: Objective-C lightweight generics are erased. Both key and
-            // value are property-list-compatible NSString instances.
-            let erased: &NSDictionary =
-                unsafe { &*(Retained::as_ptr(&typed).cast::<NSDictionary>()) };
-            // SAFETY: the dictionary contains valid NSString keys and values.
-            unsafe { content.setUserInfo(erased) };
+        if let Some(session) = &notification.thread_identifier {
+            content.setThreadIdentifier(&NSString::from_str(session));
+            content.setCategoryIdentifier(&NSString::from_str("diri-session"));
         }
         if notification.use_system_sound {
             content.setSound(Some(&UNNotificationSound::defaultSound()));
         }
-
         let request = UNNotificationRequest::requestWithIdentifier_content_trigger(
             &NSString::from_str(&notification.identifier),
             &content,
             None,
         );
-        self.center
-            .addNotificationRequest_withCompletionHandler(&request, None);
+        if !inner.authorization_requested.replace(true) {
+            let sender = inner.sender.clone();
+            let completion = RcBlock::new(move |granted: Bool, _error: *mut NSError| {
+                let _ = sender.send(NativeNotificationEvent::Health(if granted.as_bool() {
+                    "Mac alerts are enabled. Focus mode and System Settings can silence delivery.".into()
+                } else {
+                    "Mac alerts are disabled. Enable Diri in System Settings → Notifications. Your inbox still works.".into()
+                }));
+                if granted.as_bool() {
+                    deliver(&request, sender.clone(), active.clone());
+                }
+            });
+            inner
+                .center
+                .requestAuthorizationWithOptions_completionHandler(
+                    UNAuthorizationOptions::Alert | UNAuthorizationOptions::Sound,
+                    &completion,
+                );
+        } else {
+            deliver(&request, inner.sender.clone(), active);
+        }
     }
 }
 
-fn register_permission_category(center: &UNUserNotificationCenter) {
-    let approve = UNNotificationAction::actionWithIdentifier_title_options(
-        &NSString::from_str(APPROVE_ACTION_ID),
-        &NSString::from_str("Approve"),
-        UNNotificationActionOptions::empty(),
-    );
-    let deny = UNNotificationAction::actionWithIdentifier_title_options(
-        &NSString::from_str(DENY_ACTION_ID),
-        &NSString::from_str("Deny"),
-        UNNotificationActionOptions::Destructive,
-    );
-    let category = UNNotificationCategory::categoryWithIdentifier_actions_intentIdentifiers_options(
-        &NSString::from_str(PERMISSION_CATEGORY_ID),
-        &NSArray::from_retained_slice(&[approve, deny]),
-        &NSArray::new(),
-        UNNotificationCategoryOptions::empty(),
-    );
-    center.setNotificationCategories(&NSSet::from_retained_slice(&[category]));
+fn deliver(
+    request: &UNNotificationRequest,
+    sender: mpsc::UnboundedSender<NativeNotificationEvent>,
+    active: Arc<AtomicBool>,
+) {
+    if !active.load(Ordering::SeqCst) {
+        return;
+    }
+    let id = request.identifier().to_string();
+    let completion = RcBlock::new(move |error: *mut NSError| {
+        if !active.load(Ordering::SeqCst) {
+            let ids = NSArray::from_retained_slice(&[NSString::from_str(&id)]);
+            let center = UNUserNotificationCenter::currentNotificationCenter();
+            center.removePendingNotificationRequestsWithIdentifiers(&ids);
+            center.removeDeliveredNotificationsWithIdentifiers(&ids);
+        }
+        if !error.is_null() {
+            let _ = sender.send(NativeNotificationEvent::Health(
+                "macOS couldn't deliver an alert. Your notifications are available in the inbox."
+                    .into(),
+            ));
+        }
+    });
+    UNUserNotificationCenter::currentNotificationCenter()
+        .addNotificationRequest_withCompletionHandler(request, Some(&completion));
 }
 
 struct DelegateIvars {
-    action_sender: mpsc::UnboundedSender<SendTextCommand>,
-    actions: Arc<Mutex<HashMap<String, ActionData>>>,
+    sender: mpsc::UnboundedSender<NativeNotificationEvent>,
 }
-
 define_class!(
-    // SAFETY: NSObject has no subclassing requirements and this class does not
-    // implement Drop. UserNotifications may invoke its delegate off-main.
+    // SAFETY: NSObject has no subclassing requirements. Delegate callbacks may
+    // arrive off-main; they only enqueue owned values for the GPUI task.
     #[unsafe(super(NSObject))]
     #[ivars = DelegateIvars]
     struct NotificationDelegate;
-
     unsafe impl NSObjectProtocol for NotificationDelegate {}
-
     unsafe impl UNUserNotificationCenterDelegate for NotificationDelegate {
         #[unsafe(method(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:))]
-        fn did_receive_notification_response(
+        fn did_receive(
             &self,
             _center: &UNUserNotificationCenter,
             response: &UNNotificationResponse,
-            completion_handler: &block2::DynBlock<dyn Fn()>,
+            completion: &block2::DynBlock<dyn Fn()>,
         ) {
-            let identifier = response.notification().request().identifier().to_string();
-            let action_id = response.actionIdentifier().to_string();
-            let data = self
-                .ivars()
-                .actions
-                .lock()
-                .expect("notification action map poisoned")
-                .remove(&identifier)
-                .or_else(|| action_data_from_response(response));
-            if let Some(command) = data
-                .as_ref()
-                .and_then(|data| command_for_action(&action_id, data))
+            let request = response.notification().request();
+            let id = request.identifier().to_string();
+            let event = if &*response.actionIdentifier()
+                == unsafe { UNNotificationDismissActionIdentifier }
             {
-                let _ = self.ivars().action_sender.send(command);
-            }
-            completion_handler.call(());
+                NativeNotificationEvent::Read(id)
+            } else {
+                // Also covers old Approve/Deny banners delivered by a previous
+                // app version. They open the session and never send input.
+                NativeNotificationEvent::Open {
+                    session_id: request.content().threadIdentifier().to_string(),
+                    notification_id: id,
+                }
+            };
+            let _ = self.ivars().sender.send(event);
+            completion.call(());
         }
-
         #[unsafe(method(userNotificationCenter:willPresentNotification:withCompletionHandler:))]
-        fn will_present_notification(
+        fn will_present(
             &self,
             _center: &UNUserNotificationCenter,
             _notification: &UNNotification,
-            completion_handler: &block2::DynBlock<dyn Fn(UNNotificationPresentationOptions)>,
+            completion: &block2::DynBlock<dyn Fn(UNNotificationPresentationOptions)>,
         ) {
-            completion_handler.call((UNNotificationPresentationOptions::Banner
+            completion.call((UNNotificationPresentationOptions::Banner
                 | UNNotificationPresentationOptions::List
                 | UNNotificationPresentationOptions::Sound,));
         }
     }
 );
-
-fn action_data_from_response(response: &UNNotificationResponse) -> Option<ActionData> {
-    let user_info = response.notification().request().content().userInfo();
-    let key = NSString::from_str(ACTION_DATA_KEY);
-    let value = user_info.objectForKey(&*key as &AnyObject)?;
-    let json = value.downcast::<NSString>().ok()?.to_string();
-    serde_json::from_str(&json).ok()
-}
-
 impl NotificationDelegate {
-    fn new(
-        action_sender: mpsc::UnboundedSender<SendTextCommand>,
-        actions: Arc<Mutex<HashMap<String, ActionData>>>,
-    ) -> Retained<Self> {
-        let this = Self::alloc().set_ivars(DelegateIvars {
-            action_sender,
-            actions,
-        });
-        // SAFETY: NSObject's init is its designated initializer.
+    fn new(sender: mpsc::UnboundedSender<NativeNotificationEvent>) -> Retained<Self> {
+        let this = Self::alloc().set_ivars(DelegateIvars { sender });
+        // SAFETY: NSObject init is its designated initializer.
         unsafe { msg_send![super(this), init] }
     }
 }

--- a/diri/crates/diri-app/src/main.rs
+++ b/diri/crates/diri-app/src/main.rs
@@ -26,6 +26,7 @@ mod markdown_view;
 #[cfg(any(target_os = "macos", test))]
 mod menu_inbox;
 pub mod navigation;
+mod notification_feed;
 pub mod notifications;
 pub mod palette;
 mod phone_access;

--- a/diri/crates/diri-app/src/menu_inbox.rs
+++ b/diri/crates/diri-app/src/menu_inbox.rs
@@ -11,6 +11,7 @@ use crate::switcher::display_title;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum TrailingStatus {
     NeedsYou,
+    Unread,
     Done,
     Zzz,
 }

--- a/diri/crates/diri-app/src/notification_feed.rs
+++ b/diri/crates/diri-app/src/notification_feed.rs
@@ -1,0 +1,344 @@
+//! Bounded, private per-installation notification history. Execution status is
+//! owned by the Engine; reading an event never changes an agent's work state.
+use std::io::{self, Write};
+use std::path::Path;
+
+use diri_proto::{SessionId, SessionRecord, SessionStatus};
+use serde::{Deserialize, Serialize};
+
+use crate::notifications::{NotificationRequest, blocker_key};
+
+const LIMIT: usize = 200;
+const MAX_BYTES: u64 = 1024 * 1024;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NotificationKind {
+    NeedsInput,
+    Done,
+    Failed,
+    Custom,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NotificationEntry {
+    pub id: String,
+    pub session_id: SessionId,
+    pub incarnation: u64,
+    pub kind: NotificationKind,
+    pub title: String,
+    pub body: String,
+    pub created_at_ms: u64,
+    pub read: bool,
+    pub resolved: bool,
+    pub blocker: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NotificationFeed {
+    version: u32,
+    entries: Vec<NotificationEntry>,
+    #[serde(default)]
+    dismissed: Vec<String>,
+}
+
+impl Default for NotificationFeed {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            entries: Vec::new(),
+            dismissed: Vec::new(),
+        }
+    }
+}
+
+impl NotificationFeed {
+    pub fn load(path: &Path) -> io::Result<Self> {
+        let file = match std::fs::File::open(path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Self::default()),
+            Err(error) => return Err(error),
+        };
+        if file.metadata()?.len() > MAX_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "notification history is too large",
+            ));
+        }
+        let mut feed: Self = serde_json::from_reader(file)?;
+        if feed.version != 1 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unsupported notification history",
+            ));
+        }
+        feed.entries.truncate(LIMIT);
+        feed.dismissed.truncate(LIMIT);
+        Ok(feed)
+    }
+
+    pub fn save(&self, path: &Path) -> io::Result<()> {
+        let Some(parent) = path.parent() else {
+            return Ok(());
+        };
+        std::fs::create_dir_all(parent)?;
+        let mut temp = tempfile::NamedTempFile::new_in(parent)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            temp.as_file()
+                .set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        }
+        serde_json::to_writer(&mut temp, self)?;
+        temp.flush()?;
+        temp.as_file().sync_all()?;
+        temp.persist(path).map_err(|error| error.error)?;
+        Ok(())
+    }
+
+    pub fn entries(&self) -> &[NotificationEntry] {
+        &self.entries
+    }
+    pub fn unread_count(&self) -> usize {
+        self.entries.iter().filter(|entry| !entry.read).count()
+    }
+    pub fn session_unread(&self, id: &SessionId) -> bool {
+        self.entries
+            .iter()
+            .any(|entry| &entry.session_id == id && !entry.read)
+    }
+
+    pub fn record(
+        &mut self,
+        session: &SessionRecord,
+        request: &NotificationRequest,
+        read: bool,
+    ) -> bool {
+        if self.dismissed.contains(&request.identifier)
+            || self
+                .entries
+                .iter()
+                .any(|entry| entry.id == request.identifier)
+        {
+            return false;
+        }
+        let kind = match session.status {
+            SessionStatus::NeedsInput(_) => NotificationKind::NeedsInput,
+            SessionStatus::Exited(_) => NotificationKind::Failed,
+            _ => NotificationKind::Done,
+        };
+        if kind == NotificationKind::NeedsInput
+            && self.entries.iter().any(|entry| {
+                entry.session_id == session.id
+                    && entry.incarnation == session.created_at.0.to_bits()
+                    && entry.kind == kind
+                    && !entry.resolved
+                    && entry.blocker == blocker_key(session)
+            })
+        {
+            return false;
+        }
+        let created_at_ms = match kind {
+            NotificationKind::NeedsInput => session
+                .needs_input
+                .as_ref()
+                .map(|detail| detail.occurred_at.0),
+            NotificationKind::Done => session.last_turn_completed_at.map(|date| date.0),
+            _ => None,
+        }
+        .unwrap_or(session.updated_at.0)
+        .max(0.0) as u64;
+        self.entries.insert(
+            0,
+            NotificationEntry {
+                id: request.identifier.clone(),
+                session_id: session.id.clone(),
+                incarnation: session.created_at.0.to_bits(),
+                kind,
+                title: bounded(&request.title, 160),
+                body: bounded(&request.body, 1000),
+                created_at_ms,
+                read,
+                resolved: false,
+                blocker: blocker_key(session),
+            },
+        );
+        self.entries.truncate(LIMIT);
+        true
+    }
+
+    pub fn record_custom(
+        &mut self,
+        session: &SessionRecord,
+        event: &diri_proto::SessionNotificationEvent,
+        read: bool,
+    ) -> bool {
+        if self.dismissed.contains(&event.id)
+            || self.entries.iter().any(|entry| entry.id == event.id)
+        {
+            return false;
+        }
+        // Repeated terminal redraws must not flood the tray or play a chorus.
+        if self.entries.iter().any(|entry| {
+            entry.kind == NotificationKind::Custom
+                && entry.session_id == session.id
+                && entry.incarnation == session.created_at.0.to_bits()
+                && entry.title == bounded(&event.title, 160)
+                && entry.body == bounded(&event.body, 1000)
+                && (event.occurred_at.0.max(0.0) as u64).saturating_sub(entry.created_at_ms) < 5000
+        }) {
+            return false;
+        }
+        self.entries.insert(
+            0,
+            NotificationEntry {
+                id: event.id.clone(),
+                session_id: session.id.clone(),
+                incarnation: session.created_at.0.to_bits(),
+                kind: NotificationKind::Custom,
+                title: bounded(&event.title, 160),
+                body: bounded(&event.body, 1000),
+                created_at_ms: event.occurred_at.0.max(0.0) as u64,
+                read,
+                resolved: false,
+                blocker: String::new(),
+            },
+        );
+        self.entries.truncate(LIMIT);
+        true
+    }
+
+    /// Resolving a blocker clears its badge; completion history remains unread
+    /// while the agent starts more work. Read and execution state are distinct.
+    pub fn reconcile(&mut self, sessions: &[&SessionRecord]) -> Vec<String> {
+        let mut removed = Vec::new();
+        for entry in &mut self.entries {
+            let session = sessions.iter().find(|session| {
+                session.id == entry.session_id
+                    && session.created_at.0.to_bits() == entry.incarnation
+                    && !session.is_archived()
+            });
+            let resolved = session.is_none()
+                || (entry.kind == NotificationKind::NeedsInput
+                    && session.is_some_and(|session| {
+                        !matches!(session.status, SessionStatus::NeedsInput(_))
+                            || blocker_key(session) != entry.blocker
+                    }));
+            if resolved && !entry.resolved {
+                entry.resolved = true;
+                entry.read = true;
+                removed.push(entry.id.clone());
+            }
+        }
+        removed
+    }
+
+    pub fn mark_session_read(&mut self, id: &SessionId) -> Vec<String> {
+        self.mark_where(|entry| &entry.session_id == id)
+    }
+    pub fn mark_all_read(&mut self) -> Vec<String> {
+        self.mark_where(|_| true)
+    }
+    fn mark_where(&mut self, predicate: impl Fn(&NotificationEntry) -> bool) -> Vec<String> {
+        let mut ids = Vec::new();
+        for entry in &mut self.entries {
+            if !entry.read && predicate(entry) {
+                entry.read = true;
+                ids.push(entry.id.clone());
+            }
+        }
+        ids
+    }
+    pub fn set_read(&mut self, id: &str, read: bool) -> bool {
+        if let Some(entry) = self.entries.iter_mut().find(|entry| entry.id == id)
+            && entry.read != read
+        {
+            entry.read = read;
+            return true;
+        }
+        false
+    }
+    pub fn clear(&mut self) -> Vec<String> {
+        let ids: Vec<_> = self.entries.drain(..).map(|entry| entry.id).collect();
+        self.dismissed.splice(0..0, ids.clone());
+        self.dismissed.truncate(LIMIT);
+        ids
+    }
+}
+
+fn bounded(text: &str, max: usize) -> String {
+    text.chars()
+        .filter(|ch| !ch.is_control() || *ch == '\n')
+        .take(max)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::notifications::attention_request;
+    use crate::sidebar::{PreviewScenario, SidebarPreviewFixture};
+    use diri_proto::{DateMillis, NeedsInputDetail, NeedsInputKind, NeedsInputSource, RiskHint};
+
+    fn blocked() -> SessionRecord {
+        let mut session = SidebarPreviewFixture::make(PreviewScenario::Typical)
+            .list
+            .sessions
+            .remove(0);
+        session.status = SessionStatus::NeedsInput(NeedsInputKind::Permission);
+        session.needs_input = Some(NeedsInputDetail {
+            kind: NeedsInputKind::Permission,
+            source: NeedsInputSource::ScreenScrape,
+            tool_name: None,
+            summary: "Run tests?".into(),
+            prompt_excerpt: None,
+            options: None,
+            risk_hint: RiskHint::Neutral,
+            occurred_at: DateMillis(1000.0),
+        });
+        session
+    }
+
+    #[test]
+    fn resolution_clears_only_the_old_prompt_and_keeps_history() {
+        let mut session = blocked();
+        let mut feed = NotificationFeed::default();
+        let first = attention_request(&session, false, None);
+        assert!(feed.record(&session, &first, false));
+        assert!(!feed.record(&session, &first, false));
+        session.needs_input.as_mut().unwrap().summary = "Deploy?".into();
+        assert_eq!(feed.reconcile(&[&session]), vec![first.identifier]);
+        feed.record(&session, &attention_request(&session, false, None), false);
+        assert_eq!(feed.unread_count(), 1);
+        assert_eq!(feed.entries().len(), 2);
+        assert!(feed.entries()[1].resolved);
+    }
+
+    #[test]
+    fn reading_completion_never_mutates_execution_and_survives_restart() {
+        let mut session = blocked();
+        session.status = SessionStatus::Idle;
+        session.last_turn_completed_at = Some(DateMillis(2000.0));
+        session.last_seen_at = None;
+        let mut feed = NotificationFeed::default();
+        feed.record(&session, &attention_request(&session, false, None), false);
+        session.status = SessionStatus::Working;
+        assert!(feed.reconcile(&[&session]).is_empty());
+        assert_eq!(feed.unread_count(), 1);
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("notifications.json");
+        feed.save(&path).unwrap();
+        let mut restored = NotificationFeed::load(&path).unwrap();
+        assert_eq!(restored.unread_count(), 1);
+        restored.mark_session_read(&session.id);
+        assert_eq!(restored.unread_count(), 0);
+        assert_eq!(session.status, SessionStatus::Working);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+    }
+}

--- a/diri/crates/diri-app/src/notification_panel.rs
+++ b/diri/crates/diri-app/src/notification_panel.rs
@@ -341,6 +341,8 @@ impl RootView {
                             body: "You'll find agent updates in Notifications, even when Mac alerts are silenced.".into(),
                             thread_identifier: None, action_data: None, use_system_sound: false,
                         });
+                        #[cfg(not(target_os = "macos"))]
+                        { this.notification_health = "System alerts are available on macOS. Your inbox works here.".into(); }
                         cx.notify();
                     }))))
                 .child(div().text_size(px(11.0)).text_color(colors.tertiary).child(self.notification_health.clone())));

--- a/diri/crates/diri-app/src/notification_panel.rs
+++ b/diri/crates/diri-app/src/notification_panel.rs
@@ -1,0 +1,385 @@
+//! Notification tray. Uses the app's existing type, color and motion tokens.
+use super::*;
+use crate::notification_feed::{NotificationEntry, NotificationKind};
+
+impl RootView {
+    pub(super) fn toggle_notifications(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.notification_panel_open = !self.notification_panel_open;
+        self.notification_selected = 0;
+        #[cfg(target_os = "macos")]
+        if self.notification_panel_open {
+            self.notifier.refresh_health();
+        }
+        if self.notification_panel_open {
+            self.notification_focus.focus(window, cx);
+        } else if let Some(terminal) = &self.terminal {
+            terminal.update(cx, |terminal, cx| terminal.focus(window, cx));
+        }
+        cx.notify();
+    }
+
+    pub(super) fn notification_rows(&self) -> Vec<NotificationEntry> {
+        self.services
+            .store
+            .store
+            .read()
+            .expect("store")
+            .notifications()
+            .entries()
+            .iter()
+            .filter(|entry| !self.notification_filter_unread || !entry.read)
+            .cloned()
+            .collect()
+    }
+
+    pub(super) fn open_notification(
+        &mut self,
+        session: SessionId,
+        event: Option<String>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if session.0.is_empty() {
+            if !self.notification_panel_open {
+                self.toggle_notifications(window, cx);
+            }
+            cx.activate(true);
+            window.activate_window();
+            return;
+        }
+        if !self
+            .services
+            .store
+            .store
+            .read()
+            .expect("store")
+            .has_hydrated_sessions()
+        {
+            self.pending_notification_open = Some((session, event));
+            cx.activate(true);
+            window.activate_window();
+            return;
+        }
+        let available = {
+            let mut store = self.services.store.store.write().expect("store");
+            let available = store.sessions().get(&session).is_some_and(|record| {
+                !record.is_archived()
+                    && event
+                        .as_ref()
+                        .and_then(|id| {
+                            store
+                                .notifications()
+                                .entries()
+                                .iter()
+                                .find(|entry| &entry.id == id)
+                        })
+                        .is_none_or(|entry| entry.incarnation == record.created_at.0.to_bits())
+            });
+            if available {
+                store.select(session.clone());
+                store.mark_notifications_read(&session);
+                if let Some(id) = event {
+                    store.set_notification_read(&id, true);
+                }
+            }
+            available
+        };
+        if !available {
+            self.show_quote_feedback(
+                "Session unavailable",
+                "This session was closed or archived. Its notification remains in your history.",
+                cx,
+            );
+            return;
+        }
+        self.notification_panel_open = false;
+        self.launcher
+            .update(cx, |launcher, cx| launcher.dismiss(cx));
+        if let Some(surfaces) = &self.utility_surfaces {
+            surfaces.update(cx, |surfaces, cx| surfaces.dismiss(cx));
+        }
+        cx.activate(true);
+        window.activate_window();
+        if let Some(terminal) = &self.terminal {
+            terminal.update(cx, |terminal, cx| terminal.focus(window, cx));
+        }
+        cx.notify();
+    }
+
+    pub(super) fn notification_key(
+        &mut self,
+        event: &KeyDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let rows = self.notification_rows();
+        match event.keystroke.key.as_str() {
+            "escape" => self.toggle_notifications(window, cx),
+            "down" => {
+                self.notification_selected =
+                    (self.notification_selected + 1).min(rows.len().saturating_sub(1))
+            }
+            "up" => self.notification_selected = self.notification_selected.saturating_sub(1),
+            "enter" => {
+                if let Some(entry) = rows.get(self.notification_selected) {
+                    self.open_notification(
+                        entry.session_id.clone(),
+                        Some(entry.id.clone()),
+                        window,
+                        cx,
+                    );
+                }
+            }
+            _ => return false,
+        }
+        cx.stop_propagation();
+        cx.notify();
+        true
+    }
+
+    pub(super) fn notification_panel(
+        &self,
+        colors: SemanticColors,
+        window: &Window,
+        cx: &mut Context<Self>,
+    ) -> Option<AnyElement> {
+        if !self.notification_panel_open {
+            return None;
+        }
+        let rows = self.notification_rows();
+        let (unread, sounds, alerts, reduce_motion) = {
+            let store = self.services.store.store.read().expect("store");
+            (
+                store.notifications().unread_count(),
+                store.preferences().status_sounds,
+                store.preferences().status_notifications,
+                cx.reduce_motion(),
+            )
+        };
+        let height = (f32::from(window.inner_window_bounds().get_bounds().size.height) - 90.0)
+            .clamp(200.0, 620.0);
+        let mut list = div()
+            .id("notification-list")
+            .min_h(px(80.0))
+            .max_h(px(height - 180.0))
+            .overflow_y_scroll()
+            .flex()
+            .flex_col()
+            .gap(px(4.0));
+        if rows.is_empty() {
+            list = list.child(div().p(px(28.0)).flex().flex_col().items_center().gap(px(10.0))
+                .child(sf_symbol("checkmark.circle", 26.0, colors.secondary))
+                .child(div().text_color(colors.primary).child(if self.notification_filter_unread { "You're all caught up" } else { "A place for what needs you" }))
+                .child(div().text_size(px(Typo::META.size)).text_color(colors.secondary)
+                    .child("Agent results, questions, and failures appear here. Keep working—we'll keep track.")));
+        }
+        for (index, entry) in rows.into_iter().enumerate() {
+            let session = entry.session_id.clone();
+            let id = entry.id.clone();
+            let read_id = entry.id.clone();
+            let mute_session = entry.session_id.clone();
+            let muted = self
+                .services
+                .store
+                .store
+                .read()
+                .expect("store")
+                .preferences()
+                .muted_notification_sessions
+                .contains(&mute_session.0);
+            let read = entry.read;
+            let tone = match entry.kind {
+                NotificationKind::NeedsInput | NotificationKind::Failed => Ink::ATTENTION,
+                _ => Ink::FRESH,
+            };
+            let label = if entry.resolved {
+                "Resolved"
+            } else {
+                match entry.kind {
+                    NotificationKind::NeedsInput => "Needs you",
+                    NotificationKind::Done => "Completed",
+                    NotificationKind::Failed => "Stopped",
+                    NotificationKind::Custom => "Notification",
+                }
+            };
+            list = list.child(
+                div()
+                    .id(("notification-row", index))
+                    .px(px(12.0))
+                    .py(px(10.0))
+                    .rounded(px(Radius::ROW))
+                    .cursor_pointer()
+                    .border_1()
+                    .border_color(if index == self.notification_selected {
+                        colors.primary.alpha(0.13)
+                    } else {
+                        colors.primary.alpha(0.03)
+                    })
+                    .bg(colors
+                        .primary
+                        .alpha(if index == self.notification_selected {
+                            0.05
+                        } else {
+                            0.015
+                        }))
+                    .hover(|style| style.bg(colors.primary.alpha(0.07)))
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        this.open_notification(session.clone(), Some(id.clone()), window, cx)
+                    }))
+                    .child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .gap(px(8.0))
+                            .child(div().size(px(6.0)).rounded_full().bg(if read {
+                                colors.primary.alpha(0.12)
+                            } else {
+                                tone
+                            }))
+                            .child(
+                                div()
+                                    .flex_1()
+                                    .text_size(px(Typo::META.size))
+                                    .text_color(tone)
+                                    .child(label),
+                            )
+                            .child(
+                                div()
+                                    .text_size(px(Typo::META.size))
+                                    .text_color(colors.tertiary)
+                                    .child(age(entry.created_at_ms)),
+                            )
+                            .child(
+                                div()
+                                    .id(("notification-mute", index))
+                                    .px(px(5.0))
+                                    .cursor_pointer()
+                                    .text_size(px(Typo::META.size))
+                                    .text_color(colors.secondary)
+                                    .child(if muted { "Unmute" } else { "Mute" })
+                                    .on_click(cx.listener(move |this, _, _, cx| {
+                                        cx.stop_propagation();
+                                        this.services
+                                            .store
+                                            .store
+                                            .write()
+                                            .expect("store")
+                                            .toggle_notification_mute(mute_session.clone());
+                                        cx.notify();
+                                    })),
+                            )
+                            .child(
+                                div()
+                                    .id(("notification-read", index))
+                                    .px(px(5.0))
+                                    .cursor_pointer()
+                                    .text_size(px(Typo::META.size))
+                                    .text_color(colors.secondary)
+                                    .child(if read { "Mark unread" } else { "Mark read" })
+                                    .on_click(cx.listener(move |this, _, _, cx| {
+                                        cx.stop_propagation();
+                                        this.services
+                                            .store
+                                            .store
+                                            .write()
+                                            .expect("store")
+                                            .set_notification_read(&read_id, !read);
+                                        cx.notify();
+                                    })),
+                            ),
+                    )
+                    .child(
+                        div()
+                            .mt(px(5.0))
+                            .text_size(px(Typo::ROW.size))
+                            .font_weight(FontWeight::MEDIUM)
+                            .text_color(colors.primary)
+                            .child(entry.title),
+                    )
+                    .child(
+                        div()
+                            .mt(px(3.0))
+                            .text_size(px(Typo::META.size))
+                            .text_color(colors.secondary)
+                            .child(entry.body),
+                    ),
+            );
+        }
+        let panel = div().id("notification-panel").track_focus(&self.notification_focus)
+            .absolute().top(px(48.0)).right(px(14.0)).w(px(440.0)).max_h(px(height))
+            .p(px(12.0)).rounded(px(Radius::PANEL)).border_1().border_color(colors.primary.alpha(0.12))
+            .bg(colors.background).shadow_lg().flex().flex_col().gap(px(12.0))
+            .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+            .child(div().flex().items_center().gap(px(8.0))
+                .child(sf_symbol("bell", 17.0, colors.primary))
+                .child(div().flex_1().text_size(px(16.0)).font_weight(FontWeight::SEMIBOLD).child(format!("Notifications · {unread}")))
+                .child(div().id("close-notifications").cursor_pointer().p(px(5.0)).child(sf_symbol("xmark", 12.0, colors.secondary))
+                    .on_click(cx.listener(|this, _, window, cx| this.toggle_notifications(window, cx)))))
+            .child(div().flex().items_center().gap(px(14.0)).text_size(px(Typo::META.size))
+                .child(div().id("notification-filter").cursor_pointer().text_color(Ink::FRESH).child(if self.notification_filter_unread { "Unread ▾" } else { "All notifications ▾" })
+                    .on_click(cx.listener(|this, _, _, cx| { this.notification_filter_unread = !this.notification_filter_unread; this.notification_selected = 0; cx.notify(); })))
+                .child(div().flex_1())
+                .child(div().id("notification-read-all").cursor_pointer().child("Mark all read").on_click(cx.listener(|this, _, _, cx| {
+                    this.services.store.store.write().expect("store").mark_all_notifications_read(); cx.notify();
+                })))
+                .child(div().id("notification-clear").cursor_pointer().text_color(colors.secondary).child("Clear").on_click(cx.listener(|this, _, _, cx| {
+                    this.services.store.store.write().expect("store").clear_notifications(); cx.notify();
+                }))))
+            .child(list)
+            .child(div().border_t_1().border_color(colors.primary.alpha(0.07)).pt(px(10.0)).flex().flex_col().gap(px(6.0))
+                .child(div().flex().items_center().gap(px(12.0)).text_size(px(Typo::META.size))
+                    .child(div().id("notification-alerts").cursor_pointer().child(if alerts { "Alerts on" } else { "Alerts off" }).on_click(cx.listener(|this, _, _, cx| {
+                        this.services.store.store.write().expect("store").toggle_notification_alerts(); cx.notify();
+                    })))
+                    .child(div().id("notification-sounds").flex_1().cursor_pointer().child(if sounds { "Sounds on" } else { "Sounds off" }).on_click(cx.listener(|this, _, _, cx| {
+                        let _ = this.services.store.store.write().expect("store").update_preferences(|prefs| prefs.status_sounds = !prefs.status_sounds); cx.notify();
+                    })))
+                    .child(div().id("notification-test").cursor_pointer().text_color(Ink::FRESH).child("Test alert").on_click(cx.listener(|this, _, _, cx| {
+                        #[cfg(target_os = "macos")]
+                        this.notifier.post(&crate::notifications::NotificationRequest {
+                            identifier: "diri-notification-test".into(), title: "Diri notifications are ready".into(),
+                            body: "You'll find agent updates in Notifications, even when Mac alerts are silenced.".into(),
+                            thread_identifier: None, action_data: None, use_system_sound: false,
+                        });
+                        cx.notify();
+                    }))))
+                .child(div().text_size(px(11.0)).text_color(colors.tertiary).child(self.notification_health.clone())));
+        let panel = if reduce_motion {
+            panel.into_any_element()
+        } else {
+            panel
+                .with_animation(
+                    "notification-panel-arrival",
+                    Animation::new(Duration::from_millis(160)).with_easing(ease_out_quint()),
+                    |panel, delta| panel.opacity(delta).top(px(48.0 - 6.0 * (1.0 - delta))),
+                )
+                .into_any_element()
+        };
+        Some(
+            div()
+                .absolute()
+                .inset_0()
+                .id("notification-dismiss-layer")
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(|this, _, window, cx| this.toggle_notifications(window, cx)),
+                )
+                .child(panel)
+                .into_any_element(),
+        )
+    }
+}
+
+fn age(ms: u64) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    let seconds = now.saturating_sub(ms) / 1000;
+    match seconds {
+        0..60 => "now".into(),
+        60..3600 => format!("{}m ago", seconds / 60),
+        3600..86400 => format!("{}h ago", seconds / 3600),
+        _ => format!("{}d ago", seconds / 86400),
+    }
+}

--- a/diri/crates/diri-app/src/notifications.rs
+++ b/diri/crates/diri-app/src/notifications.rs
@@ -10,8 +10,10 @@ use diri_proto::{
     SessionRecord,
 };
 
-pub const PERMISSION_CATEGORY_ID: &str = "needs-input-permission";
+pub const OPEN_ACTION_ID: &str = "open-session";
+#[cfg(test)]
 pub const APPROVE_ACTION_ID: &str = "approve";
+#[cfg(test)]
 pub const DENY_ACTION_ID: &str = "deny";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -46,6 +48,8 @@ pub struct NotificationRequest {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StatusTransition {
+    /// Native alerts withdrawn after read, resolution, or session removal.
+    pub dismiss: Vec<String>,
     pub sound: Option<NotificationSound>,
     pub notification: Option<NotificationRequest>,
     /// Foreground feedback for user-initiated operations. System
@@ -78,6 +82,7 @@ fn one_shot_identifier(prefix: &str) -> String {
 
 fn plain_banner(prefix: &str, title: String, body: String) -> StatusTransition {
     StatusTransition {
+        dismiss: Vec::new(),
         sound: None,
         notification: Some(NotificationRequest {
             identifier: one_shot_identifier(prefix),
@@ -93,6 +98,7 @@ fn plain_banner(prefix: &str, title: String, body: String) -> StatusTransition {
 
 fn foreground_banner(title: String, body: String) -> StatusTransition {
     StatusTransition {
+        dismiss: Vec::new(),
         sound: None,
         notification: None,
         in_app_banner: Some(InAppBanner { title, body }),
@@ -187,6 +193,7 @@ pub fn migration_transition(
 #[must_use]
 pub fn reach_failure_transition() -> StatusTransition {
     StatusTransition {
+        dismiss: Vec::new(),
         sound: None,
         notification: Some(NotificationRequest {
             identifier: format!(
@@ -256,7 +263,9 @@ fn deny_answer(descriptor: Option<&AgentDescriptor>) -> Answer {
         )
 }
 
-/// Resolve an actionable notification response into a daemon `send_text` call.
+/// Legacy key mapping. Native actions now open the session: captured terminal
+/// keystrokes cannot safely approve a prompt after it changes.
+#[cfg(test)]
 #[must_use]
 pub fn command_for_action(action_id: &str, data: &ActionData) -> Option<SendTextCommand> {
     let answer = match action_id {
@@ -330,6 +339,7 @@ pub fn immediate_transitions_for_update(
         .is_some_and(|info| info.reason == HibernationReason::MemoryPressure);
     if !was_memory_frozen && is_memory_frozen {
         transitions.push(StatusTransition {
+            dismiss: Vec::new(),
             sound: status_sounds_enabled.then_some(NotificationSound::Frozen),
             notification: Some(memory_pressure_request(current, status_sounds_enabled)),
             in_app_banner: None,
@@ -376,8 +386,8 @@ impl PendingAttention {
 /// The attention state this update entered, if any — the trigger that arms a
 /// settle window.
 ///
-/// Entering the state is what counts. A session already blocked that swaps
-/// blockers is still the same interruption and does not re-arm.
+/// A distinct prompt or completion is a new event even if its attention
+/// level is unchanged. Repeated observations of the same prompt are not.
 #[must_use]
 pub fn attention_signal(
     previous: Option<&SessionRecord>,
@@ -387,9 +397,15 @@ pub fn attention_signal(
     let current_attention = current.attention();
     let entered =
         |level: AttentionLevel| previous_attention != Some(level) && current_attention == level;
-    if entered(AttentionLevel::NeedsInput) {
+    let changed_blocker = current_attention == AttentionLevel::NeedsInput
+        && previous.is_some_and(|previous| blocker_key(previous) != blocker_key(current));
+    let new_completion = current_attention == AttentionLevel::DoneUnseen
+        && previous.is_some_and(|previous| {
+            previous.last_turn_completed_at != current.last_turn_completed_at
+        });
+    if entered(AttentionLevel::NeedsInput) || changed_blocker {
         Some(AttentionLevel::NeedsInput)
-    } else if entered(AttentionLevel::DoneUnseen) {
+    } else if entered(AttentionLevel::DoneUnseen) || new_completion {
         Some(AttentionLevel::DoneUnseen)
     } else {
         None
@@ -410,7 +426,7 @@ pub fn attention_still_holds(current: &SessionRecord, pending: AttentionLevel) -
 ///
 /// Returns `None` when the session no longer holds the state that armed it.
 ///
-/// Chimes are emitted even for the focused session. Banners are suppressed only
+/// Chimes and banners are suppressed
 /// when that same session is selected and the app is active — both judged
 /// against where the user is *now*, so selecting the session during the window
 /// is enough to stop the banner.
@@ -440,16 +456,17 @@ pub fn settled_attention_transition(
     }
     let is_focused = selected_session_id == Some(&current.id) && app_is_active;
     Some(StatusTransition {
-        sound: status_sounds_enabled.then_some(sound),
+        dismiss: Vec::new(),
+        sound: (status_sounds_enabled && !is_focused).then_some(sound),
         notification: (!is_focused)
             .then(|| attention_request(current, status_sounds_enabled, descriptor)),
         in_app_banner: None,
     })
 }
 
-fn attention_request(
+pub fn attention_request(
     session: &SessionRecord,
-    status_sounds_enabled: bool,
+    _status_sounds_enabled: bool,
     descriptor: Option<&AgentDescriptor>,
 ) -> NotificationRequest {
     let (title, body, suffix, action_data) = match session.attention() {
@@ -461,8 +478,20 @@ fn attention_request(
                     "{} needs you",
                     display_name(session.effective_kind(), descriptor)
                 ),
-                detail.map_or_else(|| session.title.clone(), |detail| detail.summary.clone()),
-                detail.map_or_else(|| "needs-input".to_owned(), blocker_identity),
+                detail.map_or_else(
+                    || session.title.clone(),
+                    |detail| format!("{} · {}", session.title, detail.summary),
+                ),
+                detail.map_or_else(
+                    || "needs-input".to_owned(),
+                    |detail| {
+                        format!(
+                            "{}-{}",
+                            blocker_identity(detail),
+                            detail.occurred_at.0.to_bits()
+                        )
+                    },
+                ),
                 action_data,
             )
         }
@@ -472,7 +501,12 @@ fn attention_request(
                 display_name(session.effective_kind(), descriptor)
             ),
             session.title.clone(),
-            "done".to_owned(),
+            format!(
+                "done-{}",
+                session
+                    .last_turn_completed_at
+                    .map_or(0, |date| date.0.to_bits())
+            ),
             None,
         ),
         _ => unreachable!("attention requests are only built for noteworthy states"),
@@ -484,13 +518,13 @@ fn attention_request(
         body,
         thread_identifier: Some(session.id.0.clone()),
         action_data,
-        use_system_sound: !status_sounds_enabled,
+        use_system_sound: false,
     }
 }
 
 fn memory_pressure_request(
     session: &SessionRecord,
-    status_sounds_enabled: bool,
+    _status_sounds_enabled: bool,
 ) -> NotificationRequest {
     let body = session.memory_bytes.map_or_else(
         || {
@@ -513,7 +547,7 @@ fn memory_pressure_request(
         body,
         thread_identifier: Some(session.id.0.clone()),
         action_data: None,
-        use_system_sound: !status_sounds_enabled,
+        use_system_sound: false,
     }
 }
 
@@ -537,6 +571,40 @@ where
         AgentKind::SHELL_ID => "Terminal",
         _ => "Agent",
     }
+}
+
+/// Repaints refresh timestamps; semantic prompt content is the dedupe key.
+pub fn blocker_key(session: &SessionRecord) -> String {
+    session
+        .needs_input
+        .as_ref()
+        .map_or_else(String::new, blocker_identity)
+}
+
+pub fn failed_request(session: &SessionRecord) -> Option<NotificationRequest> {
+    let diri_proto::SessionStatus::Exited(exit) = &session.status else {
+        return None;
+    };
+    if session.is_archived() || (exit.code == Some(0) && exit.signal.is_none()) {
+        return None;
+    }
+    Some(NotificationRequest {
+        identifier: format!("{}-exit-{}", session.id.0, session.created_at.0.to_bits()),
+        title: format!("{} stopped", session.title),
+        body: exit.signal.map_or_else(
+            || {
+                format!(
+                    "Exited with code {}. Open the session to inspect its output.",
+                    exit.code
+                        .map_or_else(|| "unknown".into(), |code| code.to_string())
+                )
+            },
+            |signal| format!("Stopped by signal {signal}. Open the session to inspect its output."),
+        ),
+        thread_identifier: Some(session.id.0.clone()),
+        action_data: None,
+        use_system_sound: false,
+    })
 }
 
 fn blocker_identity(detail: &diri_proto::NeedsInputDetail) -> String {
@@ -753,7 +821,7 @@ mod tests {
     }
 
     #[test]
-    fn hidden_needs_input_chimes_and_posts_but_focused_only_chimes() {
+    fn hidden_needs_input_chimes_and_posts_but_focused_is_quiet() {
         let current = session(
             AgentKind::CODEX,
             SessionStatus::NeedsInput(NeedsInputKind::Permission),
@@ -763,7 +831,7 @@ mod tests {
         assert!(hidden.notification.is_some());
 
         let focused = settled(&current, Some(&current.id), true, true, None);
-        assert_eq!(focused.sound, Some(NotificationSound::NeedsInput));
+        assert_eq!(focused.sound, None);
         assert!(focused.notification.is_none());
 
         let inactive = settled(&current, Some(&current.id), false, true, None);
@@ -866,7 +934,7 @@ mod tests {
 
         let transition = settled(&replaced, None, true, true, None);
         let notification = transition.notification.as_ref().unwrap();
-        assert_eq!(notification.body, "Delete the branch?");
+        assert_eq!(notification.body, "Refactor parser · Delete the branch?");
         assert_ne!(
             notification.identifier,
             settled(&armed, None, true, true, None)
@@ -968,13 +1036,13 @@ mod tests {
     }
 
     #[test]
-    fn disabled_synth_uses_the_system_notification_sound_instead() {
+    fn disabled_chimes_are_silent_including_native_notifications() {
         let current = session(
             AgentKind::CODEX,
             SessionStatus::NeedsInput(NeedsInputKind::Permission),
         );
         let transition = settled(&current, None, true, false, None);
         assert_eq!(transition.sound, None);
-        assert!(transition.notification.as_ref().unwrap().use_system_sound);
+        assert!(!transition.notification.as_ref().unwrap().use_system_sound);
     }
 }

--- a/diri/crates/diri-app/src/notifications.rs
+++ b/diri/crates/diri-app/src/notifications.rs
@@ -10,6 +10,7 @@ use diri_proto::{
     SessionRecord,
 };
 
+#[cfg(target_os = "macos")]
 pub const OPEN_ACTION_ID: &str = "open-session";
 #[cfg(test)]
 pub const APPROVE_ACTION_ID: &str = "approve";

--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -41,6 +41,9 @@ use crate::terminal_pane::{TerminalPane, TerminalPaneEvent, TerminalViewport};
 use crate::updates::UpdatePhase;
 use crate::workbench::WorkbenchLayout;
 
+#[path = "notification_panel.rs"]
+mod notification_panel;
+
 const WINDOW_BOUNDS_SAVE_DELAY: Duration = Duration::from_millis(150);
 
 pub(crate) fn cached_window_overlay<T: Render>(view: Entity<T>) -> impl IntoElement {
@@ -209,6 +212,14 @@ pub struct RootView {
     status_banner: Option<InAppBanner>,
     status_banner_generation: u64,
     quote_target_picker: Option<QuoteTargetPicker>,
+    notification_panel_open: bool,
+    notification_filter_unread: bool,
+    notification_selected: usize,
+    notification_focus: FocusHandle,
+    notification_health: String,
+    pending_notification_open: Option<(SessionId, Option<String>)>,
+    #[cfg(target_os = "macos")]
+    _notification_events: Task<()>,
     last_quote_surface: QuoteSurface,
     sound_gate: SoundGate,
     /// Set when opening settings had to reveal a hidden sidebar to put its
@@ -489,7 +500,47 @@ impl RootView {
             menu_bar.refresh();
         }
         #[cfg(target_os = "macos")]
-        let notifier = NativeNotifier::new(services.store.notification_action_sender());
+        let (notification_tx, mut notification_rx) = tokio::sync::mpsc::unbounded_channel();
+        #[cfg(target_os = "macos")]
+        let notifier = NativeNotifier::new(notification_tx);
+        #[cfg(target_os = "macos")]
+        let notification_events = cx.spawn_in(window, async move |this, cx| {
+            while let Some(event) = notification_rx.recv().await {
+                if this
+                    .update_in(cx, |this, window, cx| {
+                        use crate::macos::notifier::NativeNotificationEvent;
+                        match event {
+                            NativeNotificationEvent::Open {
+                                session_id,
+                                notification_id,
+                            } => {
+                                this.open_notification(
+                                    SessionId::new(session_id),
+                                    Some(notification_id),
+                                    window,
+                                    cx,
+                                );
+                            }
+                            NativeNotificationEvent::Read(id) => {
+                                this.services
+                                    .store
+                                    .store
+                                    .write()
+                                    .expect("store")
+                                    .set_notification_read(&id, true);
+                            }
+                            NativeNotificationEvent::Health(message) => {
+                                this.notification_health = message
+                            }
+                        }
+                        cx.notify();
+                    })
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        });
 
         let activation_services = Arc::clone(&services);
         let activation = cx.observe_window_activation(window, move |_this, window, _cx| {
@@ -511,7 +562,11 @@ impl RootView {
             loop {
                 tokio::select! {
                     status = status_events.recv() => {
-                        let Ok(status) = status else { break };
+                        let status = match status {
+                            Ok(status) => status,
+                            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                        };
                         let _ = this.update(cx, |this, cx| {
                             #[cfg(target_os = "macos")]
                             let app_is_active = this
@@ -521,7 +576,10 @@ impl RootView {
                                 .read()
                                 .expect("session store lock poisoned")
                                 .app_is_active();
-                            if let Some(sound) = status.sound {
+                            #[cfg(target_os = "macos")]
+                            this.notifier.dismiss(&status.dismiss);
+                            let deliver = status.notification.as_ref().is_none_or(|request| this.services.store.store.read().expect("store").should_deliver_notification(request));
+                            if let Some(sound) = status.sound && deliver {
                                 let sound = match sound {
                                     NotificationSound::NeedsInput => StatusSound::NeedsInput,
                                     NotificationSound::Done => StatusSound::Done,
@@ -533,7 +591,7 @@ impl RootView {
                             }
                             #[cfg(target_os = "macos")]
                             if let Some(notification) = &status.notification
-                                && (!app_is_active || status.in_app_banner.is_none())
+                                && deliver && (!app_is_active || status.in_app_banner.is_none())
                             {
                                 this.notifier.post(notification);
                             }
@@ -658,6 +716,7 @@ impl RootView {
                                     surfaces.update(cx, |surfaces, cx| surfaces.open_settings(cx));
                                 }
                                 this.sync_auxiliary_terminal(window, cx);
+                                cx.notify();
                             })
                             .is_err()
                         {
@@ -724,6 +783,16 @@ impl RootView {
             status_banner: None,
             status_banner_generation: 0,
             quote_target_picker: None,
+            notification_panel_open: false,
+            notification_filter_unread: true,
+            notification_selected: 0,
+            notification_focus: cx.focus_handle(),
+            pending_notification_open: None,
+            notification_health:
+                "Use Test alert to check macOS delivery. Notifications remain available here."
+                    .into(),
+            #[cfg(target_os = "macos")]
+            _notification_events: notification_events,
             last_quote_surface: QuoteSurface::default(),
             sound_gate: SoundGate::default(),
             sidebar_revealed_for_settings: false,
@@ -1038,6 +1107,9 @@ impl RootView {
     }
 
     fn on_key_down(&mut self, event: &KeyDownEvent, window: &mut Window, cx: &mut Context<Self>) {
+        if self.notification_panel_open && self.notification_key(event, window, cx) {
+            return;
+        }
         // A sidebar drag rarely has sidebar focus (the press left it in the
         // terminal), so Escape is caught here, on the window's capture path.
         if event.keystroke.key == "escape"
@@ -1231,6 +1303,7 @@ impl RootView {
                     cx.propagate();
                 }
             }
+            CommandId::ToggleNotifications => self.toggle_notifications(window, cx),
             CommandId::SelectNextAttentionSession => {
                 self.sidebar
                     .update(cx, |sidebar, cx| sidebar.select_next_needing_input(cx));
@@ -2684,6 +2757,18 @@ impl RootView {
 
 impl Render for RootView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        if self.pending_notification_open.is_some()
+            && self
+                .services
+                .store
+                .store
+                .read()
+                .expect("store")
+                .has_hydrated_sessions()
+            && let Some((session, event)) = self.pending_notification_open.take()
+        {
+            self.open_notification(session, event, window, cx);
+        }
         let colors = self.colors();
         let recovery_notice = if self.preview {
             None
@@ -2697,7 +2782,29 @@ impl Render for RootView {
             RecoveryNotice::resolve(store.daemon_state(), store.action_failure())
         };
         let recovery_height = if recovery_notice.is_some() { 42.0 } else { 0.0 };
+        #[cfg(target_os = "macos")]
+        self.notifier.set_badge(
+            self.services
+                .store
+                .store
+                .read()
+                .expect("store")
+                .notifications()
+                .unread_count(),
+        );
         let launcher_open = self.launcher.read(cx).is_open();
+        let notification_surface_visible = !launcher_open
+            && !self.notification_panel_open
+            && !self
+                .utility_surfaces
+                .as_ref()
+                .is_some_and(|surfaces| surfaces.read(cx).is_open());
+        self.services
+            .store
+            .store
+            .write()
+            .expect("store")
+            .set_notification_surface_visible(notification_surface_visible);
         let sidebar_visible = self.sidebar.read(cx).is_visible();
         let sidebar_width = self.sidebar.read(cx).width();
         let window_width = f32::from(window.inner_window_bounds().get_bounds().size.width);
@@ -2784,6 +2891,11 @@ impl Render for RootView {
             .on_action(cx.listener(|this, _: &ToggleQuickOpen, window, cx| {
                 this.run_command(CommandId::ToggleQuickOpen, window, cx);
             }))
+            .on_action(cx.listener(
+                |this, _: &crate::commands::ToggleNotifications, window, cx| {
+                    this.toggle_notifications(window, cx);
+                },
+            ))
             .on_action(cx.listener(|this, _: &ToggleHistory, window, cx| {
                 this.run_command(CommandId::ToggleHistory, window, cx);
             }))
@@ -2985,6 +3097,9 @@ impl Render for RootView {
         }
         if let Some(picker) = self.quote_target_picker(colors, sidebar_width, cx) {
             root = root.child(deferred(picker));
+        }
+        if let Some(panel) = self.notification_panel(colors, window, cx) {
+            root = root.child(deferred(panel));
         }
         if let Some(status) = self.status_banner(colors, cx) {
             root = root.child(status);

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -1961,13 +1961,14 @@ impl Sidebar {
     ) -> AnyElement {
         let session = &row.session;
         let id = session.id.clone();
-        let (selected, multi, drag_selection, migrating) = {
+        let (selected, multi, drag_selection, migrating, unread) = {
             let mut store = self.store.write().expect("session store lock poisoned");
             (
                 store.selected_session_id() == Some(&id),
                 store.sidebar_selection().contains(&id),
                 (store.sidebar_selection().len() > 1).then(|| store.sidebar_selection_ordered()),
                 store.migrating().contains(&id),
+                store.notifications().session_unread(&id),
             )
         };
         let marked = self.ui.delegation_mark.as_ref() == Some(&id);
@@ -2001,6 +2002,8 @@ impl Sidebar {
             row.pinned,
             !hovered && focused && shortcut.is_some(),
         );
+        let title_available_width =
+            (title_available_width - if unread { 14.0 } else { 0.0 }).max(0.0);
         let title_marquee_id = format!("session-title-marquee:{}", id.0);
         let fill = if selected {
             RowFill::Selected
@@ -2285,6 +2288,15 @@ impl Sidebar {
                 )
                 .font_weight(Typo::ROW.weight),
             )
+            .when(unread, |element| {
+                element.child(
+                    div()
+                        .size(px(6.0))
+                        .flex_none()
+                        .rounded_full()
+                        .bg(Ink::FRESH),
+                )
+            })
             .when(row.pinned, |element| element.child(pin_mark(colors)))
             .when(marked, |element| {
                 element.child(StateChip::new("Delegating", Palette::CLAY, colors))
@@ -5085,6 +5097,13 @@ impl Sidebar {
         self.commit_rename();
         {
             let mut store = self.store.write().expect("session store lock poisoned");
+            if let Some(id) = store.next_unread_notification() {
+                store.select(id);
+                drop(store);
+                cx.emit(SidebarEvent::SessionActivated);
+                cx.notify();
+                return true;
+            }
             let sessions = store.ordered_sessions();
             if sessions.is_empty() {
                 return false;
@@ -5097,7 +5116,12 @@ impl Sidebar {
             let start = current.map_or(0, |index| index + 1);
             let Some(next) = (0..sessions.len())
                 .map(|offset| &sessions[(start + offset) % sessions.len()])
-                .find(|session| session.attention() == ProtoAttentionLevel::NeedsInput)
+                .find(|session| {
+                    matches!(
+                        session.attention(),
+                        ProtoAttentionLevel::NeedsInput | ProtoAttentionLevel::DoneUnseen
+                    )
+                })
             else {
                 return false;
             };
@@ -5463,6 +5487,51 @@ impl Render for Sidebar {
         if let Some(feedback) = self.external_drop_feedback(colors, cx) {
             root = root.child(feedback);
         }
+        let unread = self
+            .store
+            .read()
+            .expect("store")
+            .notifications()
+            .unread_count();
+        root = root.child(
+            div().px(px(Space::INSET)).py(px(4.0)).child(
+                div()
+                    .id("notification-inbox-button")
+                    .h(px(SIDEBAR_NAV_ROW_HEIGHT))
+                    .px(px(8.0))
+                    .rounded(px(SIDEBAR_ROW_RADIUS))
+                    .cursor_pointer()
+                    .flex()
+                    .items_center()
+                    .gap(px(8.0))
+                    .text_size(px(Typo::ROW.size))
+                    .text_color(colors.primary)
+                    .hover(|style| style.bg(colors.primary.alpha(0.05)))
+                    .child(sf_symbol(
+                        "bell",
+                        14.0,
+                        if unread > 0 {
+                            Ink::FRESH
+                        } else {
+                            colors.secondary
+                        },
+                    ))
+                    .child(div().flex_1().child("Notifications"))
+                    .when(unread > 0, |row| {
+                        row.child(
+                            div()
+                                .rounded(px(5.0))
+                                .px(px(6.0))
+                                .bg(Ink::FRESH.alpha(0.12))
+                                .text_color(Ink::FRESH)
+                                .child(unread.to_string()),
+                        )
+                    })
+                    .on_click(|_, window, cx| {
+                        window.dispatch_action(Box::new(crate::commands::ToggleNotifications), cx)
+                    }),
+            ),
+        );
         root = root.child(self.account_footer(colors, cx));
         if let Some(popover) = self.popover(colors, window, cx) {
             root = root.child(popover);

--- a/diri/crates/diri-app/src/store/mod.rs
+++ b/diri/crates/diri-app/src/store/mod.rs
@@ -290,6 +290,7 @@ fn repo_target_key(host: Option<&str>) -> String {
 /// Pure application model. Side effects are emitted onto a channel for the daemon adapter.
 pub struct SessionStore {
     daemon_state: DaemonState,
+    session_list_hydrated: bool,
     daemon_identity: Option<HelloResult>,
     sessions: HashMap<SessionId, Arc<SessionRecord>>,
     projects: HashMap<ProjectId, Project>,
@@ -316,6 +317,7 @@ pub struct SessionStore {
     prefs: Prefs,
     terminal_residency: TerminalResidency,
     app_is_active: bool,
+    notification_surface_visible: bool,
     last_action_failure: Option<ActionFailure>,
     sidebar_selection_anchor: Option<SessionId>,
     mru_order: Vec<SessionId>,
@@ -348,6 +350,7 @@ pub struct SessionStore {
     /// Drained by the settle task in `StoreHandle`, which is what turns one of
     /// these into a chime and a banner — see `drain_settled_attention`.
     attention_settle: HashMap<SessionId, PendingAttention>,
+    notification_feed: crate::notification_feed::NotificationFeed,
     /// Wakes the settle task when a window is armed early enough to beat the
     /// one it is currently sleeping on.
     attention_wake: Arc<Notify>,
@@ -375,9 +378,19 @@ impl SessionStore {
     ) -> (Self, mpsc::UnboundedReceiver<StoreEffect>) {
         let (effects, receiver) = mpsc::unbounded_channel();
         let selected_session_id = prefs.last_selected_session.clone();
+        let notification_feed = prefs_path
+            .as_ref()
+            .and_then(|path| path.parent())
+            .map(|parent| {
+                crate::notification_feed::NotificationFeed::load(&parent.join("notifications.json"))
+            })
+            .transpose()
+            .unwrap_or_default()
+            .unwrap_or_default();
         (
             Self {
                 daemon_state: DaemonState::Connecting,
+                session_list_hydrated: false,
                 daemon_identity: None,
                 sessions: HashMap::new(),
                 projects: HashMap::new(),
@@ -395,6 +408,7 @@ impl SessionStore {
                 prefs,
                 terminal_residency: TerminalResidency::default(),
                 app_is_active: true,
+                notification_surface_visible: true,
                 last_action_failure: None,
                 sidebar_selection_anchor: None,
                 mru_order: selected_session_id.into_iter().collect(),
@@ -412,11 +426,161 @@ impl SessionStore {
                 agent_catalog_scans: HashMap::new(),
                 agent_catalog_errors: HashMap::new(),
                 attention_settle: HashMap::new(),
+                notification_feed,
                 attention_wake: Arc::new(Notify::new()),
                 effects,
             },
             receiver,
         )
+    }
+
+    pub fn notifications(&self) -> &crate::notification_feed::NotificationFeed {
+        &self.notification_feed
+    }
+
+    fn notification_change(&self, dismiss: Vec<String>) {
+        if let Some(parent) = self.prefs_path.as_ref().and_then(|path| path.parent())
+            && let Err(error) = self
+                .notification_feed
+                .save(&parent.join("notifications.json"))
+        {
+            eprintln!("diri: could not save notification history: {error}");
+        }
+        if !dismiss.is_empty() {
+            self.emit(StoreEffect::StatusTransition(StatusTransition {
+                dismiss,
+                sound: None,
+                notification: None,
+                in_app_banner: None,
+            }));
+        }
+        self.emit(StoreEffect::PublishSnapshot);
+    }
+
+    fn reconcile_notifications(&mut self) {
+        let sessions: Vec<_> = self.sessions.values().map(Arc::as_ref).collect();
+        let dismissed = self.notification_feed.reconcile(&sessions);
+        if !dismissed.is_empty() {
+            self.notification_change(dismissed);
+        }
+    }
+
+    pub fn mark_notifications_read(&mut self, id: &SessionId) {
+        let dismissed = self.notification_feed.mark_session_read(id);
+        if !dismissed.is_empty() {
+            self.notification_change(dismissed);
+        }
+    }
+
+    pub fn mark_all_notifications_read(&mut self) {
+        let dismissed = self.notification_feed.mark_all_read();
+        self.notification_change(dismissed);
+    }
+
+    pub fn clear_notifications(&mut self) {
+        let dismissed = self.notification_feed.clear();
+        self.notification_change(dismissed);
+    }
+
+    pub fn set_notification_read(&mut self, id: &str, read: bool) {
+        if self.notification_feed.set_read(id, read) {
+            self.notification_change(if read {
+                vec![id.to_owned()]
+            } else {
+                Vec::new()
+            });
+        }
+    }
+
+    /// Recheck at delivery time: a queued transition may already be read,
+    /// resolved, or muted by the time the main thread receives it.
+    pub fn should_deliver_notification(
+        &self,
+        request: &crate::notifications::NotificationRequest,
+    ) -> bool {
+        if !self.prefs.status_notifications {
+            return false;
+        }
+        if let Some(session) = &request.thread_identifier {
+            let id = SessionId::new(session.clone());
+            if self.prefs.muted_notification_sessions.contains(&id.0)
+                || self.notification_is_focused(&id)
+            {
+                return false;
+            }
+        }
+        self.notification_feed
+            .entries()
+            .iter()
+            .find(|entry| entry.id == request.identifier)
+            .is_none_or(|entry| !entry.read && !entry.resolved)
+    }
+
+    pub fn toggle_notification_alerts(&mut self) {
+        self.prefs.status_notifications = !self.prefs.status_notifications;
+        if !self.prefs.status_notifications {
+            self.notification_change(
+                self.notification_feed
+                    .entries()
+                    .iter()
+                    .map(|entry| entry.id.clone())
+                    .collect(),
+            );
+        }
+        let _ = self.persist_preferences();
+        self.emit(StoreEffect::PublishSnapshot);
+    }
+
+    pub fn toggle_notification_mute(&mut self, session: SessionId) {
+        if !self.prefs.muted_notification_sessions.remove(&session.0) {
+            self.prefs
+                .muted_notification_sessions
+                .insert(session.0.clone());
+            let ids = self
+                .notification_feed
+                .entries()
+                .iter()
+                .filter(|entry| entry.session_id == session)
+                .map(|entry| entry.id.clone())
+                .collect();
+            self.notification_change(ids);
+        }
+        let _ = self.persist_preferences();
+        self.emit(StoreEffect::PublishSnapshot);
+    }
+
+    pub fn set_notification_surface_visible(&mut self, visible: bool) {
+        if self.notification_surface_visible == visible {
+            return;
+        }
+        self.notification_surface_visible = visible;
+        if visible
+            && self.app_is_active
+            && let Some(id) = self.selected_session_id.clone()
+        {
+            self.mark_notifications_read(&id);
+            self.emit(StoreEffect::MarkSeen(id));
+        }
+    }
+
+    fn notification_is_focused(&self, id: &SessionId) -> bool {
+        self.app_is_active
+            && self.notification_surface_visible
+            && self.selected_session_id.as_ref() == Some(id)
+    }
+
+    pub fn next_unread_notification(&self) -> Option<SessionId> {
+        self.notification_feed
+            .entries()
+            .iter()
+            .find(|entry| {
+                !entry.read
+                    && self.sessions.get(&entry.session_id).is_some_and(|session| {
+                        !session.is_archived()
+                            && session.created_at.0.to_bits() == entry.incarnation
+                    })
+            })
+            .map(|entry| entry.session_id.clone())
     }
 
     /// Re-reads hosts.json (daemon-owned, same machine). Called at startup and
@@ -1136,7 +1300,12 @@ impl SessionStore {
             .map(Arc::as_ref)
     }
 
+    pub fn has_hydrated_sessions(&self) -> bool {
+        self.session_list_hydrated
+    }
+
     pub fn hydrate(&mut self, result: SessionListResult) {
+        self.session_list_hydrated = true;
         // A full resync is the authority: anything still listed here outlived
         // its close (daemon restart, failed terminate) and belongs on screen.
         self.closing.clear();
@@ -1175,6 +1344,42 @@ impl SessionStore {
             }
         }
         self.auto_resume_selected_if_needed();
+        self.reconcile_notifications();
+        // Reconnect seeds unread current attention without replaying desktop
+        // alerts. Existing event read state wins over repeated snapshots.
+        let sessions: Vec<_> = self.sessions.values().cloned().collect();
+        let mut added = false;
+        for session in sessions {
+            let request = match session.attention() {
+                AttentionLevel::NeedsInput | AttentionLevel::DoneUnseen => {
+                    Some(crate::notifications::attention_request(
+                        &session,
+                        false,
+                        self.agent_descriptor(session.effective_kind()),
+                    ))
+                }
+                _ => crate::notifications::failed_request(&session),
+            };
+            if let Some(request) = request {
+                added |= self.notification_feed.record(&session, &request, false);
+            }
+        }
+        let dismissed = self
+            .notification_feed
+            .entries()
+            .iter()
+            .filter(|entry| entry.read)
+            .map(|entry| entry.id.clone())
+            .collect();
+        if added || !self.notification_feed.entries().is_empty() {
+            self.notification_change(dismissed);
+        }
+        if self.app_is_active
+            && self.notification_surface_visible
+            && let Some(id) = self.selected_session_id.clone()
+        {
+            self.mark_notifications_read(&id);
+        }
         self.reconcile_navigation();
     }
 
@@ -1188,6 +1393,44 @@ impl SessionStore {
 
     fn handle_event_change(&mut self, event: EventEnvelope) -> StoreEventChange {
         match event.name.as_str() {
+            EventName::SESSION_NOTIFICATION => {
+                if let Ok(mut event) =
+                    serde_json::from_value::<diri_proto::SessionNotificationEvent>(event.params)
+                    && let Some(session) = self.sessions.get(&event.session_id)
+                    && !session.is_archived()
+                    && session.created_at == event.session_created_at
+                {
+                    if event.title.is_empty() {
+                        event.title = session.title.clone();
+                    }
+                    let focused = self.notification_is_focused(&session.id);
+                    if self
+                        .notification_feed
+                        .record_custom(session, &event, focused)
+                    {
+                        self.notification_change(Vec::new());
+                        if !focused {
+                            self.emit(StoreEffect::StatusTransition(StatusTransition {
+                                dismiss: Vec::new(),
+                                in_app_banner: None,
+                                sound: self
+                                    .prefs
+                                    .status_sounds
+                                    .then_some(crate::notifications::NotificationSound::Done),
+                                notification: Some(crate::notifications::NotificationRequest {
+                                    identifier: event.id,
+                                    title: event.title,
+                                    body: event.body,
+                                    thread_identifier: Some(event.session_id.0),
+                                    action_data: None,
+                                    use_system_sound: false,
+                                }),
+                            }));
+                        }
+                        return StoreEventChange::Model;
+                    }
+                }
+            }
             EventName::SESSION_UPDATED => {
                 if let Ok(session) = serde_json::from_value::<SessionRecord>(event.params) {
                     if self
@@ -1293,7 +1536,32 @@ impl SessionStore {
             && previous
                 .as_deref()
                 .is_none_or(|record| !matches!(record.status, SessionStatus::Exited(_)));
+        let failure = (!self.closing.contains(&id)
+            && previous
+                .as_ref()
+                .is_some_and(|old| !matches!(old.status, SessionStatus::Exited(_))))
+        .then(|| crate::notifications::failed_request(&session))
+        .flatten();
         self.sessions.insert(id.clone(), Arc::new(session));
+        self.reconcile_notifications();
+        if let Some(request) = failure {
+            let current = self.sessions.get(&id).expect("inserted");
+            let focused = self.notification_is_focused(&id);
+            if self.notification_feed.record(current, &request, focused) {
+                self.notification_change(Vec::new());
+                if !focused {
+                    self.emit(StoreEffect::StatusTransition(StatusTransition {
+                        dismiss: Vec::new(),
+                        sound: self
+                            .prefs
+                            .status_sounds
+                            .then_some(crate::notifications::NotificationSound::NeedsInput),
+                        notification: Some(request),
+                        in_app_banner: None,
+                    }));
+                }
+            }
+        }
         self.settle_attention(&id, attention, arriving_attention, arriving_archived);
         // Spawn selects the id before the authoritative record arrives, and
         // only focus_session grants terminal residency -- without this, a
@@ -1401,11 +1669,20 @@ impl SessionStore {
                 session,
                 pending.level,
                 self.selected_session_id.as_ref(),
-                self.app_is_active,
+                self.app_is_active && self.notification_surface_visible,
                 self.prefs.status_sounds,
                 self.agent_descriptor(session.effective_kind()),
             ) {
-                transitions.push(transition);
+                let request = crate::notifications::attention_request(
+                    session,
+                    false,
+                    self.agent_descriptor(session.effective_kind()),
+                );
+                let focused = self.notification_is_focused(&id);
+                if self.notification_feed.record(session, &request, focused) {
+                    self.notification_change(Vec::new());
+                    transitions.push(transition);
+                }
             }
         }
         transitions
@@ -1416,6 +1693,7 @@ impl SessionStore {
             self.focus_neighbor(&HashSet::from([id.clone()]));
         }
         self.sessions.remove(id);
+        self.reconcile_notifications();
         self.attention_settle.remove(id);
         self.closing.remove(id);
         self.sidebar_selection.remove(id);
@@ -1687,6 +1965,7 @@ impl SessionStore {
     pub fn global_attention(&self) -> AttentionLevel {
         self.sessions
             .values()
+            .filter(|session| !session.is_archived())
             .fold(AttentionLevel::None, |rollup, session| {
                 let attention = session.attention();
                 if attention_rank(&attention) > attention_rank(&rollup) {
@@ -2126,12 +2405,22 @@ impl SessionStore {
             return;
         }
         self.app_is_active = active;
+        if active
+            && self.notification_surface_visible
+            && let Some(id) = self.selected_session_id.clone()
+        {
+            self.mark_notifications_read(&id);
+            self.emit(StoreEffect::MarkSeen(id));
+        }
         self.emit(StoreEffect::SetActive(active));
     }
 
     fn focus_session(&mut self, id: SessionId) {
         let selection_changed = self.selected_session_id.as_ref() != Some(&id);
         self.selected_session_id = Some(id.clone());
+        if self.notification_is_focused(&id) {
+            self.mark_notifications_read(&id);
+        }
         let revealed = self.reveal(&id);
         if selection_changed || revealed || self.prefs.last_selected_session.as_ref() != Some(&id) {
             self.prefs.last_selected_session = Some(id.clone());

--- a/diri/crates/diri-app/src/store/prefs.rs
+++ b/diri/crates/diri-app/src/store/prefs.rs
@@ -86,6 +86,8 @@ pub struct Prefs {
     pub start_at_login: bool,
     pub confirm_before_closing_session: bool,
     pub status_sounds: bool,
+    pub status_notifications: bool,
+    pub muted_notification_sessions: std::collections::BTreeSet<String>,
     /// Check, download, and verify releases in the background. A staged update
     /// installs on quit or when the user requests a restart.
     pub automatic_updates: bool,
@@ -150,6 +152,8 @@ impl Default for Prefs {
             start_at_login: false,
             confirm_before_closing_session: true,
             status_sounds: true,
+            status_notifications: true,
+            muted_notification_sessions: Default::default(),
             automatic_updates: true,
             skipped_update_version: String::new(),
             hibernate_after_minutes: 60,

--- a/diri/crates/diri-app/src/store/tests.rs
+++ b/diri/crates/diri-app/src/store/tests.rs
@@ -712,18 +712,15 @@ fn spawn_response_focuses_session_when_event_arrives_first() {
     assert!(store.terminal_residency().contains(&id("spawned")));
 }
 
-/// The menu-bar panel header tints from this, so an archived blocker still
-/// colours the glyph even though its row is not in the list. Documented rather
-/// than fixed: the rollup carries one level, and dropping archived sessions
-/// here would also drop a live `DoneUnseen` sitting behind one.
+/// An archived prompt must not keep the menu-bar attention indicator lit.
 #[test]
-fn global_attention_ranks_across_archived_sessions_too() {
+fn archived_sessions_do_not_keep_the_menu_bar_in_attention() {
     let mut shelved = session("shelved", "p", 1.0);
     shelved.status = SessionStatus::NeedsInput(diri_proto::NeedsInputKind::Question);
     shelved.archived_at = Some(DateMillis(10.0));
     let (store, _) = hydrated(vec![shelved], vec![project("p", "P")], Prefs::default());
 
-    assert_eq!(store.global_attention(), AttentionLevel::NeedsInput);
+    assert_eq!(store.global_attention(), AttentionLevel::None);
 }
 
 #[test]
@@ -872,8 +869,8 @@ fn selecting_a_session_inside_its_window_leaves_the_chime_but_drops_the_banner()
             .next_attention_deadline()
             .expect("needs-input update should arm a settle window"),
     );
-    let transition = transitions.first().expect("the chime still fires");
-    assert_eq!(transition.sound, Some(NotificationSound::NeedsInput));
+    let transition = transitions.first().expect("the inbox records the event");
+    assert_eq!(transition.sound, None);
     assert!(
         transition.notification.is_none(),
         "the session the user is looking at needs no system banner"
@@ -2193,4 +2190,111 @@ fn the_menu_bar_projection_is_cached_per_revision() {
         !Arc::ptr_eq(&first, &store.menu_bar_projection()),
         "a mutation must invalidate the cache, not serve a stale tree"
     );
+}
+
+fn custom_notification(session: &SessionRecord, event_id: &str) -> EventEnvelope {
+    EventEnvelope {
+        name: diri_proto::EventName::SESSION_NOTIFICATION.into(),
+        params: serde_json::to_value(diri_proto::SessionNotificationEvent {
+            id: event_id.into(),
+            session_id: session.id.clone(),
+            session_created_at: session.created_at,
+            occurred_at: DateMillis(10_000.0),
+            title: "Build finished".into(),
+            body: "All tests passed".into(),
+        })
+        .unwrap(),
+        seq: 1,
+    }
+}
+
+#[test]
+fn terminal_notifications_are_unread_events_not_execution_states() {
+    let record = session("hidden", "p", 1.0);
+    let (mut store, mut effects) = hydrated(
+        vec![session("visible", "p", 2.0), record.clone()],
+        vec![project("p", "P")],
+        Prefs::default(),
+    );
+    store.select(id("visible"));
+    drain(&mut effects);
+    assert!(store.handle_event(custom_notification(&record, "custom-one")));
+    assert_eq!(store.notifications().unread_count(), 1);
+    assert_eq!(
+        store.sessions().get(&record.id).unwrap().status,
+        SessionStatus::Idle
+    );
+    assert_eq!(store.next_unread_notification(), Some(record.id.clone()));
+    assert!(drain(&mut effects).iter().any(|effect| matches!(effect, StoreEffect::StatusTransition(transition) if transition.notification.is_some())));
+    assert!(!store.handle_event(custom_notification(&record, "custom-one")));
+    assert!(!store.handle_event(custom_notification(&record, "duplicate-redraw")));
+    store.select(record.id.clone());
+    assert_eq!(store.notifications().unread_count(), 0);
+    assert!(drain(&mut effects).iter().any(|effect| matches!(effect, StoreEffect::StatusTransition(transition) if transition.dismiss == ["custom-one"])));
+}
+
+#[test]
+fn selected_session_behind_settings_still_notifies_and_focus_acknowledges() {
+    let record = session("visible", "p", 1.0);
+    let (mut store, mut effects) = hydrated(
+        vec![record.clone()],
+        vec![project("p", "P")],
+        Prefs::default(),
+    );
+    store.select(record.id.clone());
+    store.set_notification_surface_visible(false);
+    drain(&mut effects);
+    store.handle_event(custom_notification(&record, "settings"));
+    assert_eq!(store.notifications().unread_count(), 1);
+    assert!(drain(&mut effects).iter().any(|effect| matches!(effect, StoreEffect::StatusTransition(transition) if transition.notification.is_some())));
+    store.set_notification_surface_visible(true);
+    assert_eq!(store.notifications().unread_count(), 0);
+}
+
+#[test]
+fn clearing_history_does_not_redeliver_replayed_notifications() {
+    let record = session("visible", "p", 1.0);
+    let (mut store, _) = hydrated(
+        vec![record.clone()],
+        vec![project("p", "P")],
+        Prefs::default(),
+    );
+    store.handle_event(custom_notification(&record, "cleared"));
+    store.clear_notifications();
+    assert!(!store.handle_event(custom_notification(&record, "cleared")));
+    assert!(store.notifications().entries().is_empty());
+    let mut stale = record.clone();
+    stale.created_at = DateMillis(999.0);
+    assert!(!store.handle_event(custom_notification(&stale, "wrong-incarnation")));
+}
+
+#[test]
+fn delivery_rechecks_read_focus_and_mute_after_the_event_was_queued() {
+    let record = session("hidden", "p", 1.0);
+    let (mut store, mut effects) = hydrated(
+        vec![session("visible", "p", 2.0), record.clone()],
+        vec![project("p", "P")],
+        Prefs::default(),
+    );
+    store.select(id("visible"));
+    drain(&mut effects);
+    store.handle_event(custom_notification(&record, "queued"));
+    let request = drain(&mut effects)
+        .into_iter()
+        .find_map(|effect| match effect {
+            StoreEffect::StatusTransition(transition) => transition.notification,
+            _ => None,
+        })
+        .unwrap();
+    assert!(store.should_deliver_notification(&request));
+    store.toggle_notification_mute(record.id.clone());
+    assert!(!store.should_deliver_notification(&request));
+    assert_eq!(store.notifications().unread_count(), 1);
+    store.toggle_notification_mute(record.id.clone());
+    assert!(store.should_deliver_notification(&request));
+    store.toggle_notification_alerts();
+    assert!(!store.should_deliver_notification(&request));
+    store.toggle_notification_alerts();
+    store.mark_notifications_read(&record.id);
+    assert!(!store.should_deliver_notification(&request));
 }

--- a/diri/crates/diri-client/src/client.rs
+++ b/diri/crates/diri-client/src/client.rs
@@ -118,8 +118,9 @@ impl ClientCore {
     /// IF YOU ADD AN EVENT KIND THAT DIRI NEEDS, ADD IT HERE TOO. Server-side
     /// filtering means an unlisted kind never reaches `route_message`, and the
     /// symptom is silence, not an error.
-    const EVENT_KINDS: [&'static str; 4] = [
+    const EVENT_KINDS: [&'static str; 5] = [
         EventName::SESSION_UPDATED,
+        EventName::SESSION_NOTIFICATION,
         EventName::SESSION_RESOURCES,
         EventName::SESSION_REMOVED,
         EventName::PROJECT_UPDATED,

--- a/diri/crates/diri-engine/src/events.rs
+++ b/diri/crates/diri-engine/src/events.rs
@@ -414,6 +414,11 @@ pub fn satisfies_wait_target(status: &diri_proto::SessionStatus, target: &str) -
 /// changes, by diffing registry views on a short cadence. The Swift daemon
 /// publishes at each mutation site inside its status engine; this engine's
 /// state changes on pump threads, so a watcher is the equivalent seam.
+fn next_notification_id() -> u64 {
+    static SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    SEQUENCE.fetch_add(1, Ordering::Relaxed)
+}
+
 pub fn spawn_registry_watcher(
     registry: Arc<Mutex<crate::registry::Registry>>,
     events: EventBus,
@@ -455,6 +460,29 @@ pub fn spawn_registry_watcher(
                         &record,
                         Some(&id),
                     );
+                    let notifications = registry.lock().expect("registry").take_notifications(&id);
+                    for notification in notifications {
+                        let event = diri_proto::SessionNotificationEvent {
+                            id: format!(
+                                "osc-{}-{}",
+                                std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .unwrap_or_default()
+                                    .as_nanos(),
+                                next_notification_id()
+                            ),
+                            session_id: record.id.clone(),
+                            session_created_at: record.created_at,
+                            occurred_at: diri_proto::DateMillis::from(std::time::SystemTime::now()),
+                            title: notification.title,
+                            body: notification.body,
+                        };
+                        events.publish_encoded(
+                            diri_proto::EventName::SESSION_NOTIFICATION,
+                            &event,
+                            Some(&id),
+                        );
+                    }
                 }
                 std::thread::sleep(Duration::from_millis(150));
             }

--- a/diri/crates/diri-engine/src/hooks.rs
+++ b/diri/crates/diri-engine/src/hooks.rs
@@ -177,9 +177,7 @@ pub fn parse_activity_seed(
 fn needs_input_kind(notification_type: Option<&str>) -> Option<NeedsInputKind> {
     match notification_type {
         Some("permission_prompt") => Some(NeedsInputKind::Permission),
-        Some("idle_prompt") | Some("agent_needs_input") | Some("elicitation_dialog") => {
-            Some(NeedsInputKind::Question)
-        }
+        Some("agent_needs_input") | Some("elicitation_dialog") => Some(NeedsInputKind::Question),
         _ => None,
     }
 }
@@ -378,7 +376,7 @@ mod tests {
     fn a_notification_asking_for_input_carries_a_detail() {
         let payload = json!({
             "session_id": "s",
-            "notification_type": "idle_prompt",
+            "notification_type": "agent_needs_input",
             "message": "Waiting for your answer",
         });
         let (_, meta) = parse_claude_hook("Notification", &payload, now()).expect("parsed");

--- a/diri/crates/diri-engine/src/registry.rs
+++ b/diri/crates/diri-engine/src/registry.rs
@@ -573,6 +573,13 @@ impl Registry {
     /// The steady-state cost — the events watcher polls this several times a
     /// second — is one integer compare per live session: no clones, no
     /// serialization.
+    pub fn take_notifications(&self, id: &str) -> Vec<diri_terminal_state::TerminalNotification> {
+        self.sessions
+            .get(id)
+            .map(|session| session.take_notifications())
+            .unwrap_or_default()
+    }
+
     pub fn changed_since(
         &mut self,
         published: &mut HashMap<String, u64>,

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -1123,6 +1123,14 @@ impl Session {
 
     /// Monotonic counter that moves exactly when status, needs-input, or
     /// title change. Poll this before paying for [`Self::view`].
+    pub fn take_notifications(&self) -> Vec<diri_terminal_state::TerminalNotification> {
+        self.shared
+            .screen
+            .lock()
+            .expect("screen")
+            .take_notifications()
+    }
+
     pub fn state_version(&self) -> u64 {
         self.shared.state_version.load(Ordering::SeqCst)
     }
@@ -1762,10 +1770,10 @@ fn new_shared(spec: &SessionSpec, log: OutputLog, engine: &ManifestEngine) -> Ar
         prompt_title: Mutex::new(None),
         prompt_input: Mutex::new(PromptInputState::default()),
         log: Mutex::new(log),
-        screen: Mutex::new(HeadlessScreen::new(
-            spec.pty.cols as usize,
-            spec.pty.rows as usize,
-        )),
+        screen: Mutex::new(
+            HeadlessScreen::new(spec.pty.cols as usize, spec.pty.rows as usize)
+                .with_notifications(),
+        ),
         reducer: Mutex::new(
             StatusReducer::new(spec.authority, SystemTime::now())
                 .with_manifest(spec.manifest_id.clone(), manifest_version),
@@ -2209,6 +2217,9 @@ fn apply_remote_output(
         .then(|| {
             let mut screen = shared.screen.lock().expect("screen");
             screen.feed(bytes);
+            if screen.has_notifications() {
+                shared.bump_state_version();
+            }
             evaluate_if_screen_changed(shared, &mut screen, engine, manifest_id, last_eval_seq)
         })
         .flatten();
@@ -2528,6 +2539,9 @@ fn feed_output_batch(
             let mut screen = shared.screen.lock().expect("screen");
             let before = *filled_before.get_or_insert_with(|| screen.filled_cells());
             screen.feed(&buffer[..count]);
+            if screen.has_notifications() {
+                shared.bump_state_version();
+            }
             let after = screen.filled_cells();
             (after < before, after == 0 && before != 0)
         };
@@ -2963,6 +2977,11 @@ fn pump_held(
             let (observation, replies) = {
                 let mut screen = shared.screen.lock().expect("screen");
                 screen.feed(output);
+                if offset <= replay_until {
+                    screen.take_notifications();
+                } else if screen.has_notifications() {
+                    shared.bump_state_version();
+                }
                 let replies = screen.take_replies();
                 let observation = if evaluate_now {
                     last_eval_at = Some(Instant::now());
@@ -3415,5 +3434,40 @@ mod grid_wake_tests {
         wake.notify();
         let background = wake.wait_for_change(trailing.generation, Duration::from_secs(1));
         assert!(!background.interactive);
+    }
+}
+
+#[cfg(test)]
+mod notification_tests {
+    use super::*;
+
+    #[test]
+    fn remote_notifications_ignore_replay_and_duplicate_offsets_without_changing_status() {
+        let temp = tempfile::tempdir().unwrap();
+        let (engine, _) = ManifestEngine::load_dir(&crate::detect::bundled_manifest_dir()).unwrap();
+        let spec = SessionSpec {
+            id: "notification-replay".into(),
+            pty: PtySpec::new(vec!["/bin/sh".into()], "/tmp"),
+            manifest_id: "shell".into(),
+            authority: Authority::ProcessOnly,
+            logs_dir: temp.path().to_path_buf(),
+            holder: None,
+            remote: None,
+            defer_launch: false,
+        };
+        let log = OutputLog::open(temp.path(), &spec.id, 4096, 8192, false).unwrap();
+        let shared = new_shared(&spec, log, &engine);
+        let mut seq = 0;
+        let bytes = b"\x1b]777;notify;Build;Passed\x07";
+        let end = apply_remote_output(&shared, &engine, "shell", &mut seq, 0, bytes, true).unwrap();
+        assert!(!shared.screen.lock().unwrap().has_notifications());
+        apply_remote_output(&shared, &engine, "shell", &mut seq, end, bytes, false).unwrap();
+        let events = shared.screen.lock().unwrap().take_notifications();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].body, "Passed");
+        assert!(shared.state_version.load(Ordering::SeqCst) > 0);
+        apply_remote_output(&shared, &engine, "shell", &mut seq, end, bytes, false).unwrap();
+        assert!(!shared.screen.lock().unwrap().has_notifications());
+        assert_eq!(*shared.status.lock().unwrap(), SessionStatus::Working);
     }
 }

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -2115,6 +2115,11 @@ fn handle_remote_message(
         }
         RemoteMessage::Terminal(frame) => match frame.frame_type {
             FrameType::ReplayBegin => {
+                shared
+                    .screen
+                    .lock()
+                    .expect("screen")
+                    .reset_notification_sequence();
                 *replaying = true;
                 RemoteConnectionDisposition::Continue
             }
@@ -2976,10 +2981,10 @@ fn pump_held(
             eval_dirty = !evaluate_now;
             let (observation, replies) = {
                 let mut screen = shared.screen.lock().expect("screen");
-                screen.feed(output);
-                if offset <= replay_until {
-                    screen.take_notifications();
-                } else if screen.has_notifications() {
+                let historical_bytes =
+                    replay_until.saturating_sub(start).min(output.len() as u64) as usize;
+                screen.feed_with_history(output, historical_bytes);
+                if screen.has_notifications() {
                     shared.bump_state_version();
                 }
                 let replies = screen.take_replies();

--- a/diri/crates/diri-engine/src/status/mod.rs
+++ b/diri/crates/diri-engine/src/status/mod.rs
@@ -47,12 +47,6 @@ pub struct ReducerTiming {
     pub hook_authority_window: Duration,
     pub blocker_clear_scans: u32,
     pub staleness_timeout: Duration,
-    /// Ignore the terminal's ordinary repaint immediately after Codex reports
-    /// completion. Output after this grace means the turn was not actually
-    /// settled yet and re-arms working without completing the turn twice.
-    pub codex_stop_rearm_grace: Duration,
-    /// A late repaint should not resurrect an old, genuinely idle turn.
-    pub codex_stop_rearm_window: Duration,
 }
 
 impl Default for ReducerTiming {
@@ -65,8 +59,6 @@ impl Default for ReducerTiming {
             hook_authority_window: Duration::from_secs(7),
             blocker_clear_scans: 2,
             staleness_timeout: Duration::from_secs(60),
-            codex_stop_rearm_grace: Duration::from_secs(5),
-            codex_stop_rearm_window: Duration::from_secs(90),
         }
     }
 }
@@ -151,9 +143,7 @@ struct InternalState {
     idle_strong: bool,
     /// Fire `turn_completed` exactly once on the next committed working→idle.
     pending_turn_completed: bool,
-    /// The last strong Codex completion signal. Kept briefly so sufficiently
-    /// late PTY output can correct an optimistic idle decision.
-    last_codex_completion_at: Option<SystemTime>,
+    last_work_hook_at: Option<SystemTime>,
 
     // On-screen blocker tracking.
     screen_blocker_active: bool,
@@ -187,7 +177,7 @@ impl InternalState {
             idle_confirms: 0,
             idle_strong: false,
             pending_turn_completed: false,
-            last_codex_completion_at: None,
+            last_work_hook_at: None,
             screen_blocker_active: false,
             blocker_miss_scans: 0,
             screen_belief: None,
@@ -340,20 +330,13 @@ impl StatusReducer {
         match signal {
             StatusSignal::ProcessExit { .. } => {} // handled above
             StatusSignal::PtyOutputActivity => {
-                // PTY activity is normally recency-only for full status
-                // models. One exception matters: Codex can report completion
-                // before its terminal has truly settled. A repaint outside the
-                // short grace period re-arms working, but keeps the completed
-                // turn consumed so callers do not notify twice.
-                if self.status == SessionStatus::Idle && self.codex_output_rearms_working(now) {
-                    self.cancel_idle_candidacy();
-                    self.set_status(SessionStatus::Working, &mut outcome);
-                }
+                // Bytes alone do not establish work: late terminal repaints,
+                // title updates and status lines continue after a turn ends.
                 self.state.last_signal_at = now;
             }
             StatusSignal::UserKeystroke => {
                 self.state.last_signal_at = now;
-                self.state.last_codex_completion_at = None;
+                self.state.hold_idle_against_screen = false;
                 if matches!(self.status, SessionStatus::NeedsInput(_)) {
                     self.state.responding_since = Some(now);
                 }
@@ -363,9 +346,6 @@ impl StatusReducer {
             }
             StatusSignal::CodexTurnComplete => {
                 self.state.last_signal_at = now;
-                if self.status == SessionStatus::Working {
-                    self.state.last_codex_completion_at = Some(now);
-                }
                 self.handle_strong_idle(now, &mut outcome);
             }
             StatusSignal::CursorTranscriptWorking => {
@@ -532,21 +512,11 @@ impl StatusReducer {
             self.state.blocker_miss_scans = 0;
         }
         self.state.turn_in_flight = true;
-        self.state.last_codex_completion_at = None;
+        if clear_screen_blocker {
+            self.state.last_work_hook_at = Some(now);
+        }
         self.state.last_signal_at = now;
         self.set_status(SessionStatus::Working, outcome);
-    }
-
-    fn codex_output_rearms_working(&mut self, now: SystemTime) -> bool {
-        let Some(completed_at) = self.state.last_codex_completion_at else {
-            return false;
-        };
-        let elapsed = now.duration_since(completed_at).unwrap_or_default();
-        if elapsed > self.timing.codex_stop_rearm_window {
-            self.state.last_codex_completion_at = None;
-            return false;
-        }
-        elapsed >= self.timing.codex_stop_rearm_grace
     }
 
     /// A strong idle signal. Commits immediately when the screen already reads
@@ -557,15 +527,24 @@ impl StatusReducer {
             self.set_status(SessionStatus::Idle, outcome);
             return;
         }
-        if self.status != SessionStatus::Working {
+        if !matches!(
+            self.status,
+            SessionStatus::Working | SessionStatus::NeedsInput(_) | SessionStatus::Unknown
+        ) {
             return;
         }
+        self.state.screen_blocker_active = false;
+        self.state.blocker_miss_scans = 0;
+        self.state.pending_needs_input = None;
+        self.state.hold_idle_against_screen = true;
         self.state.idle_strong = true;
         self.state.pending_turn_completed = self.state.turn_in_flight;
         if self.state.idle_candidate_since.is_none() {
             self.state.idle_candidate_since = Some(now);
         }
-        if self.state.screen_belief == Some(ManifestState::Idle) {
+        if self.state.screen_belief == Some(ManifestState::Idle)
+            || self.status != SessionStatus::Working
+        {
             self.state.idle_confirms += 1;
             self.commit_idle(now, outcome);
         }
@@ -580,6 +559,7 @@ impl StatusReducer {
             self.state.idle_candidate_since = Some(now);
             self.state.idle_confirms = 0;
         }
+        self.state.pending_turn_completed = self.state.turn_in_flight;
         self.state.idle_confirms += 1;
         let required = if self.state.idle_strong {
             1
@@ -702,7 +682,10 @@ impl StatusReducer {
                     outcome,
                 );
             }
-            Some("idle_prompt") | Some("agent_needs_input") | Some("elicitation_dialog") => {
+            // An idle reminder is not a question or an approval request.
+            // It must not overwrite a completed turn or an actual blocker.
+            Some("idle_prompt") => {}
+            Some("agent_needs_input") | Some("elicitation_dialog") => {
                 let text = message.unwrap_or_else(|| "Waiting for input".into());
                 let detail = NeedsInputDetail {
                     kind: NeedsInputKind::Question,
@@ -810,6 +793,15 @@ impl StatusReducer {
             }
             ManifestState::Idle => {
                 if self.status == SessionStatus::Working {
+                    if self.authority == Authority::HooksPrimary
+                        && !self.state.idle_strong
+                        && self.state.last_work_hook_at.is_some_and(|last| {
+                            now.duration_since(last).unwrap_or_default()
+                                < self.timing.hook_authority_window
+                        })
+                    {
+                        return;
+                    }
                     self.confirm_idle(now, outcome);
                 } else if self.status == SessionStatus::Starting {
                     self.set_status(SessionStatus::Idle, outcome);
@@ -863,6 +855,28 @@ impl StatusReducer {
                 self.set_status(SessionStatus::Unknown, outcome);
                 return;
             }
+        }
+        if self.status == SessionStatus::Working
+            && self.authority == Authority::HooksPrimary
+            && self.state.screen_belief == Some(ManifestState::Idle)
+            && self.state.idle_candidate_since.is_none()
+            && self.state.last_work_hook_at.is_some_and(|last| {
+                now.duration_since(last).unwrap_or_default() >= self.timing.hook_authority_window
+            })
+        {
+            self.confirm_idle(now, outcome);
+        }
+        // A settled screen often stops emitting new content sequences. One
+        // idle observation held for the debounce cap is enough; requiring
+        // more redraws leaves quiet agents stuck Working forever.
+        if self.status == SessionStatus::Working
+            && self.state.screen_belief == Some(ManifestState::Idle)
+            && !self.state.idle_strong
+            && self.state.idle_candidate_since.is_some_and(|since| {
+                now.duration_since(since).unwrap_or_default() >= self.timing.idle_confirm_cap
+            })
+        {
+            self.commit_idle(now, outcome);
         }
         // A tick can supply the single confirmation a strong idle still needs.
         if self.status == SessionStatus::Working

--- a/diri/crates/diri-engine/src/status/tests.rs
+++ b/diri/crates/diri-engine/src/status/tests.rs
@@ -434,7 +434,7 @@ fn a_notification_asking_a_question_needs_input() {
 
     let outcome = reducer.reduce(
         hook(ClaudeHook::Notification {
-            notification_type: Some("idle_prompt".into()),
+            notification_type: Some("agent_needs_input".into()),
             message: Some("Waiting for your answer".into()),
         }),
         now,
@@ -473,7 +473,7 @@ fn codex_turn_complete_then_a_tick_settles_to_idle() {
 }
 
 #[test]
-fn late_codex_output_rearms_working_without_completing_twice() {
+fn late_codex_output_keeps_completion_without_completing_twice() {
     let mut reducer = StatusReducer::new(Authority::ScreenPrimary, t0());
     let now = settled(&mut reducer, t0());
     reducer.reduce(
@@ -503,7 +503,7 @@ fn late_codex_output_rearms_working_without_completing_twice() {
         StatusSignal::PtyOutputActivity,
         completed_at + Duration::from_secs(6),
     );
-    assert_eq!(continuing.status_change, Some(SessionStatus::Working));
+    assert_eq!(continuing.status_change, None);
     assert!(!continuing.turn_completed);
 
     reducer.reduce(
@@ -514,7 +514,7 @@ fn late_codex_output_rearms_working_without_completing_twice() {
         StatusSignal::Tick,
         completed_at + Duration::from_secs(7) + Duration::from_millis(100),
     );
-    assert_eq!(settled_again.status_change, Some(SessionStatus::Idle));
+    assert_eq!(settled_again.status_change, None);
     assert!(
         !settled_again.turn_completed,
         "rearming the same logical turn must not notify twice"
@@ -674,4 +674,123 @@ fn cursor_transcript_idle_commits_even_when_the_osc_still_says_working() {
     now += Duration::from_millis(100);
     reducer.reduce(StatusSignal::CursorTranscriptWorking, now);
     assert_eq!(*reducer.status(), SessionStatus::Working);
+}
+
+#[test]
+fn idle_reminder_does_not_turn_a_finished_agent_into_a_question() {
+    let mut reducer = StatusReducer::new(Authority::HooksPrimary, t0());
+    let now = settled(&mut reducer, t0());
+    reducer.reduce(hook(ClaudeHook::UserPromptSubmit), now);
+    reducer.reduce(hook(ClaudeHook::Stop), now + Duration::from_millis(10));
+    reducer.reduce(StatusSignal::Tick, now + Duration::from_millis(100));
+    reducer.reduce(
+        hook(ClaudeHook::Notification {
+            notification_type: Some("idle_prompt".into()),
+            message: Some("Claude is waiting for your input".into()),
+        }),
+        now + Duration::from_secs(60),
+    );
+    assert_eq!(*reducer.status(), SessionStatus::Idle);
+}
+
+#[test]
+fn stop_resolves_a_stale_permission_and_completes_the_turn() {
+    let mut reducer = StatusReducer::new(Authority::HooksPrimary, t0());
+    let now = settled(&mut reducer, t0());
+    reducer.reduce(hook(ClaudeHook::UserPromptSubmit), now);
+    reducer.reduce(
+        hook(ClaudeHook::PermissionRequest {
+            tool_name: None,
+            input_summary: None,
+        }),
+        now,
+    );
+    let stopped = reducer.reduce(hook(ClaudeHook::Stop), now + Duration::from_secs(1));
+    let tick = reducer.reduce(StatusSignal::Tick, now + Duration::from_secs(2));
+    assert_eq!(*reducer.status(), SessionStatus::Idle);
+    assert!(stopped.turn_completed || tick.turn_completed);
+}
+
+#[test]
+fn redraw_after_codex_completion_does_not_invent_work() {
+    let mut reducer = StatusReducer::new(Authority::ScreenPrimary, t0());
+    let now = settled(&mut reducer, t0());
+    reducer.reduce(
+        StatusSignal::Screen(observation(ManifestState::Working, 1)),
+        now,
+    );
+    reducer.reduce(StatusSignal::CodexTurnComplete, now);
+    reducer.reduce(StatusSignal::Tick, now + Duration::from_millis(100));
+    reducer.reduce(
+        StatusSignal::PtyOutputActivity,
+        now + Duration::from_secs(6),
+    );
+    assert_eq!(*reducer.status(), SessionStatus::Idle);
+}
+
+#[test]
+fn a_completed_claude_turn_is_not_reopened_by_a_stale_working_title() {
+    let mut reducer = StatusReducer::new(Authority::HooksPrimary, t0());
+    let now = settled(&mut reducer, t0());
+    reducer.reduce(hook(ClaudeHook::UserPromptSubmit), now);
+    reducer.reduce(hook(ClaudeHook::Stop), now);
+    reducer.reduce(StatusSignal::Tick, now + Duration::from_millis(100));
+    reducer.reduce(
+        StatusSignal::Screen(observation(ManifestState::Working, 2)),
+        now + Duration::from_secs(1),
+    );
+    assert_eq!(*reducer.status(), SessionStatus::Idle);
+    reducer.reduce(
+        hook(ClaudeHook::UserPromptSubmit),
+        now + Duration::from_secs(2),
+    );
+    assert_eq!(*reducer.status(), SessionStatus::Working);
+}
+
+#[test]
+fn a_quiet_screen_completes_once_without_waiting_for_more_redraws() {
+    let mut reducer = StatusReducer::new(Authority::ScreenPrimary, t0());
+    reducer.reduce(
+        StatusSignal::Screen(observation(ManifestState::Working, 1)),
+        t0(),
+    );
+    reducer.reduce(
+        StatusSignal::Screen(observation(ManifestState::Idle, 2)),
+        t0() + Duration::from_secs(1),
+    );
+    assert_eq!(reducer.status(), &SessionStatus::Working);
+    let completed = reducer.reduce(StatusSignal::Tick, t0() + Duration::from_secs(2));
+    assert!(completed.turn_completed);
+    assert_eq!(reducer.status(), &SessionStatus::Idle);
+    assert!(
+        !reducer
+            .reduce(
+                StatusSignal::CodexTurnComplete,
+                t0() + Duration::from_secs(3)
+            )
+            .turn_completed
+    );
+}
+
+#[test]
+fn a_recent_work_hook_outranks_an_idle_prompt_during_a_tool_call() {
+    let mut reducer = StatusReducer::new(Authority::HooksPrimary, t0());
+    reducer.reduce(hook(ClaudeHook::UserPromptSubmit), t0());
+    for seq in 1..5 {
+        reducer.reduce(
+            StatusSignal::Screen(observation(ManifestState::Idle, seq)),
+            t0() + Duration::from_millis(seq * 200),
+        );
+    }
+    assert_eq!(reducer.status(), &SessionStatus::Working);
+    assert!(
+        !reducer
+            .reduce(StatusSignal::Tick, t0() + Duration::from_secs(2))
+            .turn_completed
+    );
+    assert!(
+        reducer
+            .reduce(hook(ClaudeHook::Stop), t0() + Duration::from_secs(3))
+            .turn_completed
+    );
 }

--- a/diri/crates/diri-proto/src/methods.rs
+++ b/diri/crates/diri-proto/src/methods.rs
@@ -73,6 +73,7 @@ impl Method {
 pub struct EventName;
 
 impl EventName {
+    pub const SESSION_NOTIFICATION: &'static str = "session.notification";
     pub const SESSION_UPDATED: &'static str = "session.updated";
     pub const SESSION_RESOURCES: &'static str = "session.resources";
     pub const SESSION_REMOVED: &'static str = "session.removed";
@@ -1001,4 +1002,16 @@ mod base64_bytes {
             _ => None,
         }
     }
+}
+
+/// A terminal-authored event, separate from session execution/attention state.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionNotificationEvent {
+    pub id: String,
+    pub session_id: crate::SessionId,
+    pub session_created_at: crate::DateMillis,
+    pub occurred_at: crate::DateMillis,
+    pub title: String,
+    pub body: String,
 }

--- a/diri/crates/diri-terminal-state/src/lib.rs
+++ b/diri/crates/diri-terminal-state/src/lib.rs
@@ -375,6 +375,12 @@ impl HeadlessScreen {
         self
     }
 
+    pub fn reset_notification_sequence(&mut self) {
+        if let Some(parser) = &mut self.notifications {
+            parser.reset_sequence();
+        }
+    }
+
     pub fn has_notifications(&self) -> bool {
         self.notifications
             .as_ref()
@@ -394,9 +400,18 @@ impl HeadlessScreen {
     /// fast path for plain text that byte-at-a-time feeding defeats, and the
     /// difference is multi-x on heavy output like build logs.
     pub fn feed(&mut self, bytes: &[u8]) {
+        self.feed_with_history(bytes, 0);
+    }
+
+    /// Parses all terminal bytes while excluding a replay prefix from product
+    /// notifications. A partial historical OSC cannot leak into live output.
+    pub fn feed_with_history(&mut self, bytes: &[u8], historical_bytes: usize) {
         self.scan_progress(bytes);
         if let Some(parser) = &mut self.notifications {
-            parser.feed(bytes);
+            if historical_bytes != 0 {
+                parser.reset_sequence();
+            }
+            parser.feed(&bytes[historical_bytes.min(bytes.len())..]);
         }
         self.parser.advance(&mut self.term, bytes);
         self.settle();

--- a/diri/crates/diri-terminal-state/src/lib.rs
+++ b/diri/crates/diri-terminal-state/src/lib.rs
@@ -13,6 +13,9 @@
 //! emulator does not model, so it is scanned out of the byte stream directly —
 //! see [`scan_progress`].
 
+mod notifications;
+pub use notifications::TerminalNotification;
+
 use std::sync::mpsc::{self, Receiver, SyncSender};
 
 use alacritty_terminal::event::{Event, EventListener, WindowSize};
@@ -309,6 +312,7 @@ pub struct HeadlessScreen {
     /// Trailing bytes of the previous chunk, so an OSC split across a read
     /// boundary is still recognized.
     progress_carry: Vec<u8>,
+    notifications: Option<notifications::NotificationParser>,
     /// Answers the emulator owes the child: a cursor-position report, a device
     /// attributes reply, and anything else generated in response to a query.
     /// A program that asks and is never answered blocks until its own timeout,
@@ -354,6 +358,7 @@ impl HeadlessScreen {
             current_damage_rows: vec![false; geometry.rows],
             pending_damage_rows: vec![true; geometry.rows],
             progress_carry: Vec::new(),
+            notifications: None,
             replies: Vec::new(),
             title_changed: false,
             last_cells: Vec::new(),
@@ -364,6 +369,25 @@ impl HeadlessScreen {
         screen
     }
 
+    /// Opt in only in the local Engine. Holders do not interpret product alerts.
+    pub fn with_notifications(mut self) -> Self {
+        self.notifications = Some(Default::default());
+        self
+    }
+
+    pub fn has_notifications(&self) -> bool {
+        self.notifications
+            .as_ref()
+            .is_some_and(|parser| !parser.ready.is_empty())
+    }
+
+    pub fn take_notifications(&mut self) -> Vec<TerminalNotification> {
+        self.notifications
+            .as_mut()
+            .map(|parser| parser.ready.drain(..).collect())
+            .unwrap_or_default()
+    }
+
     /// Feeds raw PTY output into the emulator.
     ///
     /// The whole chunk goes to the parser in one call — vte has a batched
@@ -371,6 +395,9 @@ impl HeadlessScreen {
     /// difference is multi-x on heavy output like build logs.
     pub fn feed(&mut self, bytes: &[u8]) {
         self.scan_progress(bytes);
+        if let Some(parser) = &mut self.notifications {
+            parser.feed(bytes);
+        }
         self.parser.advance(&mut self.term, bytes);
         self.settle();
     }

--- a/diri/crates/diri-terminal-state/src/notifications.rs
+++ b/diri/crates/diri-terminal-state/src/notifications.rs
@@ -17,6 +17,12 @@ pub(crate) struct NotificationParser {
 }
 
 impl NotificationParser {
+    pub fn reset_sequence(&mut self) {
+        self.state = 0;
+        self.payload.clear();
+        self.pending.clear();
+    }
+
     pub fn feed(&mut self, bytes: &[u8]) {
         // No copy or bytewise scan for the common plain-output case.
         if self.state == 0 && !bytes.contains(&0x1b) {
@@ -159,6 +165,18 @@ fn clean(text: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn a_replay_boundary_inside_a_read_delivers_only_complete_live_notifications() {
+        let mut screen = crate::HeadlessScreen::new(80, 24).with_notifications();
+        let old = b"\x1b]9;old\x07\x1b]9;partial";
+        let live = b" remainder\x07\x1b]9;new\x07";
+        let bytes: Vec<_> = old.iter().chain(live).copied().collect();
+        screen.feed_with_history(&bytes, old.len());
+        let messages = screen.take_notifications();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].body, "new");
+    }
+
     #[test]
     fn fragmented_osc_bel_st_and_progress() {
         let mut parser = NotificationParser::default();

--- a/diri/crates/diri-terminal-state/src/notifications.rs
+++ b/diri/crates/diri-terminal-state/src/notifications.rs
@@ -1,0 +1,213 @@
+//! Bounded OSC notification extraction, enabled only by the local Engine.
+//! Content is data: it cannot acknowledge prompts or alter execution status.
+use std::collections::VecDeque;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TerminalNotification {
+    pub title: String,
+    pub body: String,
+}
+
+#[derive(Default)]
+pub(crate) struct NotificationParser {
+    state: u8,
+    payload: Vec<u8>,
+    pending: VecDeque<(String, TerminalNotification)>,
+    pub ready: VecDeque<TerminalNotification>,
+}
+
+impl NotificationParser {
+    pub fn feed(&mut self, bytes: &[u8]) {
+        // No copy or bytewise scan for the common plain-output case.
+        if self.state == 0 && !bytes.contains(&0x1b) {
+            return;
+        }
+        for &byte in bytes {
+            match self.state {
+                0 => {
+                    if byte == 0x1b {
+                        self.state = 1;
+                    }
+                }
+                1 => {
+                    self.state = match byte {
+                        b']' => 2,
+                        b'P' | b'_' | b'^' | b'X' => 4,
+                        0x1b => 1,
+                        _ => 0,
+                    };
+                    self.payload.clear();
+                }
+                2 => match byte {
+                    7 => {
+                        self.finish();
+                        self.state = 0;
+                    }
+                    0x1b => self.state = 3,
+                    0x18 | 0x1a => {
+                        self.payload.clear();
+                        self.state = 0;
+                    }
+                    _ if self.payload.len() < 8192 => self.payload.push(byte),
+                    _ => {
+                        self.payload.clear();
+                        self.state = 4;
+                    }
+                },
+                3 => {
+                    if byte == b'\\' {
+                        self.finish();
+                        self.state = 0;
+                    } else {
+                        self.payload.clear();
+                        self.state = if byte == 0x1b { 1 } else { 0 };
+                    }
+                }
+                4 => match byte {
+                    7 | 0x18 | 0x1a => self.state = 0,
+                    0x1b => self.state = 5,
+                    _ => {}
+                },
+                5 => {
+                    self.state = if byte == b'\\' {
+                        0
+                    } else if byte == 0x1b {
+                        5
+                    } else {
+                        4
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    fn finish(&mut self) {
+        let Ok(payload) = std::str::from_utf8(&self.payload) else {
+            return;
+        };
+        let notification = if let Some(body) = payload.strip_prefix("9;") {
+            // OSC 9;4 is progress, never a desktop notification.
+            if body.starts_with("4;") {
+                return;
+            }
+            TerminalNotification {
+                title: String::new(),
+                body: clean(body, 1000),
+            }
+        } else if let Some(content) = payload.strip_prefix("777;notify;") {
+            let (title, body) = content.split_once(';').unwrap_or((content, ""));
+            TerminalNotification {
+                title: clean(title, 160),
+                body: clean(body, 1000),
+            }
+        } else if let Some(content) = payload.strip_prefix("99;") {
+            let Some((metadata, text)) = content.split_once(';') else {
+                return;
+            };
+            let value = |key: &str| metadata.split(':').find_map(|part| part.strip_prefix(key));
+            // Only textual title/body delivery. Queries, icons, close commands,
+            // encoded data and activation callbacks must never become alerts.
+            if value("e=").is_some_and(|encoding| encoding != "0") {
+                return;
+            }
+            let part = value("p=").unwrap_or("title");
+            if !matches!(part, "title" | "body") {
+                return;
+            }
+            let id = clean(value("i=").unwrap_or(""), 128);
+            let mut notification = self
+                .pending
+                .iter()
+                .position(|(key, _)| key == &id)
+                .and_then(|index| self.pending.remove(index))
+                .map(|(_, item)| item)
+                .unwrap_or_default();
+            if part == "body" {
+                notification.body = clean(text, 1000);
+            } else {
+                notification.title = clean(text, 160);
+            }
+            if value("d=") == Some("0") {
+                if self.pending.len() == 8 {
+                    self.pending.pop_front();
+                }
+                self.pending.push_back((id, notification));
+                return;
+            }
+            notification
+        } else {
+            return;
+        };
+        if notification.title.is_empty() && notification.body.is_empty() {
+            return;
+        }
+        if self.ready.len() == 32 {
+            self.ready.pop_front();
+        }
+        self.ready.push_back(notification);
+    }
+}
+
+fn clean(text: &str, max: usize) -> String {
+    text.chars()
+        .filter(|ch| !ch.is_control())
+        .take(max)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn fragmented_osc_bel_st_and_progress() {
+        let mut parser = NotificationParser::default();
+        for byte in b"\x1b]777;notify;Tests;All green\x1b\\\x1b]9;Review ready\x07\x1b]9;4;1;80\x07"
+        {
+            parser.feed(&[*byte]);
+        }
+        assert_eq!(parser.ready.len(), 2);
+        assert_eq!(
+            parser.ready[0],
+            TerminalNotification {
+                title: "Tests".into(),
+                body: "All green".into()
+            }
+        );
+        assert_eq!(parser.ready[1].body, "Review ready");
+    }
+    #[test]
+    fn kitty_multipart_and_control_messages() {
+        let mut parser = NotificationParser::default();
+        parser.feed(
+            b"\x1b]99;i=abc:d=0;Build\x07\x1b]99;i=abc:p=body;Passed\x1b\\\x1b]99;p=?;query\x07",
+        );
+        assert_eq!(parser.ready.len(), 1);
+        assert_eq!(
+            parser.ready[0],
+            TerminalNotification {
+                title: "Build".into(),
+                body: "Passed".into()
+            }
+        );
+    }
+    #[test]
+    fn malformed_and_flooded_output_is_bounded() {
+        let mut parser = NotificationParser::default();
+        parser.feed(b"\x1b]9;");
+        parser.feed(&vec![b'x'; 100_000]);
+        assert!(parser.payload.is_empty());
+        parser.feed(b"\x07\x1b]9;recovered\x07");
+        assert_eq!(parser.ready.len(), 1);
+        for _ in 0..1000 {
+            parser.feed(b"\x1b]9;bounded\x07");
+        }
+        assert_eq!(parser.ready.len(), 32);
+    }
+    #[test]
+    fn osc_inside_another_string_is_not_a_notification() {
+        let mut parser = NotificationParser::default();
+        parser.feed(b"\x1bPignored\x1b]9;not an alert\x1b\\");
+        assert!(parser.ready.is_empty());
+    }
+}

--- a/diri/crates/dirijor-mcp/src/bin/dirijor.rs
+++ b/diri/crates/dirijor-mcp/src/bin/dirijor.rs
@@ -86,7 +86,7 @@ fn print_help() {
          Usage:\n  dirijor status [--json]\n  dirijor activity [--limit N] [--json]\n  dirijor session <list|get|read|send|wait|spawn|fork|release|archive> ...\n  \
          dirijor worktree <list|create|remove> ...\n  dirijor artifacts <session> [--json]\n  \
          dirijor events <subscribe|wait> ...\n  dirijor ports [--json]\n  dirijor doctor\n  \
-         dirijor hook <event>\n  dirijor notify <json>\n  dirijor mcp-tools\n  \
+         dirijor hook <event>\n  dirijor notify <json>\n  dirijor notify --title TEXT --body TEXT\n  dirijor mcp-tools\n  \
          dirijor mcp-call --tool <name> < input.json\n\n\
          Deferred on Linux: companion forwarding (dirijor forward)."
     );
@@ -152,6 +152,37 @@ fn hook(event: Option<&str>) -> Result<(), CliError> {
 }
 
 fn notify(arguments: &[String]) -> Result<(), CliError> {
+    if arguments
+        .first()
+        .is_some_and(|argument| argument.starts_with("--"))
+    {
+        let mut title = String::from("Diri");
+        let mut body = String::new();
+        let mut arguments = arguments.iter();
+        while let Some(flag) = arguments.next() {
+            let Some(value) = arguments.next() else {
+                return Err(CliError::failure(
+                    "notify expects --title TEXT and --body TEXT",
+                ));
+            };
+            let clean: String = value
+                .chars()
+                .filter(|ch| !ch.is_control())
+                .take(1000)
+                .collect();
+            match flag.as_str() {
+                "--title" => title = clean.replace(';', " "),
+                "--body" => body = clean,
+                _ => return Err(CliError::failure("notify supports --title and --body")),
+            }
+        }
+        // Works inside local and remote terminals without a socket or hook.
+        print!("\x1b]777;notify;{title};{body}\x07");
+        io::stdout()
+            .flush()
+            .map_err(|error| CliError::failure(error.to_string()))?;
+        return Ok(());
+    }
     let Some(raw) = arguments.last() else {
         return Ok(());
     };

--- a/diri/docs/notifications.md
+++ b/diri/docs/notifications.md
@@ -1,0 +1,96 @@
+# Agent notifications
+
+Open **Notifications** from the sidebar or with **⌘⇧I**. **⌘⇧J** jumps to the
+latest unread session notification, then falls back to sessions currently
+needing attention. The tray supports unread/all views, read/unread, clear,
+session mute, and keyboard navigation with ↑, ↓, Return and Escape.
+
+Execution and unread state are separate. A completion remains in the inbox
+when an agent starts more work. Reading it does not stop the agent or answer a
+question. A resolved or replaced prompt is marked read and its Mac alert is
+withdrawn. Closing or archiving a session resolves its notifications; the
+history remains available. Failed exits notify; clean exits and sessions
+closed through the app do not.
+
+A notification for the selected, visible session in the active app is recorded
+as read and makes no sound or desktop banner. A selected session behind
+Settings, the launcher or an overlay can still notify. Delivery is checked
+again on the main thread so reading or resolving a queued event suppresses it.
+**Sounds off** is silent; it does not substitute the system sound. **Alerts
+off** and per-session **Mute** suppress interruption while preserving history.
+
+On macOS, clicking a notification or **Open session** activates Diri and
+selects its originating session. Cold-start clicks wait for the session list.
+Unavailable sessions produce an explanation. Old Approve/Deny notifications
+also open the session: notification callbacks never type into a terminal.
+Unread indicators appear in the sidebar, menu-bar session list and Dock.
+Reading, resolving, muting or clearing removes the corresponding native alerts.
+
+The tray shows macOS authorization status and includes **Test alert**. macOS
+Focus mode and system notification settings still control delivery. A bare
+Cargo binary has no application bundle and cannot deliver native alerts; the
+in-app inbox remains available.
+
+## Terminal and CLI integration
+
+An agent or command can send a notification through its current terminal:
+
+```sh
+dirijor notify --title 'Tests finished' --body 'All checks passed'
+printf '\033]777;notify;Tests finished;All checks passed\007'
+printf '\033]9;Review is ready\007'
+```
+
+The existing `dirijor notify '<Codex JSON>'` completion callback is preserved.
+The Engine accepts OSC 9, OSC 777 and plain-text OSC 99 title/body notifications,
+including BEL/ST terminators and fragmented writes. OSC 9;4 remains progress.
+Kitty queries, icons, encoded payloads and callback actions are ignored.
+Inputs, multipart state and event queues are bounded; repeated identical
+terminal messages within five seconds are coalesced.
+
+The same terminal sequences work over Diri's Remote PTY Holder transport while
+the local Engine is connected. The local Engine derives events from live raw
+output; the Holder does not run hooks or store product notifications. Replay
+cannot redeliver terminal alerts. Structured remote Claude/Codex hooks and
+reliable notification delivery while the Engine is disconnected remain
+separate enhancements; see [REMOTE_PORT.md](../REMOTE_PORT.md).
+
+History is app-local `notifications.json`, beside preferences: versioned,
+atomically saved, owner-only on Unix and bounded to 200 events. It retains
+bounded user-visible titles/bodies. Notification payloads are not added to
+operational logs. Read state belongs to this app installation, not to remote
+Holders or other clients.
+
+## Source comparison with cmux
+
+Compared against cmux commit
+[`7d5d308`](https://github.com/manaflow-ai/cmux/tree/7d5d308450eac2991e748c6387d8718704be891a)
+and Diri main `1c56e5f`. This is a source comparison, not a claim that every
+cmux notification feature or delivery condition has been reproduced.
+
+The main gaps addressed here are ordinary native-click navigation, durable
+unread history, resolved-alert withdrawal, focused-session quiet, real mute,
+unseen-completion navigation, same-level event deduplication, failure alerts,
+terminal notification ingress and delivery diagnostics. References:
+[delivery policy](https://github.com/manaflow-ai/cmux/blob/7d5d308450eac2991e748c6387d8718704be891a/Sources/TerminalNotificationDeliveryDecision.swift),
+[notification lifecycle](https://github.com/manaflow-ai/cmux/blob/7d5d308450eac2991e748c6387d8718704be891a/Sources/TerminalNotificationStore.swift),
+[session opening](https://github.com/manaflow-ai/cmux/blob/7d5d308450eac2991e748c6387d8718704be891a/Sources/AppDelegate%2BNotificationOpen.swift).
+
+Remaining notification differences include transcript-derived completion
+summaries, agent background-work metadata, notification webhooks/mobile
+forwarding, full Kitty notification protocol support, and reliable offline
+remote events. Terminal-scraped statuses still depend on each agent manifest.
+
+Other product gaps, in priority order:
+
+| Gap | Diri baseline | cmux comparison |
+| --- | --- | --- |
+| Flexible splits | Main plus auxiliary terminal; addressed in a separate PR | Arbitrary horizontal/vertical surfaces and directional focus |
+| Embedded browser | Playwright automation exists; no browser pane in the desktop workbench | Browser surfaces and remote localhost routing |
+| At-a-glance context | Branch/cwd/ports often require hover; PR/artifact UI exists | More context directly in sidebar rows |
+| Shared project workflows | Saved launch recipes exist | Repo-owned commands and inherited configuration |
+| Mobile alerts | Phone access exists | Optional notification forwarding |
+
+Remote uploads, worktrees, PR tracking, port metadata, CLI/MCP orchestration and
+session persistence already exist in Diri. Terminal quality and performance
+need a measured comparison, not an inference from renderer names.


### PR DESCRIPTION
## Why

Agent execution and notification state disagree today: idle reminders can look like questions, late repaint bytes can reopen finished work, a quiet final screen can remain Working, and native alert clicks do not select the originating session. Delivered alerts also outlive resolved prompts.

## What changed

- Fix those reducer transitions, preserve recent hook authority during tool calls, and recognize distinct prompts/completions without notifying every redraw. Archived sessions no longer keep global attention lit.
- Add a private, bounded, persistent notification inbox with unread history, context, keyboard navigation, read/unread, clear, mute, and alert/sound controls. Add sidebar/menu-bar/Dock unread indicators. Completion history survives resumed work; resolved prompts withdraw their native alerts.
- Route ordinary Mac alert clicks and “Open session” to the originating session, including cold-start queuing. Replace delayed Approve/Deny keystrokes with navigation. Recheck focus/read/mute before delivery, cancel stale pending delivery, expose permission health and a test alert.
- Accept OSC 9/777 and textual OSC 99 notifications through live local/remote terminal output, plus `dirijor notify --title TEXT --body TEXT`. Extraction is bounded and replay is silent. Remote Holder responsibilities and protocol remain unchanged.

[Behavior, integration examples, cmux source comparison, and remaining gaps](https://github.com/cristicretu/diri/blob/fix/notification-lifecycle/diri/docs/notifications.md). Flexible splits are in [stacked PR #180](https://github.com/cristicretu/diri/pull/180).

This closes the core notification lifecycle gaps, not every cmux feature. Transcript-derived summaries, background-work metadata, full Kitty protocol, mobile/webhook forwarding and reliable offline remote events remain documented enhancements.

## Verification

- `./scripts/check.sh`: passed, including format, workspace Clippy, 1,310 tests passed / 22 ignored across 56 suites, publishing guards and dependency license policy.
- Includes queued-delivery/read/focus/mute and replay-boundary regression coverage.
- `cargo build --workspace --release`: passed.
- `DIRI_PERF_ASSERT=1 cargo test -p diri-engine --release --test throughput -- --nocapture`: 3 passed; 8 MB drained at 128.3 MB/s (25 MB/s gate).
- CLI OSC encoding/control-character sanitization: passed. Regression coverage includes fragmented OSC, bounded floods, remote replay/duplicate offsets, persisted read state and resolved-prompt cleanup.

A separately identified preview app was launched with inert fixtures. Computer-use automation timed out before returning its window, so screenshot/visual verification and actual macOS banner delivery/click behavior remain unverified. No real user sessions or notification settings were changed.

GitHub’s iPhone job currently fails before compilation: its runner selects Xcode older than 26 (`Select Xcode 26 or later. App Store Connect requires iOS SDK 26+.`). This PR does not change the iPhone app or its workflow. Rust CI is still running; local gates above passed.

- [x] Contributor checks pass.
- [x] Existing session survival tests pass; no Holder protocol/storage migration.
- [x] Privacy: bounded owner-only history, no notification content added to operational logs; native callbacks cannot type approvals.
- [x] User-visible behavior documented.
- [ ] UI screenshot/native interaction smoke test — automation timeout described above.
