### PR TITLE
Fix archived session revival and sidebar restore actions

### DIFF
--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -189,6 +189,7 @@ enum RowDrop {
     Origin,
     /// Reorder among siblings; the zone is never `Onto`.
     Insert(DropZone),
+    Revive,
     Handoff,
     Refused(String),
 }
@@ -1756,6 +1757,10 @@ impl Sidebar {
         colors: SemanticColors,
         cx: &mut Context<Self>,
     ) -> AnyElement {
+        let revive_offered = self.ui.drag.as_ref().is_some_and(|item| {
+            self.revivable_drop(&DraggedSidebarItem(item.clone()), None)
+                .is_some()
+        }) && cx.has_active_drag();
         let fan_out_offered = matches!(
             self.ui.drag,
             Some(DragItem::Session {
@@ -1768,7 +1773,7 @@ impl Sidebar {
             .flex_1()
             .min_h(px(52.0))
             .rounded(px(Radius::ROW))
-            .when(fan_out_offered, |element| {
+            .when(fan_out_offered || revive_offered, |element| {
                 element
                     .debug_selector(|| "sidebar-fan-out-zone".to_owned())
                     .mt(px(6.0))
@@ -1780,10 +1785,14 @@ impl Sidebar {
                     .justify_center()
                     .text_size(px(Typo::META.size))
                     .text_color(colors.secondary)
-                    .child("Drop to fan out a sibling")
+                    .child(if revive_offered {
+                        "Drop to revive session"
+                    } else {
+                        "Drop to fan out a sibling"
+                    })
             })
             .drag_over::<DraggedSidebarItem>(move |element, dragged, _, _| {
-                if fan_out_offered && dragged.session_id().is_some() {
+                if (fan_out_offered || revive_offered) && dragged.session_id().is_some() {
                     element
                         .bg(Palette::CLAY.alpha(0.14))
                         .border_color(Palette::CLAY.alpha(0.86))
@@ -1995,14 +2004,28 @@ impl Sidebar {
                                 }
                             });
                             element.bg(colors.primary.alpha(0.08))
+                        } else if entity.read(cx).revivable_drop(dragged, Some(&id)).is_some() {
+                            element.bg(Palette::CLAY.alpha(0.18))
                         } else {
                             element
                         }
                     }
                 })
-                .on_drop(cx.listener(|this, _: &DraggedSidebarItem, _, cx| {
-                    this.finish_drag();
-                    cx.notify();
+                .on_drop(cx.listener({
+                    let id = id.clone();
+                    move |this, dragged: &DraggedSidebarItem, _, cx| {
+                        cx.stop_propagation();
+                        if this.ui.drag.is_some()
+                            && let Some(session) = this.revivable_drop(dragged, Some(&id))
+                        {
+                            this.store
+                                .write()
+                                .expect("session store lock poisoned")
+                                .revive_sessions(vec![session]);
+                        }
+                        this.finish_drag();
+                        cx.notify();
+                    }
                 }))
                 .drag_over::<ExternalPaths>(move |element, paths, _, _| {
                     if Self::can_accept_external_drop(
@@ -2388,6 +2411,15 @@ impl Sidebar {
         if source == &target.id {
             return Some(RowDrop::Origin);
         }
+        if self
+            .revivable_drop(
+                &DraggedSidebarItem(self.ui.drag.as_ref()?.clone()),
+                Some(&target.project_id),
+            )
+            .is_some()
+        {
+            return Some(RowDrop::Revive);
+        }
         // Reordering only ever moves a row inside its own sibling run, and
         // pinned rows sort ahead of the manual order, so a pin boundary is a
         // run boundary too. Anywhere else the bands fall back to the handoff
@@ -2668,7 +2700,7 @@ impl Sidebar {
             // red at every row the pointer crosses; the refusal is explained
             // on release instead.
             .drag_over::<DraggedSidebarItem>({
-                let handoff = drop == Some(RowDrop::Handoff);
+                let handoff = matches!(drop, Some(RowDrop::Handoff | RowDrop::Revive));
                 move |element, _, _, _| {
                     if handoff {
                         element
@@ -3096,6 +3128,24 @@ impl Sidebar {
                 }
                 cx.notify();
             }))
+            .on_mouse_down(
+                MouseButton::Right,
+                cx.listener({
+                    let id = id.clone();
+                    move |this, event: &gpui::MouseDownEvent, window, cx| {
+                        cx.stop_propagation();
+                        this.commit_rename();
+                        this.ui.hover_card = None;
+                        this.ui.focus_cursor = Some(id.clone());
+                        this.focus_handle.focus(window, cx);
+                        this.ui.popover = Some(Popover::SessionActions {
+                            id: id.clone(),
+                            position: event.position,
+                        });
+                        cx.notify();
+                    }
+                }),
+            )
             .on_drag(
                 DraggedSidebarItem(DragItem::Session {
                     id: id.clone(),
@@ -3145,16 +3195,15 @@ impl Sidebar {
                         },
                         colors.secondary,
                     ))
-                    .when(hovered, |button| {
-                        button.on_click(cx.listener(move |this, _, _, cx| {
-                            cx.stop_propagation();
-                            this.store
-                                .write()
-                                .expect("session store lock poisoned")
-                                .revive_sessions(vec![revive_id.clone()]);
-                            cx.notify();
-                        }))
-                    }),
+                    .aria_label("Revive session")
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        cx.stop_propagation();
+                        this.store
+                            .write()
+                            .expect("session store lock poisoned")
+                            .revive_sessions(vec![revive_id.clone()]);
+                        cx.notify();
+                    })),
             )
             .child(
                 div()
@@ -5517,6 +5566,25 @@ impl Sidebar {
         if let Some(source) = dragged.session_id().cloned()
             && live
         {
+            let target_project = self
+                .store
+                .read()
+                .expect("session store lock poisoned")
+                .sessions()
+                .get(target)
+                .map(|session| session.project_id.clone());
+            if target_project
+                .as_ref()
+                .is_some_and(|project| self.revivable_drop(dragged, Some(project)).is_some())
+            {
+                self.store
+                    .write()
+                    .expect("session store lock poisoned")
+                    .revive_sessions(vec![source]);
+                self.finish_drag();
+                cx.notify();
+                return;
+            }
             let drop = drop.unwrap_or(if &source == target {
                 RowDrop::Origin
             } else {
@@ -5551,6 +5619,7 @@ impl Sidebar {
                         Err(refusal) => self.ui.delegation_notice = Some(refusal.0),
                     }
                 }
+                RowDrop::Revive => {} // The source or destination changed since feedback.
                 RowDrop::Refused(reason) => self.ui.delegation_notice = Some(reason),
             }
         }
@@ -5558,8 +5627,32 @@ impl Sidebar {
         cx.notify();
     }
 
+    /// A restore keeps the session's existing project and conversation identity.
+    fn revivable_drop(
+        &self,
+        dragged: &DraggedSidebarItem,
+        project: Option<&ProjectId>,
+    ) -> Option<SessionId> {
+        let id = dragged.session_id()?;
+        let store = self.store.read().expect("session store lock poisoned");
+        let session = store.sessions().get(id)?;
+        (session.is_archived() && project.is_none_or(|project| project == &session.project_id))
+            .then(|| id.clone())
+    }
+
     /// Release of a dragged session on the fan-out zone below the projects.
     fn finish_fan_out_drop(&mut self, dragged: &DraggedSidebarItem, cx: &mut Context<Self>) {
+        if self.ui.drag.is_some()
+            && let Some(id) = self.revivable_drop(dragged, None)
+        {
+            self.store
+                .write()
+                .expect("session store lock poisoned")
+                .revive_sessions(vec![id]);
+            self.finish_drag();
+            cx.notify();
+            return;
+        }
         if let Some(source_id) = dragged.session_id()
             && self.ui.drag.is_some()
         {
@@ -7924,6 +8017,132 @@ mod tests {
                 sidebar.ui.pending_sibling.is_some(),
             )
         })
+    }
+
+    fn archive_drag_source(sidebar: &Entity<Sidebar>, cx: &mut VisualTestContext) {
+        sidebar.update(cx, |sidebar, cx| {
+            let mut store = sidebar.store.write().expect("store");
+            let id = SessionId::new("preview-codex");
+            let project = store.sessions()[&id].project_id.clone();
+            store.archive_sessions(vec![id]);
+            if !store
+                .preferences()
+                .sidebar_expanded_archives
+                .contains(&project)
+            {
+                store
+                    .toggle_archive_expanded(project)
+                    .expect("expand archive");
+            }
+            cx.notify();
+        });
+    }
+
+    fn assert_drag_source_revived(sidebar: &Entity<Sidebar>, cx: &VisualTestContext) {
+        sidebar.read_with(cx, |sidebar, _| {
+            let store = sidebar.store.read().expect("store");
+            let id = SessionId::new("preview-codex");
+            assert!(!store.sessions()[&id].is_archived());
+            assert_eq!(store.selected_session_id(), Some(&id));
+        });
+    }
+
+    #[gpui::test]
+    fn archived_session_right_click_opens_revive_menu(cx: &mut TestAppContext) {
+        let (sidebar, _, cx) = drag_harness(cx);
+        archive_drag_source(&sidebar, cx);
+        let archived = row_bounds(&sidebar, cx, "preview-codex");
+        cx.simulate_mouse_down(archived.center(), MouseButton::Right, Modifiers::default());
+        sidebar.read_with(cx, |sidebar, _| {
+            assert!(
+                matches!(&sidebar.ui.popover, Some(Popover::SessionActions { id, .. })
+                if id == &SessionId::new("preview-codex"))
+            );
+        });
+        cx.simulate_mouse_up(archived.center(), MouseButton::Right, Modifiers::default());
+        let menu = cx.debug_bounds("sidebar-popover").expect("revive menu");
+        cx.simulate_click(
+            menu.origin + point(px(50.0), px(16.0)),
+            Modifiers::default(),
+        );
+        assert_drag_source_revived(&sidebar, cx);
+    }
+
+    #[gpui::test]
+    fn archived_session_icon_revives(cx: &mut TestAppContext) {
+        let (sidebar, _, cx) = drag_harness(cx);
+        archive_drag_source(&sidebar, cx);
+        let archived = row_bounds(&sidebar, cx, "preview-codex");
+        let icon = point(
+            archived.left() + px(Space::ROW_H + Space::INDENT + 8.0),
+            archived.center().y,
+        );
+        cx.simulate_click(icon, Modifiers::default());
+        assert_drag_source_revived(&sidebar, cx);
+    }
+
+    #[gpui::test]
+    fn archived_session_drop_on_active_row_revives(cx: &mut TestAppContext) {
+        let (sidebar, handoffs, cx) = drag_harness(cx);
+        archive_drag_source(&sidebar, cx);
+        let archived = row_bounds(&sidebar, cx, "preview-codex");
+        let target = row_bounds(&sidebar, cx, "preview-claude");
+        drag_and_release(cx, archived.center(), target.center());
+        assert_drag_source_revived(&sidebar, cx);
+        assert!(handoffs.borrow().is_empty());
+        assert_eq!(drag_state(&sidebar, cx), (false, None, false));
+    }
+
+    #[gpui::test]
+    fn archived_session_drop_on_project_header_revives(cx: &mut TestAppContext) {
+        let (sidebar, handoffs, cx) = drag_harness(cx);
+        archive_drag_source(&sidebar, cx);
+        let archived = row_bounds(&sidebar, cx, "preview-codex");
+        let project = cx
+            .debug_bounds("PROJECT_preview-dirijor")
+            .expect("project header");
+        drag_and_release(cx, archived.center(), project.center());
+        assert_drag_source_revived(&sidebar, cx);
+        assert!(handoffs.borrow().is_empty());
+    }
+
+    #[gpui::test]
+    fn archived_session_drop_in_empty_space_revives(cx: &mut TestAppContext) {
+        let (sidebar, handoffs, cx) = drag_harness(cx);
+        archive_drag_source(&sidebar, cx);
+        let archived = row_bounds(&sidebar, cx, "preview-codex");
+        drag_to(
+            cx,
+            archived.center(),
+            archived.center() + point(px(0.0), px(10.0)),
+        );
+        let target = cx
+            .debug_bounds("sidebar-fan-out-zone")
+            .expect("revive drop zone");
+        cx.simulate_mouse_move(target.center(), MouseButton::Left, Modifiers::default());
+        cx.simulate_mouse_up(target.center(), MouseButton::Left, Modifiers::default());
+        assert_drag_source_revived(&sidebar, cx);
+        assert!(handoffs.borrow().is_empty());
+        assert_eq!(drag_state(&sidebar, cx), (false, None, false));
+    }
+
+    #[gpui::test]
+    fn cancelled_archived_session_drag_does_not_revive(cx: &mut TestAppContext) {
+        let (sidebar, _, cx) = drag_harness(cx);
+        archive_drag_source(&sidebar, cx);
+        let archived = row_bounds(&sidebar, cx, "preview-codex");
+        let target = row_bounds(&sidebar, cx, "preview-claude");
+        drag_to(cx, archived.center(), target.center());
+        sidebar.update(cx, |sidebar, cx| {
+            sidebar.cancel_active_drag(cx);
+        });
+        cx.simulate_mouse_up(target.center(), MouseButton::Left, Modifiers::default());
+        sidebar.read_with(cx, |sidebar, _| {
+            assert!(
+                sidebar.store.read().expect("store").sessions()[&SessionId::new("preview-codex")]
+                    .is_archived()
+            );
+        });
     }
 
     #[gpui::test]

--- a/diri/crates/diri-engine/src/control.rs
+++ b/diri/crates/diri-engine/src/control.rs
@@ -1968,7 +1968,7 @@ impl ControlServer {
     fn session_resume(&self, params: Option<JsonValue>) -> Result<JsonValue, ControlError> {
         let p: diri_proto::SessionIdParams = decode(params)?;
         let record = {
-            let registry = self.registry.lock().map_err(poisoned)?;
+            let mut registry = self.registry.lock().map_err(poisoned)?;
             let record = registry
                 .records()
                 .into_iter()
@@ -1983,8 +1983,7 @@ impl ControlServer {
                 && !matches!(record.status, diri_proto::SessionStatus::Exited(_))
             {
                 // Genuinely live: resuming is a no-op, not an error.
-                return serde_json::to_value(&record)
-                    .map_err(|error| ControlError::internal(error.to_string()));
+                return self.restored_resume_result(&mut registry, &p.session_id.0);
             }
             record
         };
@@ -2021,8 +2020,7 @@ impl ControlServer {
         if registry.get(&p.session_id.0).is_some() {
             if !exited {
                 // Already live: resuming is a no-op, not an error.
-                return serde_json::to_value(&record)
-                    .map_err(|error| ControlError::internal(error.to_string()));
+                return self.restored_resume_result(&mut registry, &p.session_id.0);
             }
             // An agent that died on its own leaves its session behind: only an
             // explicit kill takes one out of the registry, so presence alone
@@ -2039,12 +2037,21 @@ impl ControlServer {
                 record.remote_persistence = Some(persistence);
             });
         }
+        self.restored_resume_result(&mut registry, &p.session_id.0)
+    }
+
+    fn restored_resume_result(
+        &self,
+        registry: &mut Registry,
+        id: &str,
+    ) -> Result<JsonValue, ControlError> {
+        // Resume is also the UI's revive action. Clear the durable archive
+        // only after launch succeeds, including an already-live session.
+        registry.unarchive(id).map_err(io_control_error)?;
         let _ = registry.persist();
-        self.publish_updated(&registry, &p.session_id.0);
+        self.publish_updated(registry, id);
         let record = registry
-            .records()
-            .into_iter()
-            .find(|record| record.id.0 == p.session_id.0)
+            .record(id)
             .ok_or_else(|| ControlError::internal("the resumed session vanished"))?;
         serde_json::to_value(&record).map_err(|error| ControlError::internal(error.to_string()))
     }
@@ -4288,6 +4295,53 @@ mod tests {
     /// with no way at all to restart it.
     #[test]
     fn resume_relaunches_a_session_whose_agent_died_on_its_own() {
+        check_resume_relaunches(false);
+    }
+
+    #[test]
+    fn revive_archived_session_clears_archive_durably() {
+        check_resume_relaunches(true);
+    }
+
+    #[test]
+    fn failed_revive_keeps_the_archived_conversation() {
+        let temp = tempfile::tempdir().expect("temp");
+        let registry = Arc::new(Mutex::new(Registry::new(
+            engine(),
+            temp.path().join("state.json"),
+        )));
+        let mut record = test_record("s_archived");
+        record.kind = diri_proto::AgentKind::new("missing-manifest");
+        record.agent_session_id = Some("saved-conversation".into());
+        registry.lock().expect("registry").insert_record(record);
+        let server = Arc::new(ControlServer::new(
+            Arc::clone(&registry),
+            temp.path().join("daemon.sock"),
+        ));
+        ok_of(call(
+            &server,
+            "session.archive",
+            Some(json!({ "sessionID": "s_archived" })),
+        ));
+        let error = err_of(call(
+            &server,
+            "session.resume",
+            Some(json!({ "sessionID": "s_archived" })),
+        ));
+        assert_eq!(error.code, "not_found");
+        let record = registry
+            .lock()
+            .expect("registry")
+            .record("s_archived")
+            .expect("saved record");
+        assert!(record.is_archived());
+        assert_eq!(
+            record.agent_session_id.as_deref(),
+            Some("saved-conversation")
+        );
+    }
+
+    fn check_resume_relaunches(archived: bool) {
         let temp = tempfile::tempdir().expect("temp");
         // A manifest that resumes by flag, onto a binary that outlives the
         // call: `sh -c 'read line'` blocks on the PTY instead of exiting.
@@ -4362,11 +4416,36 @@ mod tests {
             Arc::clone(&registry),
             temp.path().join("daemon.sock"),
         ));
+        if archived {
+            ok_of(call(
+                &server,
+                "session.archive",
+                Some(json!({ "sessionID": "s_dead" })),
+            ));
+        }
         let result = ok_of(call(
             &server,
             "session.resume",
             Some(json!({ "sessionID": "s_dead" })),
         ));
+        assert!(
+            result.get("archivedAt").is_none(),
+            "revive must leave the archive"
+        );
+        let persisted: JsonValue = serde_json::from_slice(
+            &std::fs::read(temp.path().join("state.json")).expect("persisted state"),
+        )
+        .expect("state JSON");
+        let saved = persisted["sessions"]
+            .as_array()
+            .expect("sessions")
+            .iter()
+            .find(|record| record["id"] == "s_dead")
+            .expect("saved session");
+        assert!(
+            saved.get("archivedAt").is_none(),
+            "revive must survive a resync/restart"
+        );
 
         assert!(
             result["status"].get("exited").is_none(),
@@ -4381,6 +4460,33 @@ mod tests {
                 .is_some_and(|session| !session.view().exited),
             "the resumed session must be a live one"
         );
+        if archived {
+            let pid = {
+                let mut registry = registry.lock().expect("registry");
+                // Older revive attempts could leave a live process archived.
+                registry.update_record("s_dead", |record| {
+                    record.archived_at = Some(diri_proto::DateMillis(42.0));
+                });
+                registry.get("s_dead").expect("live session").child_pid()
+            };
+            let restored = ok_of(call(
+                &server,
+                "session.resume",
+                Some(json!({ "sessionID": "s_dead" })),
+            ));
+            assert!(restored.get("archivedAt").is_none());
+            assert_eq!(restored["agentSessionID"], "conv-1");
+            assert_eq!(
+                registry
+                    .lock()
+                    .expect("registry")
+                    .get("s_dead")
+                    .expect("live session")
+                    .child_pid(),
+                pid,
+                "reviving an already-live archived session must not relaunch it"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Reviving an archived conversation restarted its agent but left the engine's durable `archivedAt` flag set. The next session update put it back in the archive, making Revive appear to do nothing. Archived rows also lacked the right-click handler, and their drag targets had no restore action.

Successful resume now clears and persists the archive flag before publishing the session, including when an earlier attempt already left the agent running. Failed resumes retain the archived conversation. Archived rows expose the existing Revive context menu and accept revival through the icon, their project header, active rows in the same project, or the empty sidebar drop zone. Cancelled drags remain inert.

Validation:
- Reproduced the engine failure with a regression test before the fix.
- GPUI mouse tests cover the icon, right-click menu, three drop targets, and drag cancellation.
- Engine tests cover durable restoration, preserving an already-live PID and conversation ID, and failed revival.
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (1,411 passed, 27 ignored); final added icon and failure regressions also pass.
- `cargo build --workspace --release`
