### PR TITLE
Simplify Diri's README and contribution flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent_request.yml
+++ b/.github/ISSUE_TEMPLATE/agent_request.yml
@@ -1,55 +1,45 @@
-name: Support another agent
-description: Ask for a coding agent diri does not know yet, or report one that detects wrong
+name: Agent support
+description: Request a new agent integration or improve an existing one.
 labels: [agent-manifest]
 body:
   - type: markdown
     attributes:
-      value: >
-        Agent support is a single JSON file in
-        `diri/crates/diri-engine/manifests/` — no Rust required. If you
-        want to write it yourself, copy the closest existing manifest; the
-        fields are documented in CONTRIBUTING.md. Otherwise this issue is
-        enough for someone else to pick up.
-
+      value: >-
+        Agent launch and status rules live in JSON. The
+        [manifest guide](https://github.com/cristicretu/diri/blob/main/docs/AGENT-MANIFESTS.md)
+        covers authoring and validation. Use a disposable prompt for examples;
+        remove credentials, private output, and personal paths before posting.
   - type: input
     id: agent
     attributes:
-      label: Which agent
-      placeholder: "opencode, amp, something new…"
+      label: Agent
+      description: Include the CLI version and a link to its documentation or repository.
     validations:
       required: true
-
   - type: input
     id: command
     attributes:
-      label: How you launch it
-      description: The command you type today.
+      label: Launch command
+      description: The command you use to start the agent, without credentials or private arguments.
       placeholder: "opencode"
     validations:
       required: true
-
   - type: textarea
-    id: working
+    id: behavior
     attributes:
-      label: What it looks like while working
-      description: >
-        Paste the terminal output, or describe the spinner or status line. This
-        is what a rule matches on.
-      render: shell
-
+      label: Missing or incorrect behavior
+      description: For an existing integration, describe what Diri reports and what the agent is actually doing.
   - type: textarea
-    id: waiting
+    id: examples
     attributes:
-      label: What it looks like when it needs you
-      description: >
-        A permission prompt or question, as it appears on screen — including
-        the box drawing and the option list if there is one. This is the most
-        useful part.
-      render: shell
-
+      label: Status examples
+      description: >-
+        Show or describe the agent while working, waiting for approval or input,
+        and finished. A small, redacted terminal excerpt for each state helps
+        us write detection rules.
   - type: input
     id: resume
     attributes:
-      label: How it resumes a past conversation
-      description: The flag, if it has one.
-      placeholder: "--resume <id>, --continue, no support"
+      label: Resume command
+      description: How do you reopen a previous conversation, if supported?
+      placeholder: "--resume <id>, --continue, or unsupported"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,81 +1,63 @@
 name: Bug report
-description: Something in diri behaves wrong
+description: Report a reproducible problem in Diri.
 labels: [bug]
 body:
+  - type: markdown
+    attributes:
+      value: >-
+        Check for an existing issue and try the latest release when possible.
+        Report vulnerabilities [privately](https://github.com/cristicretu/diri/security/advisories/new).
+        Redact credentials, private prompts, and personal paths from anything you attach.
   - type: textarea
     id: what-happened
     attributes:
-      label: What happened
-      description: What you did, what you expected, what you got instead.
+      label: What happened?
+      description: Describe the result and what you expected instead.
     validations:
       required: true
-
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Include the smallest sequence that triggers the problem and how often it happens.
+      placeholder: |
+        1. Open a project…
+        2. Start a session…
+        3. …
+    validations:
+      required: true
   - type: input
     id: version
     attributes:
-      label: diri version
-      description: The version row in the account popover, or `diri --version`.
-      placeholder: "0.4.1"
+      label: Diri version
+      description: Use the version shown in Settings or the diagnostics report.
+      placeholder: "Release version or source commit"
     validations:
       required: true
-
   - type: textarea
     id: platform
     attributes:
-      label: Operating environment
-      description: >
-        On Linux include distro, kernel (`uname -a`), X11 or Wayland, GPU,
-        and desktop environment. On macOS include the version and chip.
-      placeholder: "Ubuntu 22.04; kernel 6.8; Wayland; AMD Radeon; GNOME"
+      label: Environment
+      description: >-
+        Include your OS version and installation method (DMG, Homebrew, AppImage,
+        Debian package, or source). On macOS, include your chip. For Linux
+        rendering issues, include X11/Wayland, desktop environment, GPU, and driver.
+      placeholder: "macOS 15, Apple M3, Homebrew"
     validations:
       required: true
-
-  - type: dropdown
-    id: package
-    attributes:
-      label: Installation format
-      options:
-        - Linux AppImage
-        - Linux Debian package
-        - macOS DMG / Homebrew
-        - Built from source
-    validations:
-      required: true
-
-  - type: dropdown
+  - type: input
     id: agent
     attributes:
-      label: Which agent
-      description: Status detection differs per agent, so this usually matters.
-      options:
-        - Claude Code
-        - Codex
-        - Cursor
-        - Gemini
-        - A shell
-        - Something else
-        - Not agent-specific
-    validations:
-      required: true
-
+      label: Agent and host
+      description: If session-related, include the agent CLI version and whether it runs locally or over SSH.
+      placeholder: "Claude Code, version …, local"
   - type: textarea
-    id: daemon
+    id: diagnostics
     attributes:
-      label: Privacy-safe diagnostics
-      description: >
-        In Settings → General → Support, choose Copy diagnostics, review the
-        exact report, and paste it here. If the app will not open, use
-        `dirijor doctor` when the CLI is on your PATH.
-      render: markdown
-
-  - type: textarea
-    id: logs
-    attributes:
-      label: Relevant log lines
-      description: >
-        On Linux, from `$XDG_STATE_HOME/diri/logs/dirijord.log` (normally
-        `~/.local/state/diri/logs/dirijord.log`); on macOS, from
-        `~/Library/Application Support/Dirijor/logs/dirijord.log`. Please skim
-        for paths or prompt text you would rather not post. Raw logs are an
-        optional fallback; Copy diagnostics never includes them.
-      render: shell
+      label: Diagnostics or screenshots
+      description: >-
+        Optional. In Settings → General → Support, choose Copy diagnostics,
+        review the report, and paste it here. If Diri will not open, run
+        `dirijor doctor` when the CLI is on PATH. For incorrect agent status,
+        use Session Inspector → Info → Why Diri thinks this → Copy status debug info.
+        Include only the relevant, redacted output.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Questions and workflow help
+  - name: Questions and ideas
     url: https://github.com/cristicretu/diri/discussions
-    about: Ask for setup help or talk through an idea before filing an issue.
-  - name: Security vulnerability
+    about: Get setup help, share a workflow, or discuss an early idea.
+  - name: Report a vulnerability
     url: https://github.com/cristicretu/diri/security/advisories/new
-    about: Report vulnerabilities privately; do not post sensitive details publicly.
+    about: Send security reports privately.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Propose a focused improvement to Diri.
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Describe the workflow you want to improve. For early ideas or setup
+        questions, use [Discussions](https://github.com/cristicretu/diri/discussions).
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do, and where does Diri get in the way?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Describe the smallest change that would help.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Current workaround
+      description: How do you handle this today? Include alternatives you considered.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,11 @@
-## Why
+## Change
 
-<!-- What problem does this solve? Link an issue when one exists. -->
-
-## What changed
-
-<!-- Keep this focused enough to review. -->
+<!-- Describe the problem and resulting behavior. Link an issue if relevant. -->
+<!-- For interface changes, include a screenshot or short recording. -->
 
 ## Verification
 
-<!-- Commands run and manual behavior checked. -->
-
-- [ ] `./scripts/check.sh` passes, or I explained why a check is not applicable.
-- [ ] Existing sessions still survive app and daemon restarts, or the migration is documented.
-- [ ] I considered security and privacy impact (processes, IPC, logs, updates, remote hosts).
-- [ ] User-visible behavior or setup changes are documented.
-- [ ] UI changes include a screenshot or short recording.
+<!-- List checks run and what they showed. Explain any checks you could not run. -->
+<!-- Docs-only: check links and rendered output. Rust: see CONTRIBUTING.md. -->
+<!-- If relevant, cover running sessions, restart/reconnect, protocol or stored-format
+     compatibility, and security/privacy impact. Omit what does not apply. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,94 +1,102 @@
-# Contributing to diri
+# Contributing
 
-Bug reports, fixes, and new agent support are all welcome. There is no CLA —
-contributions are Apache 2.0, same as the project.
+Diri values reliable sessions, a compact interface, and clear behavior. A good
+contribution solves a specific problem and keeps those properties intact.
 
-## What you need
+## Choose a change
 
-- macOS 15 or newer, on Apple silicon or Intel
-- Xcode command-line tools
-- Rust — the toolchain is pinned in `diri/rust-toolchain.toml` and rustup will
-  fetch it for you
-- Node 20 or newer, only if you touch the browser sidecar
+- **Bugs:** include reproduction steps, expected behavior, and your environment
+  in a [bug report](https://github.com/cristicretu/diri/issues/new?template=bug_report.yml).
+- **Fixes and docs:** open a focused PR. An issue is useful context, not a
+  prerequisite for a small change.
+- **Agent support:** start with the [manifest guide](docs/AGENT-MANIFESTS.md).
+  Launch commands and status rules live in JSON under
+  [`diri-engine/manifests`](diri/crates/diri-engine/manifests/).
+- **Larger changes:** discuss the problem first, especially when adding a new
+  trust boundary, persistent format, dependency, or compatibility commitment.
+  Use [Discussions](https://github.com/cristicretu/diri/discussions) for early
+  ideas and a [feature request](https://github.com/cristicretu/diri/issues/new?template=feature_request.yml)
+  for a concrete proposal.
 
-The first Rust build compiles GPUI from a pinned Zed revision and takes a while.
-Later builds are incremental.
+## Set up
 
-## Workspace map
+Fork and clone the repository. Install Rust through rustup; the workspace's
+[`rust-toolchain.toml`](diri/rust-toolchain.toml) selects the compiler.
 
-diri ships from the Rust workspace under `diri/`:
-
-- **`crates/diri-app`** — GPUI window, sidebar, terminal surfaces, and settings.
-- **`crates/diri-engine`** — local and remote session orchestration, PTYs,
-  holders, persistence, status detection, and the control socket.
-- **`crates/dirijor-mcp`** — the Rust `dirijor` automation CLI and MCP frontend.
-- **`crates/diri-proto`**, **`diri-client`**, and **`diri-term`** — shared wire
-  types, app-to-engine client, and terminal renderer.
-
-The app never owns a session directly. It talks to the Engine over a Unix
-socket; holder processes retain PTYs while either process restarts.
-
-## Build and test
-
-The one-command contributor check runs shell/release guards, Rust formatting,
-Clippy, workspace tests, and the dependency-license policy:
+On macOS, use macOS 15 or newer with the Xcode command-line tools. On Linux,
+follow the [native dependency setup](diri/LINUX.md#build-from-source).
+Node.js 20 or newer is needed for browser-sidecar work and packaging.
 
 ```sh
-./scripts/check.sh
+cd diri
+cargo build --workspace
+cargo test -p diri-engine    # choose the package you changed
 ```
 
-Pass `--browser` to also install the sidecar dependencies and run Playwright's
-browser integration tests. The default stays self-contained after toolchains and
-dependencies have been fetched once.
+The first build compiles GPUI from a pinned Zed revision. Subsequent builds
+are incremental. On macOS, run `./scripts/dev.sh` from `diri/` to try your change
+in an app bundle. The dev app shares sessions and preferences with the installed
+app; see the [development guide](diri/README.md#build-and-run).
 
-To build and test while iterating:
+## Find the code
+
+All desktop behavior lives in the Rust workspace under [`diri/`](diri/).
+Read [AGENTS.md](AGENTS.md) before changing it.
+
+| Area | Crate under `diri/crates/` |
+| :--- | :--- |
+| Desktop interface | `diri-app` |
+| Sessions, worktrees, status, and orchestration | `diri-engine` |
+| Wire types and local client | `diri-proto`, `diri-client` |
+| Terminal rendering and shared parsing | `diri-term`, `diri-terminal-state` |
+| Remote Helper | `diri-remote` |
+| Automation CLI and MCP server | `dirijor-mcp` |
+
+The Engine owns session records; Holders keep the PTYs and agent processes
+alive. Read the [remote architecture](diri/REMOTE_PORT.md) before changing
+remote sessions, SSH, Holders, terminal state, or packaging.
+
+## Verify
+
+Start with the narrowest relevant package or test. Before handing off Rust
+changes, run these from `diri/`:
 
 ```sh
-(cd diri && cargo build)
-(cd diri && cargo test --workspace)
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+cargo build --workspace --release
 ```
 
-Before opening a pull request, run what CI runs:
+From the repository root, `./scripts/check.sh` runs formatting, Clippy, tests,
+shell/release guards, and the dependency-license policy. Add `--browser` for
+sidecar integration tests; this also installs sidecar dependencies and
+Playwright browsers. The release build above is a separate check.
 
-```sh
-(cd diri && cargo fmt --all -- --check)
-(cd diri && cargo clippy --workspace --all-targets -- -D warnings)
-(cd diri && cargo test --workspace)
-```
+Engine tests create real PTYs, processes, and Git repositories. On a loaded
+machine, `DIRIJOR_TEST_TIMEOUT_SCALE` can extend their liveness waits. Tests
+against a real SSH host must be opt-in and document setup and cleanup.
 
-To try your change in the real app, `diri/scripts/package.sh` builds the bundle
-and `diri/scripts/install-local.sh` installs it to `~/Applications`.
+For documentation-only changes, check links and rendered output. Explain any
+checks you could not run. Never include private prompts, credentials, or raw
+session logs in fixtures or screenshots.
 
-## Notes on the test suite
+## Open a pull request
 
-The engine tests spawn real PTYs, child processes, and git repositories. A few
-consequences worth knowing:
+Keep one purpose per PR. Describe the problem, the resulting behavior, and
+how you verified it. Link an issue when one exists. Include a screenshot or
+short recording for interface changes.
 
-- They are wall-clock sensitive. `DIRIJOR_TEST_TIMEOUT_SCALE` multiplies every
-  liveness wait; CI sets it to 6. Raise it locally if your machine is loaded.
-- Browser tests are opt-in behind `DIRIJOR_RUN_BROWSER_TESTS=1` and need
-  `npx playwright install` first.
+If you change session lifecycle or persistence, explain what happens to running
+sessions during restart, reconnect, and upgrade. If you change a protocol or
+stored format, document compatibility. Update the relevant user guide when
+behavior or setup changes.
 
-## Adding an agent
+CI must pass before merge. Reviews weigh correctness and session continuity
+first, then performance and interface clarity. Keep new controls and
+configuration justified by the problem they solve.
 
-This is the easiest place to start and needs no Rust. Agent support is data:
-each agent is one JSON file in `diri/crates/diri-engine/manifests/`
-describing how to spawn it, how to resume a session, which keystrokes approve or
-deny, and the screen predicates that decide whether it is working, waiting on
-you, or done. Copy the closest existing manifest and adjust it. The
-[manifest-authoring guide](docs/AGENT-MANIFESTS.md) covers the schema,
-real-screen capture workflow, examples, overrides, and focused validation.
-
-Claude Code and Codex have first-class status detection and resume. Anything
-without a manifest still runs as a plain terminal.
-
-## Pull requests
-
-Keep the change focused, explain why in the description, and say how you tested
-it. If it changes behavior the daemon owns, mention whether existing sessions
-survive it — that property matters more than almost anything else here.
-
-CI must be green before merge. Maintainers may ask for a design issue first when
-a change creates a new trust boundary, persistent format, or compatibility
-commitment. See [GOVERNANCE.md](GOVERNANCE.md) for how decisions are made and
-[SECURITY.md](SECURITY.md) for private vulnerability reports.
+Contributions use [Apache 2.0](LICENSE); there is no CLA.
+[Governance](GOVERNANCE.md) covers project decisions, the
+[Code of Conduct](CODE_OF_CONDUCT.md) covers participation, and
+[Security](SECURITY.md) explains private vulnerability reporting.

--- a/README.md
+++ b/README.md
@@ -1,180 +1,63 @@
-<h1><img src="docs/images/diri-wordmark.png" alt="diri" width="300"></h1>
+# diri
 
-[![CI](https://github.com/cristicretu/diri/actions/workflows/ci.yml/badge.svg)](https://github.com/cristicretu/diri/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
-[![GitHub release](https://img.shields.io/github/v/release/cristicretu/diri)](https://github.com/cristicretu/diri/releases/latest)
+**A native workspace for coding agents.**
 
-Run coding agents in parallel without babysitting a wall of terminals.
+Run Claude Code, Codex, Cursor, Gemini, and other terminal agents side by side.
+See what needs you, give each task its own worktree, and review the changes in
+place. Built with Rust and GPUI for macOS, with Linux in beta.
 
-diri is a native workspace for Claude Code, Codex, Cursor, Gemini, and other
-terminal agents on macOS and Linux. See which sessions are working, waiting, or
-done; isolate parallel work in git worktrees; review changes; and reconnect
-after closing the app.
+[Download](https://github.com/cristicretu/diri/releases/latest) ·
+[Getting started](docs/GETTING_STARTED.md) ·
+[Documentation](docs/README.md) ·
+[Contributing](CONTRIBUTING.md)
 
-No Diri account or hosted relay. Your sessions run on your computer or an SSH
-host you control.
-
-![diri showing several coding-agent sessions and their live status](docs/images/diri.png)
-
-<p align="center"><img src="docs/images/diri-divider-status.png" alt="" width="760"></p>
+![Diri with agent sessions in the sidebar, a terminal in the center, and a code diff alongside it](docs/images/diri.png)
 
 ## Install
-
-### macOS
 
 ```sh
 brew install --cask cristicretu/diri/diri
 ```
 
-Or download the latest DMG from [Releases](https://github.com/cristicretu/diri/releases/latest),
-open it, and drag diri to Applications. Both routes install the same universal
-build for Apple silicon and Intel, signed and notarized. diri handles updates
-from there.
+macOS 15 or newer. Apple silicon and Intel. Signed and notarized.
+You can also download the [DMG](https://github.com/cristicretu/diri/releases/latest)
+and drag Diri to Applications.
 
-<p align="center"><img src="docs/images/diri-install.png" alt="Diri moving the app into the Applications folder" width="680"></p>
+**Linux beta:** x86_64 Ubuntu 22.04 / 24.04, X11 or Wayland, Vulkan 1.3.
+See the [Linux guide](diri/LINUX.md) for packages, source builds, and limitations.
+Linux packages are not included in every release.
 
-The Homebrew cask lives in the
-[cristicretu/diri](https://github.com/cristicretu/homebrew-diri) tap, so the full
-cask name is required. macOS 15 or newer.
+Install your agent CLIs separately. Diri uses the tools and accounts already
+on your machine; Claude Code and Codex have the deepest status and resume
+integration.
 
-### Linux beta
+## Work in parallel
 
-Download the x86_64 AppImage or Debian package from
-[Releases](https://github.com/cristicretu/diri/releases/latest). Ubuntu 22.04
-and 24.04 are supported under X11 and Wayland with a Vulkan 1.3-capable GPU.
+- **Know what needs you.** Live status and notifications distinguish working,
+  waiting, and finished sessions.
+- **Keep tasks separate.** Give agents their own Git worktrees and branches.
+- **Review in context.** Inspect diffs, stage changes, commit, and follow pull
+  request checks beside the session.
+- **Come back to your work.** Local sessions keep running when you close the
+  app or the Engine restarts.
+- **Use your own machines.** Run locally or on an SSH host you control.
+  Diri handles remote Helper setup.
 
-```sh
-sudo apt install ./diri_<version>_amd64.deb
-# or
-chmod +x diri_<version>_amd64.AppImage && ./diri_<version>_amd64.AppImage
-```
+Your agents run under your user account, in real terminals. No Diri account or
+hosted relay is required. Remote session persistence depends on the host;
+Diri reports its persistence capabilities.
 
-See the [Linux beta guide](diri/LINUX.md) for checksums, upgrades, XDG paths,
-graphics troubleshooting, and current limitations.
+## Contribute
 
-## Why use diri
+Small, well-tested changes are welcome. Start with a reproducible bug, a focused
+fix, clearer documentation, or an [agent manifest](docs/AGENT-MANIFESTS.md).
+Read the [contributor guide](CONTRIBUTING.md) for setup and review expectations.
 
-- **Know where you are needed.** Live status separates agents that are working,
-  waiting for input, or done. Notifications and the sidebar let you follow many
-  sessions without reading every terminal.
-- **Keep sessions alive.** A dedicated Holder owns each PTY. Closing diri does
-  not stop local work, and the Engine can restart and adopt the same running
-  sessions.
-- **Give parallel work room to breathe.** Create isolated git worktrees, keep
-  their lineage visible, and hand work from one agent to another.
-- **Review the result in one place.** Inspect diffs, stage or discard changes,
-  commit work, and follow pull request checks and discussion beside the session
-  that produced it.
-- **Use the tools you already chose.** diri ships 22 agent definitions and runs
-  each installed CLI in a real terminal under your user account. Claude Code
-  and Codex have the deepest status detection and resume support; other agents
-  remain fully usable as terminals even when their integration is lighter.
-- **Work on an SSH host directly.** diri verifies and bootstraps a small matching
-  Helper, then gives each remote session its own PTY Holder. It needs no `tmux`,
-  preinstalled Diri service, `sudo`, or hosted relay.
-- **Let agents coordinate when you want them to.** The included MCP server lets
-  an agent start another session, inspect its progress, read its output, and
-  answer prompts.
+[Report a bug](https://github.com/cristicretu/diri/issues/new?template=bug_report.yml) ·
+[Discuss an idea](https://github.com/cristicretu/diri/discussions) ·
+[Roadmap](ROADMAP.md)
 
-![A selection of the coding agents supported by diri](docs/images/diri-agent-lineup.png)
+---
 
-## 60-second tour
-
-1. Add a project directory and create a session for an installed agent or a
-   plain shell.
-2. Start parallel sessions in separate worktrees when they may edit the same
-   repository.
-3. Follow live status in the sidebar. Open a session when it needs you or when
-   its changes are ready to review.
-4. Quit and reopen diri. Your local sessions and terminal history are still
-   there.
-
-The [getting-started guide](docs/GETTING_STARTED.md) covers remote hosts, MCP
-orchestration, diagnostics, local data, and uninstalling.
-
-<p align="center"><img src="docs/images/diri-divider-worktrees.png" alt="" width="760"></p>
-
-## From your iPhone
-
-The companion iPhone beta can start sessions, send prompts, answer agent
-questions, follow output, and review tracked changes. It connects to the Mac
-app through your Tailscale network; Diri does not proxy session content through
-a hosted service. See the [iPhone setup and build guide](ios/README.md).
-
-## Architecture
-
-The desktop app and CLI connect to one local Rust Engine:
-
-![Diri architecture: app and CLI connect through the control socket to the engine, persistent PTY holders, and coding agents](docs/images/diri-architecture.png)
-
-- **`diri`** is the desktop app, built with Rust and
-  [GPUI](https://github.com/zed-industries/zed). It owns the window, sidebar,
-  terminal renderer, command palette, and usage views.
-- **`dirijord-rs`** is the headless local Engine. It owns session records,
-  orchestration, worktrees, status reduction, terminal history, and the control
-  socket.
-- **`diri-holder`** owns a local session's PTY and agent process tree so the
-  Engine can restart without ending the work.
-- **`diri-remote`** is the bootstrapped remote Helper. One independent Holder
-  owns each remote PTY while SSH carries the encrypted protocol connection.
-
-`dirijor` is the automation CLI for hooks, notifications, status, and
-diagnostics. `dirijor-mcp` is the MCP stdio server injected into agents. Every
-shipped executable is built from the Rust workspace in [`diri/`](diri/).
-
-## Adding an agent
-
-Agent support is data. Each JSON file in
-`diri/crates/diri-engine/manifests/` describes how to start and resume an agent,
-which keys approve or deny a prompt, and the screen rules that determine its
-status. Copy the closest manifest and adjust it; no Rust changes are required.
-The [manifest-authoring guide](docs/AGENT-MANIFESTS.md) explains the schema,
-capture workflow, examples, overrides, and validation.
-
-## Building from source
-
-The Rust toolchain is pinned in `diri/rust-toolchain.toml`. macOS builds require
-the Xcode command-line tools. Linux dependencies and packaging commands are in
-the [Linux beta guide](diri/LINUX.md). The first build compiles GPUI from a
-pinned Zed revision and takes a while.
-
-```sh
-(cd diri && cargo build)                   # app, engine, holders, CLI, MCP
-(cd diri && cargo test --workspace)
-(cd diri && cargo run -p diri-app)         # run the app from source
-
-diri/scripts/package.sh                    # full macOS bundle
-diri/scripts/package-linux.sh              # AppImage + DEB, on x86_64 Linux
-diri/scripts/install-local.sh
-```
-
-Run the same core checks as CI with one command:
-
-```sh
-./scripts/check.sh
-```
-
-[`diri/PACKAGING.md`](diri/PACKAGING.md) covers signing and notarization,
-[`diri/UPDATING.md`](diri/UPDATING.md) covers updates and releases, and
-[`diri/NODE.md`](diri/NODE.md) covers the optional enhanced remote-node mode.
-The [documentation index](docs/README.md) links the remaining user and
-engineering guides.
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md). Bug reports, fixes, docs, and new agent
-manifests are welcome. New contributors can start with
-[`good first issue`](https://github.com/cristicretu/diri/labels/good%20first%20issue)
-or [`help wanted`](https://github.com/cristicretu/diri/labels/help%20wanted).
-
-Questions belong in [Discussions](https://github.com/cristicretu/diri/discussions),
-reproducible bugs in [Issues](https://github.com/cristicretu/diri/issues), and
-vulnerabilities in [private security reports](SECURITY.md). See the
-[roadmap](ROADMAP.md), [support guide](SUPPORT.md), [privacy notice](PRIVACY.md),
-and [governance](GOVERNANCE.md) for project expectations.
-
-## License
-
-Diri's original source is Apache 2.0. Builds also contain third-party software
-under its own licenses; see [LICENSE](LICENSE), [NOTICE](NOTICE), and the
-machine-checked dependency policy in [`license-policy.json`](license-policy.json).
+[Apache 2.0](LICENSE) · [Third-party notices](NOTICE) ·
+[Privacy](PRIVACY.md) · [Security](SECURITY.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,35 +1,25 @@
 # Roadmap
 
-This is direction, not a promise or release calendar. Concrete work is tracked
-in [Issues](https://github.com/cristicretu/diri/issues).
+Diri's priorities are session reliability, useful agent integrations, and a
+compact workspace. This is direction, not a release calendar. Specific work
+is tracked in [Issues](https://github.com/cristicretu/diri/issues).
 
-## Now
+## Focus
 
-- Keep `main` green and protected by required CI checks.
-- Make session persistence and daemon upgrades boring and recoverable.
-- Expand first-class agent manifests and status-detection coverage.
-- Improve contributor docs, security reporting, privacy disclosure, and release
-  supply-chain checks.
+- **Session continuity.** Reliable persistence, Engine upgrades, and recovery;
+  deeper tests for updates and reconnects.
+- **Agent integration.** More launch and resume support, with accurate status
+  detection and real terminal fixtures.
+- **Platform coverage.** Harden the Rust Engine across supported platforms and
+  improve remote setup and diagnostics.
+- **Release quality.** Keep CI green, strengthen provenance and supply-chain
+  checks, and maintain signed, notarized macOS builds and the Homebrew tap.
 
-## Next
+## Boundaries
 
-- Harden the Rust Engine upgrade path and expand cross-platform coverage.
-- Improve remote-node setup, diagnostics, and least-privilege guidance.
-- Add deeper end-to-end tests for app updates and session recovery.
-- Move more release provenance into reproducible, attestable CI steps while
-  preserving Apple signing and notarization requirements.
+A hosted Diri account or telemetry service is not planned. Agent processes run
+with your user permissions; Diri does not sandbox them.
 
-## Distribution
-
-- Continue publishing signed, notarized releases and the maintained Homebrew
-  tap.
-- Submit Diri to the official Homebrew cask repository once it is eligible.
-  Homebrew normally requires a repository to be at least 30 days old and applies
-  a higher notability threshold to owner submissions. Until then, the supported
-  command is `brew install --cask cristicretu/diri/diri`.
-
-## Not planned
-
-- A hosted Diri account or telemetry service.
-- Treating agent processes as a security sandbox. Diri orchestrates trusted
-  developer tools; it does not contain them.
+For proposals, describe the workflow and the smallest useful improvement in
+[Discussions](https://github.com/cristicretu/diri/discussions) or a
+[feature request](https://github.com/cristicretu/diri/issues/new?template=feature_request.yml).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ Please use [GitHub's private vulnerability reporting](https://github.com/cristic
 Do not include an exploit, private terminal output, tokens, or personal paths in
 a public issue.
 
-Include the affected version and macOS version, a minimal reproduction, the
+Include the affected Diri and operating-system versions, a minimal reproduction, the
 impact you believe is possible, and any suggested mitigation. You should receive
 an acknowledgement within seven days. Timing for a fix or disclosure depends on
 severity and complexity; the maintainer will coordinate that with the reporter.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,34 +1,43 @@
 # Support
 
-Use [GitHub Discussions](https://github.com/cristicretu/diri/discussions) for
-setup questions, workflows, and ideas that are not yet concrete bug reports.
-Use [Issues](https://github.com/cristicretu/diri/issues) for reproducible bugs
-and scoped feature requests.
+[Discussions](https://github.com/cristicretu/diri/discussions) is for setup
+questions and workflows. Use a
+[bug report](https://github.com/cristicretu/diri/issues/new?template=bug_report.yml)
+for something broken or a
+[feature request](https://github.com/cristicretu/diri/issues/new?template=feature_request.yml)
+for a concrete improvement. Report vulnerabilities [privately](SECURITY.md).
 
-Before reporting a bug, check the latest release. In the app, open **Settings →
-General → Support → Copy diagnostics**, preview the exact report, and then copy
-it into the issue. The report is deliberately limited to app/platform/daemon
-metadata, agent availability, remote-host ids and reachability state, and
-storage reachability. Review it before posting publicly anyway.
+## Report a bug
 
-If the app will not open or the action is unavailable, run `dirijor doctor`
-when the CLI is on `PATH`. Include the Diri version, macOS version and chip, the
-agent involved, reproduction steps, and the smallest useful log excerpt.
+Check for an existing issue and try the latest release when possible. Include:
 
-Logs under `~/Library/Application Support/Dirijor` may contain prompt text,
-command output, repository paths, or secrets printed by a process. Redact them
-before posting publicly.
+- Steps to reproduce, expected behavior, and what actually happens.
+- Diri version, OS version, and installation method.
+- Agent CLI version and local or SSH host, if relevant.
 
-## Status debug info
+On macOS, include your chip. For Linux rendering problems, include the display
+server, desktop environment, GPU, and driver; see the
+[Linux troubleshooting guide](diri/LINUX.md#troubleshooting-graphics-and-display-startup).
 
-If an agent is shown as working, waiting, done, or unknown at the wrong time,
-open **Session Inspector → Info → Why Diri thinks this**. The disclosure shows
-the structured authority, manifest/rule id, timing guards, and fallback reason;
-it never includes a screen capture or prompt. Use **Copy status debug info** for
-a bounded snippet suitable for an issue.
+## Collect diagnostics
 
-User-provided manifest identifiers are validated at the copy boundary. Invalid
-or path-like ids are omitted instead of being redacted after the fact.
+Open **Settings → General → Support → Copy diagnostics**, review the report,
+and paste it into the issue. It includes app, platform, and Engine metadata;
+agent availability; remote-host identifiers and reachability; and storage
+reachability. It does not include raw logs.
 
-Report security issues privately as described in [SECURITY.md](SECURITY.md),
-not through Discussions or a public issue.
+If the app will not open, run `dirijor doctor` when the CLI is on `PATH`.
+For incorrect session status, use **Session Inspector → Info → Why Diri thinks
+this → Copy status debug info**. This gives the detection rule and timing
+context without a screen capture or prompt.
+
+Raw logs are an optional fallback:
+
+| Platform | Default Engine log |
+| :--- | :--- |
+| macOS | `~/Library/Application Support/Dirijor/logs/dirijord.log` |
+| Linux | `~/.local/state/diri/logs/dirijord.log` |
+
+Linux paths follow `XDG_STATE_HOME` when set. Logs and screenshots can contain
+prompts, command output, personal paths, and credentials. Share only relevant
+excerpts and redact private content before posting.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -12,10 +12,11 @@ Alternatively, download the latest DMG from [GitHub Releases](https://github.com
 open it, and drag Diri to Applications. The app checks the same release feed for
 updates; it never installs one until you click restart.
 
-On x86_64 Ubuntu 22.04 or 24.04, download the AppImage or Debian package from
-[GitHub Releases](https://github.com/cristicretu/diri/releases/latest). The
-[Linux beta guide](../diri/LINUX.md) covers installation and current platform
-limits.
+On x86_64 Ubuntu 22.04 or 24.04, use an AppImage or Debian package from a
+[GitHub release](https://github.com/cristicretu/diri/releases) that includes Linux
+artifacts, or build from source. Linux packages are not included in every
+release. The [Linux beta guide](../diri/LINUX.md) covers installation, source
+builds, and current platform limits.
 
 ## Your first session
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,21 +1,37 @@
 # Documentation
 
-- [Getting started](GETTING_STARTED.md) — installation, first session, worktrees,
-  remote hosts, diagnostics, and local data.
-- [Keyboard shortcuts](KEYBOARD_SHORTCUTS.md) — every binding, grouped by task,
-  plus how Diri resolves an ambiguous keystroke.
-- [Security model](SECURITY-MODEL.md) — trust boundaries and safe-use guidance.
-- [Agent manifests](AGENT-MANIFESTS.md) — add an agent, author screen rules,
-  capture safe fixtures, and validate both engines.
-- [Remote architecture](../diri/REMOTE_PORT.md) — direct SSH bootstrap, remote
-  PTY Holders, persistence, and protocol guarantees.
-- [Remote nodes](../diri/NODE.md) — optional VPS accounts, fleet usage, and
-  transactional handoff.
-- [Packaging](../diri/PACKAGING.md) — build, signing, and notarization.
-- [Updates and releases](../diri/UPDATING.md) — updater design and release flow.
-- [Engine port history](../diri/PORT.md) — record of the completed Rust migration.
-- [Performance](../diri/PERF.md) — budgets and measurement workflow.
+## Use Diri
 
-Project policies live at the repository root: [contributing](../CONTRIBUTING.md),
-[support](../SUPPORT.md), [security](../SECURITY.md), [privacy](../PRIVACY.md),
-and [governance](../GOVERNANCE.md).
+| Guide | Covers |
+| :--- | :--- |
+| [Getting started](GETTING_STARTED.md) | Install, launch your first agent, use worktrees, and connect an SSH host. |
+| [Keyboard shortcuts](KEYBOARD_SHORTCUTS.md) | Navigation, the command palette, and terminal input. |
+| [Linux beta](../diri/LINUX.md) | Packages, source builds, graphics setup, and platform limits. |
+| [iPhone companion](../ios/README.md) | Beta setup and builds for access through your Tailscale network. |
+| [Support](../SUPPORT.md) | Troubleshooting, diagnostics, and bug reports. |
+| [Security model](SECURITY-MODEL.md) | Process permissions and trust boundaries. |
+
+## Build Diri
+
+Start with [Contributing](../CONTRIBUTING.md) for local setup and review
+expectations. The [Rust workspace guide](../diri/README.md) covers development
+builds and preview fixtures.
+
+| Reference | Covers |
+| :--- | :--- |
+| [Agent manifests](AGENT-MANIFESTS.md) | Launch commands, status rules, safe fixtures, and validation. |
+| [Remote architecture](../diri/REMOTE_PORT.md) | The current SSH transport, PTY Holders, and persistence guarantees. |
+| [Remote nodes](../diri/NODE.md) | Optional enhanced node mode, fleet usage, and handoff. |
+| [Packaging](../diri/PACKAGING.md) | App bundles, signing, and notarization. |
+| [Updates and releases](../diri/UPDATING.md) | Updater behavior and publishing. |
+| [Performance](../diri/PERF.md) | Budgets and measurement. |
+
+## Project
+
+[Roadmap](../ROADMAP.md) · [Governance](../GOVERNANCE.md) ·
+[Code of Conduct](../CODE_OF_CONDUCT.md) · [Privacy](../PRIVACY.md) ·
+[Security reporting](../SECURITY.md)
+
+The [Rust migration record](../diri/PORT.md) is historical context.
+[AGENTS.md](../AGENTS.md) and the remote architecture describe the current
+implementation baseline.


### PR DESCRIPTION
## Change

The repository front page mixes product copy, decorative graphics, setup instructions, and architecture detail. This reduces the README to one product screenshot, a direct install path, five concrete workflows, and contribution links. Badges, decorative dividers, and repeated feature explanations are removed.

The same concise voice carries through the contributor guide, docs index, support guide, and roadmap. PRs now ask for the change and verification, with conditional guidance instead of universal checkboxes. Bug and agent forms collect focused evidence, and a new feature-request form fills the gap in the issue picker. Linux instructions no longer imply that every release includes Linux packages.

[Preview the README](https://github.com/cristicretu/diri/blob/polish/repository-presentation/README.md) · [Contributor guide](https://github.com/cristicretu/diri/blob/polish/repository-presentation/CONTRIBUTING.md)

## Verification

- Checked all 55 relative Markdown links and anchors in changed documents.
- Parsed all four issue-template YAML files and checked form metadata, field types, and unique IDs.
- Rendered the README, contributor guide, and docs index through GitHub's Markdown API; visually reviewed the README on GitHub.
- Cross-checked build instructions against the workspace scripts and release copy against published assets.
- `git diff --check` passed.

Documentation and GitHub templates only; Rust builds and tests were not run locally. Application code, transport architecture, and CI configuration are unchanged.
