### PR TITLE
Keep terminal focused when switching conversations

### DIFF
--- a/diri/crates/diri-app/src/inspector.rs
+++ b/diri/crates/diri-app/src/inspector.rs
@@ -77,7 +77,12 @@ pub enum InspectorEvent {
     Close,
     SessionChanged,
     WorkspaceChanged(WorkspaceSurface),
-    WorkspaceClosed { surface: WorkspaceSurface, id: u64 },
+    /// Restore a conversation's inspector without moving keyboard focus into it.
+    WorkspaceRestored(WorkspaceSurface),
+    WorkspaceClosed {
+        surface: WorkspaceSurface,
+        id: u64,
+    },
     RequestTerminal,
     Browser(BrowserAction),
 }
@@ -883,8 +888,10 @@ impl WorkbenchInspector {
         self.state = LoadState::NoSession;
         self.review_state = ReviewLoadState::NoSession;
         self.transcript_state = TranscriptLoadState::Unavailable;
-        if let Some(id) = next.active {
-            self.activate_workspace(id, cx);
+        if let Some(id) = next.active
+            && let Some(surface) = self.load_workspace(id, cx)
+        {
+            cx.emit(InspectorEvent::WorkspaceRestored(surface));
         }
         self.reconcile_diff_polling(cx);
         cx.emit(InspectorEvent::SessionChanged);
@@ -1002,14 +1009,18 @@ impl WorkbenchInspector {
     }
 
     fn activate_workspace(&mut self, id: u64, cx: &mut Context<Self>) {
+        if let Some(surface) = self.load_workspace(id, cx) {
+            cx.emit(InspectorEvent::WorkspaceChanged(surface));
+        }
+    }
+
+    fn load_workspace(&mut self, id: u64, cx: &mut Context<Self>) -> Option<WorkspaceSurface> {
         self.workspace_chooser_open = false;
         if self.workspace_active == Some(id) {
             cx.notify();
-            return;
+            return None;
         }
-        let Some(index) = self.workspace_tabs.iter().position(|tab| tab.id == id) else {
-            return;
-        };
+        let index = self.workspace_tabs.iter().position(|tab| tab.id == id)?;
         let previous_index = self
             .workspace_tabs
             .iter()
@@ -1071,8 +1082,8 @@ impl WorkbenchInspector {
             self.refresh_transcript(&context, false, cx);
         }
         self.reconcile_diff_polling(cx);
-        cx.emit(InspectorEvent::WorkspaceChanged(surface));
         cx.notify();
+        Some(surface)
     }
 
     fn close_workspace(&mut self, id: u64, cx: &mut Context<Self>) {

--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -527,8 +527,12 @@ impl RootView {
                         this.begin_inspector_slide(cx);
                         cx.notify();
                     }
-                    InspectorEvent::WorkspaceChanged(surface) => {
-                        window.focus(&this.focus, cx);
+                    InspectorEvent::WorkspaceChanged(surface)
+                    | InspectorEvent::WorkspaceRestored(surface) => {
+                        let focus_workspace = matches!(event, InspectorEvent::WorkspaceChanged(_));
+                        if focus_workspace {
+                            window.focus(&this.focus, cx);
+                        }
                         #[cfg(target_os = "macos")]
                         if *surface == crate::inspector::WorkspaceSurface::Browser
                             && let Some(inspector) = &this.inspector
@@ -539,13 +543,14 @@ impl RootView {
                             let blank = state.url.is_none();
                             inspector.update(cx, |inspector, cx| {
                                 inspector.set_browser_state(state, cx);
-                                if blank {
+                                if blank && focus_workspace {
                                     inspector.focus_browser_address(window, cx);
                                 }
                             });
                         }
                         if let Some(terminal) = &this.auxiliary_terminal
                             && *surface == crate::inspector::WorkspaceSurface::Terminal
+                            && focus_workspace
                         {
                             terminal.update(cx, |terminal, cx| terminal.focus(window, cx));
                         }
@@ -3793,6 +3798,114 @@ mod tests {
                     .unwrap(),
             ),
         })
+    }
+
+    #[gpui::test]
+    fn switching_sidebar_conversations_keeps_terminal_focused(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| cx.set_reduce_motion(true));
+        let services = test_services();
+        let fixture = SidebarPreviewFixture::make(PreviewScenario::Typical);
+        let runtime = services.store.clone();
+        {
+            let mut store = services.store.store.write().unwrap();
+            store
+                .update_preferences(|prefs| *prefs = fixture.prefs)
+                .unwrap();
+            store.hydrate(fixture.list);
+            store.select(SessionId::new("preview-claude"));
+            store.select(SessionId::new("preview-codex"));
+        }
+        let (root, cx) = cx.add_window_view(move |window, cx| {
+            RootView::new(services, false, PreviewScenario::Empty, window, cx)
+        });
+        let mut input = root.update(cx, |root, cx| {
+            root.terminal
+                .as_ref()
+                .unwrap()
+                .update(cx, |terminal, _| terminal.capture_input_for_test())
+        });
+        // Explicit inspector navigation may take focus; restoring this same
+        // blank browser tab after a conversation switch must not.
+        root.update(cx, |root, cx| {
+            root.inspector
+                .as_ref()
+                .unwrap()
+                .update(cx, |inspector, cx| {
+                    inspector.select_workspace(crate::inspector::WorkspaceSurface::Browser, cx);
+                });
+        });
+        cx.simulate_resize(size(px(1000.0), px(700.0)));
+        cx.run_until_parked();
+        root.update_in(cx, |root, window, cx| {
+            assert!(
+                !root.terminal.as_ref().unwrap().read(cx).is_focused(window),
+                "explicit browser tab activation still takes focus"
+            );
+        });
+        for peeking in [false, true] {
+            if peeking {
+                root.update(cx, |root, cx| {
+                    root.sidebar.update(cx, |sidebar, cx| sidebar.conceal(cx));
+                });
+                cx.run_until_parked();
+                let edge = cx.debug_bounds("sidebar-peek-edge").unwrap();
+                cx.simulate_mouse_move(edge.center(), None, Modifiers::default());
+                cx.executor().advance_clock(Duration::from_millis(25));
+                cx.run_until_parked();
+            }
+            for id in ["preview-claude", "preview-codex", "preview-claude"] {
+                // Debug selectors are paint-local; refresh the cached sidebar
+                // before locating a row, never after the click under test.
+                root.update(cx, |root, cx| root.sidebar.update(cx, |_, cx| cx.notify()));
+                cx.run_until_parked();
+                let session = cx
+                    .debug_bounds(if id == "preview-claude" {
+                        "SESSION_preview-claude"
+                    } else {
+                        "SESSION_preview-codex"
+                    })
+                    .unwrap_or_else(|| panic!("visible row {id} (peek={peeking})"));
+                cx.simulate_click(session.center(), Modifiers::default());
+                // The inert runtime has no effect worker. Deliver the real local
+                // change broadcast so inspector restoration runs after the click.
+                runtime.publish_local_change();
+                cx.run_until_parked();
+                root.update_in(cx, |root, window, cx| {
+                    assert!(
+                        root.terminal.as_ref().unwrap().read(cx).is_focused(window),
+                        "terminal must accept typing after sidebar selection (peek={peeking})"
+                    );
+                });
+                cx.simulate_input("a");
+                cx.simulate_keystrokes("enter");
+                let mut bytes = Vec::new();
+                while let Ok((target, chunk)) = input.try_recv() {
+                    assert_eq!(
+                        target,
+                        SessionId::new(id),
+                        "typing must reach the selected conversation"
+                    );
+                    bytes.extend(chunk);
+                }
+                assert_eq!(
+                    bytes, b"a\r",
+                    "typing must work without clicking the terminal"
+                );
+            }
+            if peeking {
+                cx.simulate_mouse_move(
+                    gpui::point(px(600.0), px(300.0)),
+                    None,
+                    Modifiers::default(),
+                );
+                cx.executor().advance_clock(Duration::from_millis(300));
+                cx.run_until_parked();
+                root.update_in(cx, |root, window, cx| {
+                    assert!(!root.sidebar.read(cx).is_peeking());
+                    assert!(root.terminal.as_ref().unwrap().read(cx).is_focused(window));
+                });
+            }
+        }
     }
 
     #[gpui::test]

--- a/diri/crates/diri-app/src/terminal_pane.rs
+++ b/diri/crates/diri-app/src/terminal_pane.rs
@@ -262,15 +262,24 @@ enum AttachmentCommand {
     Close,
 }
 
+#[cfg(test)]
+type InputObserver = mpsc::UnboundedSender<(SessionId, Vec<u8>)>;
+
 #[derive(Clone)]
 struct AttachmentControl {
     tx: mpsc::UnboundedSender<AttachmentCommand>,
+    #[cfg(test)]
+    input_observer: Option<(SessionId, InputObserver)>,
 }
 
 impl AttachmentControl {
     fn input(&self, bytes: Vec<u8>) {
         if bytes.is_empty() {
             return;
+        }
+        #[cfg(test)]
+        if let Some((id, observer)) = &self.input_observer {
+            let _ = observer.send((id.clone(), bytes.clone()));
         }
         let _ = self.tx.send(AttachmentCommand::Input(bytes));
     }
@@ -625,6 +634,8 @@ pub struct TerminalPane {
     /// daemon-created id asynchronously, so this transition is also the
     /// reliable point at which keyboard focus can leave the picker.
     observed_selected_id: Option<SessionId>,
+    #[cfg(test)]
+    input_observer: Option<InputObserver>,
     viewport: Option<TerminalViewport>,
     sidebar_visible: bool,
     inspector_open: bool,
@@ -749,6 +760,8 @@ impl TerminalPane {
             started_at: Instant::now(),
             session_source,
             observed_selected_id,
+            #[cfg(test)]
+            input_observer: None,
             viewport: None,
             sidebar_visible: true,
             inspector_open: false,
@@ -827,6 +840,11 @@ impl TerminalPane {
                 generation,
                 self.pane_tx.clone(),
             );
+            #[cfg(test)]
+            let attachment = AttachmentControl {
+                input_observer: self.input_observer.clone().map(|tx| (id.clone(), tx)),
+                ..attachment
+            };
             let ime_attachment = attachment.clone();
             let element = match parked {
                 // The parked cells paint on the first frame; the attach's
@@ -944,6 +962,22 @@ impl TerminalPane {
 
     pub fn is_focused(&self, window: &Window) -> bool {
         self.focus.is_focused(window)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn capture_input_for_test(
+        &mut self,
+    ) -> mpsc::UnboundedReceiver<(SessionId, Vec<u8>)> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.input_observer = Some(tx.clone());
+        for (id, resident) in &mut self.residents {
+            resident.attachment.input_observer = Some((id.clone(), tx.clone()));
+            let attachment = resident.attachment.clone();
+            resident.element = resident.element.clone().on_text_input(move |text| {
+                attachment.input(text.as_bytes().to_vec());
+            });
+        }
+        rx
     }
 
     #[must_use]
@@ -3352,7 +3386,11 @@ fn spawn_attachment(
     pane_tx: PaneEventSender,
 ) -> AttachmentControl {
     let (command_tx, mut commands) = mpsc::unbounded_channel();
-    let control = AttachmentControl { tx: command_tx };
+    let control = AttachmentControl {
+        tx: command_tx,
+        #[cfg(test)]
+        input_observer: None,
+    };
     runtime.spawn(async move {
         // The first resize must be the measured pane geometry: deferred agent
         // launch waits for it. Do not seed an arbitrary 80×24 size.


### PR DESCRIPTION
## Summary

Fix terminal focus disappearing after clicking a conversation in the sidebar.

The click correctly focused the terminal, but the subsequent local-store notification restored the conversation's inspector tab using the same `WorkspaceChanged` event as an explicit inspector click. Root then focused the workbench (or the restored browser address / auxiliary terminal), undoing the sidebar's focus handoff. This path was introduced by per-session inspector restoration in #191, before the sidebar peek changes.

- Distinguish passive `WorkspaceRestored` from explicit `WorkspaceChanged` events.
- Restore inspector content and native browser state without taking keyboard focus; explicit inspector navigation retains its existing focus behavior.
- Add an integrated GPUI regression that clicks real conversation rows, delivers the asynchronous store broadcast, and verifies focus plus actual input bytes going only to the selected conversation. Cover docked and floating peek, A → B → A, a restored blank browser tab, and mouse-out dismissal.
- The input observer is test-only and adds no production overhead.

## Verification

- Reproduced the focus failure before the fix; the targeted regression passes afterward.
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --workspace --release`

Created in a separate worktree and branch from `main`. No visual styling changes.
