### PR TITLE
Polish notifications and terminal controls

### DIFF
--- a/diri/crates/diri-app/src/icons.rs
+++ b/diri/crates/diri-app/src/icons.rs
@@ -46,6 +46,7 @@ mod tests {
     fn former_platform_symbols_resolve_to_svg_icons() {
         for name in [
             "terminal",
+            "bell",
             "magnifyingglass",
             "folder",
             "gearshape",

--- a/diri/crates/diri-app/src/notification_panel.rs
+++ b/diri/crates/diri-app/src/notification_panel.rs
@@ -156,6 +156,15 @@ impl RootView {
                 cx.reduce_motion(),
             )
         };
+        let settings_open = self
+            .utility_surfaces
+            .as_ref()
+            .is_some_and(|surfaces| surfaces.read(cx).is_settings_open());
+        let panel_top = if settings_open {
+            14.0
+        } else {
+            Metrics::TITLE_BAR + 6.0
+        };
         let height = (f32::from(window.inner_window_bounds().get_bounds().size.height) - 90.0)
             .clamp(200.0, 620.0);
         let mut list = div()
@@ -305,16 +314,18 @@ impl RootView {
                     ),
             );
         }
-        let panel = div().id("notification-panel").track_focus(&self.notification_focus)
-            .absolute().top(px(48.0)).right(px(14.0)).w(px(440.0)).max_h(px(height))
+        let panel = div().id("notification-panel").debug_selector(|| "notification-panel".into()).track_focus(&self.notification_focus)
+            .absolute().top(px(panel_top)).right(px(14.0)).w(px(440.0)).max_h(px(height))
             .p(px(12.0)).rounded(px(Radius::PANEL)).border_1().border_color(colors.primary.alpha(0.12))
-            .bg(colors.background).shadow_lg().flex().flex_col().gap(px(12.0))
+            .bg(colors.background).shadow_lg().flex().flex_col().gap(px(12.0)).text_color(colors.primary)
             .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
             .child(div().flex().items_center().gap(px(8.0))
                 .child(sf_symbol("bell", 17.0, colors.primary))
                 .child(div().flex_1().text_size(px(16.0)).font_weight(FontWeight::SEMIBOLD).child(format!("Notifications · {unread}")))
-                .child(div().id("close-notifications").cursor_pointer().p(px(5.0)).child(sf_symbol("xmark", 12.0, colors.secondary))
-                    .on_click(cx.listener(|this, _, window, cx| this.toggle_notifications(window, cx)))))
+                .when(!settings_open, |header| {
+                    header.child(div().id("close-notifications").cursor_pointer().p(px(5.0)).child(sf_symbol("xmark", 12.0, colors.secondary))
+                        .on_click(cx.listener(|this, _, window, cx| this.toggle_notifications(window, cx))))
+                }))
             .child(div().flex().items_center().gap(px(14.0)).text_size(px(Typo::META.size))
                 .child(div().id("notification-filter").cursor_pointer().text_color(Ink::FRESH).child(if self.notification_filter_unread { "Unread ▾" } else { "All notifications ▾" })
                     .on_click(cx.listener(|this, _, _, cx| { this.notification_filter_unread = !this.notification_filter_unread; this.notification_selected = 0; cx.notify(); })))
@@ -353,7 +364,11 @@ impl RootView {
                 .with_animation(
                     "notification-panel-arrival",
                     Animation::new(Duration::from_millis(160)).with_easing(ease_out_quint()),
-                    |panel, delta| panel.opacity(delta).top(px(48.0 - 6.0 * (1.0 - delta))),
+                    move |panel, delta| {
+                        panel
+                            .opacity(delta)
+                            .top(px(panel_top - 6.0 * (1.0 - delta)))
+                    },
                 )
                 .into_any_element()
         };
@@ -362,11 +377,33 @@ impl RootView {
                 .absolute()
                 .inset_0()
                 .id("notification-dismiss-layer")
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(|this, _, window, cx| this.toggle_notifications(window, cx)),
-                )
+                .on_click(cx.listener(|this, _, window, cx| {
+                    cx.stop_propagation();
+                    this.toggle_notifications(window, cx);
+                }))
                 .child(panel)
+                .when(settings_open, |layer| {
+                    layer.child(
+                        div()
+                            .id("notification-inbox-toggle-close")
+                            .absolute()
+                            .top(px(7.0))
+                            .right(px(14.0))
+                            .size(px(Metrics::TOOLBAR_CONTROL_SIZE))
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .rounded(px(Radius::BADGE))
+                            .bg(colors.background)
+                            .cursor_pointer()
+                            .hover(move |button| button.bg(colors.primary.alpha(0.05)))
+                            .child(sf_symbol("xmark", 12.0, colors.secondary))
+                            .on_click(cx.listener(|this, _, window, cx| {
+                                cx.stop_propagation();
+                                this.toggle_notifications(window, cx);
+                            })),
+                    )
+                })
                 .into_any_element(),
         )
     }

