### PR TITLE
Prevent titlebar controls from dragging the window

### DIFF
--- a/diri/crates/diri-app/src/inspector.rs
+++ b/diri/crates/diri-app/src/inspector.rs
@@ -1599,6 +1599,7 @@ impl WorkbenchInspector {
                                 .child(count.to_string()),
                         )
                     })
+                    .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
                     .on_click(cx.listener(move |this, _, _, cx| {
                         this.select_tab(tab, cx);
                         cx.stop_propagation();
@@ -1812,6 +1813,7 @@ impl WorkbenchInspector {
                     .hover(move |tab| {
                         tab.bg(colors.primary.alpha(if active { 0.12 } else { 0.055 }))
                     })
+                    .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
                     .child({
                         let state = if active {
                             &self.browser_state
@@ -1906,6 +1908,7 @@ impl WorkbenchInspector {
                     .cursor_pointer()
                     .hover(move |button| button.bg(Fill::subtle(colors)))
                     .child(sf_symbol("plus", 13.0, colors.secondary))
+                    .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
                     .on_click(cx.listener(|this, _, _, cx| {
                         this.workspace_chooser_open = !this.workspace_chooser_open;
                         cx.notify();
@@ -1930,6 +1933,7 @@ impl WorkbenchInspector {
                         SymbolWeight::Bold,
                         colors.secondary,
                     ))
+                    .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
                     .on_click(cx.listener(|_, _, _, cx| {
                         cx.emit(InspectorEvent::Close);
                         cx.stop_propagation();

--- a/diri/crates/diri-app/src/launcher.rs
+++ b/diri/crates/diri-app/src/launcher.rs
@@ -3910,6 +3910,7 @@ impl Render for LauncherOverlay {
                     .text_size(px(12.0))
                     .text_color(colors.secondary)
                     .hover(move |button| button.bg(Fill::subtle(colors)))
+                    .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
                     .on_click(cx.listener(|this, _, _, cx| this.close(cx)))
                     .child("Back")
                     .child(div().text_color(colors.tertiary).child("esc")),

--- a/diri/crates/diri-app/src/main.rs
+++ b/diri/crates/diri-app/src/main.rs
@@ -559,6 +559,10 @@ fn open_main_window(
             // surfaces even though only the sidebar used that material.
             window_background: WindowBackgroundAppearance::Opaque,
             app_id: Some(app_id),
+            // Diri paints the whole titlebar. Keep AppKit from turning presses on
+            // its controls into window drags; RootView explicitly moves the
+            // window from unhandled titlebar presses instead.
+            app_owns_titlebar_drag: cfg!(target_os = "macos"),
             titlebar: Some(TitlebarOptions {
                 title,
                 appears_transparent: cfg!(target_os = "macos"),

--- a/diri/crates/diri-app/src/notification_panel.rs
+++ b/diri/crates/diri-app/src/notification_panel.rs
@@ -621,6 +621,7 @@ impl RootView {
                             .cursor_pointer()
                             .hover(move |button| button.bg(Fill::hover(colors, true)))
                             .child(Icon::new(IconName::Close, 14.0, colors.secondary))
+                            .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
                             .on_click(cx.listener(|this, _, window, cx| {
                                 cx.stop_propagation();
                                 this.toggle_notifications(window, cx);

--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -190,6 +190,10 @@ pub struct RootView {
     browser: std::rc::Rc<std::cell::RefCell<NativeBrowser>>,
     services: Arc<AppServices>,
     focus: FocusHandle,
+    /// A press on otherwise-unhandled titlebar chrome. Button presses stop the
+    /// mouse-down before it bubbles here, so even a one-pixel move remains a
+    /// button click rather than becoming a window drag.
+    titlebar_drag_armed: bool,
     resize_origin: Option<(f32, f32)>,
     /// The sidebar open/close currently being painted, if any.
     sidebar_slide: Option<SeamSlide>,
@@ -929,6 +933,7 @@ impl RootView {
             browser,
             services,
             focus: cx.focus_handle(),
+            titlebar_drag_armed: false,
             resize_origin: None,
             sidebar_slide: None,
             sidebar_panel_slide: None,
@@ -3387,6 +3392,32 @@ impl Render for RootView {
             // treatment above this base.
             .bg(colors.background)
             .track_focus(&self.focus)
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |this, event: &gpui::MouseDownEvent, _, _| {
+                    let pointer_y = f32::from(event.position.y);
+                    this.titlebar_drag_armed = cfg!(target_os = "macos")
+                        && pointer_y >= recovery_height
+                        && pointer_y < recovery_height + Metrics::TITLE_BAR;
+                }),
+            )
+            .on_mouse_move(
+                cx.listener(|this, event: &gpui::MouseMoveEvent, window, _| {
+                    if this.titlebar_drag_armed && event.pressed_button == Some(MouseButton::Left) {
+                        this.titlebar_drag_armed = false;
+                        window.start_window_move();
+                    }
+                }),
+            )
+            .on_mouse_up(
+                MouseButton::Left,
+                cx.listener(|this, event: &gpui::MouseUpEvent, window, _| {
+                    if this.titlebar_drag_armed && event.click_count == 2 {
+                        window.titlebar_double_click();
+                    }
+                    this.titlebar_drag_armed = false;
+                }),
+            )
             .capture_key_down(cx.listener(Self::on_key_down))
             .capture_key_up(cx.listener(Self::on_key_up))
             .on_action(cx.listener(Self::close_selected_session))
@@ -3786,7 +3817,7 @@ fn preview_hint(system_image: &str, label: &str, colors: SemanticColors) -> AnyE
 mod tests {
     use super::*;
     use crate::sidebar::{PreviewScenario, SidebarPreviewFixture};
-    use gpui::{Modifiers, size};
+    use gpui::{Modifiers, point, size};
 
     pub(super) fn test_services() -> Arc<AppServices> {
         Arc::new(AppServices {
@@ -3805,6 +3836,7 @@ mod tests {
         })
     }
 
+    #[cfg(target_os = "macos")]
     #[gpui::test]
     fn switching_sidebar_conversations_keeps_terminal_focused(cx: &mut gpui::TestAppContext) {
         cx.update(|cx| cx.set_reduce_motion(true));
@@ -4251,6 +4283,80 @@ mod tests {
         assert!(
             !root.read_with(cx, |root, _| root.notification_panel_open),
             "clicking the notification trigger again must close the panel without reopening it"
+        );
+    }
+
+    #[gpui::test]
+    fn titlebar_controls_do_not_arm_window_drag_but_empty_chrome_does(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let services = test_services();
+        let session = SidebarPreviewFixture::make(PreviewScenario::Typical)
+            .list
+            .sessions[0]
+            .clone();
+        {
+            let mut store = services.store.store.write().expect("store");
+            store.upsert_session(session.clone());
+            store.select(session.id);
+        }
+        let (root, cx) = cx.add_window_view(move |window, cx| {
+            RootView::new(services, true, PreviewScenario::Empty, window, cx)
+        });
+        cx.simulate_resize(size(px(1_000.0), px(700.0)));
+        cx.run_until_parked();
+        for selector in [
+            "show-sidebar",
+            "session-links-trigger",
+            "notification-inbox-button",
+        ] {
+            let control = cx
+                .debug_bounds(selector)
+                .unwrap_or_else(|| panic!("missing titlebar control {selector}"));
+            assert!(
+                control.center().y < px(Metrics::TITLE_BAR),
+                "fixture must place {selector} in the titlebar: {control:?}"
+            );
+            cx.simulate_event(gpui::MouseDownEvent {
+                position: control.center(),
+                modifiers: Modifiers::default(),
+                button: MouseButton::Left,
+                click_count: 1,
+                first_mouse: false,
+            });
+            assert!(
+                !root.read_with(cx, |root, _| root.titlebar_drag_armed),
+                "{selector} must remain a click even if the pointer moves by a pixel"
+            );
+            cx.simulate_event(gpui::MouseUpEvent {
+                position: point(px(500.0), px(100.0)),
+                modifiers: Modifiers::default(),
+                button: MouseButton::Left,
+                click_count: 1,
+            });
+        }
+
+        let trigger = cx.debug_bounds("session-links-trigger").unwrap().center();
+        cx.simulate_click(trigger, Modifiers::default());
+        cx.run_until_parked();
+        assert!(
+            cx.debug_bounds("session-links-panel").is_some(),
+            "the protected dropdown trigger must still activate normally"
+        );
+
+        cx.simulate_click(trigger, Modifiers::default());
+        cx.run_until_parked();
+        let empty_titlebar = point(px(520.0), px(20.0));
+        cx.simulate_event(gpui::MouseDownEvent {
+            position: empty_titlebar,
+            modifiers: Modifiers::default(),
+            button: MouseButton::Left,
+            click_count: 1,
+            first_mouse: false,
+        });
+        assert!(
+            root.read_with(cx, |root, _| root.titlebar_drag_armed),
+            "unhandled titlebar chrome must still move the window"
         );
     }
 

--- a/diri/crates/diri-app/src/session_links.rs
+++ b/diri/crates/diri-app/src/session_links.rs
@@ -452,6 +452,7 @@ impl TerminalPane {
             })
             .child(Icon::new(IconName::ChevronDown, 14.0, colors.tertiary))
             .tooltip(move |_, cx| cx.new(|_| PaletteTooltip(help.clone(), colors)).into())
+            .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
             .on_click(cx.listener(|this, _, window, cx| {
                 if this.session_links.open {
                     this.close_session_links(window, cx);

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -6517,6 +6517,7 @@ fn icon_button(
         .cursor_pointer()
         .text_size(px(15.0))
         .text_color(colors.secondary)
+        .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
         .on_click(on_click)
         .on_hover(on_hover)
         .child(sf_symbol(system_image, 15.0, colors.secondary))

--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -5275,6 +5275,7 @@ fn notification_titlebar_button(unread: usize, colors: SemanticColors) -> AnyEle
                     .bg(Ink::FRESH),
             )
         })
+        .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
         .on_click(|_, window, cx| {
             window.dispatch_action(Box::new(crate::commands::ToggleNotifications), cx);
             cx.stop_propagation();

--- a/diri/crates/diri-app/src/terminal_pane.rs
+++ b/diri/crates/diri-app/src/terminal_pane.rs
@@ -2370,6 +2370,7 @@ impl TerminalPane {
                     .cursor_pointer()
                     .hover(move |button| button.bg(Fill::subtle(colors)))
                     .child(sf_symbol("sidebar.left", 15.0, colors.secondary))
+                    .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
                     .on_click(cx.listener(|_, _, window, cx| {
                         window.dispatch_action(Box::new(ToggleSidebar), cx);
                         cx.stop_propagation();
@@ -2473,6 +2474,7 @@ impl TerminalPane {
                                         colors.secondary
                                     },
                                 ))
+                                .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
                                 .on_click(cx.listener(|_, _, window, cx| {
                                     window.dispatch_action(Box::new(ToggleInspector), cx);
                                     cx.stop_propagation();
@@ -2513,6 +2515,7 @@ impl TerminalPane {
                                             .bg(Ink::FRESH),
                                     )
                                 })
+                                .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
                                 .on_click(|_, window, cx| {
                                     window.dispatch_action(
                                         Box::new(crate::commands::ToggleNotifications),


### PR DESCRIPTION
## Summary
- make Diri own macOS titlebar movement and start window drags only from unhandled titlebar chrome
- stop top toolbar buttons, tabs, dropdown triggers, and notification controls from arming a window drag
- add a regression test proving controls stay clickable while empty titlebar space remains draggable

## Root cause
The transparent macOS titlebar let AppKit treat presses on custom GPUI controls as native window drags. A tiny pointer movement could therefore consume the press before the dropdown click fired.

## Verification
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --quiet
- cargo build --workspace --release