### PR TITLE
Add floating sidebar peek with continuous docking animation

### DIFF
--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -190,6 +190,9 @@ pub struct RootView {
     /// from this rather than from the settled width so it picks up wherever the
     /// previous frame left the panel.
     sidebar_seam: f32,
+    sidebar_peek_slide: Option<SeamSlide>,
+    sidebar_peek_seam: f32,
+    sidebar_peek_dwell: Option<Task<()>>,
     auxiliary_terminal: Option<Entity<TerminalPane>>,
     auxiliary_id: Option<SessionId>,
     auxiliary_parent: Option<SessionId>,
@@ -408,6 +411,14 @@ impl RootView {
                 });
             }
             if matches!(event, SidebarEvent::VisibilityChanged) {
+                // Pinning adopts the overlay's current position. Render the
+                // same sidebar only once as it becomes part of the layout.
+                if this.sidebar.read(cx).is_visible() && this.sidebar_peek_seam > 0.0 {
+                    this.sidebar_seam = this.sidebar_peek_seam;
+                }
+                this.sidebar_peek_slide = None;
+                this.sidebar_peek_seam = 0.0;
+                this.sidebar_peek_dwell = None;
                 this.begin_sidebar_slide(cx);
                 // Settings navigation lives in the sidebar, so hiding the
                 // sidebar is also the way out of settings.
@@ -417,6 +428,19 @@ impl RootView {
                 {
                     this.sidebar_revealed_for_settings = false;
                     surfaces.update(cx, |surfaces, cx| surfaces.dismiss(cx));
+                }
+            }
+            if matches!(event, SidebarEvent::PeekChanged) {
+                let to = if this.sidebar.read(cx).is_peeking() {
+                    this.sidebar.read(cx).width()
+                } else {
+                    0.0
+                };
+                this.sidebar_peek_slide = (!cx.reduce_motion())
+                    .then(|| SeamSlide::begin(this.sidebar_peek_seam, to))
+                    .flatten();
+                if this.sidebar_peek_slide.is_none() {
+                    this.sidebar_peek_seam = to;
                 }
             }
             cx.notify();
@@ -890,6 +914,9 @@ impl RootView {
             focus: cx.focus_handle(),
             resize_origin: None,
             sidebar_slide: None,
+            sidebar_peek_slide: None,
+            sidebar_peek_seam: 0.0,
+            sidebar_peek_dwell: None,
             sidebar_seam,
             auxiliary_terminal: None,
             auxiliary_id: None,
@@ -3143,6 +3170,11 @@ impl Render for RootView {
             .set_notification_surface_visible(notification_surface_visible);
         let sidebar_visible = self.sidebar.read(cx).is_visible();
         let sidebar_width = self.sidebar.read(cx).width();
+        let peek_width = if self.sidebar.read(cx).is_peeking() {
+            sidebar_width
+        } else {
+            0.0
+        };
         let window_width = f32::from(window.inner_window_bounds().get_bounds().size.width);
         let occupied_sidebar_width = if sidebar_visible { sidebar_width } else { 0.0 };
         self.inspector_max_width =
@@ -3156,6 +3188,9 @@ impl Render for RootView {
             0.0
         };
         let now = Instant::now();
+        self.sidebar_peek_seam =
+            advance_seam(&mut self.sidebar_peek_slide, peek_width, now, window);
+        let peeking = self.sidebar_peek_seam > 0.0;
         self.sidebar_seam =
             advance_seam(&mut self.sidebar_slide, occupied_sidebar_width, now, window);
         self.inspector_seam = advance_seam(&mut self.inspector_slide, inspector_width, now, window);
@@ -3178,29 +3213,46 @@ impl Render for RootView {
         // lives against -- the sidebar's right, the inspector's left -- so
         // narrowing a wrapper slides its panel out under the clip instead of
         // squeezing every row's contents down with it.
-        let sidebar_wrapper = div()
-            .relative()
-            .flex_none()
-            .h_full()
-            .overflow_hidden()
-            .w(px(seam))
-            .when(seam > 0.0, |wrapper| {
-                wrapper.child(
-                    div()
+        let painted_sidebar_width = if peeking {
+            self.sidebar_peek_seam
+        } else {
+            seam
+        };
+        let mut sidebar_wrapper = Some(
+            div()
+                .relative()
+                .flex_none()
+                .h_full()
+                .overflow_hidden()
+                .w(px(painted_sidebar_width))
+                .when(peeking, |wrapper| {
+                    wrapper
                         .absolute()
-                        .top(px(0.0))
-                        .right(px(0.0))
-                        .h_full()
-                        .w(px(sidebar_width))
-                        // A reactive boundary: the sidebar re-renders on its
-                        // own notifies, not on the terminal's 60fps repaints.
-                        .child(
-                            self.sidebar
-                                .clone()
-                                .cached(StyleRefinement::default().size_full()),
-                        ),
-                )
-            });
+                        .left_0()
+                        .top(px(recovery_height))
+                        .bottom_0()
+                        .h_auto()
+                        .shadow_md()
+                        .occlude()
+                })
+                .when(painted_sidebar_width > 0.0, |wrapper| {
+                    wrapper.child(
+                        div()
+                            .absolute()
+                            .top(px(0.0))
+                            .right(px(0.0))
+                            .h_full()
+                            .w(px(sidebar_width))
+                            // A reactive boundary: the sidebar re-renders on its
+                            // own notifies, not on the terminal's 60fps repaints.
+                            .child(
+                                self.sidebar
+                                    .clone()
+                                    .cached(StyleRefinement::default().size_full()),
+                            ),
+                    )
+                }),
+        );
 
         let mut root = div()
             .id("root")
@@ -3354,7 +3406,7 @@ impl Render for RootView {
                     this.drag_inspector_resize(f32::from(event.event.position.x), cx);
                 },
             ))
-            .child(sidebar_wrapper)
+            .children((!peeking).then(|| sidebar_wrapper.take().expect("sidebar wrapper")))
             .when(seam > 0.0, |root| root.child(self.resize_handle(cx)));
         if launcher_open {
             // Command-N behaves like an unsaved new tab: preserve the app
@@ -3410,6 +3462,37 @@ impl Render for RootView {
                         ),
                 );
             }
+        }
+        // This overlay never participates in the terminal's flex layout or
+        // viewport sizing. Keep it below dialogs and above workbench content.
+        root = root.children(sidebar_wrapper);
+        if !sidebar_visible && seam == 0.0 && !peeking && peek_width == 0.0 {
+            root = root.child(
+                div()
+                    .id("sidebar-peek-edge")
+                    .debug_selector(|| "sidebar-peek-edge".into())
+                    .absolute()
+                    .left_0()
+                    .top(px(recovery_height + 36.0))
+                    .bottom_0()
+                    .w(px(8.0))
+                    .on_hover(cx.listener(|this, hovered: &bool, window, cx| {
+                        this.sidebar_peek_dwell = None;
+                        if *hovered {
+                            this.sidebar_peek_dwell =
+                                Some(cx.spawn_in(window, async move |this, cx| {
+                                    cx.background_executor()
+                                        .timer(Duration::from_millis(100))
+                                        .await;
+                                    let _ = this.update_in(cx, |this, window, cx| {
+                                        this.sidebar_peek_dwell = None;
+                                        this.sidebar
+                                            .update(cx, |sidebar, cx| sidebar.peek(window, cx));
+                                    });
+                                }));
+                        }
+                    })),
+            );
         }
         if self.resize_origin.is_some()
             || self.terminal_resize_origin.is_some()
