### PR TITLE
release: prepare diri 0.6.0

### DIFF
--- a/diri/Cargo.lock
+++ b/diri/Cargo.lock
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "diri-app"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "block2 0.6.2",
  "diri-client",

--- a/diri/crates/diri-app/Cargo.toml
+++ b/diri/crates/diri-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diri-app"
-version = "0.5.2"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
- bump the desktop app and lockfile to 0.6.0
- prepare the next release after 27 merged feature, UX, and reliability changes

## Verification
- `cargo check -p diri-app`