### PR TITLE
Fix worktree check caching and background completion

### DIFF
--- a/diri/crates/diri-app/src/surface_shell.rs
+++ b/diri/crates/diri-app/src/surface_shell.rs
@@ -484,14 +484,23 @@ impl UtilitySurfaces {
             .preferences()
             .clone();
         self.surface = Surface::Worktrees;
-        self.refresh_worktrees(cx);
+        self.load_worktrees(cx);
+    }
+
+    fn load_worktrees(&mut self, cx: &mut Context<Self>) {
+        // Tab navigation preserves checked results. A new window joins the
+        // engine's existing job/cache rather than requesting another scan.
+        if self.worktrees.scan_generation.is_none() || self.worktrees.error.is_some() {
+            self.start_worktree_scan(false, false, cx);
+        }
+        cx.notify();
     }
 
     fn refresh_worktrees(&mut self, cx: &mut Context<Self>) {
-        self.start_worktree_scan(false, cx);
+        self.start_worktree_scan(true, false, cx);
     }
 
-    fn start_worktree_scan(&mut self, measure_disk: bool, cx: &mut Context<Self>) {
+    fn start_worktree_scan(&mut self, refresh: bool, measure_disk: bool, cx: &mut Context<Self>) {
         if self.worktrees.loading {
             return;
         }
@@ -502,23 +511,15 @@ impl UtilitySurfaces {
         let runtime = Arc::clone(&self.runtime);
         cx.spawn(async move |this, cx| {
             let mut params = diri_proto::WorktreeScanParams {
-                refresh: true,
+                refresh,
                 measure_disk,
                 ..Default::default()
             };
             loop {
-                let visible = this
-                    .update(cx, |this, _| {
-                        let visible = this.surface == Surface::Worktrees
-                            || (this.surface == Surface::Settings
-                                && this.settings_tab == SettingsTab::Worktrees);
-                        if !visible && this.worktrees.poll_epoch == epoch {
-                            this.worktrees.loading = false;
-                        }
-                        visible && this.worktrees.poll_epoch == epoch
-                    })
+                let active = this
+                    .update(cx, |this, _| this.worktrees.poll_epoch == epoch)
                     .unwrap_or(false);
-                if !visible {
+                if !active {
                     break;
                 }
                 let client = Arc::clone(&client);
@@ -555,8 +556,8 @@ impl UtilitySurfaces {
                 if !again {
                     break;
                 }
-                // Drain bounded pages promptly; idle progress checks run only
-                // while this page is visible and the worker is active.
+                // Drain bounded pages promptly, including while the sidebar is
+                // closed. Stop polling once the engine job and pages finish.
                 cx.background_executor()
                     .timer(Duration::from_millis(if has_more { 16 } else { 500 }))
                     .await;
@@ -1180,7 +1181,7 @@ impl UtilitySurfaces {
             self.refresh_release_notes(cx);
         }
         if tab == SettingsTab::Worktrees {
-            self.refresh_worktrees(cx);
+            self.load_worktrees(cx);
         }
         if tab == SettingsTab::Skills {
             self.refresh_skills(cx);
@@ -6292,6 +6293,69 @@ mod tests {
             SettingsTab::WhatsNew,
             "latest changes"
         ));
+    }
+
+    #[gpui::test]
+    fn worktree_checks_keep_running_after_closing_the_sidebar(cx: &mut TestAppContext) {
+        let (harness, cx) = open_settings_workbench(cx);
+        let surfaces = harness.read_with(cx, |harness, _| harness.surfaces.clone());
+        surfaces.update(cx, |surfaces, cx| {
+            surfaces.open_settings_tab(SettingsTab::Worktrees, cx);
+            assert!(surfaces.worktrees.loading);
+            surfaces.close_surface(cx);
+        });
+        cx.run_until_parked();
+        surfaces.read_with(cx, |surfaces, _| {
+            assert!(
+                surfaces.worktrees.loading,
+                "hiding the sidebar must not stop progress updates"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn worktree_checks_survive_reopening_both_entry_points(cx: &mut TestAppContext) {
+        let (harness, cx) = open_settings_workbench(cx);
+        let surfaces = harness.read_with(cx, |harness, _| harness.surfaces.clone());
+        surfaces.update(cx, |surfaces, cx| {
+            let entries = worktree_settings::preview_entries();
+            surfaces
+                .worktrees
+                .apply_scan(diri_proto::WorktreeScanResult {
+                    generation: 7,
+                    cursor: entries.len(),
+                    total: entries.len(),
+                    checked: entries.len(),
+                    entries: entries.clone(),
+                    running: false,
+                    has_more: false,
+                    error: None,
+                });
+            let entries = surfaces.worktrees.entries.clone();
+            let epoch = surfaces.worktrees.poll_epoch;
+            surfaces.open_settings_tab(SettingsTab::General, cx);
+            surfaces.open_settings_tab(SettingsTab::Worktrees, cx);
+            assert!(
+                !surfaces.worktrees.loading,
+                "reopening settings must keep checked results"
+            );
+            assert_eq!(surfaces.worktrees.poll_epoch, epoch);
+            assert_eq!(surfaces.worktrees.entries, entries);
+            surfaces.close_surface(cx);
+            surfaces.open_worktrees(cx);
+            assert!(
+                !surfaces.worktrees.loading,
+                "reopening the sheet must keep checked results"
+            );
+            assert_eq!(surfaces.worktrees.poll_epoch, epoch);
+            assert_eq!(surfaces.worktrees.entries, entries);
+            surfaces.refresh_worktrees(cx);
+            assert!(
+                surfaces.worktrees.loading,
+                "explicit refresh still starts a scan"
+            );
+            assert_eq!(surfaces.worktrees.poll_epoch, epoch + 1);
+        });
     }
 
     #[gpui::test]

--- a/diri/crates/diri-app/src/surface_shell/worktree_settings.rs
+++ b/diri/crates/diri-app/src/surface_shell/worktree_settings.rs
@@ -82,7 +82,7 @@ impl UtilitySurfaces {
                                 "worktrees-measure",
                                 colors,
                                 cx,
-                                |this, cx| this.start_worktree_scan(true, cx),
+                                |this, cx| this.start_worktree_scan(true, true, cx),
                             ))
                         })
                         .child(surface_button(

--- a/diri/crates/diri-engine/src/worktree_scan.rs
+++ b/diri/crates/diri-engine/src/worktree_scan.rs
@@ -1,12 +1,11 @@
 //! One on-demand worker shared by all windows. Polling transfers bounded deltas,
-//! not the inventory again. No worker or timer exists when the scan is idle.
+//! not the inventory again. Jobs finish even when no view is polling; results
+//! remain available until an explicit refresh. No idle worker or timer remains.
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
 
 use diri_proto::{ControlError, WorktreeOverviewEntry, WorktreeScanParams, WorktreeScanResult};
 
 const PAGE_SIZE: usize = 32;
-const VIEW_LEASE: Duration = Duration::from_secs(10);
 
 pub(crate) type Emit<'a> = dyn FnMut(Option<WorktreeOverviewEntry>, bool) -> bool + 'a;
 
@@ -16,7 +15,6 @@ pub(crate) struct ScanStore(Arc<Mutex<State>>);
 struct State {
     generation: u64,
     running: bool,
-    last_poll: Option<Instant>,
     // At most two updates per discovered checkout. Replaced on a new scan.
     updates: Vec<WorktreeOverviewEntry>,
     total: usize,
@@ -38,7 +36,6 @@ impl ScanStore {
             *state = State {
                 generation: state.generation + 1,
                 running: true,
-                last_poll: Some(Instant::now()),
                 ..Default::default()
             };
             let shared = Arc::clone(&self.0);
@@ -47,12 +44,6 @@ impl ScanStore {
                 .spawn(move || {
                     let result = scan(p.measure_disk, &mut |entry, checked| {
                         let mut state = shared.lock().expect("worktree scan state");
-                        if state
-                            .last_poll
-                            .is_none_or(|last| last.elapsed() > VIEW_LEASE)
-                        {
-                            return false;
-                        }
                         if let Some(entry) = entry {
                             state.updates.push(entry);
                             if checked {
@@ -72,7 +63,6 @@ impl ScanStore {
                 state.error = Some(format!("Could not start worktree scan: {error}"));
             }
         }
-        state.last_poll = Some(Instant::now());
         let cursor = if p.generation == Some(state.generation) {
             p.cursor.min(state.updates.len())
         } else {
@@ -96,6 +86,7 @@ impl ScanStore {
 mod tests {
     use super::*;
     use std::sync::mpsc;
+    use std::time::{Duration, Instant};
 
     fn entry(n: usize) -> WorktreeOverviewEntry {
         WorktreeOverviewEntry {
@@ -180,20 +171,46 @@ mod tests {
     }
 
     #[test]
-    fn worktree_scan_stops_when_the_last_view_stops_polling() {
+    fn worktree_scan_continues_when_the_last_view_stops_polling() {
         let store = ScanStore::default();
-        let (release, waiting) = mpsc::channel();
-        let (finished, result) = mpsc::channel();
-        store
+        let first = store
             .request(Default::default(), move |_, emit| {
-                waiting.recv().unwrap();
-                finished.send(emit(None, false)).unwrap();
+                assert!(emit(Some(entry(0)), false));
+                // Outlive the former ten-second view lease without any polls.
+                std::thread::sleep(Duration::from_secs(11));
+                if !emit(Some(entry(0)), true) {
+                    return Err("closing Worktrees cancelled the engine job".into());
+                }
                 Ok(())
             })
             .unwrap();
-        store.0.lock().unwrap().last_poll =
-            Some(Instant::now() - VIEW_LEASE - Duration::from_secs(1));
-        release.send(()).unwrap();
-        assert!(!result.recv_timeout(Duration::from_secs(1)).unwrap());
+        let deadline = Instant::now() + Duration::from_secs(15);
+        // Observe completion directly so the test cannot keep a view lease alive.
+        while store.0.lock().unwrap().running {
+            assert!(Instant::now() < deadline, "background scan did not finish");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let reopened = store
+            .request(Default::default(), |_, _| {
+                panic!("reopening must reuse the scan")
+            })
+            .unwrap();
+        assert_eq!(reopened.generation, first.generation);
+        assert_eq!(reopened.total, 1);
+        assert_eq!(reopened.checked, 1);
+        assert_eq!(reopened.entries.len(), 2);
+        assert!(!reopened.running);
+        assert_eq!(reopened.error, None);
+
+        let refreshed = store
+            .request(
+                WorktreeScanParams {
+                    refresh: true,
+                    ..Default::default()
+                },
+                |_, _| Ok(()),
+            )
+            .unwrap();
+        assert_eq!(refreshed.generation, first.generation + 1);
     }
 }


### PR DESCRIPTION
Reopening Worktrees previously requested a fresh scan, and leaving the page stopped UI polling. The Engine then cancelled the job when its ten-second view lease expired, so checks only finished while the sidebar stayed open.

Keep completed results when reopening either the Worktrees settings tab or sheet. New windows join the Engine's existing scan/cache. Let the Engine job and UI progress updates finish with the sidebar closed; polling stops at completion. Explicit Refresh and Measure Sizes still request a new scan, and cleanup retains its existing safety revalidation. Results remain in memory for the Engine lifetime.

Validation:
- Reproduced both UI failures and the Engine cancellation before the fix; added regressions for reopening, hidden progress, completion without polling beyond ten seconds, cache reuse, and explicit refresh.
- 36 worktree-related tests passed.
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`: 1,396 passed, 27 ignored. Reran outside the sandbox after fixture Unix socket bindings were denied.
- `cargo build --workspace --release`
