### PR TITLE
Refresh Diri marketing and remote positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,17 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![GitHub release](https://img.shields.io/github/v/release/cristicretu/diri)](https://github.com/cristicretu/diri/releases/latest)
 
-Native desktop orchestrator for coding agents on macOS and Linux. Run Claude Code, Codex, Cursor, Gemini and plain
-shells in parallel — across git worktrees or on remote hosts — each with a live status
-(working / needs-you / done) and tmux-like persistence: closing the app never kills a session,
-and a daemon restart brings conversations back.
+Run coding agents in parallel without babysitting a wall of terminals.
 
-![diri](docs/images/diri.png)
+diri is a native workspace for Claude Code, Codex, Cursor, Gemini, and other
+terminal agents on macOS and Linux. See which sessions are working, waiting, or
+done; isolate parallel work in git worktrees; review changes; and reconnect
+after closing the app.
+
+No Diri account or hosted relay. Your sessions run on your computer or an SSH
+host you control.
+
+![diri showing several coding-agent sessions and their live status](docs/images/diri.png)
 
 <p align="center"><img src="docs/images/diri-divider-status.png" alt="" width="760"></p>
 
@@ -22,16 +27,15 @@ brew install --cask cristicretu/diri/diri
 ```
 
 Or download the latest DMG from [Releases](https://github.com/cristicretu/diri/releases/latest),
-open it, and drag diri to Applications. Either way it is the same universal build (Apple
-silicon and Intel), signed and notarized. diri updates itself from there.
+open it, and drag diri to Applications. Both routes install the same universal
+build for Apple silicon and Intel, signed and notarized. diri handles updates
+from there.
 
 <p align="center"><img src="docs/images/diri-install.png" alt="Diri moving the app into the Applications folder" width="680"></p>
 
-The tap has to be named in full — a bare `diri` resolves only against Homebrew's default
-taps. The cask lives in [cristicretu/homebrew-diri](https://github.com/cristicretu/homebrew-diri)
-rather than `homebrew-cask`, which requires a notability threshold diri does not meet yet.
-
-macOS 15 or newer.
+The Homebrew cask lives in the
+[cristicretu/diri](https://github.com/cristicretu/homebrew-diri) tap, so the full
+cask name is required. macOS 15 or newer.
 
 ### Linux beta
 
@@ -45,83 +49,101 @@ sudo apt install ./diri_<version>_amd64.deb
 chmod +x diri_<version>_amd64.AppImage && ./diri_<version>_amd64.AppImage
 ```
 
-See the [Linux beta guide](diri/LINUX.md) for checksums, upgrade and uninstall
-steps, XDG paths, graphics troubleshooting, and current limitations.
+See the [Linux beta guide](diri/LINUX.md) for checksums, upgrades, XDG paths,
+graphics troubleshooting, and current limitations.
+
+## Why use diri
+
+- **Know where you are needed.** Live status separates agents that are working,
+  waiting for input, or done. Notifications and the sidebar let you follow many
+  sessions without reading every terminal.
+- **Keep sessions alive.** A dedicated Holder owns each PTY. Closing diri does
+  not stop local work, and the Engine can restart and adopt the same running
+  sessions.
+- **Give parallel work room to breathe.** Create isolated git worktrees, keep
+  their lineage visible, and hand work from one agent to another.
+- **Review the result in one place.** Inspect diffs, stage or discard changes,
+  commit work, and follow pull request checks and discussion beside the session
+  that produced it.
+- **Use the tools you already chose.** diri ships 22 agent definitions and runs
+  each installed CLI in a real terminal under your user account. Claude Code
+  and Codex have the deepest status detection and resume support; other agents
+  remain fully usable as terminals even when their integration is lighter.
+- **Work on an SSH host directly.** diri verifies and bootstraps a small matching
+  Helper, then gives each remote session its own PTY Holder. It needs no `tmux`,
+  preinstalled Diri service, `sudo`, or hosted relay.
+- **Let agents coordinate when you want them to.** The included MCP server lets
+  an agent start another session, inspect its progress, read its output, and
+  answer prompts.
+
+![A selection of the coding agents supported by diri](docs/images/diri-agent-lineup.png)
 
 ## 60-second tour
 
-1. Add a project directory and create a session for Claude Code, Codex, another
-   supported agent, or a plain shell.
-2. Start several sessions, ideally in separate git worktrees when they edit the
-   same repository.
-3. Watch the sidebar instead of every terminal: it shows which agents are
-   working, waiting for you, or done.
-4. Quit and reopen diri. The daemon keeps each PTY alive and replays the session
-   when you return.
+1. Add a project directory and create a session for an installed agent or a
+   plain shell.
+2. Start parallel sessions in separate worktrees when they may edit the same
+   repository.
+3. Follow live status in the sidebar. Open a session when it needs you or when
+   its changes are ready to review.
+4. Quit and reopen diri. Your local sessions and terminal history are still
+   there.
 
 The [getting-started guide](docs/GETTING_STARTED.md) covers remote hosts, MCP
 orchestration, diagnostics, local data, and uninstalling.
 
 <p align="center"><img src="docs/images/diri-divider-worktrees.png" alt="" width="760"></p>
 
-## What it does
+## From your iPhone
 
-- **Many agents at once.** Each session is a real terminal with a real PTY. Group them by
-  project, split them across git worktrees, or run them on a remote host over ssh+tmux.
-- **Status you can trust.** diri reads what an agent actually painted on its screen and tells
-  you which ones are working, which are waiting on you, and which are done — so you can watch
-  ten sessions without reading ten terminals.
-- **Sessions outlive the app.** A background daemon owns the PTYs. Quit diri, reopen it, and
-  everything is still there.
-- **Agents can orchestrate agents.** An MCP server lets a running agent spawn another one,
-  watch it, read its output, and answer its prompts.
-
-First-class status detection and resume are Claude Code and Codex. Cursor and Gemini run with
-partial support, and anything else runs as a terminal with running/exited status.
-
-![Claude Code, Codex, Cursor, Gemini, and shell agents](docs/images/diri-agent-lineup.png)
+The companion iPhone beta can start sessions, send prompts, answer agent
+questions, follow output, and review tracked changes. It connects to the Mac
+app through your Tailscale network; Diri does not proxy session content through
+a hosted service. See the [iPhone setup and build guide](ios/README.md).
 
 ## Architecture
 
-Two processes, one wire protocol:
+The desktop app and CLI connect to one local Rust Engine:
 
 ![Diri architecture: app and CLI connect through the control socket to the engine, persistent PTY holders, and coding agents](docs/images/diri-architecture.png)
 
-- **`diri`** — the desktop app: Rust + [GPUI](https://github.com/zed-industries/zed). Owns the
-  window, sidebar, terminal renderer, command palette, and usage accounting. Lives in
-  [`diri/`](diri/).
-- **`dirijord-rs`** — the headless Rust engine, launched by the app and outliving it. Owns PTYs and
-  child agent processes, an offset-addressed output log per session (for detach and replay), a
-  headless terminal emulator for status detection, the session registry and persistence,
-  worktrees, and the control socket.
+- **`diri`** is the desktop app, built with Rust and
+  [GPUI](https://github.com/zed-industries/zed). It owns the window, sidebar,
+  terminal renderer, command palette, and usage views.
+- **`dirijord-rs`** is the headless local Engine. It owns session records,
+  orchestration, worktrees, status reduction, terminal history, and the control
+  socket.
+- **`diri-holder`** owns a local session's PTY and agent process tree so the
+  Engine can restart without ending the work.
+- **`diri-remote`** is the bootstrapped remote Helper. One independent Holder
+  owns each remote PTY while SSH carries the encrypted protocol connection.
 
-`dirijor` is the automation CLI for hooks, notifications, status, and diagnostics;
-`dirijor-mcp` is the MCP stdio server injected into agents. `diri-holder` owns each PTY master so
-sessions survive an engine restart. Every shipped executable is built from the Rust workspace in
-[`diri/`](diri/).
+`dirijor` is the automation CLI for hooks, notifications, status, and
+diagnostics. `dirijor-mcp` is the MCP stdio server injected into agents. Every
+shipped executable is built from the Rust workspace in [`diri/`](diri/).
 
 ## Adding an agent
 
-Agent support is data, not code. Each agent is one JSON file in
-`diri/crates/diri-engine/manifests/` describing how to spawn it, how to resume, which keys
-approve or deny a prompt, and the screen rules that decide whether it is working, waiting, or
-done. Copy the closest existing manifest and adjust it — no code changes required. The
-[manifest-authoring guide](docs/AGENT-MANIFESTS.md) explains the schema, safe capture workflow,
-examples, overrides, and validation. This is the easiest way to contribute.
+Agent support is data. Each JSON file in
+`diri/crates/diri-engine/manifests/` describes how to start and resume an agent,
+which keys approve or deny a prompt, and the screen rules that determine its
+status. Copy the closest manifest and adjust it; no Rust changes are required.
+The [manifest-authoring guide](docs/AGENT-MANIFESTS.md) explains the schema,
+capture workflow, examples, overrides, and validation.
 
 ## Building from source
 
-Needs Rust (pinned in `diri/rust-toolchain.toml`) plus the platform build dependencies. On macOS
-that means the Xcode command-line tools; Linux dependencies and packaging commands are listed in
-[`diri/LINUX.md`](diri/LINUX.md). The first
-build compiles GPUI from a pinned Zed revision and takes a while.
+The Rust toolchain is pinned in `diri/rust-toolchain.toml`. macOS builds require
+the Xcode command-line tools. Linux dependencies and packaging commands are in
+the [Linux beta guide](diri/LINUX.md). The first build compiles GPUI from a
+pinned Zed revision and takes a while.
 
 ```sh
-(cd diri && cargo build)                   # app, engine, holder, CLI, MCP
+(cd diri && cargo build)                   # app, engine, holders, CLI, MCP
 (cd diri && cargo test --workspace)
 (cd diri && cargo run -p diri-app)         # run the app from source
 
-diri/scripts/package.sh                    # full bundle
+diri/scripts/package.sh                    # full macOS bundle
 diri/scripts/package-linux.sh              # AppImage + DEB, on x86_64 Linux
 diri/scripts/install-local.sh
 ```
@@ -133,15 +155,15 @@ Run the same core checks as CI with one command:
 ```
 
 [`diri/PACKAGING.md`](diri/PACKAGING.md) covers signing and notarization,
-[`diri/UPDATING.md`](diri/UPDATING.md) the updater and release flow,
-[`diri/NODE.md`](diri/NODE.md) running agents on a remote VPS node.
-
-The [documentation index](docs/README.md) links user and engineering guides.
+[`diri/UPDATING.md`](diri/UPDATING.md) covers updates and releases, and
+[`diri/NODE.md`](diri/NODE.md) covers the optional enhanced remote-node mode.
+The [documentation index](docs/README.md) links the remaining user and
+engineering guides.
 
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md). Bug reports, fixes, docs, and new agent
-manifests are all welcome. New contributors can start with
+manifests are welcome. New contributors can start with
 [`good first issue`](https://github.com/cristicretu/diri/labels/good%20first%20issue)
 or [`help wanted`](https://github.com/cristicretu/diri/labels/help%20wanted).
 

--- a/diri/LINUX.md
+++ b/diri/LINUX.md
@@ -79,8 +79,9 @@ daemon, agent discovery, state file, and active socket without opening the UI.
 ## Optional integrations
 
 - Coding-agent executables must be installed separately and visible on the
-  login shell's `PATH`. Diri currently advertises Claude Code, Codex, Cursor,
-  and Gemini when their commands are available.
+  login shell's `PATH`. Diri ships 22 agent definitions and shows the installed
+  CLIs it detects. Claude Code and Codex have the deepest status and resume
+  integration; every supported CLI still runs in a real terminal.
 - Status sounds use the first available command among `pw-play`, `paplay`, and
   `aplay`. Diri remains fully usable when none is installed.
 - SSH password or key-passphrase dialogs use `zenity`, with `kdialog` as a

--- a/diri/crates/diri-web/src/ui/manifest.webmanifest
+++ b/diri/crates/diri-web/src/ui/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "diri",
   "short_name": "diri",
-  "description": "Your agent sessions, from a phone.",
+  "description": "Monitor and control your Diri agent sessions from your phone.",
   "start_url": "/",
   "scope": "/",
   "display": "standalone",

--- a/diri/scripts/linux-packager-config.py
+++ b/diri/scripts/linux-packager-config.py
@@ -35,7 +35,7 @@ def main() -> int:
         "productName": "diri",
         "version": args.version,
         "identifier": "com.dirijor.diri",
-        "description": "A focused desktop orchestrator for coding agents",
+        "description": "Run and monitor coding agents in local and direct SSH sessions",
         "homepage": "https://github.com/cristicretu/diri",
         "authors": ["Cristi Cretu"],
         "licenseFile": str(repository / "LICENSE"),

--- a/diri/scripts/release.sh
+++ b/diri/scripts/release.sh
@@ -353,7 +353,8 @@ if [ ! -f "$NOTES_FILE" ]; then
     cat > "$NOTES_FILE" <<NOTES
 ## diri $VERSION
 
-Native desktop orchestrator for coding agents on macOS and Linux.
+Run coding agents in parallel with live status, persistent local sessions, git
+worktrees, review tools, and direct SSH hosts.
 
 **macOS:** download the DMG below, open it, drag diri to Applications.
 Universal (Apple silicon and Intel), signed and notarized, so it opens without

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -2,7 +2,7 @@
 
 ## Install
 
-Diri requires macOS 15 or newer. Install the signed, notarized universal build:
+On macOS 15 or newer, install the signed and notarized universal build:
 
 ```sh
 brew install --cask cristicretu/diri/diri
@@ -11,6 +11,11 @@ brew install --cask cristicretu/diri/diri
 Alternatively, download the latest DMG from [GitHub Releases](https://github.com/cristicretu/diri/releases/latest),
 open it, and drag Diri to Applications. The app checks the same release feed for
 updates; it never installs one until you click restart.
+
+On x86_64 Ubuntu 22.04 or 24.04, download the AppImage or Debian package from
+[GitHub Releases](https://github.com/cristicretu/diri/releases/latest). The
+[Linux beta guide](../diri/LINUX.md) covers installation and current platform
+limits.
 
 ## Your first session
 
@@ -58,9 +63,17 @@ it to agents you trust and review requested actions.
 
 ## Remote hosts
 
-Remote sessions use SSH and tmux; Diri does not run a hosted relay. Start with
-the [remote-node guide](../diri/NODE.md), use a dedicated non-admin account when
-possible, and avoid forwarding credentials the remote job does not need.
+Remote sessions connect directly over SSH; Diri does not run a hosted relay.
+On first use, Diri probes the host and installs a verified matching Helper in
+the remote user's private cache. Each session gets an independent PTY Holder,
+so the remote host needs neither `tmux` nor a preinstalled Diri service.
+
+Diri reports whether the host can keep user processes alive after logout. Use
+a dedicated non-admin account when possible, and avoid forwarding credentials
+the remote job does not need. The [remote architecture](../diri/REMOTE_PORT.md)
+documents the transport and persistence model. The
+[remote-node guide](../diri/NODE.md) covers the optional enhanced mode for VPS
+accounts, fleet usage, and transactional handoff.
 
 ## Diagnostics
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,10 @@
 - [Security model](SECURITY-MODEL.md) — trust boundaries and safe-use guidance.
 - [Agent manifests](AGENT-MANIFESTS.md) — add an agent, author screen rules,
   capture safe fixtures, and validate both engines.
-- [Remote nodes](../diri/NODE.md) — run sessions over SSH and tmux.
+- [Remote architecture](../diri/REMOTE_PORT.md) — direct SSH bootstrap, remote
+  PTY Holders, persistence, and protocol guarantees.
+- [Remote nodes](../diri/NODE.md) — optional VPS accounts, fleet usage, and
+  transactional handoff.
 - [Packaging](../diri/PACKAGING.md) — build, signing, and notarization.
 - [Updates and releases](../diri/UPDATING.md) — updater design and release flow.
 - [Engine port history](../diri/PORT.md) — record of the completed Rust migration.

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,18 +1,22 @@
 # diri for iPhone
 
-A native SwiftUI client for a Dirijor daemon. It talks to [`diri-web`](../diri/crates/diri-web),
-which is a frontend on a `dirijord` control socket — the phone never speaks the
-daemon's unix-socket protocol itself.
+Start, monitor, and control Diri coding-agent sessions from an iPhone. The
+native SwiftUI client can create local or preconfigured SSH sessions, send
+prompts, answer agent questions, follow terminal output, and review tracked
+changes.
+
+The client talks to [`diri-web`](../diri/crates/diri-web), a small HTTP frontend
+on the local `dirijord` control socket. The phone never speaks the daemon's Unix
+socket protocol itself.
 
 ```
 iPhone ──http──▶ diri-web ──unix socket──▶ dirijord ──pty──▶ claude/codex
        (tailnet)
 ```
 
-That indirection is the point. The control protocol assumes a persistent
-connection and an event cursor, both of which a phone loses every time it
-changes cell tower. HTTP against `diri-web` is stateless per request, so
-reconnecting is just the next request succeeding.
+The control protocol assumes a persistent connection and an event cursor, both
+of which a phone can lose as its network changes. HTTP requests to `diri-web`
+are stateless, so the next successful request reconnects the client.
 
 ## Build
 

--- a/ios/TESTFLIGHT.md
+++ b/ios/TESTFLIGHT.md
@@ -90,16 +90,17 @@ has no offline demo mode today; plan reviewer access before submitting.
 
 Suggested beta description:
 
-> Diri lets you control coding sessions on your Mac from your iPhone. Requires
-> Diri running on a powered Mac and Tailscale connected on both devices. Start
-> a session, send a prompt, answer an agent question, and review tracked changes.
+> Run and monitor coding agents on your Mac from your iPhone. See which sessions
+> need you, start work in a separate git worktree, send prompts, answer agent
+> questions, follow output, and review tracked changes. Requires Diri running on
+> a powered Mac and Tailscale connected on both devices.
 
 Suggested “What to test”:
 
-> Follow setup without using Terminal. Scan the pairing code, start a session
-> in a separate workspace, and send a prompt. Switch from Wi-Fi to mobile data,
-> lock and unlock your phone, and continue the same session. Report any unclear
-> step or lost draft. Please remove prompts, code, and pairing keys from feedback
+> Complete setup without using Terminal. Scan the pairing code, start a session
+> in a separate worktree, and send a prompt. Switch from Wi-Fi to mobile data,
+> lock and unlock your phone, then continue the same session. Report unclear
+> steps or lost drafts. Remove prompts, code, and pairing keys from feedback
 > screenshots. Push notifications are not available in this beta.
 
 ## Real-device gate before inviting nontechnical testers


### PR DESCRIPTION
The public copy still described remote sessions as SSH plus tmux and did not
explain several of Diri's strongest shipped capabilities. This refresh
positions Diri around live agent status, persistent PTYs, worktree isolation,
native review tools, direct SSH sessions, orchestration, and iPhone access.

It also updates onboarding, Linux package metadata, the phone web manifest,
TestFlight copy, and generated release notes so the same product story appears
across every public marketing surface.

Validation:

- `git diff --check`
- `bash -n diri/scripts/release.sh`
- Parsed the Linux packaging script with Python `ast`
- Parsed the phone web manifest as JSON
- Verified relative Markdown links in the changed documentation
