### PR TITLE
Fix Accounts connecting to an outdated engine

### DIFF
--- a/diri/REMOTE_PORT.md
+++ b/diri/REMOTE_PORT.md
@@ -630,6 +630,11 @@ confirmed Rust Engine whose hash differs from the bundled executable is upgraded
 without abandoning live Holder/Agent state, ensuring subsequent remote actions
 use the current Helper catalog.
 
+An inherited `DIRIJOR_SOCKET` equal to the app's ordinary socket does not bypass
+this startup verification: Agents launched by Diri inherit that path, and an
+app started from their environment must still refresh an outdated Engine.
+Only a different, explicitly supplied socket skips app-owned supervision.
+
 ## Tailscale, iPhone Companion, and `diri-node`
 
 These features are separate from Remote Holder transport:

--- a/diri/crates/diri-app/src/daemon_launch.rs
+++ b/diri/crates/diri-app/src/daemon_launch.rs
@@ -74,16 +74,24 @@ pub(super) struct DeferredDaemonStartup {
 impl DeferredDaemonStartup {
     /// Plans app-owned Engine supervision from the current process layout.
     ///
-    /// A harness that supplied `DIRIJOR_SOCKET` owns its daemon lifecycle, so
-    /// there is no deferred work and the client may connect immediately.
+    /// A harness using a custom `DIRIJOR_SOCKET` owns its daemon lifecycle.
+    /// The ordinary socket may also be inherited from an Agent launched by
+    /// Diri; that must still verify and refresh the bundled Engine.
     pub(super) fn for_process() -> Option<Self> {
-        if std::env::var_os(ENV_SOCKET).is_some() {
-            return None;
-        }
         let home = std::env::var_os("HOME")
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from("/nonexistent"));
         let socket_path = DirijorPaths::socket(home);
+        Self::for_socket(
+            socket_path,
+            std::env::var_os(ENV_SOCKET).map(PathBuf::from).as_deref(),
+        )
+    }
+
+    fn for_socket(socket_path: PathBuf, socket_override: Option<&Path>) -> Option<Self> {
+        if socket_override.is_some_and(|path| path != socket_path) {
+            return None;
+        }
         let release_socket = socket_path.clone();
         Some(Self {
             socket_path,
@@ -1369,6 +1377,21 @@ mod tests {
     }
 
     #[test]
+    fn inherited_default_socket_still_supervises_the_engine() {
+        let socket = PathBuf::from("/fixture/Dirijor/daemon.sock");
+        assert!(DeferredDaemonStartup::for_socket(socket.clone(), Some(&socket)).is_some());
+    }
+
+    #[test]
+    fn custom_socket_remains_externally_managed() {
+        let socket = PathBuf::from("/fixture/Dirijor/daemon.sock");
+        assert!(
+            DeferredDaemonStartup::for_socket(socket, Some(Path::new("/fixture/harness.sock")),)
+                .is_none()
+        );
+    }
+
+    #[test]
     fn an_outdated_live_daemon_is_replaced_by_the_resolved_bundle() {
         let tmp = tempfile::tempdir().unwrap();
         let socket = tmp.path().join("daemon.sock");
@@ -1397,7 +1420,9 @@ mod tests {
             ],
         );
 
-        ensure_daemon_running_with(&socket, Some(daemon), None);
+        let startup = DeferredDaemonStartup::for_socket(socket.clone(), Some(&socket))
+            .expect("an inherited ordinary socket must not bypass the upgrade");
+        ensure_daemon_running_with(&startup.socket_path, Some(daemon), None);
         assert_eq!(
             server.join().expect("fixture server"),
             vec![Method::HELLO, Method::DAEMON_SHUTDOWN]

--- a/diri/crates/diri-engine/src/control.rs
+++ b/diri/crates/diri-engine/src/control.rs
@@ -3926,6 +3926,14 @@ mod tests {
     }
 
     #[test]
+    fn account_profiles_list_is_available_to_settings() {
+        let temp = tempfile::tempdir().expect("temp");
+        let server = server(temp.path());
+        let result = ok_of(call(&server, "account.profiles.list", None));
+        assert_eq!(result["profiles"], json!([]));
+    }
+
+    #[test]
     fn hello_reports_the_protocol_and_the_engine_build() {
         let temp = tempfile::tempdir().expect("temp");
         let server = server(temp.path());


### PR DESCRIPTION
## Why

Accounts displayed `not_found: method "account.profiles.list" is not implemented by this engine yet` because the app remained connected to an older Engine. The running app inherited `DIRIJOR_SOCKET` pointing to its ordinary socket, which incorrectly disabled startup verification and upgrade despite a newer Engine being installed in the bundle.

## What changed

Allow startup supervision when the inherited socket equals the app's ordinary socket. Custom sockets remain externally managed. The existing upgrade path persists Engine state and replaces the outdated daemon while Holder-owned sessions survive.

Add regression coverage for default/custom sockets, exercise replacement of an outdated daemon through that startup decision, and verify the Accounts list request reaches the Engine dispatcher. Document the startup rule in `diri/REMOTE_PORT.md`.

## Verification

The inherited-default-socket regression failed before the fix and passed afterward. Reproduced the reported error against the installed Engine and confirmed its hash differed from the bundled executable. The installed app was not replaced.

- [x] Rust checks passed from `diri/`: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, and `cargo build --workspace --release`. These are the repository's authoritative Rust gates; `./scripts/check.sh` was not run.
- [x] Existing session-survival and daemon-upgrade tests passed in the workspace suite; the Holder lifecycle is unchanged.
- [x] Security and privacy considered: no credentials or profile payloads logged; custom sockets retain their existing supervision behavior.
- [x] Startup behavior documented in `diri/REMOTE_PORT.md`.
- [x] No visual UI changes; screenshot requirement is not applicable.
