### PR TITLE
release: prepare diri 0.6.2

### DIFF
--- a/diri/Cargo.lock
+++ b/diri/Cargo.lock
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "diri-app"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "block2 0.6.2",
  "diri-client",

--- a/diri/crates/diri-app/Cargo.toml
+++ b/diri/crates/diri-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diri-app"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
- bump the desktop app and lockfile to 0.6.2
- prepare the release for pnpm agent discovery, reliable background worktree checks, and hardened network/checkpoint/updater trust boundaries

## Verification
- `cargo check -p diri-app`