@@ -3593,6 +3676,153 @@ mod tests {
                     .unwrap(),
             ),
         })
+    }
+
+    #[gpui::test]
+    fn sidebar_peek_reveals_on_the_edge_and_leaves_the_layout_collapsed(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        cx.update(|cx| cx.set_reduce_motion(true));
+        let services = test_services();
+        let (root, cx) = cx.add_window_view(move |window, cx| {
+            RootView::new(services, true, PreviewScenario::Typical, window, cx)
+        });
+        cx.simulate_resize(size(px(1000.0), px(700.0)));
+        root.update(cx, |root, cx| {
+            root.sidebar.update(cx, |sidebar, cx| sidebar.conceal(cx))
+        });
+        cx.run_until_parked();
+        let edge = cx
+            .debug_bounds("sidebar-peek-edge")
+            .expect("collapsed edge");
+        cx.simulate_mouse_move(edge.center(), None, Modifiers::default());
+        cx.executor().advance_clock(Duration::from_millis(40));
+        cx.simulate_mouse_move(
+            gpui::point(px(600.0), px(300.0)),
+            None,
+            Modifiers::default(),
+        );
+        cx.executor().advance_clock(Duration::from_millis(120));
+        cx.run_until_parked();
+        assert!(!root.read_with(cx, |root, cx| root.sidebar.read(cx).is_peeking()));
+        cx.simulate_mouse_move(edge.center(), None, Modifiers::default());
+        cx.executor().advance_clock(Duration::from_millis(120));
+        cx.run_until_parked();
+        root.read_with(cx, |root, cx| {
+            assert!(root.sidebar.read(cx).is_peeking());
+            assert!(!root.sidebar.read(cx).is_visible());
+            assert_eq!(
+                root.sidebar_seam, 0.0,
+                "peeking must not resize the terminal"
+            );
+            assert_eq!(root.sidebar_peek_seam, root.sidebar.read(cx).width());
+        });
+        let session = cx
+            .debug_bounds("SESSION_preview-claude")
+            .expect("peek session row");
+        cx.simulate_click(session.center(), Modifiers::default());
+        root.read_with(cx, |root, cx| {
+            assert_eq!(
+                root.sidebar.read(cx).selected_session().unwrap().id,
+                SessionId::new("preview-claude")
+            );
+            assert!(
+                root.sidebar.read(cx).is_peeking(),
+                "selecting a session keeps the peek interactive"
+            );
+        });
+        cx.simulate_mouse_move(
+            gpui::point(px(150.0), px(300.0)),
+            None,
+            Modifiers::default(),
+        );
+        cx.executor().advance_clock(Duration::from_secs(1));
+        cx.run_until_parked();
+        assert!(root.read_with(cx, |root, cx| root.sidebar.read(cx).is_peeking()));
+        cx.simulate_mouse_move(
+            gpui::point(px(600.0), px(300.0)),
+            None,
+            Modifiers::default(),
+        );
+        cx.executor().advance_clock(Duration::from_millis(100));
+        cx.run_until_parked();
+        assert!(root.read_with(cx, |root, cx| root.sidebar.read(cx).is_peeking()));
+        // Returning during the grace period cancels the pending dismissal.
+        cx.simulate_mouse_move(
+            gpui::point(px(150.0), px(300.0)),
+            None,
+            Modifiers::default(),
+        );
+        cx.executor().advance_clock(Duration::from_millis(300));
+        cx.run_until_parked();
+        assert!(root.read_with(cx, |root, cx| root.sidebar.read(cx).is_peeking()));
+        cx.simulate_mouse_move(
+            gpui::point(px(600.0), px(300.0)),
+            None,
+            Modifiers::default(),
+        );
+        cx.executor().advance_clock(Duration::from_millis(300));
+        cx.run_until_parked();
+        assert!(!root.read_with(cx, |root, cx| root.sidebar.read(cx).is_peeking()));
+        assert!(cx.debug_bounds("sidebar-peek-edge").is_some());
+
+        cx.simulate_mouse_move(edge.center(), None, Modifiers::default());
+        cx.executor().advance_clock(Duration::from_millis(120));
+        cx.run_until_parked();
+        let pin = cx.debug_bounds("sidebar-toggle").expect("peek pin control");
+        cx.simulate_click(pin.center(), Modifiers::default());
+        cx.simulate_mouse_move(
+            gpui::point(px(600.0), px(300.0)),
+            None,
+            Modifiers::default(),
+        );
+        cx.executor().advance_clock(Duration::from_secs(1));
+        cx.run_until_parked();
+        root.read_with(cx, |root, cx| {
+            assert!(root.sidebar.read(cx).is_visible());
+            assert!(!root.sidebar.read(cx).is_peeking());
+            assert_eq!(root.sidebar_peek_seam, 0.0);
+            assert_eq!(root.sidebar_seam, root.sidebar.read(cx).width());
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "writes a visual preview to DIRI_PEEK_SCREENSHOT"]
+    fn render_sidebar_peek_screenshot() {
+        use gpui::{AppContext as _, HeadlessAppContext};
+        let output = std::env::var("DIRI_PEEK_SCREENSHOT").expect("DIRI_PEEK_SCREENSHOT");
+        let platform = gpui_platform::current_platform(true);
+        let mut cx = HeadlessAppContext::with_platform(
+            platform.text_system(),
+            Arc::new(diri_ui::IconAssets),
+            gpui_platform::current_headless_renderer,
+        );
+        cx.update(|cx| {
+            crate::fonts::init(cx);
+            cx.set_reduce_motion(true);
+        });
+        let services = test_services();
+        let window = cx
+            .open_window(size(px(1000.0), px(700.0)), |window, cx| {
+                cx.new(|cx| {
+                    let root = RootView::new(services, true, PreviewScenario::Typical, window, cx);
+                    root.sidebar.update(cx, |sidebar, cx| {
+                        sidebar.conceal(cx);
+                        sidebar.peek(window, cx);
+                    });
+                    root
+                })
+            })
+            .expect("preview window");
+        cx.run_until_parked();
+        cx.capture_screenshot(window.into())
+            .expect("peek screenshot")
+            .save(output)
+            .expect("save peek screenshot");
+        cx.update_window(window.into(), |_, window, _| window.remove_window())
+            .expect("close preview window");
+        cx.run_until_parked();
     }
 
     #[gpui::test]

--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -5,8 +5,8 @@ use std::time::{Duration, Instant};
 use diri_proto::{AgentKind, SessionId, SessionRecord, SessionStatus};
 use diri_ui::{FloatingSurface, Ink, Metrics, Radius, SemanticColors, Typo};
 use gpui::{
-    Animation, AnimationExt, AnyElement, App, Context, CursorStyle, DragMoveEvent, Entity,
-    FocusHandle, Focusable, FontWeight, KeyContext, KeyDownEvent, KeyUpEvent,
+    Animation, AnimationExt, AnyElement, App, BoxShadow, Context, CursorStyle, DragMoveEvent,
+    Entity, FocusHandle, Focusable, FontWeight, KeyContext, KeyDownEvent, KeyUpEvent,
     ModifiersChangedEvent, MouseButton, Render, StyleRefinement, Subscription, Task, Window,
     deferred, div, ease_out_quint, prelude::*, px, rgba,
 };
@@ -47,6 +47,7 @@ use crate::workbench::WorkbenchLayout;
 mod notification_panel;
 
 const WINDOW_BOUNDS_SAVE_DELAY: Duration = Duration::from_millis(150);
+const SIDEBAR_PEEK_INSET: f32 = 10.0;
 
 pub(crate) fn cached_window_overlay<T: Render>(view: Entity<T>) -> impl IntoElement {
     view.cached(StyleRefinement::default().absolute().inset_0())
@@ -190,8 +191,13 @@ pub struct RootView {
     /// from this rather than from the settled width so it picks up wherever the
     /// previous frame left the panel.
     sidebar_seam: f32,
-    sidebar_peek_slide: Option<SeamSlide>,
-    sidebar_peek_seam: f32,
+    /// The panel is always mounted in one absolute slot. Only this exposure
+    /// and its floating treatment change; the layout seam independently makes room.
+    sidebar_panel_slide: Option<SeamSlide>,
+    sidebar_panel_width: f32,
+    sidebar_float_slide: Option<SeamSlide>,
+    sidebar_float: f32,
+    sidebar_floating: bool,
     sidebar_peek_dwell: Option<Task<()>>,
     auxiliary_terminal: Option<Entity<TerminalPane>>,
     auxiliary_id: Option<SessionId>,
@@ -261,7 +267,11 @@ impl RootView {
         cx: &mut Context<Self>,
     ) -> Self {
         let sidebar_runtime = (!preview).then(|| Arc::clone(&services.store));
-        let sidebar = cx.new(|cx| Sidebar::new(sidebar_runtime, preview, preview_scenario, cx));
+        let sidebar = cx.new(|cx| {
+            let mut sidebar = Sidebar::new(sidebar_runtime, preview, preview_scenario, cx);
+            sidebar.set_surface_in_parent();
+            sidebar
+        });
         let terminal = (!preview || preview_scenario == PreviewScenario::Empty).then(|| {
             let runtime = Arc::clone(&services.store);
             let tokio = Arc::clone(&services.tokio);
@@ -411,14 +421,8 @@ impl RootView {
                 });
             }
             if matches!(event, SidebarEvent::VisibilityChanged) {
-                // Pinning adopts the overlay's current position. Render the
-                // same sidebar only once as it becomes part of the layout.
-                if this.sidebar.read(cx).is_visible() && this.sidebar_peek_seam > 0.0 {
-                    this.sidebar_seam = this.sidebar_peek_seam;
-                }
-                this.sidebar_peek_slide = None;
-                this.sidebar_peek_seam = 0.0;
                 this.sidebar_peek_dwell = None;
+                this.sidebar_floating = false;
                 this.begin_sidebar_slide(cx);
                 // Settings navigation lives in the sidebar, so hiding the
                 // sidebar is also the way out of settings.
@@ -431,17 +435,12 @@ impl RootView {
                 }
             }
             if matches!(event, SidebarEvent::PeekChanged) {
-                let to = if this.sidebar.read(cx).is_peeking() {
-                    this.sidebar.read(cx).width()
-                } else {
-                    0.0
-                };
-                this.sidebar_peek_slide = (!cx.reduce_motion())
-                    .then(|| SeamSlide::begin(this.sidebar_peek_seam, to))
-                    .flatten();
-                if this.sidebar_peek_slide.is_none() {
-                    this.sidebar_peek_seam = to;
+                this.sidebar_floating = true;
+                // Establish the floating shape offscreen; exits retain it.
+                if this.sidebar_panel_width == 0.0 {
+                    this.sidebar_float = 1.0;
                 }
+                this.begin_sidebar_panel_slide(Instant::now(), cx);
             }
             cx.notify();
         })
@@ -914,8 +913,11 @@ impl RootView {
             focus: cx.focus_handle(),
             resize_origin: None,
             sidebar_slide: None,
-            sidebar_peek_slide: None,
-            sidebar_peek_seam: 0.0,
+            sidebar_panel_slide: None,
+            sidebar_panel_width: sidebar_seam,
+            sidebar_float_slide: None,
+            sidebar_float: 0.0,
+            sidebar_floating: false,
             sidebar_peek_dwell: None,
             sidebar_seam,
             auxiliary_terminal: None,
@@ -1915,11 +1917,35 @@ impl RootView {
     /// Reduced-motion users get the settled width immediately.
     fn begin_sidebar_slide(&mut self, cx: &mut Context<Self>) {
         let to = self.settled_sidebar_seam(cx);
+        let now = Instant::now();
         self.sidebar_slide = (!cx.reduce_motion())
-            .then(|| SeamSlide::begin(self.sidebar_seam, to))
+            .then(|| SeamSlide::begin_at(self.sidebar_seam, to, now))
             .flatten();
         if self.sidebar_slide.is_none() {
             self.sidebar_seam = to;
+        }
+        self.begin_sidebar_panel_slide(now, cx);
+    }
+
+    fn begin_sidebar_panel_slide(&mut self, now: Instant, cx: &mut Context<Self>) {
+        let sidebar = self.sidebar.read(cx);
+        let to = if sidebar.is_visible() || sidebar.is_peeking() {
+            sidebar.width()
+        } else {
+            0.0
+        };
+        let float_to = if self.sidebar_floating { 1.0 } else { 0.0 };
+        self.sidebar_panel_slide = (!cx.reduce_motion())
+            .then(|| SeamSlide::begin_at(self.sidebar_panel_width, to, now))
+            .flatten();
+        self.sidebar_float_slide = (!cx.reduce_motion())
+            .then(|| SeamSlide::begin_at(self.sidebar_float, float_to, now))
+            .flatten();
+        if self.sidebar_panel_slide.is_none() {
+            self.sidebar_panel_width = to;
+        }
+        if self.sidebar_float_slide.is_none() {
+            self.sidebar_float = float_to;
         }
     }
 
@@ -3170,7 +3196,7 @@ impl Render for RootView {
             .set_notification_surface_visible(notification_surface_visible);
         let sidebar_visible = self.sidebar.read(cx).is_visible();
         let sidebar_width = self.sidebar.read(cx).width();
-        let peek_width = if self.sidebar.read(cx).is_peeking() {
+        let panel_width = if sidebar_visible || self.sidebar.read(cx).is_peeking() {
             sidebar_width
         } else {
             0.0
@@ -3188,9 +3214,14 @@ impl Render for RootView {
             0.0
         };
         let now = Instant::now();
-        self.sidebar_peek_seam =
-            advance_seam(&mut self.sidebar_peek_slide, peek_width, now, window);
-        let peeking = self.sidebar_peek_seam > 0.0;
+        self.sidebar_panel_width =
+            advance_seam(&mut self.sidebar_panel_slide, panel_width, now, window);
+        self.sidebar_float = advance_seam(
+            &mut self.sidebar_float_slide,
+            if self.sidebar_floating { 1.0 } else { 0.0 },
+            now,
+            window,
+        );
         self.sidebar_seam =
             advance_seam(&mut self.sidebar_slide, occupied_sidebar_width, now, window);
         self.inspector_seam = advance_seam(&mut self.inspector_slide, inspector_width, now, window);
@@ -3209,50 +3240,106 @@ impl Render for RootView {
         let mut key_context = KeyContext::new_with_defaults();
         key_context.add(APP_CONTEXT);
         key_context.add(SESSION_NAVIGATION_CONTEXT);
-        // Each panel keeps its full width and is pinned to the wrapper edge it
-        // lives against -- the sidebar's right, the inspector's left -- so
-        // narrowing a wrapper slides its panel out under the clip instead of
-        // squeezing every row's contents down with it.
-        let painted_sidebar_width = if peeking {
-            self.sidebar_peek_seam
-        } else {
-            seam
-        };
-        let mut sidebar_wrapper = Some(
-            div()
-                .relative()
-                .flex_none()
-                .h_full()
-                .overflow_hidden()
-                .w(px(painted_sidebar_width))
-                .when(peeking, |wrapper| {
-                    wrapper
+        let inset = SIDEBAR_PEEK_INSET * self.sidebar_float;
+        let radius = Radius::PANEL * self.sidebar_float;
+        let exposed = self.sidebar_panel_width;
+        let peek_pointer_tracking = self.sidebar.read(cx).is_peeking().then(|| {
+            let region = gpui::Bounds::new(
+                gpui::point(px(0.0), px(recovery_height)),
+                gpui::size(
+                    px(sidebar_width + inset),
+                    window.viewport_size().height - px(recovery_height),
+                ),
+            );
+            // Capture moves even when a terminal or menu handles the bubble
+            // phase. The gap and panel are one hover target, including the
+            // first stationary frame after the edge dwell opens it.
+            let sidebar = self.sidebar.downgrade();
+            gpui::canvas(
+                |_, _, _| (),
+                move |_, _, window, _| {
+                    let moving_sidebar = sidebar.clone();
+                    window.on_mouse_event(
+                        move |event: &gpui::MouseMoveEvent, phase, window, cx| {
+                            if phase == gpui::DispatchPhase::Capture {
+                                let _ = moving_sidebar.update(cx, |sidebar, cx| {
+                                    sidebar.hover_peek_region(
+                                        region.contains(&event.position),
+                                        window,
+                                        cx,
+                                    );
+                                });
+                            }
+                        },
+                    );
+                    let sidebar = sidebar.clone();
+                    window.on_mouse_event(move |_: &gpui::MouseExitEvent, phase, window, cx| {
+                        if phase == gpui::DispatchPhase::Capture {
+                            let _ = sidebar.update(cx, |sidebar, cx| {
+                                sidebar.hover_peek_region(false, window, cx)
+                            });
+                        }
+                    });
+                },
+            )
+            .absolute()
+            .size_full()
+        });
+        let sidebar_wrapper = div()
+            .id("sidebar-frame")
+            .absolute()
+            .left_0()
+            .top(px(recovery_height))
+            .bottom_0()
+            // Include the inset in the hover region so the edge and card
+            // are one continuous target, including during docking.
+            .w(px(exposed + inset * exposed / sidebar_width))
+            .when(exposed > 0.0, |wrapper| {
+                wrapper.occlude().child(
+                    div()
+                        .id("sidebar-surface")
+                        .debug_selector(|| "sidebar-surface".into())
                         .absolute()
-                        .left_0()
-                        .top(px(recovery_height))
-                        .bottom_0()
-                        .h_auto()
-                        .shadow_md()
+                        .top(px(inset))
+                        .bottom(px(inset))
+                        .right(px(0.0))
+                        .w(px(sidebar_width))
+                        .rounded(px(radius))
+                        .bg(colors.sidebar_surface())
                         .occlude()
-                })
-                .when(painted_sidebar_width > 0.0, |wrapper| {
-                    wrapper.child(
-                        div()
-                            .absolute()
-                            .top(px(0.0))
-                            .right(px(0.0))
-                            .h_full()
-                            .w(px(sidebar_width))
-                            // A reactive boundary: the sidebar re-renders on its
-                            // own notifies, not on the terminal's 60fps repaints.
-                            .child(
-                                self.sidebar
-                                    .clone()
-                                    .cached(StyleRefinement::default().size_full()),
-                            ),
-                    )
-                }),
-        );
+                        .shadow(vec![BoxShadow {
+                            color: gpui::black().opacity(0.32 * self.sidebar_float),
+                            offset: gpui::point(px(0.0), px(8.0 * self.sidebar_float)),
+                            blur_radius: px(24.0 * self.sidebar_float),
+                            spread_radius: px(0.0),
+                            inset: false,
+                        }])
+                        // A reactive boundary: the sidebar re-renders on its
+                        // own notifies, not on the terminal's 60fps repaints.
+                        .child(
+                            self.sidebar
+                                .clone()
+                                .cached(StyleRefinement::default().size_full()),
+                        )
+                        .child(
+                            div()
+                                .absolute()
+                                .inset_0()
+                                .rounded(px(radius))
+                                .border_1()
+                                .border_color(colors.floating_stroke().opacity(self.sidebar_float)),
+                        )
+                        .child(
+                            div()
+                                .absolute()
+                                .right_0()
+                                .top_0()
+                                .bottom_0()
+                                .w(px(1.0))
+                                .bg(colors.sidebar_stroke().opacity(1.0 - self.sidebar_float)),
+                        ),
+                )
+            });
 
         let mut root = div()
             .id("root")
@@ -3406,7 +3493,7 @@ impl Render for RootView {
                     this.drag_inspector_resize(f32::from(event.event.position.x), cx);
                 },
             ))
-            .children((!peeking).then(|| sidebar_wrapper.take().expect("sidebar wrapper")))
+            .child(div().flex_none().h_full().w(px(seam)))
             .when(seam > 0.0, |root| root.child(self.resize_handle(cx)));
         if launcher_open {
             // Command-N behaves like an unsaved new tab: preserve the app
@@ -3465,8 +3552,8 @@ impl Render for RootView {
         }
         // This overlay never participates in the terminal's flex layout or
         // viewport sizing. Keep it below dialogs and above workbench content.
-        root = root.children(sidebar_wrapper);
-        if !sidebar_visible && seam == 0.0 && !peeking && peek_width == 0.0 {
+        root = root.child(sidebar_wrapper).children(peek_pointer_tracking);
+        if !sidebar_visible && seam == 0.0 && exposed == 0.0 && panel_width == 0.0 {
             root = root.child(
                 div()
                     .id("sidebar-peek-edge")
@@ -3486,8 +3573,10 @@ impl Render for RootView {
                                         .await;
                                     let _ = this.update_in(cx, |this, window, cx| {
                                         this.sidebar_peek_dwell = None;
-                                        this.sidebar
-                                            .update(cx, |sidebar, cx| sidebar.peek(window, cx));
+                                        this.sidebar.update(cx, |sidebar, cx| {
+                                            sidebar.hover_peek_region(true, window, cx);
+                                            sidebar.peek(window, cx);
+                                        });
                                     });
                                 }));
                         }
@@ -3715,8 +3804,20 @@ mod tests {
                 root.sidebar_seam, 0.0,
                 "peeking must not resize the terminal"
             );
-            assert_eq!(root.sidebar_peek_seam, root.sidebar.read(cx).width());
+            assert_eq!(root.sidebar_panel_width, root.sidebar.read(cx).width());
         });
+        // Resting in the new inset must not start a close/reopen loop.
+        cx.executor().advance_clock(Duration::from_secs(1));
+        cx.run_until_parked();
+        assert!(root.read_with(cx, |root, cx| root.sidebar.read(cx).is_peeking()));
+        let floating = cx
+            .debug_bounds("sidebar-surface")
+            .expect("floating sidebar");
+        assert_eq!(
+            floating.origin,
+            gpui::point(px(SIDEBAR_PEEK_INSET), px(SIDEBAR_PEEK_INSET))
+        );
+        assert_eq!(floating.size.height, px(700.0 - 2.0 * SIDEBAR_PEEK_INSET));
         let session = cx
             .debug_bounds("SESSION_preview-claude")
             .expect("peek session row");
@@ -3781,7 +3882,7 @@ mod tests {
         root.read_with(cx, |root, cx| {
             assert!(root.sidebar.read(cx).is_visible());
             assert!(!root.sidebar.read(cx).is_peeking());
-            assert_eq!(root.sidebar_peek_seam, 0.0);
+            assert_eq!(root.sidebar_float, 0.0);
             assert_eq!(root.sidebar_seam, root.sidebar.read(cx).width());
         });
     }
@@ -3810,6 +3911,9 @@ mod tests {
                     root.sidebar.update(cx, |sidebar, cx| {
                         sidebar.conceal(cx);
                         sidebar.peek(window, cx);
+                        if std::env::var_os("DIRI_PEEK_PINNED").is_some() {
+                            sidebar.toggle(cx);
+                        }
                     });
                     root
                 })
@@ -3823,6 +3927,52 @@ mod tests {
         cx.update_window(window.into(), |_, window, _| window.remove_window())
             .expect("close preview window");
         cx.run_until_parked();
+    }
+
+    #[gpui::test]
+    fn sidebar_peek_docks_the_same_panel_on_one_motion_curve(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| cx.set_reduce_motion(true));
+        let services = test_services();
+        let (root, cx) = cx.add_window_view(move |window, cx| {
+            RootView::new(services, true, PreviewScenario::Typical, window, cx)
+        });
+        root.update_in(cx, |root, window, cx| {
+            root.sidebar.update(cx, |sidebar, cx| {
+                sidebar.conceal(cx);
+                sidebar.peek(window, cx);
+            });
+        });
+        cx.run_until_parked();
+        let sidebar = root.read_with(cx, |root, _| root.sidebar.clone());
+        root.update(cx, |root, cx| {
+            cx.set_reduce_motion(false);
+            root.sidebar.update(cx, |sidebar, cx| sidebar.toggle(cx));
+        });
+        root.read_with(cx, |root, cx| {
+            assert_eq!(root.sidebar, sidebar);
+            let width = sidebar.read(cx).width();
+            assert_eq!(
+                root.sidebar_panel_width, width,
+                "the peek stays fully exposed when pinned"
+            );
+            assert!(
+                root.sidebar_panel_slide.is_none(),
+                "the panel must not replay its reveal"
+            );
+            let seam = root.sidebar_slide.expect("content makes room gradually");
+            let float = root
+                .sidebar_float_slide
+                .expect("inset and corners ease into the dock");
+            let halfway = Instant::now() + crate::seam::SEAM_SLIDE / 2;
+            let occupied = seam.seam_at(width, halfway);
+            let floating = float.seam_at(0.0, halfway);
+            assert!(occupied > 0.0 && occupied < width);
+            assert!(floating > 0.0 && floating < 1.0);
+            assert!(
+                (occupied / width + floating - 1.0).abs() < 0.001,
+                "layout, inset, radius and shadow must share the same curve and clock"
+            );
+        });
     }
 
     #[gpui::test]

--- a/diri/crates/diri-app/src/seam.rs
+++ b/diri/crates/diri-app/src/seam.rs
@@ -39,10 +39,12 @@ pub struct SeamSlide {
 impl SeamSlide {
     /// Starts a slide away from `from`, unless there is nowhere to travel.
     pub fn begin(from: f32, to: f32) -> Option<Self> {
-        (from != to).then(|| Self {
-            from,
-            started_at: Instant::now(),
-        })
+        Self::begin_at(from, to, Instant::now())
+    }
+
+    /// Share an origin time when several parts of the same panel move together.
+    pub fn begin_at(from: f32, to: f32, started_at: Instant) -> Option<Self> {
+        (from != to).then_some(Self { from, started_at })
     }
 
     pub fn progress(&self, now: Instant) -> f32 {

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -122,6 +122,8 @@ pub(crate) enum SidebarEvent {
     RefreshUsageLimits,
     ContinueAccount(SessionId),
     VisibilityChanged,
+    /// Transient overlay visibility; never changes the saved sidebar layout.
+    PeekChanged,
     WidthChanged,
     /// The Agents page of Settings, for one target host. Plain Settings goes
     /// through the typed `OpenSettings` action; this event carries the host
@@ -223,6 +225,9 @@ pub struct Sidebar {
     _preview_effects: Option<mpsc::UnboundedReceiver<StoreEffect>>,
     _store_changes: Option<Task<()>>,
     ui: SidebarUiState,
+    peek_open: bool,
+    peek_hovered: bool,
+    peek_close: Option<Task<()>>,
     /// Session list scroll position, read back each frame to size the top and
     /// bottom fades.
     list_scroll: ScrollHandle,
@@ -344,6 +349,9 @@ impl Sidebar {
             _preview_effects: preview_effects,
             _store_changes: store_changes,
             ui,
+            peek_open: false,
+            peek_hovered: false,
+            peek_close: None,
             list_scroll: ScrollHandle::new(),
             row_bounds: Rc::new(RefCell::new(HashMap::new())),
             drag_preview: None,
@@ -389,6 +397,70 @@ impl Sidebar {
 
     pub fn is_visible(&self) -> bool {
         self.ui.visible
+    }
+
+    pub(crate) fn is_peeking(&self) -> bool {
+        self.peek_open
+    }
+
+    pub(crate) fn peek(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.ui.visible || self.peek_open {
+            return;
+        }
+        self.peek_open = true;
+        self.schedule_peek_close(window, cx);
+        cx.emit(SidebarEvent::PeekChanged);
+        cx.notify();
+    }
+
+    fn peek_interaction_active(&self) -> bool {
+        self.ui.popover.is_some()
+            || self.ui.renaming.is_some()
+            || self.ui.drag.is_some()
+            || self.ui.pending_sibling.is_some()
+            || self.ui.delegation_notice.is_some()
+            || self
+                .store
+                .read()
+                .expect("session store lock poisoned")
+                .pending_close()
+                .is_some()
+    }
+
+    fn hover_peek(&mut self, hovered: bool, window: &mut Window, cx: &mut Context<Self>) {
+        self.peek_hovered = hovered;
+        if hovered {
+            self.peek_close = None;
+        } else {
+            self.schedule_peek_close(window, cx);
+        }
+    }
+
+    fn schedule_peek_close(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if !self.peek_open
+            || self.peek_hovered
+            || self.peek_interaction_active()
+            || self.peek_close.is_some()
+        {
+            return;
+        }
+        self.peek_close = Some(cx.spawn_in(window, async move |this, cx| {
+            cx.background_executor()
+                .timer(Duration::from_millis(240))
+                .await;
+            let _ = this.update_in(cx, |this, window, cx| {
+                this.peek_close = None;
+                if this.peek_open && !this.peek_hovered && !this.peek_interaction_active() {
+                    this.peek_open = false;
+                    this.ui.hover_card = None;
+                    if this.focus_handle.contains_focused(window, cx) {
+                        cx.emit(SidebarEvent::FocusTerminal);
+                    }
+                    cx.emit(SidebarEvent::PeekChanged);
+                    cx.notify();
+                }
+            });
+        }));
     }
 
     pub fn selected_session(&self) -> Option<SessionRecord> {
@@ -543,6 +615,8 @@ impl Sidebar {
             return;
         }
         self.last_toggle = Some(now);
+        self.peek_open = false;
+        self.peek_close = None;
         self.ui.toggle();
         let visible = self.ui.visible;
         if let Err(error) = self
@@ -569,6 +643,8 @@ impl Sidebar {
             return;
         }
         self.ui.visible = true;
+        self.peek_open = false;
+        self.peek_close = None;
         if let Err(error) = self
             .store
             .write()
@@ -839,6 +915,8 @@ impl Sidebar {
     /// subsequent trips to the terminal.
     pub fn focus(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if !self.ui.visible {
+            self.peek_open = false;
+            self.peek_close = None;
             self.ui.visible = true;
             self.last_toggle = Some(Instant::now());
             if let Err(error) = self
@@ -1318,7 +1396,11 @@ impl Sidebar {
             .child(primary_button)
             .child(icon_button(
                 "sidebar-toggle",
-                "Hide sidebar",
+                if self.peek_open {
+                    "Pin sidebar open"
+                } else {
+                    "Hide sidebar"
+                },
                 "sidebar.left",
                 toggle_hover,
                 colors,
@@ -6142,6 +6224,9 @@ fn reveal_tracked_row(
 
 impl Render for Sidebar {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        // A menu or editor may finish after the pointer has already left.
+        // Resume dismissal on that notification without polling while idle.
+        self.schedule_peek_close(window, cx);
         let colors = self.colors();
         let (
             projection,
@@ -6252,6 +6337,9 @@ impl Render for Sidebar {
             .text_color(colors.primary)
             .bg(Self::surface_fill(colors))
             .track_focus(&self.focus_handle)
+            .on_hover(cx.listener(|this, hovered: &bool, window, cx| {
+                this.hover_peek(*hovered, window, cx);
+            }))
             .on_key_down(cx.listener(Self::on_key_down))
             .on_mouse_up_out(
                 MouseButton::Left,
@@ -7585,6 +7673,52 @@ mod tests {
             sidebar.read_with(cx, |sidebar, _| sidebar.ui.popover.clone()),
             None
         );
+    }
+
+    #[gpui::test]
+    fn sidebar_peek_waits_for_menu_and_rename_without_saving_visibility(cx: &mut TestAppContext) {
+        let (view, cx) = cx.add_window_view(|_, cx| {
+            let sidebar = cx.new(|cx| Sidebar::new(None, true, PreviewScenario::Typical, cx));
+            SidebarPopoverHarness { sidebar }
+        });
+        let sidebar = view.read_with(cx, |harness, _| harness.sidebar.clone());
+        cx.simulate_mouse_move(point(px(500.0), px(320.0)), None, Modifiers::default());
+        sidebar.update_in(cx, |sidebar, window, cx| {
+            sidebar.conceal(cx);
+            sidebar.peek(window, cx);
+            sidebar.ui.popover = Some(Popover::SidebarLayout);
+            cx.notify();
+        });
+        cx.run_until_parked();
+        cx.executor().advance_clock(Duration::from_secs(1));
+        cx.run_until_parked();
+        sidebar.update(cx, |sidebar, cx| {
+            assert!(sidebar.is_peeking(), "menu must survive leaving the panel");
+            assert!(!sidebar.store.read().unwrap().preferences().sidebar_visible);
+            sidebar.ui.popover = None;
+            sidebar
+                .ui
+                .begin_rename(SessionId::new("preview-claude"), "Renaming");
+            cx.notify();
+        });
+        cx.run_until_parked();
+        cx.executor().advance_clock(Duration::from_secs(1));
+        cx.run_until_parked();
+        sidebar.update(cx, |sidebar, cx| {
+            assert!(
+                sidebar.is_peeking(),
+                "rename must survive leaving the panel"
+            );
+            sidebar.ui.cancel_rename();
+            cx.notify();
+        });
+        cx.run_until_parked();
+        cx.executor().advance_clock(Duration::from_millis(300));
+        cx.run_until_parked();
+        sidebar.read_with(cx, |sidebar, _| {
+            assert!(!sidebar.is_peeking());
+            assert!(!sidebar.store.read().unwrap().preferences().sidebar_visible);
+        });
     }
 
     #[gpui::test]

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -227,6 +227,8 @@ pub struct Sidebar {
     ui: SidebarUiState,
     peek_open: bool,
     peek_hovered: bool,
+    peek_region_hovered: bool,
+    surface_in_parent: bool,
     peek_close: Option<Task<()>>,
     /// Session list scroll position, read back each frame to size the top and
     /// bottom fades.
@@ -351,6 +353,8 @@ impl Sidebar {
             ui,
             peek_open: false,
             peek_hovered: false,
+            peek_region_hovered: false,
+            surface_in_parent: false,
             peek_close: None,
             list_scroll: ScrollHandle::new(),
             row_bounds: Rc::new(RefCell::new(HashMap::new())),
@@ -403,6 +407,29 @@ impl Sidebar {
         self.peek_open
     }
 
+    /// Root paints the material so its corners can morph without rebuilding
+    /// the sidebar's cached contents on every animation frame.
+    pub(crate) fn set_surface_in_parent(&mut self) {
+        self.surface_in_parent = true;
+    }
+
+    pub(crate) fn hover_peek_region(
+        &mut self,
+        hovered: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.peek_region_hovered == hovered {
+            return;
+        }
+        self.peek_region_hovered = hovered;
+        if hovered {
+            self.peek_close = None;
+        } else {
+            self.schedule_peek_close(window, cx);
+        }
+    }
+
     pub(crate) fn peek(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if self.ui.visible || self.peek_open {
             return;
@@ -439,6 +466,7 @@ impl Sidebar {
     fn schedule_peek_close(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if !self.peek_open
             || self.peek_hovered
+            || self.peek_region_hovered
             || self.peek_interaction_active()
             || self.peek_close.is_some()
         {
@@ -450,7 +478,11 @@ impl Sidebar {
                 .await;
             let _ = this.update_in(cx, |this, window, cx| {
                 this.peek_close = None;
-                if this.peek_open && !this.peek_hovered && !this.peek_interaction_active() {
+                if this.peek_open
+                    && !this.peek_hovered
+                    && !this.peek_region_hovered
+                    && !this.peek_interaction_active()
+                {
                     this.peek_open = false;
                     this.ui.hover_card = None;
                     if this.focus_handle.contains_focused(window, cx) {
@@ -6335,10 +6367,14 @@ impl Render for Sidebar {
             .flex()
             .flex_col()
             .text_color(colors.primary)
-            .bg(Self::surface_fill(colors))
+            .when(!self.surface_in_parent, |root| {
+                root.bg(Self::surface_fill(colors))
+            })
             .track_focus(&self.focus_handle)
             .on_hover(cx.listener(|this, hovered: &bool, window, cx| {
-                this.hover_peek(*hovered, window, cx);
+                if !this.surface_in_parent {
+                    this.hover_peek(*hovered, window, cx);
+                }
             }))
             .on_key_down(cx.listener(Self::on_key_down))
             .on_mouse_up_out(
@@ -6399,15 +6435,17 @@ impl Render for Sidebar {
         }
         root = root.child(self.account_footer(colors, cx));
         // Paint the edge without reducing the shared sidebar content width.
-        root = root.child(
-            div()
-                .absolute()
-                .right_0()
-                .top_0()
-                .bottom_0()
-                .w(px(1.0))
-                .bg(colors.sidebar_stroke()),
-        );
+        root = root.when(!self.surface_in_parent, |root| {
+            root.child(
+                div()
+                    .absolute()
+                    .right_0()
+                    .top_0()
+                    .bottom_0()
+                    .w(px(1.0))
+                    .bg(colors.sidebar_stroke()),
+            )
+        });
         if let Some(popover) = self.popover(colors, window, cx) {
             root = root.child(popover);
         }


### PR DESCRIPTION
When the sidebar is collapsed, hovering at the left edge slides in a floating sidebar with a 10 px inset, 12 px corners, and a soft shadow. Users can select sessions, open menus, rename, and drag; moving away dismisses the peek after a short grace period.

Pinning glides the same panel into its normal dock. Its inset, corner radius, and shadow ease away on the same clock and curve as the workbench makes room. The sidebar stays mounted in one stable slot throughout, preserving its contents and scroll position. Peeking itself leaves the terminal width and saved sidebar preference unchanged.

A 100 ms edge dwell avoids accidental reveals, and the inset belongs to the hover region so resting at the window edge keeps the panel open. Menus, rename fields, drags, and confirmations hold dismissal until the interaction finishes. Reduced-motion users get the settled layout immediately.

Screenshots (native Rust app preview with fixture data):

| Collapsed | Floating peek | Pinned into the dock |
| --- | --- | --- |
| ![Collapsed sidebar](https://raw.githubusercontent.com/cristicretu/diri/018a466c67bd26d6036ba744866f078e66af6167/sidebar-collapsed.png) | ![Inset sidebar with rounded corners and shadow](https://raw.githubusercontent.com/cristicretu/diri/018a466c67bd26d6036ba744866f078e66af6167/sidebar-peek.png) | ![Same sidebar settled into its dock](https://raw.githubusercontent.com/cristicretu/diri/018a466c67bd26d6036ba744866f078e66af6167/sidebar-docked.png) |

Validation:

- Workspace formatting, Clippy with warnings denied, tests, and release build passed.
- GPUI coverage checks edge dwell cancellation, stationary hover in the inset, session selection, mouse-out, re-entry, pinning, menu/rename retention, and unchanged peek layout preferences.
- A docking test verifies that the same sidebar remains fully exposed and that the layout, inset, corners, and shadow share one animation curve and start time.
- Rendered and inspected the floating and docked views. The optional `render_sidebar_peek_screenshot` test writes to `DIRI_PEEK_SCREENSHOT`; set `DIRI_PEEK_PINNED=1` for the docked endpoint.

Fixture socket tests and the native renderer were run outside the sandbox to allow local Unix sockets and macOS graphics services.
