### PR TITLE
Fix discovery and launch paths for pnpm-installed agents

### DIFF
--- a/diri/REMOTE_PORT.md
+++ b/diri/REMOTE_PORT.md
@@ -358,6 +358,13 @@ each configured SSH host have independent catalog state. The Engine owns the
 catalog and preferences; the Helper only reports filesystem facts from the
 remote account.
 
+Local desktop discovery and launches share a normalized PATH: captured login
+shell entries first, inherited entries next, then user package-manager and
+standard executable directories. Fallbacks include pnpm's old home-directory
+shims and pnpm 11's `bin` layout, `PNPM_HOME`, `XDG_DATA_HOME`, Bun, Cargo,
+mise, and Volta. They also apply when local shell capture fails or times out.
+These local fallbacks are never added to remote launch environments.
+
 Protocol 1.3 adds the required `executable-discovery` capability. One bounded
 `executables` request carries every bundled manifest binary and any configured
 override. The Helper captures the login environment exactly once, resolves all

--- a/diri/crates/diri-engine/src/agent.rs
+++ b/diri/crates/diri-engine/src/agent.rs
@@ -415,6 +415,9 @@ impl AgentDescriptor {
             }
             spec.env.push((key, value));
         }
+        let path = crate::local_path::search_path(None, spec.env.iter().cloned());
+        spec.env.retain(|(key, _)| key != "PATH");
+        spec.env.push(("PATH".into(), path));
         assert_color_environment(&mut spec.env);
         for (key, value) in &self.env {
             spec.env.retain(|(existing, _)| existing != key);

--- a/diri/crates/diri-engine/src/agent_catalog.rs
+++ b/diri/crates/diri-engine/src/agent_catalog.rs
@@ -187,7 +187,8 @@ impl AgentCatalogStore {
 
 #[must_use]
 pub fn resolve_local(binary: &str, configured: Option<&str>) -> ExecutableResolution {
-    let detected_path = resolve_on_path(binary, &std::env::var("PATH").unwrap_or_default());
+    let path = crate::local_path::search_path(None, std::env::vars());
+    let detected_path = resolve_on_path(binary, &path);
     let (configured_path, configured_error) = match configured {
         Some(path) => match validate_executable(path) {
             Ok(path) => (Some(path), None),
@@ -226,7 +227,7 @@ pub fn validate_executable(path: &str) -> io::Result<String> {
     })
 }
 
-fn resolve_on_path(binary: &str, path: &str) -> Option<String> {
+pub(crate) fn resolve_on_path(binary: &str, path: &str) -> Option<String> {
     if binary.contains('/') {
         return validate_executable(binary).ok();
     }

--- a/diri/crates/diri-engine/src/bin/dirijord-rs.rs
+++ b/diri/crates/diri-engine/src/bin/dirijord-rs.rs
@@ -61,10 +61,10 @@ fn main() {
     let user_shell = login_shell();
     // SAFETY: single-threaded startup, before any spawn.
     unsafe { std::env::set_var("SHELL", &user_shell) };
-    if let Some(path) = login_path(&user_shell) {
-        // SAFETY: single-threaded startup, before any spawn.
-        unsafe { std::env::set_var("PATH", &path) };
-    }
+    let captured_path = login_path(&user_shell);
+    let path = diri_engine::local_path::search_path(captured_path.as_deref(), std::env::vars());
+    // SAFETY: single-threaded startup, before any spawn.
+    unsafe { std::env::set_var("PATH", &path) };
 
     let home = std::env::var_os("HOME")
         .map(PathBuf::from)
@@ -271,9 +271,9 @@ const fn default_shell() -> &'static str {
     "/bin/sh"
 }
 
-/// Mirrors the Swift daemon's `LoginEnvironment`: `printenv PATH` prints the
-/// real colon-separated variable regardless of shell — fish stores $PATH as a
-/// space-separated list, so `echo $PATH` produces garbage there — and `-i -l`
+/// `printenv PATH` prints the real colon-separated variable regardless of
+/// shell — fish stores $PATH as a space-separated list, so `echo $PATH`
+/// produces garbage there — and `-i -l`
 /// sources both interactive and login files, which is where agent PATHs are
 /// actually configured.
 ///
@@ -301,11 +301,6 @@ fn capture_login_path(
     use std::process::{Command, Stdio};
     use std::time::{Duration, Instant};
 
-    let fallback = || {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-        format!("{home}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin")
-    };
-
     // A background process from an rc file can inherit stdout after its shell
     // exits. Capturing into an unlinked regular file means reading stops at the
     // current length instead of waiting for that descendant to close a pipe.
@@ -314,6 +309,7 @@ fn capture_login_path(
     let mut child = unsafe {
         Command::new(shell)
             .args(arguments)
+            .stdin(Stdio::null())
             .stdout(Stdio::from(child_stdout))
             .stderr(Stdio::null())
             .pre_exec(|| {
@@ -330,7 +326,8 @@ fn capture_login_path(
     let started = Instant::now();
     let timed_out = loop {
         match child.try_wait() {
-            Ok(Some(_)) => break false,
+            Ok(Some(status)) if status.success() => break false,
+            Ok(Some(_)) => return None,
             Ok(None) if started.elapsed() < capture_timeout => {
                 std::thread::sleep(Duration::from_millis(50));
             }
@@ -346,7 +343,7 @@ fn capture_login_path(
             let _ = libc::kill(pid, libc::SIGKILL);
         }
         let _ = child.wait();
-        return Some(fallback());
+        return None;
     }
 
     capture.rewind().ok()?;
@@ -361,16 +358,7 @@ fn capture_login_path(
         .map(str::trim)
         .find(|line| line.contains('/'))
         .map(str::to_owned)?;
-    if path.is_empty() {
-        return Some(fallback());
-    }
-    // A single-entry answer smells like a broken profile: keep it, but append
-    // the standard locations so spawns still work.
-    Some(if path.contains(':') {
-        path
-    } else {
-        format!("{path}:{}", fallback())
-    })
+    Some(path)
 }
 
 #[cfg(unix)]
@@ -739,8 +727,38 @@ mod tests {
             Duration::from_millis(500),
         );
 
-        assert_ne!(path.as_deref(), Some("/too-late:/usr/bin"));
+        assert!(path.is_none());
         assert!(started.elapsed() < Duration::from_secs(3));
+    }
+
+    #[test]
+    fn failed_login_path_capture_preserves_inherited_and_pnpm_paths() {
+        for (shell, arguments) in [
+            (
+                "/does-not-exist/diri-test-shell",
+                vec!["-c", "printenv PATH"],
+            ),
+            (
+                "/bin/sh",
+                vec!["-c", "printf '/misleading/path\\n'; exit 1"],
+            ),
+            ("/bin/sh", vec!["-c", "/bin/sleep 5"]),
+        ] {
+            let captured =
+                capture_login_path(shell, &arguments, std::time::Duration::from_millis(100));
+            assert!(captured.is_none());
+            let path = diri_engine::local_path::search_path(
+                captured.as_deref(),
+                [
+                    ("PATH".into(), "/inherited/node/bin:/usr/bin".into()),
+                    ("PNPM_HOME".into(), "/custom/pnpm".into()),
+                ],
+            );
+            assert!(
+                path.starts_with("/inherited/node/bin:/usr/bin:/custom/pnpm/bin:/custom/pnpm:")
+            );
+            assert!(!path.contains("misleading"));
+        }
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/lib.rs
+++ b/diri/crates/diri-engine/src/lib.rs
@@ -40,6 +40,7 @@ pub mod hosts;
 pub mod inject;
 mod lifecycle;
 pub mod limits;
+pub mod local_path;
 pub mod log;
 pub mod migrate;
 pub mod pr_monitor;

--- a/diri/crates/diri-engine/src/local_path.rs
+++ b/diri/crates/diri-engine/src/local_path.rs
@@ -1,0 +1,292 @@
+//! Local desktop PATH normalization shared by discovery and Agent launches.
+
+use std::collections::{BTreeMap, HashSet};
+use std::path::{Path, PathBuf};
+
+/// Keep the shell's choices first, preserve inherited tools, then fill gaps
+/// left by desktop launchers or failed shell initialization. Do not scan
+/// version-manager installs: their shell-selected version remains authoritative.
+pub fn search_path(
+    shell_path: Option<&str>,
+    environment: impl IntoIterator<Item = (String, String)>,
+) -> String {
+    let environment = environment
+        .into_iter()
+        .filter(|(key, _)| {
+            matches!(
+                key.as_str(),
+                "PATH" | "HOME" | "PNPM_HOME" | "XDG_DATA_HOME"
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut directories = Vec::new();
+    for path in [shell_path, environment.get("PATH").map(String::as_str)]
+        .into_iter()
+        .flatten()
+    {
+        directories.extend(
+            path.split(':')
+                .filter(|entry| !entry.is_empty())
+                .map(PathBuf::from),
+        );
+    }
+    let absolute = |key: &str| {
+        environment
+            .get(key)
+            .map(Path::new)
+            .filter(|path| path.is_absolute())
+    };
+    // pnpm <= 10 puts shims in PNPM_HOME; pnpm 11 uses PNPM_HOME/bin.
+    // Retain both so upgrades and older global installs continue to work.
+    let mut pnpm_homes = Vec::new();
+    pnpm_homes.extend(absolute("PNPM_HOME").map(Path::to_path_buf));
+    pnpm_homes.extend(absolute("XDG_DATA_HOME").map(|path| path.join("pnpm")));
+    if let Some(home) = absolute("HOME") {
+        if cfg!(target_os = "macos") {
+            pnpm_homes.push(home.join("Library/pnpm"));
+        }
+        pnpm_homes.push(home.join(".local/share/pnpm"));
+    }
+    for home in pnpm_homes {
+        directories.push(home.join("bin"));
+        directories.push(home);
+    }
+    if let Some(home) = absolute("HOME") {
+        for relative in [
+            ".local/bin",
+            ".bun/bin",
+            ".cargo/bin",
+            ".local/share/mise/shims",
+            ".volta/bin",
+        ] {
+            directories.push(home.join(relative));
+        }
+    }
+    directories.extend(
+        [
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/usr/bin",
+            "/bin",
+            "/usr/sbin",
+            "/sbin",
+        ]
+        .map(PathBuf::from),
+    );
+    let mut seen = HashSet::new();
+    directories
+        .into_iter()
+        .filter_map(|directory| directory.to_str().map(str::to_owned))
+        // A colon in HOME/PNPM_HOME must not inject additional PATH entries.
+        .filter(|directory| !directory.contains(':') && !directory.contains('\0'))
+        .filter(|directory| seen.insert(directory.clone()))
+        .collect::<Vec<_>>()
+        .join(":")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn pnpm_codex_is_discovered_with_a_desktop_path() {
+        let temporary = tempfile::tempdir().unwrap();
+        let home = temporary.path();
+        let pnpm = home.join(if cfg!(target_os = "macos") {
+            "Library/pnpm"
+        } else {
+            ".local/share/pnpm"
+        });
+        std::fs::create_dir_all(&pnpm).unwrap();
+        let codex = pnpm.join("codex");
+        std::fs::write(&codex, "#!/bin/sh\nprintf 'codex fixture\\n'\n").unwrap();
+        std::fs::set_permissions(&codex, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let path = search_path(
+            Some("/usr/bin:/bin"),
+            [("HOME".into(), home.to_string_lossy().into_owned())],
+        );
+        assert_eq!(
+            crate::agent_catalog::resolve_on_path("codex", &path),
+            Some(codex.to_string_lossy().into_owned()),
+            "pnpm-installed Codex must appear in the Agent catalog"
+        );
+        // Exercise the first-party login-shell wrapper with a fixture shell
+        // so this test never loads the developer's or CI host's profiles.
+        let shell = home.join("fixture-shell");
+        std::fs::write(
+            &shell,
+            "#!/bin/sh\nif [ \"$#\" -eq 4 ]; then exec /bin/sh -c \"$4\"; fi\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&shell, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let descriptor = crate::agent::AgentDescriptor {
+            binary: Some("codex".into()),
+            return_to_login_shell: true,
+            ..Default::default()
+        };
+        let spec = descriptor
+            .spawn_spec(
+                home,
+                [
+                    ("HOME".into(), home.to_string_lossy().into_owned()),
+                    ("SHELL".into(), shell.to_string_lossy().into_owned()),
+                    ("PATH".into(), "/usr/bin:/bin".into()),
+                ],
+                &[],
+            )
+            .unwrap();
+        let output = std::process::Command::new(&spec.argv[0])
+            .args(&spec.argv[1..])
+            .env_clear()
+            .envs(spec.env)
+            .current_dir(home)
+            .stdin(std::process::Stdio::null())
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains("codex fixture"),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn package_manager_shims_and_their_runtime_share_the_launch_path() {
+        use crate::agent::AgentDescriptor;
+
+        let temporary = tempfile::tempdir().unwrap();
+        let home = temporary.path();
+        let runtime_dir = home.join("runtime with spaces");
+        std::fs::create_dir_all(&runtime_dir).unwrap();
+        let node = runtime_dir.join("diri-fixture-node");
+        std::fs::write(&node, "#!/bin/sh\nprintf 'runtime reached\\n'\n").unwrap();
+        std::fs::set_permissions(&node, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        for (relative, variable) in [
+            ("custom pnpm", "PNPM_HOME"),
+            ("custom pnpm/bin", "PNPM_HOME"),
+            ("data/pnpm", "XDG_DATA_HOME"),
+            ("data/pnpm/bin", "XDG_DATA_HOME"),
+            (".local/share/pnpm", "HOME"),
+            (".local/share/pnpm/bin", "HOME"),
+            (".bun/bin", "HOME"),
+            (".local/share/mise/shims", "HOME"),
+            (".volta/bin", "HOME"),
+        ] {
+            let bin = home.join(relative);
+            std::fs::create_dir_all(&bin).unwrap();
+            let codex = bin.join("codex");
+            // pnpm launchers may depend on another executable on PATH.
+            std::fs::write(&codex, "#!/bin/sh\nexec diri-fixture-node \"$@\"\n").unwrap();
+            std::fs::set_permissions(&codex, std::fs::Permissions::from_mode(0o700)).unwrap();
+            let value = match variable {
+                "PNPM_HOME" => home.join("custom pnpm"),
+                "XDG_DATA_HOME" => home.join("data"),
+                _ => home.to_path_buf(),
+            };
+            let environment = vec![
+                (variable.into(), value.to_string_lossy().into_owned()),
+                ("PATH".into(), runtime_dir.to_string_lossy().into_owned()),
+            ];
+            let path = search_path(None, environment.clone());
+            assert_eq!(
+                crate::agent_catalog::resolve_on_path("codex", &path),
+                Some(codex.to_string_lossy().into_owned()),
+                "catalog must find {relative}"
+            );
+            let descriptor = AgentDescriptor {
+                binary: Some("codex".into()),
+                ..Default::default()
+            };
+            let spec = descriptor.spawn_spec(home, environment, &[]).unwrap();
+            assert_eq!(spec.argv[0], codex.to_string_lossy());
+            let output = std::process::Command::new(&spec.argv[0])
+                .args(&spec.argv[1..])
+                .env_clear()
+                .envs(spec.env)
+                .output()
+                .unwrap();
+            assert!(output.status.success(), "launcher failed for {relative}");
+            assert_eq!(output.stdout, b"runtime reached\n");
+            std::fs::remove_file(codex).unwrap();
+        }
+    }
+
+    #[test]
+    fn shell_and_inherited_paths_keep_precedence_without_duplicates() {
+        let path = search_path(
+            Some("/chosen node:/usr/bin"),
+            [
+                ("PATH".into(), "/inherited:/usr/bin:/chosen node".into()),
+                ("PNPM_HOME".into(), "/custom/pnpm".into()),
+            ],
+        );
+        assert!(
+            path.starts_with("/chosen node:/usr/bin:/inherited:/custom/pnpm/bin:/custom/pnpm:")
+        );
+        assert_eq!(
+            path.split(':').filter(|entry| *entry == "/usr/bin").count(),
+            1
+        );
+        assert_eq!(search_path(None, [("PATH".into(), path.clone())]), path);
+    }
+
+    #[test]
+    fn invalid_homes_do_not_add_relative_or_injected_search_directories() {
+        let path = search_path(
+            None,
+            [
+                ("HOME".into(), "relative".into()),
+                ("PNPM_HOME".into(), "/unsafe:/injected".into()),
+                ("XDG_DATA_HOME".into(), "".into()),
+                ("PATH".into(), ":/usr/bin::/bin:".into()),
+            ],
+        );
+        assert!(!path.contains("relative"));
+        assert!(!path.contains("unsafe"));
+        assert!(!path.contains("injected"));
+        assert!(path.split(':').all(|entry| entry.starts_with('/')));
+    }
+
+    #[test]
+    fn discovery_rejects_non_executable_files_and_accepts_package_manager_symlinks() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path();
+        let path = root.to_string_lossy();
+        std::fs::write(root.join("codex"), "not executable").unwrap();
+        assert!(crate::agent_catalog::resolve_on_path("codex", &path).is_none());
+        std::fs::create_dir(root.join("directory")).unwrap();
+        assert!(crate::agent_catalog::resolve_on_path("directory", &path).is_none());
+        std::os::unix::fs::symlink(root.join("missing"), root.join("broken")).unwrap();
+        assert!(crate::agent_catalog::resolve_on_path("broken", &path).is_none());
+        std::os::unix::fs::symlink("/bin/sh", root.join("linked")).unwrap();
+        assert_eq!(
+            crate::agent_catalog::resolve_on_path("linked", &path),
+            Some(root.join("linked").to_string_lossy().into_owned())
+        );
+    }
+
+    #[test]
+    fn remote_launch_uses_only_the_remote_path() {
+        let descriptor = crate::agent::AgentDescriptor {
+            binary: Some("codex".into()),
+            ..Default::default()
+        };
+        let spec = descriptor
+            .remote_spawn_spec(
+                Path::new("/remote"),
+                [
+                    ("PATH".into(), "/remote/bin".into()),
+                    ("HOME".into(), "/remote/home".into()),
+                ],
+                &[],
+            )
+            .unwrap();
+        assert_eq!(
+            spec.env.iter().find(|(key, _)| key == "PATH").unwrap().1,
+            "/remote/bin"
+        );
+    }
+}

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -31,6 +31,13 @@ Claude Code and Codex have first-class status detection and resume support.
 Other agents may offer partial detection; every agent can still run as a normal
 terminal.
 
+Install each agent's CLI separately. For local agents, Diri checks your login
+shell's PATH and common package-manager locations, including pnpm's global
+executables in both `PNPM_HOME` and `PNPM_HOME/bin` (pnpm 11). After installing
+an agent while Diri is open, use **Settings → Agents → Refresh**. For a custom
+location that still isn't detected, use **Add…** on that agent's row to select
+its executable.
+
 ## Drag and drop in the sidebar
 
 Drag a session between two rows to reorder it among its siblings; an insertion


### PR DESCRIPTION
## Why

A pnpm-installed Codex can work in a terminal but appear missing in Diri. Local discovery searched only the Engine's PATH; login-shell capture replaced the inherited PATH, and its fallback omitted pnpm's global directories. A fixture with an executable at `~/Library/pnpm/codex` reproduced the missing catalog entry before the fix.

## What changed

- Share local PATH normalization across Engine startup, Agent discovery, and launch environments. Preserve shell and inherited ordering, then append package-manager and standard locations without duplicates.
- Cover `PNPM_HOME`, `XDG_DATA_HOME/pnpm`, macOS/Linux defaults, and both pnpm <= 10's root shims and pnpm 11's `bin` layout. Include Bun, Cargo, mise, and Volta fallback directories.
- Preserve inherited tools when shell capture fails, exits unsuccessfully, or times out. Keep the existing bounded capture and process-group cleanup.
- Exercise discovery and launcher runtime lookup with fixture executables. Document Refresh and manual executable selection in Settings.

Remote environments and explicit executable overrides retain their existing behavior. No dependencies, protocol changes, or background processes were added.

Compared [Waku's shared discovery/child PATH](https://github.com/egoist/waku/blob/main/crates/waku-core/src/command_env.rs) and [T3 Code's PATH merging](https://github.com/pingdotgg/t3code/blob/main/packages/shared/src/shell.ts); also checked [pnpm 11's global-bin change](https://github.com/pnpm/pnpm.io/blob/main/blog/releases/11.0.md).

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`: 1,401 passed, 27 ignored, zero failures
- `cargo build --workspace --release`
- Shell syntax checks, both release-publishing regression scripts, and dependency license policy passed.

The initial sandboxed workspace run could not bind fixture sockets; the complete rerun with local socket/PTY access passed. New tests use fixture homes and executables, including a controlled login-shell wrapper, without installing or invoking a real agent.

- [x] All constituent checks from `./scripts/check.sh` passed, run individually.
- [x] Existing session restart/adoption tests passed.
- [x] Security/privacy reviewed: executable validation preserved; remote PATH isolation tested; no environment logging added.
- [x] User-visible discovery and recovery behavior documented.

No visual UI changes; screenshots are not applicable.
