### PR TITLE
Add What's New release notes

### DIFF
--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -428,6 +428,11 @@ impl RootView {
                     surfaces.open_add_remote_host(window, cx);
                 });
             }
+            if matches!(event, SidebarEvent::OpenWhatsNew)
+                && let Some(surfaces) = &this.utility_surfaces
+            {
+                surfaces.update(cx, |surfaces, cx| surfaces.open_whats_new(cx));
+            }
             if matches!(event, SidebarEvent::VisibilityChanged) {
                 this.sidebar_peek_dwell = None;
                 this.sidebar_floating = false;

--- a/diri/crates/diri-app/src/settings.rs
+++ b/diri/crates/diri-app/src/settings.rs
@@ -43,6 +43,7 @@ pub struct SettingsNav {
 pub enum SettingsTab {
     #[default]
     General,
+    WhatsNew,
     Agents,
     Skills,
     Accounts,
@@ -56,8 +57,9 @@ pub enum SettingsTab {
 }
 
 impl SettingsTab {
-    pub const ALL: [Self; 11] = [
+    pub const ALL: [Self; 12] = [
         Self::General,
+        Self::WhatsNew,
         Self::Agents,
         Self::Skills,
         Self::Accounts,
@@ -73,6 +75,7 @@ impl SettingsTab {
     pub const fn label(self) -> &'static str {
         match self {
             Self::General => "General",
+            Self::WhatsNew => "What's New",
             Self::Agents => "Agents",
             Self::Skills => "Skills",
             Self::Accounts => "Accounts",
@@ -89,6 +92,7 @@ impl SettingsTab {
     pub const fn subtitle(self) -> &'static str {
         match self {
             Self::General => "Startup, sessions, and updates",
+            Self::WhatsNew => "Latest release notes",
             Self::Agents => "Installed CLIs and quick create",
             Self::Skills => "Browse local and project skills",
             Self::Accounts => "Profiles for work and personal accounts",
@@ -107,6 +111,7 @@ impl SettingsTab {
     pub const fn section(self) -> SettingsSection {
         match self {
             Self::General
+            | Self::WhatsNew
             | Self::Agents
             | Self::Skills
             | Self::Accounts
@@ -122,6 +127,7 @@ impl SettingsTab {
     pub const fn icon(self) -> &'static str {
         match self {
             Self::General => "gearshape",
+            Self::WhatsNew => "sparkles",
             Self::Agents => "sparkles",
             Self::Skills => "doc.text",
             Self::Accounts => "account.circle",

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -131,6 +131,8 @@ pub(crate) enum SidebarEvent {
     OpenAgentSettings(Option<String>),
     /// One-click path from the footer menu into the Remote host editor.
     AddRemoteHost,
+    /// One-click path from the account menu to the latest release notes.
+    OpenWhatsNew,
     /// A plain click (or shortcut) selected a session: hand keyboard focus
     /// to its terminal surface so the user can type immediately.
     SessionActivated,
@@ -4632,6 +4634,37 @@ impl Sidebar {
             .child(menu_divider(colors))
             .child(
                 div()
+                    .id("account-whats-new")
+                    .debug_selector(|| "account-whats-new".into())
+                    .mx(px(6.0))
+                    .px(px(8.0))
+                    .h(px(30.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(9.0))
+                    .rounded(px(SIDEBAR_MENU_ROW_RADIUS))
+                    .cursor_pointer()
+                    .hover(move |element| element.bg(colors.primary.alpha(0.06)))
+                    .text_size(px(Typo::ROW.size))
+                    .text_color(colors.primary)
+                    .child(
+                        div()
+                            .w(px(24.0))
+                            .flex_none()
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .child(sf_symbol("sparkles", 11.0, colors.secondary)),
+                    )
+                    .child(div().flex_1().child("What's New"))
+                    .on_click(cx.listener(|this, _, _, cx| {
+                        this.ui.popover = None;
+                        cx.emit(SidebarEvent::OpenWhatsNew);
+                        cx.notify();
+                    })),
+            )
+            .child(
+                div()
                     .id("quick-add-remote-host")
                     .debug_selector(|| "quick-add-remote-host".into())
                     .mx(px(6.0))
@@ -8189,6 +8222,7 @@ mod tests {
         assert!(cx.debug_bounds("account-usage-session").is_some());
         assert!(cx.debug_bounds("account-usage-today").is_some());
         assert!(cx.debug_bounds("account-usage-month").is_some());
+        assert!(cx.debug_bounds("account-whats-new").is_some());
         assert!(cx.debug_bounds("quick-add-remote-host").is_some());
         assert!(cx.debug_bounds("account-settings").is_some());
     }

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -65,6 +65,18 @@ enum SettingsMenu {
     MemoryLimit,
 }
 
+#[derive(Default)]
+enum ReleaseNotesState {
+    #[default]
+    Idle,
+    Loading,
+    Loaded {
+        release: diri_updater::ReleaseNotes,
+        document: Arc<crate::markdown::MarkdownDocument>,
+    },
+    Failed(String),
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 enum HostFormField {
     #[default]
@@ -266,6 +278,7 @@ pub struct UtilitySurfaces {
     usage_days: usize,
     usage_tokens: bool,
     usage_by_day: bool,
+    release_notes: ReleaseNotesState,
     settings_scroll: ScrollHandle,
     settings_search: QueryEditor,
     settings_search_active: bool,
@@ -321,6 +334,7 @@ impl UtilitySurfaces {
             .map(|value| value.to_ascii_lowercase());
         let settings_tab = match settings_preview.as_deref() {
             Some("terminal" | "appearance") => SettingsTab::Terminal,
+            Some("whats-new" | "what's-new") => SettingsTab::WhatsNew,
             Some("agents") => SettingsTab::Agents,
             Some("skills") => SettingsTab::Skills,
             Some("accounts") => SettingsTab::Accounts,
@@ -414,6 +428,7 @@ impl UtilitySurfaces {
             usage_days: 30,
             usage_tokens: false,
             usage_by_day: false,
+            release_notes: ReleaseNotesState::default(),
             settings_scroll: ScrollHandle::new(),
             settings_search: QueryEditor::default(),
             settings_search_active: false,
@@ -492,6 +507,39 @@ impl UtilitySurfaces {
             };
             let _ = this.update(cx, |this, cx| {
                 this.worktrees.finish_refresh(result);
+                cx.notify();
+            });
+        })
+        .detach();
+    }
+
+    fn refresh_release_notes(&mut self, cx: &mut Context<Self>) {
+        if matches!(
+            self.release_notes,
+            ReleaseNotesState::Loading | ReleaseNotesState::Loaded { .. }
+        ) {
+            return;
+        }
+        self.release_notes = ReleaseNotesState::Loading;
+        cx.notify();
+
+        let runtime = Arc::clone(&self.runtime);
+        cx.spawn(async move |this, cx| {
+            let task = runtime.spawn_blocking(diri_updater::fetch_latest_release_notes);
+            let result = match task.await {
+                Ok(Ok(release)) => Ok(release),
+                Ok(Err(error)) => Err(error.to_string()),
+                Err(error) => Err(error.to_string()),
+            };
+            let _ = this.update(cx, |this, cx| {
+                this.release_notes = match result {
+                    Ok(release) => {
+                        let document =
+                            Arc::new(crate::markdown::MarkdownDocument::parse(&release.body));
+                        ReleaseNotesState::Loaded { release, document }
+                    }
+                    Err(error) => ReleaseNotesState::Failed(error),
+                };
                 cx.notify();
             });
         })
@@ -998,6 +1046,9 @@ impl UtilitySurfaces {
         if self.settings_tab == SettingsTab::Skills {
             self.refresh_skills(cx);
         }
+        if self.settings_tab == SettingsTab::WhatsNew {
+            self.refresh_release_notes(cx);
+        }
         cx.notify();
     }
 
@@ -1070,6 +1121,9 @@ impl UtilitySurfaces {
             self.settings_scroll.set_offset(point(px(0.0), px(0.0)));
         }
         self.settings_tab = tab;
+        if tab == SettingsTab::WhatsNew {
+            self.refresh_release_notes(cx);
+        }
         if tab == SettingsTab::Worktrees {
             self.refresh_worktrees(cx);
         }
@@ -1354,6 +1408,11 @@ impl UtilitySurfaces {
             .expect("session store lock poisoned")
             .request_agent_catalog(host, false);
         cx.notify();
+    }
+
+    pub(crate) fn open_whats_new(&mut self, cx: &mut Context<Self>) {
+        self.open_settings(cx);
+        self.select_settings_tab(SettingsTab::WhatsNew, cx);
     }
 
     fn open_diagnostics(&mut self, cx: &mut Context<Self>) {
@@ -1843,6 +1902,7 @@ impl UtilitySurfaces {
         let generation = self.settings_transition_generation;
         let pane = match self.settings_tab {
             SettingsTab::General => self.general_settings(cx).into_any_element(),
+            SettingsTab::WhatsNew => self.whats_new_settings(cx).into_any_element(),
             SettingsTab::Agents => self.agents_settings(cx).into_any_element(),
             SettingsTab::Skills => self.skills.clone().into_any_element(),
             SettingsTab::Accounts => self.accounts_settings(cx).into_any_element(),
@@ -2003,6 +2063,115 @@ impl UtilitySurfaces {
                     }))
             });
         settings_page("Phone access", content, colors)
+    }
+
+    fn whats_new_settings(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let colors = self.settings_colors();
+        let content = match &self.release_notes {
+            ReleaseNotesState::Idle | ReleaseNotesState::Loading => div()
+                .id("release-notes-loading")
+                .p(px(16.0))
+                .flex()
+                .items_center()
+                .gap(px(9.0))
+                .text_size(px(Typo::ROW.size))
+                .text_color(colors.secondary)
+                .child(LoadingIndicator::new(
+                    "release-notes-loading-indicator",
+                    14.0,
+                    colors.tertiary,
+                ))
+                .child("Loading the latest release notes…")
+                .into_any_element(),
+            ReleaseNotesState::Failed(error) => div()
+                .id("release-notes-error")
+                .p(px(16.0))
+                .flex()
+                .items_center()
+                .justify_between()
+                .gap(px(16.0))
+                .child(
+                    div()
+                        .min_w(px(0.0))
+                        .flex_1()
+                        .flex()
+                        .flex_col()
+                        .gap(px(3.0))
+                        .child(
+                            div()
+                                .text_size(px(Typo::ROW_EMPHASIZED.size))
+                                .font_weight(Typo::ROW_EMPHASIZED.weight)
+                                .text_color(colors.primary)
+                                .child("Release notes couldn't be loaded"),
+                        )
+                        .child(
+                            div()
+                                .whitespace_normal()
+                                .text_size(px(Typo::META.size))
+                                .line_height(px(14.0))
+                                .text_color(colors.tertiary)
+                                .child(wrappable_setting_copy(error.clone().into())),
+                        ),
+                )
+                .child(surface_button(
+                    "Try Again",
+                    "retry-release-notes",
+                    colors,
+                    cx,
+                    |this, cx| this.refresh_release_notes(cx),
+                ))
+                .into_any_element(),
+            ReleaseNotesState::Loaded { release, document } => {
+                let version = release.tag_name.trim_start_matches('v');
+                let published = release
+                    .published_at
+                    .as_deref()
+                    .and_then(|date| date.split('T').next())
+                    .unwrap_or("Publication date unavailable");
+                div()
+                    .id("release-notes-content")
+                    .debug_selector(|| "release-notes-content".into())
+                    .p(px(16.0))
+                    .flex()
+                    .flex_col()
+                    .gap(px(14.0))
+                    .child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .justify_between()
+                            .gap(px(12.0))
+                            .child(
+                                div()
+                                    .text_size(px(Typo::TITLE.size))
+                                    .font_weight(Typo::TITLE.weight)
+                                    .text_color(colors.primary)
+                                    .child(
+                                        release
+                                            .name
+                                            .clone()
+                                            .unwrap_or_else(|| format!("diri {version}")),
+                                    ),
+                            )
+                            .child(
+                                div()
+                                    .flex_none()
+                                    .text_size(px(Typo::META.size))
+                                    .text_color(colors.tertiary)
+                                    .child(format!("Released {published}")),
+                            ),
+                    )
+                    .child(HairlineDivider::horizontal(colors))
+                    .child(crate::markdown_view::render_markdown(document, colors))
+                    .into_any_element()
+            }
+        };
+
+        settings_page(
+            "What's New",
+            setting_section("LATEST RELEASE", content, colors),
+            colors,
+        )
     }
 
     fn general_settings(&self, cx: &mut Context<Self>) -> impl IntoElement {
@@ -5039,6 +5208,9 @@ fn settings_tab_matches(tab: SettingsTab, query: &str) -> bool {
         SettingsTab::General => {
             "general default startup login sessions close confirmation sounds chimes support diagnostics quick open search roots updates"
         }
+        SettingsTab::WhatsNew => {
+            "what's new whats new release notes latest version changes features improvements"
+        }
         SettingsTab::Agents => {
             "agents codex claude cursor gemini executable installed command line quick create default"
         }
@@ -5977,6 +6149,7 @@ mod tests {
         let tab = match std::env::var("DIRI_VISUAL_SETTINGS_TAB").as_deref() {
             Ok("shortcuts") => SettingsTab::Shortcuts,
             Ok("general") => SettingsTab::General,
+            Ok("whats-new") => SettingsTab::WhatsNew,
             Ok("agents") => SettingsTab::Agents,
             Ok("skills") => SettingsTab::Skills,
             Ok("accounts") => SettingsTab::Accounts,
@@ -6024,6 +6197,32 @@ mod tests {
             std::fs::create_dir_all(parent).expect("create screenshot directory");
         }
         screenshot.save(output).expect("save settings screenshot");
+    }
+
+    #[gpui::test]
+    fn whats_new_is_searchable_and_renders_release_markdown(cx: &mut TestAppContext) {
+        let (harness, cx) = open_settings_workbench(cx);
+        let surfaces = harness.read_with(cx, |harness, _| harness.surfaces.clone());
+        surfaces.update(cx, |surfaces, cx| {
+            let release = diri_updater::ReleaseNotes {
+                tag_name: "v0.6.0".into(),
+                name: Some("diri 0.6.0".into()),
+                body: "## Highlights\n\n- Faster sessions".into(),
+                published_at: Some("2026-09-05T12:17:55Z".into()),
+            };
+            let document = Arc::new(crate::markdown::MarkdownDocument::parse(&release.body));
+            surfaces.release_notes = ReleaseNotesState::Loaded { release, document };
+            surfaces.settings_tab = SettingsTab::WhatsNew;
+            cx.notify();
+        });
+        cx.run_until_parked();
+
+        assert!(cx.debug_bounds("release-notes-content").is_some());
+        assert!(settings_tab_matches(SettingsTab::WhatsNew, "release notes"));
+        assert!(settings_tab_matches(
+            SettingsTab::WhatsNew,
+            "latest changes"
+        ));
     }
 
     #[gpui::test]
@@ -6356,6 +6555,17 @@ mod tests {
                 );
                 surfaces.open_settings(cx);
                 surfaces.settings_tab = tab;
+                if tab == SettingsTab::WhatsNew {
+                    let release = diri_updater::ReleaseNotes {
+                        tag_name: "v0.6.0".into(),
+                        name: Some("diri 0.6.0 — Your agent workspace".into()),
+                        body: "## Everything in one place\n\n- Open browser and shell tabs beside a session.\n- Search conversation history and resume previous work.\n\n### Polish and reliability\n\nSettings, navigation, and session recovery now feel more at home on macOS."
+                            .into(),
+                        published_at: Some("2026-09-05T12:17:55Z".into()),
+                    };
+                    let document = Arc::new(crate::markdown::MarkdownDocument::parse(&release.body));
+                    surfaces.release_notes = ReleaseNotesState::Loaded { release, document };
+                }
                 if tab == SettingsTab::Worktrees {
                     surfaces.worktrees.entries = worktree_settings::preview_entries();
                 }

--- a/diri/crates/diri-updater/src/lib.rs
+++ b/diri/crates/diri-updater/src/lib.rs
@@ -44,6 +44,12 @@ pub const RELEASES_HOST: &str = "github.com";
 /// URL that always resolves to the newest one.
 pub const DEFAULT_FEED_URL: &str =
     "https://github.com/cristicretu/diri/releases/latest/download/appcast.json";
+/// Canonical release metadata. The update feed deliberately stays small and
+/// archive-focused; GitHub owns the human-written release body shown by the
+/// app's What's New page.
+pub const LATEST_RELEASE_URL: &str =
+    "https://api.github.com/repos/cristicretu/diri/releases/latest";
+const MAX_RELEASE_METADATA_BYTES: usize = 512 * 1024;
 
 /// Set to `1` to let an unsigned local build run the whole flow. Only useful
 /// for exercising the updater against a test feed; the signature check still
@@ -51,6 +57,40 @@ pub const DEFAULT_FEED_URL: &str =
 pub const ALLOW_UNSIGNED_ENV: &str = "DIRI_UPDATER_ALLOW_UNSIGNED";
 /// Overrides the feed URL, for staging a release before it goes live.
 pub const FEED_URL_ENV: &str = "DIRI_UPDATE_FEED";
+
+#[derive(Clone, Debug, Default, serde::Deserialize, PartialEq, Eq)]
+pub struct ReleaseNotes {
+    pub tag_name: String,
+    pub name: Option<String>,
+    #[serde(default)]
+    pub body: String,
+    pub published_at: Option<String>,
+}
+
+/// Fetches the latest public GitHub release and its Markdown notes.
+///
+/// This is separate from update eligibility: an up-to-date install should
+/// still be able to read the notes for the version it is already running.
+pub fn fetch_latest_release_notes() -> Result<ReleaseNotes> {
+    let body = Http::new().fetch_text(LATEST_RELEASE_URL)?;
+    parse_release_notes(&body)
+}
+
+fn parse_release_notes(body: &str) -> Result<ReleaseNotes> {
+    if body.len() > MAX_RELEASE_METADATA_BYTES {
+        return Err(UpdateError::Feed(
+            "latest release metadata is unexpectedly large".to_owned(),
+        ));
+    }
+    let release: ReleaseNotes =
+        serde_json::from_str(body).map_err(|error| UpdateError::Feed(error.to_string()))?;
+    if release.tag_name.trim().is_empty() || release.body.trim().is_empty() {
+        return Err(UpdateError::Feed(
+            "latest release has no version or release notes".to_owned(),
+        ));
+    }
+    Ok(release)
+}
 
 #[derive(Clone, Debug)]
 pub struct UpdaterConfig {
@@ -256,6 +296,41 @@ mod tests {
             cache_dir: PathBuf::from("/tmp/diri-updates"),
             installed_signature: SignatureInfo::default(),
         }
+    }
+
+    #[test]
+    fn latest_release_metadata_keeps_the_canonical_markdown_body() {
+        let release = parse_release_notes(
+            r###"{
+                "tag_name": "v0.6.0",
+                "name": "diri 0.6.0",
+                "body": "## Highlights\n\n- Faster sessions",
+                "published_at": "2026-09-05T12:17:55Z"
+            }"###,
+        )
+        .expect("release metadata");
+
+        assert_eq!(release.tag_name, "v0.6.0");
+        assert_eq!(release.body, "## Highlights\n\n- Faster sessions");
+        assert_eq!(
+            release.published_at.as_deref(),
+            Some("2026-09-05T12:17:55Z")
+        );
+    }
+
+    #[test]
+    fn latest_release_metadata_requires_notes() {
+        let error = parse_release_notes(r#"{"tag_name":"v0.6.0","body":""}"#)
+            .expect_err("empty notes must not render as a successful release");
+        assert!(matches!(error, UpdateError::Feed(_)));
+    }
+
+    #[test]
+    #[ignore = "requires network access to GitHub's releases API"]
+    fn the_latest_release_notes_are_reachable() {
+        let release = fetch_latest_release_notes().expect("latest release notes");
+        assert!(release.tag_name.starts_with('v'));
+        assert!(!release.body.trim().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a searchable What's New page to Settings
- add a What's New shortcut to the bottom-left account menu
- fetch the canonical latest GitHub release notes once per app session, with loading and retry states
- render release Markdown using the existing bounded native renderer

## Verification
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --quiet
- cargo build --workspace --release
- live latest-release endpoint test
- headless visual checks for Settings and the account menu