### PR TITLE
Fix mouse Back clicks dismissing the command palette

### DIFF
--- a/diri/crates/diri-app/src/navigation.rs
+++ b/diri/crates/diri-app/src/navigation.rs
@@ -1070,6 +1070,7 @@ impl NavigationOverlay {
                     .child(
                         div()
                             .id("palette-back")
+                            .debug_selector(|| "palette-back".into())
                             .size(px(28.0))
                             .flex_none()
                             .flex()
@@ -1260,6 +1261,9 @@ impl NavigationOverlay {
             )
             .child(
                 div()
+                    // Consume hit tests inside the surface before the dismiss
+                    // backdrop sees mouse-down, including header controls.
+                    .occlude()
                     .on_mouse_down_out(
                         cx.listener(|this, _, window, cx| this.close_overlay(window, cx)),
                     )

--- a/diri/crates/diri-app/src/navigation/page_tests.rs
+++ b/diri/crates/diri-app/src/navigation/page_tests.rs
@@ -312,3 +312,59 @@ fn pending_project_search_cannot_change_a_new_page(cx: &mut TestAppContext) {
         assert!(overlay.rank_task.is_none());
     });
 }
+
+#[gpui::test]
+fn clicking_back_keeps_the_palette_open(cx: &mut TestAppContext) {
+    cx.update(|cx| cx.set_reduce_motion(true));
+    let (view, cx) = cx.add_window_view(|window, cx| {
+        let previous_focus = cx.focus_handle();
+        let overlay = cx.new(|cx| {
+            let mut overlay =
+                NavigationOverlay::opened_for_test(Arc::new(StoreRuntime::inert()), cx);
+            seed_history(&mut overlay);
+            overlay.focus_handle.focus(window, cx);
+            overlay
+        });
+        Harness {
+            overlay,
+            previous_focus,
+        }
+    });
+    cx.simulate_resize(size(px(800.0), px(700.0)));
+    cx.run_until_parked();
+    let back = cx.debug_bounds("palette-back").expect("back button");
+    cx.simulate_click(back.center(), gpui::Modifiers::default());
+    cx.run_until_parked();
+    let overlay = view.read_with(cx, |view, _| view.overlay.clone());
+    overlay.read_with(cx, |overlay, _| {
+        assert_eq!(
+            overlay.overlay,
+            Some(Overlay::CommandPalette),
+            "clicking Back should return to commands, not dismiss the palette"
+        );
+    });
+    overlay.update_in(cx, |overlay, window, cx| {
+        overlay.query.insert("settings");
+        overlay.query_changed(cx);
+        overlay.push_page(Overlay::Settings, window, cx);
+        overlay.push_page(Overlay::Themes, window, cx);
+        overlay.move_highlight(1, cx);
+    });
+    cx.run_until_parked();
+    for expected in [Overlay::Settings, Overlay::CommandPalette] {
+        let back = cx.debug_bounds("palette-back").unwrap();
+        cx.simulate_click(back.center(), gpui::Modifiers::default());
+        cx.run_until_parked();
+        overlay.read_with(cx, |overlay, _| {
+            assert_eq!(overlay.overlay, Some(expected));
+            assert!(overlay.store.read().unwrap().preview_theme_id().is_none());
+        });
+    }
+    overlay.update_in(cx, |overlay, window, _| {
+        assert_eq!(overlay.query.text(), "settings");
+        assert!(overlay.focus_handle.is_focused(window));
+    });
+    cx.simulate_click(point(px(5.0), px(600.0)), gpui::Modifiers::default());
+    cx.run_until_parked();
+    assert!(!overlay.read_with(cx, |overlay, _| overlay.is_open()));
+}


### PR DESCRIPTION
## Why

Clicking the palette's Back arrow dismissed the menu instead of navigating to the previous page. The palette surface did not occlude the dismiss backdrop, so the backdrop received mouse-down before the button could receive its click.

## What changed

Make the palette surface occlude the backdrop. Clicks inside reach its controls; outside clicks still dismiss it. Appearance and keyboard behavior stay the same.

## Verification

The new GPUI mouse regression failed before the fix (`None` instead of `Some(CommandPalette)`) and passes after it. It covers direct chat-page Back, nested Themes → Settings → Commands, restoring the query and focus, canceling a theme preview, and outside-click dismissal.

Passed: workspace formatting, Clippy with warnings denied, workspace tests, and release build. All 15 navigation tests passed.
