### PR TITLE
Fix browser blanking and layout jumps during resize

### DIFF
--- a/diri/crates/diri-app/Cargo.toml
+++ b/diri/crates/diri-app/Cargo.toml
@@ -115,6 +115,7 @@ objc2-foundation = { version = "=0.3.2", default-features = false, features = [
     "NSRunLoop",
     "NSError",
     "NSGeometry",
+    "NSKeyValueObserving",
     "NSNotification",
     "NSObject",
     "NSOperation",

--- a/diri/crates/diri-app/src/inspector.rs
+++ b/diri/crates/diri-app/src/inspector.rs
@@ -252,6 +252,8 @@ pub struct WorkbenchInspector {
     browser_query: QueryEditor,
     browser_address_focused: bool,
     browser_state: BrowserState,
+    #[cfg(target_os = "macos")]
+    native_browser: Option<std::rc::Rc<std::cell::RefCell<crate::macos::browser::NativeBrowser>>>,
     context: Option<DiffContext>,
     state: LoadState,
     review_state: ReviewLoadState,
@@ -363,6 +365,8 @@ impl WorkbenchInspector {
             browser_query: QueryEditor::default(),
             browser_address_focused: false,
             browser_state: BrowserState::default(),
+            #[cfg(target_os = "macos")]
+            native_browser: None,
             context: None,
             state: LoadState::NoSession,
             review_state: ReviewLoadState::NoSession,
@@ -448,6 +452,14 @@ impl WorkbenchInspector {
     #[cfg(target_os = "macos")]
     pub fn is_browser_tab(&self) -> bool {
         self.workspace_selected == Some(WorkspaceSurface::Browser)
+    }
+
+    #[cfg(target_os = "macos")]
+    pub fn set_native_browser(
+        &mut self,
+        browser: std::rc::Rc<std::cell::RefCell<crate::macos::browser::NativeBrowser>>,
+    ) {
+        self.native_browser = Some(browser);
     }
 
     #[must_use]
@@ -1741,6 +1753,7 @@ impl WorkbenchInspector {
             .child(
                 div()
                     .id("workspace-browser-loading-space")
+                    .relative()
                     .min_h(px(0.0))
                     .flex_1()
                     .flex()
@@ -1755,7 +1768,14 @@ impl WorkbenchInspector {
                         .child(div().text_size(px(13.0)).font_weight(FontWeight::MEDIUM).text_color(colors.secondary).child("Open a page"))
                         .child(div().max_w(px(230.0)).text_size(px(11.0)).line_height(px(17.0)).child("Browse a local preview or any secure web address without leaving the workspace.")))
                     .when_some(self.browser_state.error.clone(), |body, error| body.child(div().max_w(px(260.0)).text_size(px(12.0)).child(error)))
-                    .when(self.browser_state.is_loading, |body| body.child(div().text_size(px(10.0)).child("Loading…"))),
+                    .when(self.browser_state.is_loading, |body| body.child(div().text_size(px(10.0)).child("Loading…")))
+                    .map(|body| {
+                        #[cfg(target_os = "macos")]
+                        let body = body.when_some(self.native_browser.clone(), |body, browser| {
+                            body.child(crate::macos::browser::NativeBrowser::surface(browser))
+                        });
+                        body
+                    }),
             )
             .into_any_element()
     }
@@ -4027,19 +4047,22 @@ impl Render for WorkbenchInspector {
         .then(|| self.render_ask_composer(colors, cx))
         .flatten();
         let body = div().relative().size_full().child(body);
-        let body = if cx.reduce_motion() {
-            body.into_any_element()
-        } else {
-            body.with_animation(
-                transition_id,
-                Animation::new(Duration::from_millis(190)).with_easing(ease_out_quint()),
-                move |body, delta| {
-                    body.left(px(direction * (1.0 - delta) * 8.0))
-                        .opacity(0.70 + 0.30 * delta)
-                },
-            )
-            .into_any_element()
-        };
+        // A native child cannot share GPUI's opacity or clipping animation.
+        // Keep its measured viewport stable when entering the Browser tab.
+        let body =
+            if cx.reduce_motion() || self.workspace_selected == Some(WorkspaceSurface::Browser) {
+                body.into_any_element()
+            } else {
+                body.with_animation(
+                    transition_id,
+                    Animation::new(Duration::from_millis(190)).with_easing(ease_out_quint()),
+                    move |body, delta| {
+                        body.left(px(direction * (1.0 - delta) * 8.0))
+                            .opacity(0.70 + 0.30 * delta)
+                    },
+                )
+                .into_any_element()
+            };
         div()
             .id("workbench-inspector")
             .size_full()

--- a/diri/crates/diri-app/src/macos/browser.rs
+++ b/diri/crates/diri-app/src/macos/browser.rs
@@ -11,13 +11,18 @@ use objc2::runtime::ProtocolObject;
 use objc2::{DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send};
 use objc2_app_kit::NSView;
 use objc2_foundation::{
-    NSError, NSObject, NSObjectProtocol, NSPoint, NSRect, NSSize, NSString, NSURL, NSURLRequest,
+    NSDictionary, NSError, NSKeyValueChangeKey, NSKeyValueObservingOptions, NSObject,
+    NSObjectNSKeyValueObserverRegistration, NSObjectProtocol, NSPoint, NSRect, NSSize, NSString,
+    NSURL, NSURLRequest,
 };
 use objc2_web_kit::{WKNavigation, WKNavigationDelegate, WKWebView, WKWebViewConfiguration};
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
 
 use crate::inspector::BrowserState;
+
+const STATE_KEYS: [&str; 5] = ["URL", "title", "canGoBack", "canGoForward", "loading"];
 
 /// Top-left frame coordinates in GPUI points.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -30,12 +35,14 @@ pub struct BrowserFrame {
 
 /// A lazily-attached, single-tab WebKit view.
 pub struct NativeBrowser {
-    web_view: Option<objc2::rc::Retained<WKWebView>>,
+    web_view: Option<Retained<BrowserWebView>>,
     /// Non-owning: AppKit owns the GPUI root view for the window lifetime.
     parent: Option<*const NSView>,
     pending_url: Option<String>,
     delegate: Option<Retained<BrowserDelegate>>,
     events: tokio::sync::mpsc::Sender<()>,
+    visible: bool,
+    pointer_passthrough: bool,
 }
 
 impl NativeBrowser {
@@ -48,6 +55,8 @@ impl NativeBrowser {
                 pending_url: None,
                 delegate: None,
                 events,
+                visible: false,
+                pointer_passthrough: false,
             },
             receiver,
         )
@@ -55,6 +64,56 @@ impl NativeBrowser {
 
     pub fn has_page(&self) -> bool {
         self.pending_url.is_some()
+    }
+
+    /// Native content shares the measured GPUI body, including its borders,
+    /// toolbars and recovery banner. Apply the frame during paint, after layout
+    /// has resolved, without a bounds notification or a second layout pass.
+    pub fn surface(browser: Rc<RefCell<Self>>) -> impl gpui::IntoElement {
+        use gpui::prelude::*;
+        gpui::canvas(
+            |_, _, _| (),
+            move |bounds, (), window, _| {
+                let mut browser = browser.borrow_mut();
+                let visible = browser.visible;
+                browser.sync(
+                    window,
+                    visible,
+                    BrowserFrame {
+                        x: bounds.origin.x.into(),
+                        y: bounds.origin.y.into(),
+                        width: bounds.size.width.into(),
+                        height: bounds.size.height.into(),
+                    },
+                );
+            },
+        )
+        .absolute()
+        .inset_0()
+    }
+
+    pub fn set_visible(&mut self, visible: bool) {
+        if self.visible == visible {
+            return;
+        }
+        self.visible = visible;
+        if !visible {
+            self.hide();
+        } else if self.has_page()
+            && self.error().is_none()
+            && let Some(view) = &self.web_view
+        {
+            // Cached GPUI bodies may reuse their paint when only an overlay
+            // closes. Their native frame remains valid; no relayout is needed.
+            view.setHidden(false);
+        }
+    }
+
+    pub fn set_pointer_passthrough(&mut self, passthrough: bool) {
+        self.pointer_passthrough = passthrough;
+        if let Some(view) = &self.web_view {
+            view.ivars().pointer_passthrough.set(passthrough);
+        }
     }
 
     pub fn sync(&mut self, window: &impl HasWindowHandle, visible: bool, frame: BrowserFrame) {
@@ -84,11 +143,16 @@ impl NativeBrowser {
         } else {
             (bounds.size.height - f64::from(frame.y + frame.height)).max(0.0)
         };
-        view.setFrame(NSRect::new(
+        let frame = NSRect::new(
             NSPoint::new(f64::from(frame.x), y),
             NSSize::new(f64::from(frame.width), f64::from(frame.height)),
-        ));
-        view.setHidden(false);
+        );
+        if view.frame() != frame {
+            view.setFrame(frame);
+        }
+        if view.isHidden() {
+            view.setHidden(false);
+        }
     }
 
     pub fn load(&mut self, url: String) {
@@ -157,12 +221,14 @@ impl NativeBrowser {
     }
 
     pub fn hide(&mut self) {
-        if let Some(view) = &self.web_view {
+        if let Some(view) = &self.web_view
+            && !view.isHidden()
+        {
             view.setHidden(true);
         }
     }
 
-    fn ensure_view(&mut self, parent: *const NSView) -> Option<&WKWebView> {
+    fn ensure_view(&mut self, parent: *const NSView) -> Option<&BrowserWebView> {
         if self.parent != Some(parent) {
             self.detach();
             self.parent = Some(parent);
@@ -170,16 +236,18 @@ impl NativeBrowser {
         if self.web_view.is_none() {
             let mtm = MainThreadMarker::new()?;
             let configuration = unsafe { WKWebViewConfiguration::new(mtm) };
-            let view = unsafe {
-                WKWebView::initWithFrame_configuration(
-                    mtm.alloc(),
-                    NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(1.0, 1.0)),
-                    &configuration,
-                )
-            };
+            let view = BrowserWebView::new(mtm, &configuration, self.pointer_passthrough);
             let delegate = BrowserDelegate::new(mtm, self.events.clone());
             unsafe {
                 view.setNavigationDelegate(Some(ProtocolObject::from_ref(&*delegate)));
+                for key in STATE_KEYS {
+                    view.addObserver_forKeyPath_options_context(
+                        &delegate,
+                        &NSString::from_str(key),
+                        NSKeyValueObservingOptions::empty(),
+                        std::ptr::null_mut(),
+                    );
+                }
             }
             self.delegate = Some(delegate);
             // The parent receives its own retain. `self` retains the child so
@@ -198,6 +266,11 @@ impl NativeBrowser {
             // Remove while our retain still exists. The old parent also holds
             // the view, so dropping first could otherwise leave an overlay.
             unsafe {
+                if let Some(delegate) = &self.delegate {
+                    for key in STATE_KEYS {
+                        view.removeObserver_forKeyPath(delegate, &NSString::from_str(key));
+                    }
+                }
                 view.setNavigationDelegate(None);
                 view.stopLoading();
             }
@@ -211,6 +284,45 @@ impl NativeBrowser {
 impl Drop for NativeBrowser {
     fn drop(&mut self) {
         self.detach();
+    }
+}
+
+struct BrowserWebViewIvars {
+    pointer_passthrough: Cell<bool>,
+}
+
+define_class!(
+    #[unsafe(super(WKWebView))]
+    #[thread_kind = MainThreadOnly]
+    #[name = "DiriWorkspaceWebView"]
+    #[ivars = BrowserWebViewIvars]
+    struct BrowserWebView;
+
+    unsafe impl NSObjectProtocol for BrowserWebView {}
+
+    impl BrowserWebView {
+        #[unsafe(method_id(hitTest:))]
+        fn hit_test(&self, point: NSPoint) -> Option<Retained<NSView>> {
+            if self.ivars().pointer_passthrough.get() {
+                None
+            } else {
+                unsafe { msg_send![super(self), hitTest: point] }
+            }
+        }
+    }
+);
+
+impl BrowserWebView {
+    fn new(
+        mtm: MainThreadMarker,
+        configuration: &WKWebViewConfiguration,
+        passthrough: bool,
+    ) -> Retained<Self> {
+        let this = mtm.alloc().set_ivars(BrowserWebViewIvars {
+            pointer_passthrough: Cell::new(passthrough),
+        });
+        let frame = NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(1.0, 1.0));
+        unsafe { msg_send![super(this), initWithFrame: frame, configuration: configuration] }
     }
 }
 
@@ -241,6 +353,23 @@ define_class!(
     struct BrowserDelegate;
 
     unsafe impl NSObjectProtocol for BrowserDelegate {}
+
+    impl BrowserDelegate {
+        // WebKit marks these properties KVO-compliant, including same-document
+        // history and script-driven titles. Coalesce changes on the existing
+        // bounded notification channel instead of polling during root renders.
+        #[unsafe(method(observeValueForKeyPath:ofObject:change:context:))]
+        fn observed_state(
+            &self,
+            _key_path: Option<&NSString>,
+            _object: Option<&objc2::runtime::AnyObject>,
+            _change: Option<&NSDictionary<NSKeyValueChangeKey, objc2::runtime::AnyObject>>,
+            _context: *mut std::ffi::c_void,
+        ) {
+            self.changed();
+        }
+    }
+
     unsafe impl WKNavigationDelegate for BrowserDelegate {
         #[unsafe(method(webView:didStartProvisionalNavigation:))]
         fn started(&self, _view: &WKWebView, _navigation: Option<&WKNavigation>) {
@@ -311,8 +440,11 @@ impl BrowserDelegate {
 /// uses only an ephemeral loopback server; never connects to a Diri daemon.
 #[cfg(debug_assertions)]
 pub fn smoke_test() {
-    use objc2_app_kit::{NSApplication, NSBackingStoreType, NSWindow, NSWindowStyleMask};
-    use objc2_foundation::{NSDate, NSRunLoop};
+    use objc2_app_kit::{
+        NSApplication, NSApplicationActivationPolicy, NSBackingStoreType, NSEventMask, NSWindow,
+        NSWindowStyleMask,
+    };
+    use objc2_foundation::{NSDate, NSDefaultRunLoopMode, NSRunLoop};
     use raw_window_handle::{AppKitWindowHandle, HandleError, WindowHandle};
     use std::io::{Read, Write};
     use std::sync::{
@@ -328,6 +460,20 @@ pub fn smoke_test() {
             Ok(unsafe { WindowHandle::borrow_raw(RawWindowHandle::AppKit(handle)) })
         }
     }
+    fn pump() {
+        let app = NSApplication::sharedApplication(MainThreadMarker::new().unwrap());
+        while let Some(event) = app.nextEventMatchingMask_untilDate_inMode_dequeue(
+            NSEventMask::Any,
+            Some(&NSDate::distantPast()),
+            unsafe { NSDefaultRunLoopMode },
+            true,
+        ) {
+            app.sendEvent(&event);
+        }
+        app.updateWindows();
+        NSRunLoop::currentRunLoop().runUntilDate(&NSDate::dateWithTimeIntervalSinceNow(0.008));
+    }
+    #[track_caller]
     fn until(mut condition: impl FnMut() -> bool) {
         let deadline = Instant::now() + Duration::from_secs(15);
         while !condition() {
@@ -335,7 +481,7 @@ pub fn smoke_test() {
                 Instant::now() < deadline,
                 "native browser fixture timed out"
             );
-            NSRunLoop::currentRunLoop().runUntilDate(&NSDate::dateWithTimeIntervalSinceNow(0.01));
+            pump();
         }
     }
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("fixture listener");
@@ -373,6 +519,7 @@ pub fn smoke_test() {
     });
     let mtm = MainThreadMarker::new().expect("fixture must run on the main thread");
     let app = NSApplication::sharedApplication(mtm);
+    app.setActivationPolicy(NSApplicationActivationPolicy::Regular);
     app.finishLaunching();
     let window = unsafe {
         NSWindow::initWithContentRect_styleMask_backing_defer(
@@ -430,6 +577,123 @@ pub fn smoke_test() {
     until(|| {
         browser.state().title.as_deref() == Some("Fixture Two") && !browser.state().is_loading
     });
+    let mut resize_time = Duration::ZERO;
+    while events.try_recv().is_ok() {}
+    unsafe {
+        view.evaluateJavaScript_completionHandler(
+            &NSString::from_str("history.pushState({}, '', '/same-document')"),
+            None,
+        );
+    }
+    until(|| {
+        browser
+            .state()
+            .url
+            .as_deref()
+            .is_some_and(|url| url.ends_with("/same-document"))
+    });
+    assert!(
+        events.try_recv().is_ok(),
+        "same-document URLs must notify the toolbar"
+    );
+    let script_done = Rc::new(Cell::new(false));
+    let done = script_done.clone();
+    let completion = block2::RcBlock::new(
+        move |_: *mut objc2::runtime::AnyObject, error: *mut NSError| {
+            assert!(error.is_null(), "resize script failed: {:?}", unsafe {
+                error.as_ref()
+            });
+            done.set(true);
+        },
+    );
+    unsafe {
+        view.evaluateJavaScript_completionHandler(&NSString::from_str(
+            "window.resizeFrames = 0; window.resizeEvents = 0; addEventListener('resize', () => resizeEvents++); function tick() { resizeFrames++; document.title = innerWidth + ':' + resizeFrames + ':' + resizeEvents; requestAnimationFrame(tick); } requestAnimationFrame(tick);"
+        ), Some(&completion));
+    }
+    until(|| script_done.get());
+    until(|| {
+        browser
+            .state()
+            .title
+            .as_deref()
+            .is_some_and(|title| title.contains(':'))
+    });
+    while events.try_recv().is_ok() {}
+    until(|| events.try_recv().is_ok());
+    browser.set_pointer_passthrough(true);
+    assert!(
+        view.hitTest(NSPoint::new(20.0, 20.0)).is_none(),
+        "resize motion must reach GPUI"
+    );
+    for step in 0..240 {
+        let width = 320.0 + (step % 120) as f32 * 2.0;
+        let resized = BrowserFrame { width, ..frame };
+        let start = Instant::now();
+        // Repeated root paints without geometry changes are common while a
+        // terminal streams output next to the page.
+        for _ in 0..8 {
+            browser.sync(&host, true, resized);
+        }
+        resize_time += start.elapsed();
+        assert!(!view.isHidden(), "resize must keep the website painted");
+        assert_eq!(view.frame().size.width, f64::from(width));
+        assert!(std::ptr::eq(&**browser.web_view.as_ref().unwrap(), &*view));
+        pump();
+        if step == 119 || step == 239 {
+            until(|| {
+                browser
+                    .state()
+                    .title
+                    .as_deref()
+                    .is_some_and(|title| title.starts_with("558:"))
+            });
+            let title = browser.state().title.unwrap();
+            let values: Vec<u32> = title
+                .split(':')
+                .map(|value| value.parse().unwrap())
+                .collect();
+            assert!(
+                values[1] > 10 && values[2] > 10,
+                "page must keep painting and reflowing during the drag: {title}"
+            );
+        }
+    }
+    browser.set_pointer_passthrough(false);
+    assert!(
+        view.hitTest(NSPoint::new(20.0, 20.0)).is_some(),
+        "page interaction must resume after release"
+    );
+    println!(
+        "Native resize sweep: 240 sizes / 1920 syncs in {resize_time:?} of main-thread sync work"
+    );
+    // Window resizing also changes the AppKit coordinate conversion. Keep the
+    // page aligned below a toolbar, with no reload or visibility transition.
+    for step in 0..32 {
+        let width = 500.0 + f64::from(step) * 8.0;
+        let height = 380.0 + f64::from(step) * 4.0;
+        window.setContentSize(NSSize::new(width, height));
+        browser.sync(
+            &host,
+            true,
+            BrowserFrame {
+                x: 200.0,
+                y: 84.0,
+                width: (width - 200.0) as f32,
+                height: (height - 84.0) as f32,
+            },
+        );
+        pump();
+        assert!(!view.isHidden());
+        assert_eq!(view.frame().origin, NSPoint::new(200.0, 0.0));
+        assert_eq!(view.frame().size, NSSize::new(width - 200.0, height - 84.0));
+    }
+    // Overlay close may reuse the cached GPUI body without another paint.
+    browser.set_visible(true);
+    browser.set_visible(false);
+    assert!(view.isHidden());
+    browser.set_visible(true);
+    assert!(!view.isHidden());
     browser.sync(&host, false, frame);
     assert!(view.isHidden());
     browser.sync(&host, true, frame);
@@ -447,6 +711,6 @@ pub fn smoke_test() {
     browser.clear();
     window.close();
     println!(
-        "Native browser fixture passed: DOM load, link navigation, history, event delivery, hide/show, close, load failure."
+        "Native browser fixture passed: DOM load, navigation/history, live resize/animation frames, pointer passthrough/release, window resize alignment, cached overlay restoration, close, load failure."
     );
 }

--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -28,7 +28,7 @@ use crate::icons::{SymbolWeight, sf_symbol, sf_symbol_weighted};
 use crate::inspector::{BrowserAction, InspectorEvent, WorkbenchInspector};
 use crate::launcher::{LauncherEvent, LauncherOverlay};
 #[cfg(target_os = "macos")]
-use crate::macos::browser::{BrowserFrame, NativeBrowser};
+use crate::macos::browser::NativeBrowser;
 use crate::navigation::NavigationOverlay;
 use crate::notifications::{InAppBanner, NotificationSound};
 use crate::quote::Quote;
@@ -180,7 +180,7 @@ pub struct RootView {
     launcher: Entity<LauncherOverlay>,
     inspector: Option<Entity<WorkbenchInspector>>,
     #[cfg(target_os = "macos")]
-    browser: NativeBrowser,
+    browser: std::rc::Rc<std::cell::RefCell<NativeBrowser>>,
     services: Arc<AppServices>,
     focus: FocusHandle,
     resize_origin: Option<(f32, f32)>,
@@ -495,7 +495,7 @@ impl RootView {
                     InspectorEvent::WorkspaceClosed(surface) => {
                         #[cfg(target_os = "macos")]
                         if *surface == crate::inspector::WorkspaceSurface::Browser {
-                            this.browser.clear();
+                            this.browser.borrow_mut().clear();
                         }
                         if *surface == crate::inspector::WorkspaceSurface::Terminal {
                             this.hide_auxiliary_terminal(window, cx);
@@ -505,10 +505,12 @@ impl RootView {
                     InspectorEvent::Browser(action) => {
                         #[cfg(target_os = "macos")]
                         match action {
-                            BrowserAction::Navigate(url) => this.browser.load(url.clone()),
-                            BrowserAction::Back => this.browser.go_back(),
-                            BrowserAction::Forward => this.browser.go_forward(),
-                            BrowserAction::Reload => this.browser.reload(),
+                            BrowserAction::Navigate(url) => {
+                                this.browser.borrow_mut().load(url.clone())
+                            }
+                            BrowserAction::Back => this.browser.borrow().go_back(),
+                            BrowserAction::Forward => this.browser.borrow().go_forward(),
+                            BrowserAction::Reload => this.browser.borrow().reload(),
                             BrowserAction::OpenExternal(url) => cx.open_url(url),
                         }
                         #[cfg(not(target_os = "macos"))]
@@ -803,12 +805,20 @@ impl RootView {
         #[cfg(target_os = "macos")]
         let (browser, mut browser_events) = NativeBrowser::new();
         #[cfg(target_os = "macos")]
+        let browser = std::rc::Rc::new(std::cell::RefCell::new(browser));
+        #[cfg(target_os = "macos")]
+        if let Some(inspector) = &inspector {
+            inspector.update(cx, |inspector, _| {
+                inspector.set_native_browser(browser.clone())
+            });
+        }
+        #[cfg(target_os = "macos")]
         let browser_state_sync = cx.spawn_in(window, async move |this, cx| {
             while browser_events.recv().await.is_some() {
                 if this
                     .update_in(cx, |this, _window, cx| {
                         if let Some(inspector) = this.inspector.clone() {
-                            let state = this.browser.state();
+                            let state = this.browser.borrow().state();
                             inspector
                                 .update(cx, |inspector, cx| inspector.set_browser_state(state, cx));
                             cx.notify();
@@ -1964,11 +1974,14 @@ impl RootView {
         let Some((origin_y, base_height)) = self.terminal_resize_origin else {
             return;
         };
+        let previous = self.workbench_layout;
         self.workbench_layout.resize_primary(
             base_height + pointer_y - origin_y,
             self.terminal_available_height,
         );
-        cx.notify();
+        if self.workbench_layout != previous {
+            cx.notify();
+        }
     }
 
     fn finish_terminal_resize(&mut self, cx: &mut Context<Self>) {
@@ -1995,6 +2008,9 @@ impl RootView {
         if self.resize_origin.take().is_some() {
             self.sidebar
                 .update(cx, |sidebar, cx| sidebar.commit_width(cx));
+            // Width persistence does not notify the sidebar. Retire the drag
+            // shield now, even when the last motion was beyond the clamp.
+            cx.notify();
         }
     }
 
@@ -2104,10 +2120,14 @@ impl RootView {
         let Some((origin_x, base_width)) = self.inspector_resize_origin else {
             return;
         };
-        self.inspector_width = (base_width - pointer_x + origin_x).clamp(
+        let width = (base_width - pointer_x + origin_x).clamp(
             300.0_f32.min(self.inspector_max_width),
             self.inspector_max_width,
         );
+        if self.inspector_width == width {
+            return;
+        }
+        self.inspector_width = width;
         cx.notify();
     }
 
@@ -2164,6 +2184,30 @@ impl RootView {
                 ),
         )
         .into_any_element()
+    }
+
+    #[cfg(target_os = "macos")]
+    fn browser_visible(&self, launcher_open: bool, panel_width: f32, cx: &App) -> bool {
+        self.browser.borrow().has_page()
+            && panel_width > 1.0
+            && !launcher_open
+            && !self
+                .utility_surfaces
+                .as_ref()
+                .is_some_and(|view| view.read(cx).is_open())
+            && !self
+                .navigation
+                .as_ref()
+                .is_some_and(|view| view.read(cx).is_open())
+            && !self.arrow_surface_visible()
+            && self.quote_target_picker.is_none()
+            && self.sidebar.read(cx).pending_close_copy().is_none()
+            && self.inspector_open
+            && self.inspector_seam >= panel_width - 0.5
+            && self.inspector.as_ref().is_some_and(|view| {
+                let inspector = view.read(cx);
+                inspector.is_browser_tab() && !inspector.blocks_native_browser()
+            })
     }
 
     /// `visible_sidebar` and `inspector_width` are the settled layout and drive
@@ -3021,49 +3065,13 @@ impl Render for RootView {
         let inspector_seam = self.inspector_seam;
         #[cfg(target_os = "macos")]
         {
-            let utility_open = self
-                .utility_surfaces
-                .as_ref()
-                .is_some_and(|surfaces| surfaces.read(cx).is_open());
-            let navigation_open = self
-                .navigation
-                .as_ref()
-                .is_some_and(|navigation| navigation.read(cx).is_open());
-            let inspector_blocks_browser = self
-                .inspector
-                .as_ref()
-                .is_some_and(|inspector| inspector.read(cx).blocks_native_browser());
-            let browser_active = self.browser.has_page()
-                && self.resize_origin.is_none()
-                && self.inspector_resize_origin.is_none()
-                && !launcher_open
-                && !utility_open
-                && !navigation_open
-                && !self.arrow_surface_visible()
-                && self.quote_target_picker.is_none()
-                && self.sidebar.read(cx).pending_close_copy().is_none()
-                && !inspector_blocks_browser
-                && self.inspector_open
-                && inspector_seam >= inspector_panel_width - 0.5
-                && self
-                    .inspector
-                    .as_ref()
-                    .is_some_and(|inspector| inspector.read(cx).is_browser_tab());
-            let height = f32::from(window.inner_window_bounds().get_bounds().size.height);
-            self.browser.sync(
-                window,
-                browser_active,
-                BrowserFrame {
-                    x: window_width - inspector_panel_width,
-                    y: recovery_height + Metrics::TITLE_BAR + 42.0,
-                    width: inspector_panel_width,
-                    height: (height - recovery_height - Metrics::TITLE_BAR - 42.0).max(0.0),
-                },
+            let browser_active = self.browser_visible(launcher_open, inspector_panel_width, cx);
+            self.browser.borrow_mut().set_visible(browser_active);
+            self.browser.borrow_mut().set_pointer_passthrough(
+                self.resize_origin.is_some()
+                    || self.inspector_resize_origin.is_some()
+                    || self.terminal_resize_origin.is_some(),
             );
-            let state = self.browser.state();
-            if let Some(inspector) = &self.inspector {
-                inspector.update(cx, |inspector, cx| inspector.set_browser_state(state, cx));
-            }
         }
         let mut key_context = KeyContext::new_with_defaults();
         key_context.add(APP_CONTEXT);
@@ -3467,9 +3475,71 @@ fn preview_hint(system_image: &str, label: &str, colors: SemanticColors) -> AnyE
 }
 
 #[cfg(test)]
-mod quote_target_tests {
+mod tests {
     use super::*;
     use crate::sidebar::{PreviewScenario, SidebarPreviewFixture};
+
+    #[cfg(target_os = "macos")]
+    #[gpui::test]
+    fn browser_stays_visible_through_every_resize(cx: &mut gpui::TestAppContext) {
+        let services = Arc::new(AppServices {
+            store: Arc::new(crate::store::StoreRuntime::inert()),
+            usage_tx: tokio::sync::watch::channel(crate::usage::UsageSnapshot::default()).0,
+            usage_limits_refresh: tokio::sync::mpsc::channel(1).0,
+            updates: crate::updates::inert(),
+            dev_build: None,
+            daemon_startup: None,
+            tokio: Arc::new(
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap(),
+            ),
+        });
+        let (root, cx) = cx.add_window_view(move |window, cx| {
+            RootView::new(services, true, PreviewScenario::Artifacts, window, cx)
+        });
+        root.update(cx, |root, cx| {
+            root.inspector_open = true;
+            root.inspector_seam = 440.0;
+            root.browser
+                .borrow_mut()
+                .load("http://127.0.0.1:9/resize-fixture".into());
+            root.inspector
+                .as_ref()
+                .unwrap()
+                .update(cx, |inspector, cx| {
+                    inspector.select_workspace(crate::inspector::WorkspaceSurface::Browser, cx);
+                });
+            assert!(root.browser_visible(false, 440.0, cx));
+            root.resize_origin = Some((250.0, 250.0));
+            assert!(
+                root.browser_visible(false, 440.0, cx),
+                "left sidebar resize hid the website"
+            );
+            root.resize_origin = None;
+            root.inspector_resize_origin = Some((700.0, 440.0));
+            assert!(
+                root.browser_visible(false, 440.0, cx),
+                "right sidebar resize hid the website"
+            );
+            root.inspector_resize_origin = None;
+            root.terminal_resize_origin = Some((300.0, 300.0));
+            assert!(root.browser_visible(false, 440.0, cx));
+            root.terminal_resize_origin = None;
+            assert!(
+                !root.browser_visible(true, 440.0, cx),
+                "launcher must cover native content"
+            );
+            assert!(
+                !root.browser_visible(false, 0.0, cx),
+                "a collapsed panel must not leave a native overlay"
+            );
+            // TestWindow has no AppKit handle; the separate native fixture
+            // exercises painting and hit testing with an actual WKWebView.
+            root.browser.borrow_mut().clear();
+        });
+    }
 
     #[test]
     fn picker_resolves_the_chosen_target_without_changing_the_active_id() {

--- a/diri/crates/diri-app/src/workbench.rs
+++ b/diri/crates/diri-app/src/workbench.rs
@@ -44,8 +44,11 @@ impl WorkbenchLayout {
     pub fn pane_heights(&self, available_height: f32) -> PaneHeights {
         let available_height = available_height.max(0.0);
         if available_height <= MIN_PRIMARY_HEIGHT + MIN_AUXILIARY_HEIGHT {
+            // Compress both minimums proportionally. At the threshold this
+            // meets the normal clamp exactly, so a continuous window resize
+            // cannot jump the divider (or trigger an extra terminal reflow).
             let primary =
-                (available_height * DEFAULT_PRIMARY_FRACTION).clamp(0.0, available_height);
+                available_height * MIN_PRIMARY_HEIGHT / (MIN_PRIMARY_HEIGHT + MIN_AUXILIARY_HEIGHT);
             return PaneHeights {
                 primary,
                 auxiliary: available_height - primary,
@@ -61,14 +64,13 @@ impl WorkbenchLayout {
     }
 
     pub fn resize_primary(&mut self, primary_height: f32, available_height: f32) {
-        if available_height <= 0.0 {
+        // Below the combined minimum, pane_heights compresses both panes and
+        // the divider cannot move. Preserve the ratio restored on expansion.
+        if available_height <= MIN_PRIMARY_HEIGHT + MIN_AUXILIARY_HEIGHT {
             return;
         }
-        let clamped = if available_height > MIN_PRIMARY_HEIGHT + MIN_AUXILIARY_HEIGHT {
-            primary_height.clamp(MIN_PRIMARY_HEIGHT, available_height - MIN_AUXILIARY_HEIGHT)
-        } else {
-            primary_height.clamp(0.0, available_height)
-        };
+        let clamped =
+            primary_height.clamp(MIN_PRIMARY_HEIGHT, available_height - MIN_AUXILIARY_HEIGHT);
         self.primary_fraction = clamped / available_height;
     }
 
@@ -108,5 +110,36 @@ mod tests {
         layout.resize_primary(400.0, 600.0);
         layout.reset();
         assert_eq!(layout.pane_heights(600.0).primary, 372.0);
+    }
+
+    #[test]
+    fn resizing_window_has_no_jump_at_minimum_pane_heights() {
+        for fraction in [0.0, 0.3, DEFAULT_PRIMARY_FRACTION, 0.9, 1.0] {
+            let layout = WorkbenchLayout::from_fraction(fraction);
+            let mut previous = layout.pane_heights(359.0);
+            for step in 1..=200 {
+                let height = 359.0 + step as f32 * 0.01;
+                let next = layout.pane_heights(height);
+                assert!(
+                    (next.primary - previous.primary).abs() <= 0.011,
+                    "split jumped from {previous:?} to {next:?} at height {height}"
+                );
+                assert!((next.primary + next.auxiliary - height).abs() < 0.001);
+                previous = next;
+            }
+        }
+    }
+
+    #[test]
+    fn dragging_a_fully_compressed_split_preserves_the_restored_ratio() {
+        let mut layout = WorkbenchLayout::from_fraction(0.8);
+        let previous = layout;
+        for pointer in [0.0, 100.0, 250.0, 500.0] {
+            layout.resize_primary(pointer, 320.0);
+            assert_eq!(
+                layout, previous,
+                "an immovable divider must not change hidden layout intent"
+            );
+        }
     }
 }


### PR DESCRIPTION
Dragging either sidebar hid the native browser for the entire gesture. Keep the same WebKit page visible and rendering, while native hit testing passes resize gestures through to GPUI. Apply the browser frame from its actual laid-out body during paint, including toolbar and border offsets, and keep browser tab entry from translating a native layer outside GPUI's clip.

Skip unchanged native frame/visibility writes and unchanged clamped splitter updates. Browser toolbar state now follows bounded native property notifications, including script-driven titles and same-document URLs, instead of polling on each root render. Releasing the left splitter explicitly retires its input shield.

The horizontal split also jumped 3.2 points when window height crossed the combined pane minimum. Compress its minimums continuously and preserve its saved ratio while the divider cannot move.

Validation:

- Reproduced the browser visibility failure and split-height discontinuity with failing regression tests before fixing them; added coverage for compressed split intent.
- Reviewed window, left/right sidebar, horizontal split, and terminal resize paths; existing PTY cadence, final-size delivery, and reflow tests pass.
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --workspace --release`
- `DIRI_NATIVE_BROWSER_SMOKE=1 <debug diri binary>`: isolated loopback pages; live animation/resize events across 240 browser sizes, pointer passthrough/release, 32 window sizes with frame alignment assertions, cached-overlay restoration, navigation, close, and load failure. No user daemon or sessions are used.

Local debug diagnostic: 1,920 browser syncs across 240 distinct sizes took 126.6 ms of summed main-thread sync work before the change and 37–70 ms in subsequent runs. This measures native sync work, not whole-app frame rate. Only the existing Foundation binding's KVO feature is enabled; no new dependency or transport change.