--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -2290,6 +2290,7 @@ impl RootView {
         if terminal_in_workspace_panel && let Some(auxiliary) = &self.auxiliary_terminal {
             auxiliary.update(cx, |terminal, cx| {
                 terminal.set_shell_chrome(visible_sidebar, true, cx);
+                terminal.set_header_trailing_inset(0.0, cx);
                 terminal.set_viewport(
                     TerminalViewport {
                         x: sidebar_width + card_width,
@@ -2342,6 +2343,7 @@ impl RootView {
                 .overflow_hidden();
             if let Some(terminal) = &self.auxiliary_terminal {
                 terminal.update(cx, |terminal, cx| {
+                    terminal.set_header_trailing_inset(48.0, cx);
                     terminal.set_viewport(
                         TerminalViewport {
                             x: sidebar_width,
@@ -2373,9 +2375,10 @@ impl RootView {
                     div()
                         .id("close-auxiliary-terminal")
                         .absolute()
-                        .top(px(12.0))
+                        .top(px(9.0))
                         .right(px(12.0))
                         .size(px(24.0))
+                        .debug_selector(|| "close-auxiliary-terminal".into())
                         .flex()
                         .items_center()
                         .justify_center()
@@ -3478,11 +3481,10 @@ fn preview_hint(system_image: &str, label: &str, colors: SemanticColors) -> AnyE
 mod tests {
     use super::*;
     use crate::sidebar::{PreviewScenario, SidebarPreviewFixture};
+    use gpui::{Modifiers, size};
 
-    #[cfg(target_os = "macos")]
-    #[gpui::test]
-    fn browser_stays_visible_through_every_resize(cx: &mut gpui::TestAppContext) {
-        let services = Arc::new(AppServices {
+    fn test_services() -> Arc<AppServices> {
+        Arc::new(AppServices {
             store: Arc::new(crate::store::StoreRuntime::inert()),
             usage_tx: tokio::sync::watch::channel(crate::usage::UsageSnapshot::default()).0,
             usage_limits_refresh: tokio::sync::mpsc::channel(1).0,
@@ -3495,7 +3497,134 @@ mod tests {
                     .build()
                     .unwrap(),
             ),
+        })
+    }
+
+    #[gpui::test]
+    fn notification_trigger_closes_an_open_panel_in_one_click(cx: &mut gpui::TestAppContext) {
+        let services = test_services();
+        let session = SidebarPreviewFixture::make(PreviewScenario::Typical)
+            .list
+            .sessions[0]
+            .clone();
+        {
+            let mut store = services.store.store.write().expect("store");
+            store.upsert_session(session.clone());
+            store.select(session.id);
+        }
+        let (root, cx) = cx.add_window_view(move |window, cx| {
+            RootView::new(services, true, PreviewScenario::Empty, window, cx)
         });
+        cx.simulate_resize(size(px(1_000.0), px(700.0)));
+        cx.run_until_parked();
+        let trigger = cx
+            .debug_bounds("notification-inbox-button")
+            .expect("notification trigger");
+
+        root.update_in(cx, |root, window, cx| {
+            root.toggle_notifications(window, cx);
+            assert!(root.notification_panel_open);
+        });
+        cx.simulate_click(trigger.center(), Modifiers::default());
+        cx.run_until_parked();
+
+        assert!(
+            !root.read_with(cx, |root, _| root.notification_panel_open),
+            "clicking the notification trigger again must close the panel without reopening it"
+        );
+    }
+
+    #[gpui::test]
+    fn auxiliary_close_control_does_not_cover_terminal_identity(cx: &mut gpui::TestAppContext) {
+        let services = test_services();
+        let mut parent = SidebarPreviewFixture::make(PreviewScenario::Typical)
+            .list
+            .sessions[0]
+            .clone();
+        parent.parent = None;
+        let mut auxiliary = parent.clone();
+        auxiliary.id = SessionId::new("auxiliary-terminal");
+        auxiliary.kind = AgentKind::SHELL;
+        auxiliary.parent = Some(parent.id.clone());
+        auxiliary.title = crate::store::AUXILIARY_TERMINAL_TITLE.to_owned();
+        {
+            let mut store = services.store.store.write().expect("store");
+            store.upsert_session(parent.clone());
+            store.upsert_session(auxiliary);
+            store.select(parent.id.clone());
+            assert!(store.auxiliary_terminal_for(&parent.id).is_some());
+            assert_eq!(store.selected_session_id(), Some(&parent.id));
+        }
+        let (root, cx) = cx.add_window_view(move |window, cx| {
+            RootView::new(services, false, PreviewScenario::Empty, window, cx)
+        });
+        assert_eq!(
+            root.read_with(cx, |root, _| root.auxiliary_id.clone()),
+            Some(SessionId::new("auxiliary-terminal")),
+            "fixture must mount the auxiliary terminal before the first async refresh"
+        );
+        cx.simulate_resize(size(px(1_000.0), px(700.0)));
+        cx.run_until_parked();
+
+        assert_eq!(
+            root.read_with(cx, |root, _| root.auxiliary_id.clone()),
+            Some(SessionId::new("auxiliary-terminal")),
+            "fixture must mount the auxiliary terminal"
+        );
+
+        let identity = cx
+            .debug_bounds("terminal-session-identity-auxiliary-terminal")
+            .expect("auxiliary terminal identity");
+        let close = cx
+            .debug_bounds("close-auxiliary-terminal")
+            .expect("auxiliary terminal close control");
+        assert!(
+            identity.right() <= close.left(),
+            "the close control must occupy reserved title-bar space instead of covering {identity:?}"
+        );
+    }
+
+    #[gpui::test]
+    fn notification_panel_uses_the_settings_canvas_top_edge(cx: &mut gpui::TestAppContext) {
+        let services = test_services();
+        let (root, cx) = cx.add_window_view(move |window, cx| {
+            RootView::new(services, false, PreviewScenario::Empty, window, cx)
+        });
+        cx.simulate_resize(size(px(1_000.0), px(700.0)));
+        root.update_in(cx, |root, window, cx| {
+            root.run_command(CommandId::OpenSettings, window, cx);
+            root.toggle_notifications(window, cx);
+        });
+        cx.run_until_parked();
+        cx.executor().advance_clock(Duration::from_millis(200));
+        cx.run_until_parked();
+
+        let settings = cx.debug_bounds("settings-shell").expect("settings shell");
+        let trigger = cx
+            .debug_bounds("notification-inbox-button")
+            .expect("settings notification trigger");
+        let panel = cx
+            .debug_bounds("notification-panel")
+            .expect("notification panel");
+        assert_eq!(trigger.top(), settings.top() + px(7.0));
+        assert!(
+            panel.top() <= settings.top() + px(14.0)
+                && panel.top() < settings.top() + px(Metrics::TITLE_BAR),
+            "Settings has no workbench navbar, so the panel must enter from its canvas edge: {panel:?}"
+        );
+
+        cx.simulate_click(trigger.center(), Modifiers::default());
+        cx.run_until_parked();
+        assert!(
+            !root.read_with(cx, |root, _| root.notification_panel_open),
+            "the Settings notification trigger must close its open panel in one click"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[gpui::test]
+    fn browser_stays_visible_through_every_resize(cx: &mut gpui::TestAppContext) {
+        let services = test_services();
         let (root, cx) = cx.add_window_view(move |window, cx| {
             RootView::new(services, true, PreviewScenario::Artifacts, window, cx)
         });

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -6309,51 +6309,6 @@ impl Render for Sidebar {
         if let Some(feedback) = self.external_drop_feedback(colors, cx) {
             root = root.child(feedback);
         }
-        let unread = self
-            .store
-            .read()
-            .expect("store")
-            .notifications()
-            .unread_count();
-        root = root.child(
-            div().px(px(Space::INSET)).py(px(4.0)).child(
-                div()
-                    .id("notification-inbox-button")
-                    .h(px(SIDEBAR_NAV_ROW_HEIGHT))
-                    .px(px(8.0))
-                    .rounded(px(SIDEBAR_ROW_RADIUS))
-                    .cursor_pointer()
-                    .flex()
-                    .items_center()
-                    .gap(px(8.0))
-                    .text_size(px(Typo::ROW.size))
-                    .text_color(colors.primary)
-                    .hover(|style| style.bg(colors.primary.alpha(0.05)))
-                    .child(sf_symbol(
-                        "bell",
-                        14.0,
-                        if unread > 0 {
-                            Ink::FRESH
-                        } else {
-                            colors.secondary
-                        },
-                    ))
-                    .child(div().flex_1().child("Notifications"))
-                    .when(unread > 0, |row| {
-                        row.child(
-                            div()
-                                .rounded(px(5.0))
-                                .px(px(6.0))
-                                .bg(Ink::FRESH.alpha(0.12))
-                                .text_color(Ink::FRESH)
-                                .child(unread.to_string()),
-                        )
-                    })
-                    .on_click(|_, window, cx| {
-                        window.dispatch_action(Box::new(crate::commands::ToggleNotifications), cx)
-                    }),
-            ),
-        );
         root = root.child(self.account_footer(colors, cx));
         // Paint the edge without reducing the shared sidebar content width.
         root = root.child(

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -2241,6 +2241,12 @@ impl UtilitySurfaces {
          * layout immediately.
          * ───────────────────────────────────────────────────────── */
         let colors = self.settings_colors();
+        let unread = self
+            .store
+            .read()
+            .expect("session store lock poisoned")
+            .notifications()
+            .unread_count();
         let generation = self.settings_transition_generation;
         let pane = match self.settings_tab {
             SettingsTab::General => self.general_settings(cx).into_any_element(),
@@ -2292,6 +2298,7 @@ impl UtilitySurfaces {
         div()
             .id("settings-shell")
             .debug_selector(|| "settings-shell".into())
+            .relative()
             .size_full()
             .pt(px(Metrics::TITLE_BAR))
             .overflow_hidden()
@@ -2310,6 +2317,7 @@ impl UtilitySurfaces {
                 }),
             )
             .child(pane)
+            .child(notification_titlebar_button(unread, colors))
     }
 
     fn phone_settings(&self, cx: &mut Context<Self>) -> impl IntoElement {
@@ -5136,11 +5144,7 @@ fn shortcut_row(
     let binding_label: SharedString = if editing {
         "Press keys…".into()
     } else {
-        assignment
-            .as_deref()
-            .unwrap_or("Unassigned")
-            .to_owned()
-            .into()
+        spaced_shortcut_label(assignment.as_deref().unwrap_or("Unassigned")).into()
     };
     let detail: SharedString = error.unwrap_or(metadata.description).to_owned().into();
 
@@ -5153,9 +5157,9 @@ fn shortcut_row(
             let stable_id = command.stable_id;
             move || format!("SHORTCUT_BINDING_{stable_id}")
         })
-        .h(px(27.0))
-        .min_w(px(if editing { 92.0 } else { 42.0 }))
-        .px(px(9.0))
+        .h(px(31.0))
+        .min_w(px(if editing { 96.0 } else { 48.0 }))
+        .px(px(11.0))
         .rounded(px(Radius::BADGE))
         .border_1()
         .border_color(if error.is_some() {
@@ -5174,7 +5178,7 @@ fn shortcut_row(
         .items_center()
         .justify_center()
         .font_family(crate::fonts::mono_family())
-        .text_size(px(11.0))
+        .text_size(px(Typo::ROW.size))
         .text_color(if assignment.is_none() && !editing {
             colors.tertiary
         } else {
@@ -5472,6 +5476,78 @@ fn settings_tab_matches(tab: SettingsTab, query: &str) -> bool {
     query
         .split_whitespace()
         .all(|word| searchable.contains(word))
+}
+
+fn notification_titlebar_button(unread: usize, colors: SemanticColors) -> AnyElement {
+    div()
+        .id("notification-inbox-button")
+        .debug_selector(|| "notification-inbox-button".into())
+        .absolute()
+        .top(px(7.0))
+        .right(px(14.0))
+        .size(px(Metrics::TOOLBAR_CONTROL_SIZE))
+        .flex()
+        .items_center()
+        .justify_center()
+        .rounded(px(Radius::BADGE))
+        .cursor_pointer()
+        .hover(move |button| button.bg(Fill::subtle(colors)))
+        .child(sf_symbol(
+            if unread > 0 { "bell.fill" } else { "bell" },
+            14.0,
+            if unread > 0 {
+                Ink::FRESH
+            } else {
+                colors.secondary
+            },
+        ))
+        .when(unread > 0, |button| {
+            button.child(
+                div()
+                    .absolute()
+                    .top(px(2.0))
+                    .right(px(2.0))
+                    .size(px(5.0))
+                    .rounded_full()
+                    .bg(Ink::FRESH),
+            )
+        })
+        .on_click(|_, window, cx| {
+            window.dispatch_action(Box::new(crate::commands::ToggleNotifications), cx);
+            cx.stop_propagation();
+        })
+        .into_any_element()
+}
+
+fn spaced_shortcut_label(label: &str) -> String {
+    if label.contains('+') {
+        return label.replace('+', "\u{2009}+\u{2009}");
+    }
+
+    let mut rest = label;
+    let mut parts = Vec::new();
+    if let Some(without_fn) = rest.strip_prefix("fn") {
+        parts.push("fn");
+        rest = without_fn;
+    }
+    while let Some(modifier) = rest
+        .chars()
+        .next()
+        .filter(|character| matches!(character, '⌃' | '⌥' | '⇧' | '⌘'))
+    {
+        parts.push(match modifier {
+            '⌃' => "⌃",
+            '⌥' => "⌥",
+            '⇧' => "⇧",
+            '⌘' => "⌘",
+            _ => unreachable!(),
+        });
+        rest = &rest[modifier.len_utf8()..];
+    }
+    if !rest.is_empty() {
+        parts.push(rest);
+    }
+    parts.join("\u{2009}")
 }
 
 fn settings_page(
@@ -7521,6 +7597,20 @@ mod tests {
         assert!(settings_tab_matches(SettingsTab::Shortcuts, "keyboard"));
         assert!(settings_tab_matches(SettingsTab::Terminal, "appearance"));
         assert!(!settings_tab_matches(SettingsTab::Terminal, "ssh"));
+    }
+
+    #[test]
+    fn shortcut_labels_separate_modifiers_from_each_other_and_the_key() {
+        assert_eq!(
+            spaced_shortcut_label("⌥⇧⌘C"),
+            "⌥\u{2009}⇧\u{2009}⌘\u{2009}C"
+        );
+        assert_eq!(spaced_shortcut_label("⌘Space"), "⌘\u{2009}Space");
+        assert_eq!(
+            spaced_shortcut_label("Ctrl+Shift+C"),
+            "Ctrl\u{2009}+\u{2009}Shift\u{2009}+\u{2009}C"
+        );
+        assert_eq!(spaced_shortcut_label("Unassigned"), "Unassigned");
     }
 
     #[gpui::test]

--- a/diri/crates/diri-app/src/terminal_pane.rs
+++ b/diri/crates/diri-app/src/terminal_pane.rs
@@ -881,6 +881,9 @@ pub struct TerminalPane {
     viewport: Option<TerminalViewport>,
     sidebar_visible: bool,
     inspector_open: bool,
+    /// Space in the title bar reserved for workbench-owned controls painted
+    /// above this pane, such as the auxiliary terminal's close button.
+    header_trailing_inset: f32,
     navigation: Option<Entity<NavigationOverlay>>,
     utility_surfaces: Option<Entity<UtilitySurfaces>>,
     local_clipboard_images: Vec<StagedClipboardImage>,
@@ -1003,6 +1006,7 @@ impl TerminalPane {
             viewport: None,
             sidebar_visible: true,
             inspector_open: false,
+            header_trailing_inset: 0.0,
             navigation: None,
             utility_surfaces: None,
             local_clipboard_images: Vec::new(),
@@ -1180,6 +1184,14 @@ impl TerminalPane {
         }
         self.sidebar_visible = sidebar_visible;
         self.inspector_open = inspector_open;
+        cx.notify();
+    }
+
+    pub fn set_header_trailing_inset(&mut self, inset: f32, cx: &mut Context<Self>) {
+        if (self.header_trailing_inset - inset).abs() < f32::EPSILON {
+            return;
+        }
+        self.header_trailing_inset = inset.max(0.0);
         cx.notify();
     }
 
@@ -2603,10 +2615,19 @@ impl TerminalPane {
                 .host_display_name(host)
         });
         let kind = ui_agent_kind(session.effective_kind());
+        let identity_selector = format!("terminal-session-identity-{}", session.id.0);
         let shell_controls = matches!(self.session_source, SessionSource::FollowSelection);
         let show_sidebar = shell_controls && !self.sidebar_visible;
         let sidebar_reveal = show_sidebar.then(|| self.render_sidebar_reveal_control(colors, cx));
         let inspector_open = self.inspector_open;
+        let header_trailing_inset = self.header_trailing_inset;
+        let unread = self
+            .runtime
+            .store
+            .read()
+            .expect("session store lock poisoned")
+            .notifications()
+            .unread_count();
         let visible_chip_count = visible_chip_count.min(chips.len());
         let overflow_count = chips.len().saturating_sub(visible_chip_count);
         let mut toolbar_links = div()
@@ -2646,7 +2667,8 @@ impl TerminalPane {
         div()
             .h(px(Metrics::TITLE_BAR))
             .flex_none()
-            .px(px(Metrics::TOOLBAR_EDGE_INSET))
+            .pl(px(Metrics::TOOLBAR_EDGE_INSET))
+            .pr(px(Metrics::TOOLBAR_EDGE_INSET + header_trailing_inset))
             .flex()
             .items_center()
             .justify_between()
@@ -2720,6 +2742,7 @@ impl TerminalPane {
                     .gap(px(Metrics::TOOLBAR_ITEM_GAP))
                     .child(
                         div()
+                            .debug_selector(move || identity_selector.clone())
                             .flex()
                             .items_center()
                             .gap(px(Metrics::TOOLBAR_COMPACT_GAP))
@@ -2757,6 +2780,49 @@ impl TerminalPane {
                                     window.dispatch_action(Box::new(ToggleInspector), cx);
                                     cx.stop_propagation();
                                 })),
+                        )
+                    })
+                    .when(shell_controls, |trailing| {
+                        trailing.child(
+                            div()
+                                .id("notification-inbox-button")
+                                .debug_selector(|| "notification-inbox-button".into())
+                                .relative()
+                                .size(px(Metrics::TOOLBAR_CONTROL_SIZE))
+                                .flex_none()
+                                .flex()
+                                .items_center()
+                                .justify_center()
+                                .rounded(px(Radius::BADGE))
+                                .cursor_pointer()
+                                .hover(move |button| button.bg(Fill::subtle(colors)))
+                                .child(sf_symbol(
+                                    if unread > 0 { "bell.fill" } else { "bell" },
+                                    14.0,
+                                    if unread > 0 {
+                                        Ink::FRESH
+                                    } else {
+                                        colors.secondary
+                                    },
+                                ))
+                                .when(unread > 0, |button| {
+                                    button.child(
+                                        div()
+                                            .absolute()
+                                            .top(px(2.0))
+                                            .right(px(2.0))
+                                            .size(px(5.0))
+                                            .rounded_full()
+                                            .bg(Ink::FRESH),
+                                    )
+                                })
+                                .on_click(|_, window, cx| {
+                                    window.dispatch_action(
+                                        Box::new(crate::commands::ToggleNotifications),
+                                        cx,
+                                    );
+                                    cx.stop_propagation();
+                                }),
                         )
                     }),
             )

--- a/diri/crates/diri-ui/assets/icons/bell.svg
+++ b/diri/crates/diri-ui/assets/icons/bell.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" viewBox="0 0 24 24"><path d="M10.27 21a2 2 0 0 0 3.46 0"/><path d="M3.26 15.1A2 2 0 0 0 5 18h14a2 2 0 0 0 1.74-2.9C19.68 13.25 18 11.6 18 8a6 6 0 0 0-12 0c0 3.6-1.68 5.25-2.74 7.1Z"/></svg>

--- a/diri/crates/diri-ui/src/icon.rs
+++ b/diri/crates/diri-ui/src/icon.rs
@@ -50,6 +50,7 @@ pub enum IconName {
     Activity,
     Archive,
     ArrowDown,
+    Bell,
     Branch,
     ChartBar,
     Check,
@@ -100,11 +101,12 @@ pub enum IconName {
 }
 
 impl IconName {
-    pub const ALL: [Self; 51] = [
+    pub const ALL: [Self; 52] = [
         Self::Account,
         Self::Activity,
         Self::Archive,
         Self::ArrowDown,
+        Self::Bell,
         Self::Branch,
         Self::ChartBar,
         Self::Check,
@@ -160,6 +162,7 @@ impl IconName {
             Self::Activity => "icons/activity.svg",
             Self::Archive => "icons/archive.svg",
             Self::ArrowDown => "icons/arrow-down.svg",
+            Self::Bell => "icons/bell.svg",
             Self::Branch => "icons/branch.svg",
             Self::ChartBar => "icons/chart-bar.svg",
             Self::Check => "icons/check.svg",
@@ -217,6 +220,7 @@ impl IconName {
             "waveform.circle" | "waveform.circle.fill" => Self::Activity,
             "archivebox" | "archivebox.fill" => Self::Archive,
             "arrow.down" => Self::ArrowDown,
+            "bell" | "bell.fill" => Self::Bell,
             "arrow.branch" => Self::Branch,
             "chart.bar" | "chart.bar.xaxis" => Self::ChartBar,
             "checkmark" => Self::Check,
@@ -328,6 +332,7 @@ fn embedded_svg(path: &str) -> Option<&'static [u8]> {
         "icons/activity.svg" => include_bytes!("../assets/icons/activity.svg"),
         "icons/archive.svg" => include_bytes!("../assets/icons/archive.svg"),
         "icons/arrow-down.svg" => include_bytes!("../assets/icons/arrow-down.svg"),
+        "icons/bell.svg" => include_bytes!("../assets/icons/bell.svg"),
         "icons/branch.svg" => include_bytes!("../assets/icons/branch.svg"),
         "icons/chart-bar.svg" => include_bytes!("../assets/icons/chart-bar.svg"),
         "icons/check.svg" => include_bytes!("../assets/icons/check.svg"),


### PR DESCRIPTION
## Why

Several compact UI surfaces had regressions: the auxiliary terminal close control could cover the session label, the notification panel inherited unreadable dark text and reopened after a second trigger click, its Settings placement assumed the workbench navbar, and shortcut keycaps were too cramped to scan.

## What changed

- Reserve titlebar space for the auxiliary terminal close control and align the control vertically.
- Move Notifications from the sidebar footer to a bell at the right edge of the terminal and Settings titlebars, with an unread indicator.
- Make the bell a true open/close toggle, including when the compact Settings panel covers its anchor.
- Give the notification panel explicit semantic text colors and place it against the Settings canvas edge.
- Increase shortcut keycap size and add thin spacing between modifier glyphs and keys.
- Add a native SVG bell to the shared icon catalog.
- Add GPUI regressions for one-click notification toggling, Settings placement, and auxiliary titlebar overlap.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --workspace --release`
- Rendered and visually inspected the Settings shortcuts fixture in dark mode.

- [x] The repository's full Rust formatting, lint, test, and release-build gates pass.
- [x] Session transport and persistence behavior are unchanged.
- [x] Security and privacy impact considered; this changes local presentation and action routing only.
- [x] User-visible behavior is described above.
- [ ] UI fixture was inspected locally; no generated screenshot is committed to the repository.

## CI baseline notes

- `Rust workspace`, `Rust engine (Linux x86_64)`, and `Dependency review` pass on this PR.
- `Lints` fails identically on current `main`: Linux clippy reports the macOS-only `TrailingStatus::Unread` variant as dead code.
- `iPhone app` fails identically on current `main`: the `macos-15-arm64` runner does not provide the Xcode 26 / iOS 26 SDK required by `scripts/testflight.sh check`.
