### PR TITLE
Prevent premature Claude completion notifications

### DIFF
--- a/diri/crates/diri-engine/manifests/claude-code.json
+++ b/diri/crates/diri-engine/manifests/claude-code.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "id": "claude-code",
-  "version": "2026.08.15.1",
+  "version": "2026.09.07.1",
   "statusModel": "full",
   "agent": {
     "id": "claude-code",
@@ -190,7 +190,44 @@
       "priority": 900,
       "region": "osc_title",
       "when": {
-        "regex": "^[\u2800-\u28ff]"
+        "regex": "^[\u2800-\u28ff\u25d0-\u25d3]"
+      }
+    },
+    {
+      "id": "working-live-turn",
+      "state": "working",
+      "priority": 890,
+      "region": "bottom_non_empty_lines",
+      "regionLines": 12,
+      "when": {
+        "any": [
+          {
+            "lineRegex": "^\\s*[\u23f8\u23f5].*esc to interrupt(?:\\s|\u00b7|$)"
+          },
+          {
+            "lineRegex": "^\\s*[*\u00b7\u2722\u2736\u273b\u273d]\\s+\\S.*\u2026(?:\\s+\\(\\d+[smh](?:\\s|\u00b7)|\\s*$)"
+          }
+        ]
+      }
+    },
+    {
+      "id": "working-background-agents",
+      "state": "working",
+      "priority": 880,
+      "region": "bottom_non_empty_lines",
+      "regionLines": 12,
+      "when": {
+        "lineRegex": "^\\s*[*\u00b7\u2722\u2736\u273b\u273d]\\s+Waiting for [1-9]\\d* background agents? to finish\\s*$"
+      }
+    },
+    {
+      "id": "working-background-mcp",
+      "state": "working",
+      "priority": 880,
+      "region": "bottom_non_empty_lines",
+      "regionLines": 12,
+      "when": {
+        "regex": "(?m)^[*\u00b7\u2722\u2736\u273b\u273d][ \\t]+\\S[^\\n]*?(?:\\n[ \\t]+[^\\n]*?){0,3}\u00b7(?:[ \\t]+|\\n[ \\t]*)[1-9]\\d*(?:[ \\t]+|\\n[ \\t]*)MCP(?:[ \\t]+|\\n[ \\t]*)tasks?(?:[ \\t]+|\\n[ \\t]*)still(?:[ \\t]+|\\n[ \\t]*)running[ \\t]*$"
       }
     },
     {

--- a/diri/crates/diri-engine/src/detect/mod.rs
+++ b/diri/crates/diri-engine/src/detect/mod.rs
@@ -268,6 +268,71 @@ mod tests {
         engine
     }
 
+    #[test]
+    fn claude_live_work_outranks_its_visible_input_box() {
+        let engine = engine();
+        for (title, activity) in [
+            ("◐ Working", ""),
+            ("◑ Working", ""),
+            ("◒ Working", ""),
+            ("◓ Working", ""),
+            ("✳ Project", "⏵ processing · esc to interrupt"),
+            ("✳ Project", "✻ Thinking… (12s · ↓ 100 tokens)"),
+            ("✳ Project", "✻ Waiting for 2 background agents to finish"),
+            ("✳ Project", "✻ Working… · 2 MCP tasks still running"),
+        ] {
+            let snapshot = ScreenSnapshot {
+                lines: vec![
+                    activity.into(),
+                    "──────────".into(),
+                    "❯".into(),
+                    "──────────".into(),
+                ],
+                osc_title: Some(title.into()),
+                ..Default::default()
+            };
+            let observation = engine
+                .evaluate(&snapshot, "claude-code")
+                .expect("Claude rule");
+            assert_eq!(
+                observation.state,
+                ManifestState::Working,
+                "title={title}, activity={activity}"
+            );
+        }
+    }
+
+    #[test]
+    fn claude_work_indicators_do_not_hide_blockers_or_match_user_prompt_text() {
+        let engine = engine();
+        let mut blocked = ScreenSnapshot::from_lines([
+            "✻ Working… · 2 MCP tasks still running",
+            "Do you want to proceed?",
+            "❯ 1. Yes",
+            "2. No",
+            "esc to cancel",
+        ]);
+        blocked.osc_title = Some("◐ Working".into());
+        assert_eq!(
+            engine.evaluate(&blocked, "claude-code").unwrap().state,
+            ManifestState::BlockedPermission
+        );
+        for text in [
+            "❯ ✻ Waiting for 2 background agents to finish",
+            "❯ ✻ Working… · 2 MCP tasks still running",
+            "❯ ⏵ processing · esc to interrupt",
+            "1 background shell · ↓ to view",
+        ] {
+            let mut idle = ScreenSnapshot::from_lines([text]);
+            idle.osc_title = Some("✳ Project".into());
+            assert_eq!(
+                engine.evaluate(&idle, "claude-code").unwrap().state,
+                ManifestState::Idle,
+                "{text}"
+            );
+        }
+    }
+
     /// Every manifest decoding is also the proof that every pattern in them
     /// compiles under the `regex` crate — the one real risk in moving off ICU,
     /// since `regex` has no backreferences or lookaround. A pattern that needed
@@ -332,7 +397,7 @@ mod tests {
             .into_iter()
             .map(|id| engine.manifest(id).expect("manifest").rules.len())
             .sum();
-        assert_eq!(rules, 99, "the shipped ruleset lost rules");
+        assert_eq!(rules, 102, "the shipped ruleset lost rules");
 
         for id in engine.ids() {
             let expected_empty = matches!(id, "shell" | "generic" | "pi");

--- a/diri/crates/diri-engine/src/hooks.rs
+++ b/diri/crates/diri-engine/src/hooks.rs
@@ -29,6 +29,16 @@ pub fn parse_claude_hook(
     payload: &Value,
     now: std::time::SystemTime,
 ) -> Option<(StatusSignal, HookMetadata)> {
+    // A stale hook configuration must not route a child lifecycle callback
+    // through the parent's Stop command. Payloads without the discriminator
+    // retain compatibility with older agents.
+    if payload
+        .get("hook_event_name")
+        .and_then(Value::as_str)
+        .is_some_and(|reported| reported != event)
+    {
+        return None;
+    }
     let mut meta = HookMetadata::default();
     let is_subagent = string(payload, "agent_id").is_some();
 
@@ -105,7 +115,14 @@ pub fn parse_claude_hook(
         _ => return None,
     };
 
-    Some((StatusSignal::ClaudeHook { hook, is_subagent }, meta))
+    Some((
+        StatusSignal::ClaudeHook {
+            hook,
+            is_subagent,
+            pending_work: diri_proto::recovery::claude_pending_work(payload),
+        },
+        meta,
+    ))
 }
 
 /// Parses a Codex notify payload. Only turn-completion is meaningful.
@@ -164,7 +181,13 @@ pub fn parse_activity_seed(
     }
     let payload = Value::Object(payload);
     match seed.kind.as_str() {
-        "claude-hook" => parse_claude_hook(seed.event.as_deref()?, &payload, now),
+        "claude-hook" => {
+            let (mut signal, metadata) = parse_claude_hook(seed.event.as_deref()?, &payload, now)?;
+            if let StatusSignal::ClaudeHook { pending_work, .. } = &mut signal {
+                *pending_work = seed.claude_pending_work;
+            }
+            Some((signal, metadata))
+        }
         "codex-notify" => {
             let mut payload = payload.as_object().cloned().unwrap_or_default();
             payload.insert("type".into(), Value::String("agent-turn-complete".into()));
@@ -259,6 +282,116 @@ mod tests {
 
     fn now() -> std::time::SystemTime {
         std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000)
+    }
+
+    #[test]
+    fn claude_background_work_suppresses_completion_until_a_drained_stop() {
+        use crate::status::{Authority, StatusReducer};
+        use diri_proto::SessionStatus;
+        use std::time::Duration;
+
+        for pending in [
+            json!({"background_tasks": [{"status": "running"}]}),
+            json!({"session_crons": [{"id": "wake-later"}]}),
+        ] {
+            let mut reducer = StatusReducer::new(Authority::HooksPrimary, now());
+            let (start, _) = parse_claude_hook("UserPromptSubmit", &json!({}), now()).unwrap();
+            reducer.reduce(start, now());
+            for (seconds, event, payload) in [
+                (1, "Stop", pending.clone()),
+                (2, "Stop", pending),
+                (
+                    3,
+                    "Notification",
+                    json!({"notification_type": "agent_completed"}),
+                ),
+                (
+                    30,
+                    "Notification",
+                    json!({"notification_type": "idle_prompt"}),
+                ),
+            ] {
+                let at = now() + Duration::from_secs(seconds);
+                let (signal, _) = parse_claude_hook(event, &payload, at).unwrap();
+                assert!(!reducer.reduce(signal, at).turn_completed);
+                assert!(!reducer.reduce(StatusSignal::Tick, at).turn_completed);
+                assert_eq!(reducer.status(), &SessionStatus::Working);
+            }
+            let at = now() + Duration::from_secs(31);
+            let (stop, _) = parse_claude_hook(
+                "Stop",
+                &json!({"background_tasks": [], "session_crons": []}),
+                at,
+            )
+            .unwrap();
+            let first = reducer.reduce(stop.clone(), at);
+            let settled = reducer.reduce(StatusSignal::Tick, at);
+            assert_eq!(
+                usize::from(first.turn_completed) + usize::from(settled.turn_completed),
+                1
+            );
+            assert!(!reducer.reduce(stop, at).turn_completed);
+        }
+    }
+
+    #[test]
+    fn claude_pending_work_keeps_permission_alerts_and_ignores_child_stops() {
+        use crate::status::{Authority, StatusReducer};
+        use diri_proto::SessionStatus;
+        let mut reducer = StatusReducer::new(Authority::HooksPrimary, now());
+        for (event, payload) in [
+            ("UserPromptSubmit", json!({})),
+            ("Stop", json!({"background_tasks": [{"status": "running"}]})),
+            (
+                "Notification",
+                json!({"notification_type": "permission_prompt", "message": "Approve this command"}),
+            ),
+        ] {
+            let (signal, _) = parse_claude_hook(event, &payload, now()).unwrap();
+            assert!(!reducer.reduce(signal, now()).turn_completed);
+        }
+        assert_eq!(
+            reducer.status(),
+            &SessionStatus::NeedsInput(NeedsInputKind::Permission)
+        );
+        for payload in [
+            json!({"agent_id": "child", "background_tasks": []}),
+            json!({"hook_event_name": "SubagentStop"}),
+        ] {
+            if let Some((signal, _)) = parse_claude_hook("Stop", &payload, now()) {
+                assert!(!reducer.reduce(signal, now()).turn_completed);
+            }
+            assert_eq!(
+                reducer.status(),
+                &SessionStatus::NeedsInput(NeedsInputKind::Permission)
+            );
+        }
+        let (reminder, _) = parse_claude_hook("Notification", &json!({"notification_type": "idle_prompt", "background_tasks": [{"status": "running"}]}), now()).unwrap();
+        reducer.reduce(reminder, now());
+        assert_eq!(
+            reducer.status(),
+            &SessionStatus::NeedsInput(NeedsInputKind::Permission)
+        );
+    }
+
+    #[test]
+    fn claude_old_and_drained_payloads_still_complete_once() {
+        use crate::status::{Authority, StatusReducer};
+        use diri_proto::SessionStatus;
+        for payload in [
+            json!({}),
+            json!({"background_tasks": [], "session_crons": []}),
+            json!({"background_tasks": [{"status": "completed"}, {"status": "failed"}, {"status": "cancelled"}]}),
+        ] {
+            let mut reducer = StatusReducer::new(Authority::HooksPrimary, now());
+            let (start, _) = parse_claude_hook("UserPromptSubmit", &json!({}), now()).unwrap();
+            reducer.reduce(start, now());
+            let (stop, _) = parse_claude_hook("Stop", &payload, now()).unwrap();
+            reducer.reduce(stop.clone(), now());
+            assert!(reducer.reduce(StatusSignal::Tick, now()).turn_completed);
+            assert!(!reducer.reduce(stop, now()).turn_completed);
+            assert_eq!(reducer.status(), &SessionStatus::Idle);
+        }
     }
 
     #[test]
@@ -417,6 +550,7 @@ mod tests {
     #[test]
     fn a_durable_seed_rehydrates_lifecycle_and_safe_identity() {
         let seed = diri_proto::recovery::HookActivitySeed {
+            claude_pending_work: None,
             version: diri_proto::recovery::HookActivitySeed::VERSION,
             kind: "claude-hook".into(),
             event: Some("PermissionRequest".into()),

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -1645,7 +1645,11 @@ impl Session {
     }
 
     pub fn claude_hook(&self, hook: ClaudeHook, is_subagent: bool) -> ReducerOutcome {
-        self.feed_signal(StatusSignal::ClaudeHook { hook, is_subagent })
+        self.feed_signal(StatusSignal::ClaudeHook {
+            hook,
+            is_subagent,
+            pending_work: None,
+        })
     }
 
     /// Ends the session, killing the child's whole tree.

--- a/diri/crates/diri-engine/src/status/mod.rs
+++ b/diri/crates/diri-engine/src/status/mod.rs
@@ -44,7 +44,6 @@ pub struct ReducerTiming {
     pub recheck_interval: Duration,
     pub idle_confirm_cap: Duration,
     pub startup_grace: Duration,
-    pub hook_authority_window: Duration,
     pub blocker_clear_scans: u32,
     pub staleness_timeout: Duration,
 }
@@ -56,7 +55,6 @@ impl Default for ReducerTiming {
             recheck_interval: Duration::from_millis(100),
             idle_confirm_cap: Duration::from_millis(700),
             startup_grace: Duration::from_secs(3),
-            hook_authority_window: Duration::from_secs(7),
             blocker_clear_scans: 2,
             staleness_timeout: Duration::from_secs(60),
         }
@@ -143,7 +141,10 @@ struct InternalState {
     idle_strong: bool,
     /// Fire `turn_completed` exactly once on the next committed working→idle.
     pending_turn_completed: bool,
-    last_work_hook_at: Option<SystemTime>,
+    /// A parent work hook owns its turn until a strong completion signal.
+    /// Tool calls and thinking have no time limit; an idle-looking input box
+    /// must not expire hook authority and announce completion mid-turn.
+    hook_turn_in_flight: bool,
 
     // On-screen blocker tracking.
     screen_blocker_active: bool,
@@ -177,7 +178,7 @@ impl InternalState {
             idle_confirms: 0,
             idle_strong: false,
             pending_turn_completed: false,
-            last_work_hook_at: None,
+            hook_turn_in_flight: false,
             screen_blocker_active: false,
             blocker_miss_scans: 0,
             screen_belief: None,
@@ -513,7 +514,7 @@ impl StatusReducer {
         }
         self.state.turn_in_flight = true;
         if clear_screen_blocker {
-            self.state.last_work_hook_at = Some(now);
+            self.state.hook_turn_in_flight = true;
         }
         self.state.last_signal_at = now;
         self.set_status(SessionStatus::Working, outcome);
@@ -552,7 +553,11 @@ impl StatusReducer {
 
     /// Register one idle-confirming observation.
     fn confirm_idle(&mut self, now: SystemTime, outcome: &mut ReducerOutcome) {
-        if self.status != SessionStatus::Working {
+        if self.status != SessionStatus::Working
+            || (self.authority == Authority::HooksPrimary
+                && self.state.hook_turn_in_flight
+                && !self.state.idle_strong)
+        {
             return;
         }
         if self.state.idle_candidate_since.is_none() {
@@ -582,6 +587,7 @@ impl StatusReducer {
         let fire = self.state.pending_turn_completed;
         self.set_status(SessionStatus::Idle, outcome);
         self.state.turn_in_flight = false;
+        self.state.hook_turn_in_flight = false;
         if fire {
             outcome.turn_completed = true;
         }
@@ -793,22 +799,18 @@ impl StatusReducer {
             }
             ManifestState::Idle => {
                 if self.status == SessionStatus::Working {
-                    if self.authority == Authority::HooksPrimary
-                        && !self.state.idle_strong
-                        && self.state.last_work_hook_at.is_some_and(|last| {
-                            now.duration_since(last).unwrap_or_default()
-                                < self.timing.hook_authority_window
-                        })
-                    {
-                        return;
-                    }
                     self.confirm_idle(now, outcome);
                 } else if self.status == SessionStatus::Starting {
                     self.set_status(SessionStatus::Idle, outcome);
                 } else if cleared_blocker && matches!(self.status, SessionStatus::NeedsInput(_)) {
-                    // The blocker was released and the screen now reads idle.
-                    self.cancel_idle_candidacy();
-                    self.set_status(SessionStatus::Idle, outcome);
+                    if self.authority == Authority::HooksPrimary && self.state.hook_turn_in_flight {
+                        // Dismissing a permission/question does not finish the
+                        // turn whose tool call was waiting for that answer.
+                        self.go_working(now, false, outcome);
+                    } else {
+                        self.cancel_idle_candidacy();
+                        self.set_status(SessionStatus::Idle, outcome);
+                    }
                 }
             }
             // Handled elsewhere.
@@ -855,16 +857,6 @@ impl StatusReducer {
                 self.set_status(SessionStatus::Unknown, outcome);
                 return;
             }
-        }
-        if self.status == SessionStatus::Working
-            && self.authority == Authority::HooksPrimary
-            && self.state.screen_belief == Some(ManifestState::Idle)
-            && self.state.idle_candidate_since.is_none()
-            && self.state.last_work_hook_at.is_some_and(|last| {
-                now.duration_since(last).unwrap_or_default() >= self.timing.hook_authority_window
-            })
-        {
-            self.confirm_idle(now, outcome);
         }
         // A settled screen often stops emitting new content sequences. One
         // idle observation held for the debounce cap is enough; requiring

--- a/diri/crates/diri-engine/src/status/mod.rs
+++ b/diri/crates/diri-engine/src/status/mod.rs
@@ -89,6 +89,8 @@ pub enum StatusSignal {
     ClaudeHook {
         hook: ClaudeHook,
         is_subagent: bool,
+        /// Optional aggregate from the payload or the durable recovery seed.
+        pending_work: Option<bool>,
     },
     CodexTurnComplete,
     /// Cursor jsonl tail: last object is a user prompt or `tool_use`.
@@ -145,6 +147,8 @@ struct InternalState {
     /// Tool calls and thinking have no time limit; an idle-looking input box
     /// must not expire hook authority and announce completion mid-turn.
     hook_turn_in_flight: bool,
+    /// Retained across idle reminders, which omit background task metadata.
+    claude_pending_work: bool,
 
     // On-screen blocker tracking.
     screen_blocker_active: bool,
@@ -179,6 +183,7 @@ impl InternalState {
             idle_strong: false,
             pending_turn_completed: false,
             hook_turn_in_flight: false,
+            claude_pending_work: false,
             screen_blocker_active: false,
             blocker_miss_scans: 0,
             screen_belief: None,
@@ -342,9 +347,11 @@ impl StatusReducer {
                     self.state.responding_since = Some(now);
                 }
             }
-            StatusSignal::ClaudeHook { hook, is_subagent } => {
-                self.handle_claude_hook(hook, is_subagent, now, &mut outcome)
-            }
+            StatusSignal::ClaudeHook {
+                hook,
+                is_subagent,
+                pending_work,
+            } => self.handle_claude_hook(hook, is_subagent, pending_work, now, &mut outcome),
             StatusSignal::CodexTurnComplete => {
                 self.state.last_signal_at = now;
                 self.handle_strong_idle(now, &mut outcome);
@@ -601,6 +608,7 @@ impl StatusReducer {
         &mut self,
         hook: ClaudeHook,
         is_subagent: bool,
+        pending_work: Option<bool>,
         now: SystemTime,
         outcome: &mut ReducerOutcome,
     ) {
@@ -622,6 +630,9 @@ impl StatusReducer {
         // state must not move because a child of it did something.
         if is_subagent {
             return;
+        }
+        if let Some(pending) = pending_work {
+            self.state.claude_pending_work = pending;
         }
 
         match hook {
@@ -652,11 +663,30 @@ impl StatusReducer {
             ClaudeHook::Notification {
                 notification_type,
                 message,
-            } => self.handle_notification(notification_type, message, now, outcome),
-            ClaudeHook::Stop => self.handle_strong_idle(now, outcome),
+            } => self.handle_notification(notification_type, message, pending_work, now, outcome),
+            ClaudeHook::Stop => {
+                self.handle_claude_completion(pending_work.unwrap_or(false), now, outcome)
+            }
             // A hint only.
             ClaudeHook::SessionEnd => {}
             ClaudeHook::SubagentStart(_) | ClaudeHook::SubagentStop(_) => {}
+        }
+    }
+
+    fn handle_claude_completion(
+        &mut self,
+        pending_work: bool,
+        now: SystemTime,
+        outcome: &mut ReducerOutcome,
+    ) {
+        self.state.claude_pending_work = pending_work;
+        if pending_work {
+            // The foreground response ended, but Claude still has live work.
+            // Keep screen idle and subsequent metadata-free reminders from
+            // announcing completion until a fresh completion says it drained.
+            self.go_working(now, true, outcome);
+        } else {
+            self.handle_strong_idle(now, outcome);
         }
     }
 
@@ -664,6 +694,7 @@ impl StatusReducer {
         &mut self,
         notification_type: Option<String>,
         message: Option<String>,
+        pending_work: Option<bool>,
         now: SystemTime,
         outcome: &mut ReducerOutcome,
     ) {
@@ -690,7 +721,16 @@ impl StatusReducer {
             }
             // An idle reminder is not a question or an approval request.
             // It must not overwrite a completed turn or an actual blocker.
-            Some("idle_prompt") => {}
+            Some("idle_prompt") => {
+                if pending_work == Some(true)
+                    && !matches!(self.status, SessionStatus::NeedsInput(_))
+                {
+                    // A recovered reminder can be the first signal after a
+                    // daemon restart. Its retained work fact still outranks
+                    // the word "idle", without dismissing a live blocker.
+                    self.handle_claude_completion(true, now, outcome);
+                }
+            }
             Some("agent_needs_input") | Some("elicitation_dialog") => {
                 let text = message.unwrap_or_else(|| "Waiting for input".into());
                 let detail = NeedsInputDetail {
@@ -708,7 +748,11 @@ impl StatusReducer {
                 self.cancel_idle_candidacy();
                 self.set_status(SessionStatus::NeedsInput(NeedsInputKind::Question), outcome);
             }
-            Some("agent_completed") => self.handle_strong_idle(now, outcome),
+            Some("agent_completed") => self.handle_claude_completion(
+                pending_work.unwrap_or(self.state.claude_pending_work),
+                now,
+                outcome,
+            ),
             _ => {}
         }
     }

--- a/diri/crates/diri-engine/src/status/tests.rs
+++ b/diri/crates/diri-engine/src/status/tests.rs
@@ -139,6 +139,7 @@ fn hook(hook: ClaudeHook) -> StatusSignal {
     StatusSignal::ClaudeHook {
         hook,
         is_subagent: false,
+        pending_work: None,
     }
 }
 
@@ -382,6 +383,7 @@ fn subagent_events_never_move_the_parent() {
         StatusSignal::ClaudeHook {
             hook: ClaudeHook::Stop,
             is_subagent: true,
+            pending_work: None,
         },
         now + Duration::from_millis(100),
     );

--- a/diri/crates/diri-engine/src/status/tests.rs
+++ b/diri/crates/diri-engine/src/status/tests.rs
@@ -794,3 +794,101 @@ fn a_recent_work_hook_outranks_an_idle_prompt_during_a_tool_call() {
             .turn_completed
     );
 }
+
+#[test]
+fn claude_long_tool_calls_do_not_publish_finished_between_tools() {
+    let mut reducer = StatusReducer::new(Authority::HooksPrimary, t0());
+    let mut now = settled(&mut reducer, t0());
+    reducer.reduce(hook(ClaudeHook::UserPromptSubmit), now);
+    let mut completions = 0;
+    for seq in 1..=3 {
+        reducer.reduce(hook(ClaudeHook::PreToolUse), now);
+        // Claude's input box can remain visible throughout a long tool call.
+        reducer.reduce(
+            StatusSignal::Screen(observation(ManifestState::Idle, seq)),
+            now + Duration::from_millis(100),
+        );
+        for seconds in 1..=30 {
+            let outcome = reducer.reduce(StatusSignal::Tick, now + Duration::from_secs(seconds));
+            completions += usize::from(outcome.turn_completed);
+        }
+        now += Duration::from_secs(30);
+    }
+    assert_eq!(
+        completions, 0,
+        "active Claude tools must not emit finished notifications"
+    );
+    assert_eq!(reducer.status(), &SessionStatus::Working);
+    assert!(reducer.reduce(hook(ClaudeHook::Stop), now).turn_completed);
+    assert!(!reducer.reduce(hook(ClaudeHook::Stop), now).turn_completed);
+}
+
+#[test]
+fn claude_idle_redraws_and_subagent_completion_do_not_finish_the_parent_turn() {
+    let mut reducer = StatusReducer::new(Authority::HooksPrimary, t0());
+    let now = settled(&mut reducer, t0());
+    reducer.reduce(hook(ClaudeHook::UserPromptSubmit), now);
+    reducer.reduce(hook(ClaudeHook::SubagentStart("child".into())), now);
+    for seq in 1..=120 {
+        let at = now + Duration::from_secs(seq);
+        if seq == 30 {
+            reducer.reduce(hook(ClaudeHook::SubagentStop("child".into())), at);
+        }
+        let frame = reducer.reduce(
+            StatusSignal::Screen(observation(ManifestState::Idle, seq)),
+            at,
+        );
+        let tick = reducer.reduce(StatusSignal::Tick, at);
+        assert!(!frame.turn_completed && !tick.turn_completed);
+        assert_eq!(reducer.status(), &SessionStatus::Working);
+    }
+    assert!(
+        reducer
+            .reduce(hook(ClaudeHook::Stop), now + Duration::from_secs(121))
+            .turn_completed
+    );
+}
+
+#[test]
+fn claude_screen_fallback_still_completes_when_no_work_hook_was_received() {
+    let mut reducer = StatusReducer::new(Authority::HooksPrimary, t0());
+    let now = settled(&mut reducer, t0());
+    // Remote/adopted sessions may only have terminal observations.
+    reducer.reduce(
+        StatusSignal::Screen(observation(ManifestState::Working, 1)),
+        now,
+    );
+    reducer.reduce(
+        StatusSignal::Screen(observation(ManifestState::Idle, 2)),
+        now,
+    );
+    let completed = reducer.reduce(StatusSignal::Tick, now + Duration::from_secs(1));
+    assert!(completed.turn_completed);
+    assert_eq!(reducer.status(), &SessionStatus::Idle);
+    assert!(
+        !reducer
+            .reduce(StatusSignal::Tick, now + Duration::from_secs(2))
+            .turn_completed
+    );
+}
+
+#[test]
+fn claude_answering_a_screen_blocker_resumes_the_hook_owned_turn() {
+    let mut reducer = StatusReducer::new(Authority::HooksPrimary, t0());
+    let now = settled(&mut reducer, t0());
+    reducer.reduce(hook(ClaudeHook::UserPromptSubmit), now);
+    reducer.reduce(StatusSignal::Screen(blocker(1, "Allow tool?")), now);
+    for seq in 2..=4 {
+        let outcome = reducer.reduce(
+            StatusSignal::Screen(observation(ManifestState::Idle, seq)),
+            now + Duration::from_secs(seq * 10),
+        );
+        assert!(!outcome.turn_completed);
+    }
+    assert_eq!(reducer.status(), &SessionStatus::Working);
+    assert!(
+        reducer
+            .reduce(hook(ClaudeHook::Stop), now + Duration::from_secs(41))
+            .turn_completed
+    );
+}

--- a/diri/crates/diri-engine/tests/holder_session.rs
+++ b/diri/crates/diri-engine/tests/holder_session.rs
@@ -227,6 +227,7 @@ fn a_capsule_and_hook_seed_recover_a_holder_when_global_state_is_gone() {
         .expect("capsule");
     store
         .write_activity(&diri_proto::recovery::HookActivitySeed {
+            claude_pending_work: None,
             version: diri_proto::recovery::HookActivitySeed::VERSION,
             kind: "claude-hook".into(),
             event: Some("Stop".into()),

--- a/diri/crates/diri-proto/src/recovery.rs
+++ b/diri/crates/diri-proto/src/recovery.rs
@@ -69,10 +69,35 @@ pub struct HookActivitySeed {
     pub notification_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_name: Option<String>,
+    /// Aggregate lifecycle fact only; never persist task payloads or cron prompts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_pending_work: Option<bool>,
 }
 
 impl HookActivitySeed {
     pub const VERSION: u32 = 1;
+}
+
+/// Extract the same bounded fact for live hooks and the CLI's durable seed.
+/// Older Claude payloads omit both fields. Notifications can also omit them,
+/// in which case callers retain the last known fact instead of clearing it.
+/// A present field with an invalid shape is conservatively treated as pending.
+pub fn claude_pending_work(payload: &serde_json::Value) -> Option<bool> {
+    let tasks = payload.get("background_tasks");
+    let crons = payload.get("session_crons");
+    if tasks.is_none() && crons.is_none() {
+        return None;
+    }
+    let tasks_pending = tasks.is_some_and(|value| {
+        value.as_array().is_none_or(|tasks| {
+            tasks.iter().any(|task| {
+                task.get("status").and_then(serde_json::Value::as_str) == Some("running")
+            })
+        })
+    });
+    let crons_pending =
+        crons.is_some_and(|value| value.as_array().is_none_or(|crons| !crons.is_empty()));
+    Some(tasks_pending || crons_pending)
 }
 
 /// Filesystem adapter for one session's recovery directory.
@@ -207,6 +232,7 @@ mod tests {
         let directory = tempfile::tempdir().expect("temporary directory");
         let store = SessionRecoveryStore::new(directory.path().join("s_one"));
         let seed = HookActivitySeed {
+            claude_pending_work: None,
             version: HookActivitySeed::VERSION,
             kind: "claude-hook".into(),
             event: Some("Stop".into()),
@@ -225,6 +251,15 @@ mod tests {
 
         assert_eq!(store.read_capsule().expect("read"), Some(updated));
         assert_eq!(store.read_activity().expect("read"), Some(seed));
+    }
+
+    #[test]
+    fn old_activity_seeds_load_without_a_background_work_fact() {
+        let seed: HookActivitySeed = serde_json::from_value(serde_json::json!({
+            "version": 1, "kind": "claude-hook", "event": "Stop", "occurredAtMs": 99,
+        }))
+        .expect("version-one seed");
+        assert_eq!(seed.claude_pending_work, None);
     }
 
     #[test]

--- a/diri/crates/dirijor-mcp/src/bin/dirijor.rs
+++ b/diri/crates/dirijor-mcp/src/bin/dirijor.rs
@@ -206,6 +206,17 @@ fn notify(arguments: &[String]) -> Result<(), CliError> {
 /// Records only lifecycle and identity fields before attempting delivery.
 /// Raw prompts, tool inputs, and notification messages never enter this file.
 fn persist_hook_activity(kind: &str, event: Option<&str>, payload: &Value) {
+    if kind == "claude-hook"
+        && (payload.get("agent_id").and_then(Value::as_str).is_some()
+            || matches!(event, Some("SubagentStart" | "SubagentStop"))
+            || payload
+                .get("hook_event_name")
+                .and_then(Value::as_str)
+                .is_some_and(|reported| Some(reported) != event))
+    {
+        // A child's activity must not replace the parent's recovery signal.
+        return;
+    }
     let Some(directory) = std::env::var_os(diri_proto::paths::ENV_SESSION_RECOVERY_DIR)
         .map(PathBuf::from)
         .filter(|path| path.is_absolute())
@@ -225,6 +236,24 @@ fn persist_hook_activity(kind: &str, event: Option<&str>, payload: &Value) {
             .filter(|value| !value.is_empty())
             .map(str::to_owned)
     };
+    let store = diri_proto::recovery::SessionRecoveryStore::new(directory);
+    let claude_pending_work = if kind == "claude-hook" {
+        diri_proto::recovery::claude_pending_work(payload).or_else(|| {
+            if event == Some("Stop") {
+                return Some(false);
+            }
+            store
+                .read_activity()
+                .ok()
+                .flatten()
+                .filter(|previous| {
+                    previous.kind == kind && previous.agent_session_id == string("session_id")
+                })
+                .and_then(|previous| previous.claude_pending_work)
+        })
+    } else {
+        None
+    };
     let seed = diri_proto::recovery::HookActivitySeed {
         version: diri_proto::recovery::HookActivitySeed::VERSION,
         kind: kind.to_owned(),
@@ -238,10 +267,11 @@ fn persist_hook_activity(kind: &str, event: Option<&str>, payload: &Value) {
         transcript_path: string("transcript_path"),
         notification_type: string("notification_type"),
         tool_name: string("tool_name"),
+        claude_pending_work,
     };
     // Hook contracts are fail-open. A read-only disk or interrupted rename
     // must not prevent the provider from completing its own callback.
-    let _ = diri_proto::recovery::SessionRecoveryStore::new(directory).write_activity(&seed);
+    let _ = store.write_activity(&seed);
 }
 
 fn mcp_stdio() -> Result<(), CliError> {

--- a/diri/crates/dirijor-mcp/tests/hook_recovery.rs
+++ b/diri/crates/dirijor-mcp/tests/hook_recovery.rs
@@ -5,6 +5,129 @@ use std::process::{Command, Stdio};
 
 use diri_proto::recovery::{HookActivitySeed, SessionRecoveryStore};
 
+fn run_hook(directory: &std::path::Path, event: &str, payload: serde_json::Value) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_dirijor"))
+        .args(["hook", event])
+        .env("DIRIJOR_SESSION_ID", "s_hook")
+        .env("DIRIJOR_SESSION_RECOVERY_DIR", directory)
+        .env("DIRIJOR_SOCKET", directory.join("missing.sock"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn hook");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(payload.to_string().as_bytes())
+        .unwrap();
+    assert!(child.wait_with_output().unwrap().status.success());
+}
+
+#[test]
+fn claude_background_work_survives_recovery_and_child_callbacks() {
+    use diri_engine::hooks::{parse_activity_seed, parse_claude_hook};
+    use diri_engine::status::{Authority, StatusReducer, StatusSignal};
+    use diri_proto::SessionStatus;
+    use serde_json::json;
+
+    let directory = tempfile::tempdir().unwrap();
+    let store = SessionRecoveryStore::new(directory.path());
+    run_hook(
+        directory.path(),
+        "Stop",
+        json!({
+            "session_id": "parent", "hook_event_name": "Stop",
+            "background_tasks": [{"status": "running", "prompt": "secret task"}],
+            "session_crons": [{"prompt": "secret schedule"}],
+        }),
+    );
+    let original = store.read_activity().unwrap().unwrap();
+    assert_eq!(original.claude_pending_work, Some(true));
+    assert!(
+        !std::fs::read_to_string(directory.path().join("last-activity.json"))
+            .unwrap()
+            .contains("secret")
+    );
+    for (event, payload) in [
+        ("Stop", json!({"session_id": "parent", "agent_id": "child"})),
+        ("SubagentStop", json!({"session_id": "parent"})),
+        (
+            "Stop",
+            json!({"session_id": "parent", "hook_event_name": "SubagentStop"}),
+        ),
+    ] {
+        run_hook(directory.path(), event, payload);
+        assert_eq!(store.read_activity().unwrap().unwrap(), original);
+    }
+    run_hook(
+        directory.path(),
+        "PreToolUse",
+        json!({"session_id": "parent", "tool_name": "Bash"}),
+    );
+    let work = store.read_activity().unwrap().unwrap();
+    assert_eq!(work.claude_pending_work, Some(true));
+    run_hook(
+        directory.path(),
+        "Notification",
+        json!({
+            "session_id": "parent", "notification_type": "idle_prompt",
+        }),
+    );
+    let reminder = store.read_activity().unwrap().unwrap();
+    assert_eq!(reminder.claude_pending_work, Some(true));
+    let bytes = std::fs::read_to_string(directory.path().join("last-activity.json")).unwrap();
+    assert!(!bytes.contains("secret"));
+
+    for seed in [original, work, reminder] {
+        let now = std::time::SystemTime::now();
+        let mut reducer = StatusReducer::new(Authority::HooksPrimary, now);
+        let (signal, _) = parse_activity_seed(&seed).unwrap();
+        assert!(!reducer.reduce(signal, now).turn_completed);
+        assert_eq!(reducer.status(), &SessionStatus::Working);
+        let (completed, _) = parse_claude_hook(
+            "Notification",
+            &json!({"notification_type": "agent_completed"}),
+            now,
+        )
+        .unwrap();
+        reducer.reduce(completed, now);
+        assert!(!reducer.reduce(StatusSignal::Tick, now).turn_completed);
+        let (stop, _) = parse_claude_hook(
+            "Stop",
+            &json!({"background_tasks": [], "session_crons": []}),
+            now,
+        )
+        .unwrap();
+        reducer.reduce(stop, now);
+        assert!(reducer.reduce(StatusSignal::Tick, now).turn_completed);
+    }
+    run_hook(
+        directory.path(),
+        "Stop",
+        json!({"session_id": "parent", "background_tasks": [], "session_crons": []}),
+    );
+    assert_eq!(
+        store.read_activity().unwrap().unwrap().claude_pending_work,
+        Some(false)
+    );
+
+    run_hook(
+        directory.path(),
+        "Stop",
+        json!({"session_id": "parent", "session_crons": [{}]}),
+    );
+    run_hook(
+        directory.path(),
+        "Notification",
+        json!({"session_id": "different", "notification_type": "idle_prompt"}),
+    );
+    assert_eq!(
+        store.read_activity().unwrap().unwrap().claude_pending_work,
+        None
+    );
+}
+
 #[test]
 fn a_hook_records_its_safe_seed_before_unreachable_daemon_delivery() {
     let directory = tempfile::tempdir().expect("temporary directory");
@@ -36,6 +159,7 @@ fn a_hook_records_its_safe_seed_before_unreachable_daemon_delivery() {
     assert_eq!(
         seed,
         HookActivitySeed {
+            claude_pending_work: None,
             version: HookActivitySeed::VERSION,
             kind: "claude-hook".into(),
             event: Some("PermissionRequest".into()),

--- a/diri/docs/claude-notification-validation.md
+++ b/diri/docs/claude-notification-validation.md
@@ -1,0 +1,49 @@
+# Live Claude notification validation
+
+Validated on 2026-09-07 with Claude Code 2.1.263, using the release Rust Engine
+from this PR. The Engine used a separate `DIRIJOR_APP_SUPPORT` directory and
+real Claude PTY sessions in a temporary working directory. The installed app
+and its sessions were left running separately.
+
+The probe polled `session.list` every 100 ms, tracking status and
+`lastTurnCompletedAt`, and inspected the test terminal and aggregate recovery
+seed. Harmless shell scripts slept before creating completion marker files.
+A completion timestamp must remain unchanged while work is pending and advance
+once after the final response.
+
+| Scenario | Live result |
+| --- | --- |
+| Foreground Bash call sleeping 20 seconds | Working throughout the call; one completion after the marker and final response, at 23.6 seconds from submission. |
+| Background Bash call sleeping 40 seconds; parent replies immediately | Real parent `Stop` persisted `claudePendingWork: true`; no completion while the job ran. One completion after the marker and final response, at 43.2 seconds. |
+| Background general-purpose Agent running a 25-second shell call; parent replies immediately | Parent seed remained `Stop` with pending work despite child activity. Working while the terminal said “Waiting for 1 background agent to finish”; one completion after the child and final parent response, at 45.8 seconds. |
+| Bash permission request in manual mode | Needs-input persisted for roughly 46 seconds with no completion. One-time approval resumed Working, then completed once after the response. |
+| Real idle reminder after completion | An `idle_prompt` notification arrived about 60 seconds after the background-agent turn completed. Status stayed Idle and the completion timestamp was unchanged. |
+
+No new failure was found in these live scenarios. These observations validate
+the Engine signals consumed by the notification policy. Native macOS banner
+presentation was not exercised; it requires a packaged app. This is not a
+claim of complete cmux/Herdr feature parity. Scheduled work, recovery, duplicate
+callbacks and older hook payloads are covered by deterministic Rust regressions,
+not by this live run.
+
+## Repeat the check
+
+1. Build the PR's release workspace. Start its `dirijord-rs` with
+   `DIRIJOR_APP_SUPPORT` pointing at a fresh temporary directory. Keep the real
+   home unchanged so the installed Claude CLI can authenticate normally.
+2. Verify `hello.engineKind` is `diri-rust-engine`. Spawn `claude-code` through
+   `session.spawn` in a temporary directory. For a controlled run, pass
+   `--setting-sources '' --strict-mcp-config --no-chrome`; Diri still injects its
+   own hooks. Use `--permission-mode manual` for the permission scenario.
+3. Create harmless scripts for the durations above. Send prompts through
+   `session.send_text`; request foreground execution with a sufficiently long
+   timeout, then background execution with `run_in_background: true`, and then
+   a background Agent. For background cases, ask the parent to reply immediately
+   and respond again when the completion arrives.
+4. Observe `session.read_screen`, `session.list`, marker files, and only the
+   aggregate fields of the session's `last-activity.json`. Do not capture full
+   hook payloads. Check completion timestamps before/after markers and after an
+   idle reminder. Leave the permission request unanswered before approving its
+   one-time Yes choice.
+5. Kill only the test sessions with `session.kill`, then shut down the isolated
+   Engine with `daemon.shutdown_if_idle`.

--- a/diri/docs/notifications.md
+++ b/diri/docs/notifications.md
@@ -12,6 +12,12 @@ withdrawn. Closing or archiving a session resolves its notifications; the
 history remains available. Failed exits notify; clean exits and sessions
 closed through the app do not.
 
+For Claude, a parent work hook keeps the turn active until a completion hook
+arrives. Long tool calls, idle-looking input boxes and subagent completions do
+not produce “finished” alerts. If signals disappear, status can become unknown;
+elapsed time alone never completes a hook-owned turn. Sessions without work
+hooks retain terminal-based status detection.
+
 A notification for the selected, visible session in the active app is recorded
 as read and makes no sound or desktop banner. A selected session behind
 Settings, the launcher or an overlay can still notify. Delivery is checked

--- a/diri/docs/notifications.md
+++ b/diri/docs/notifications.md
@@ -31,6 +31,9 @@ stored. Metadata-free reminders retain the fact for the same conversation;
 child callbacks cannot replace the parent's recovery signal. Old seeds without
 the additive field continue to load.
 
+See the [live Claude validation](claude-notification-validation.md) for observed
+foreground, background-agent, permission and idle-reminder behavior.
+
 A notification for the selected, visible session in the active app is recorded
 as read and makes no sound or desktop banner. A selected session behind
 Settings, the launcher or an overlay can still notify. Delivery is checked
@@ -96,8 +99,8 @@ terminal notification ingress and delivery diagnostics. References:
 [session opening](https://github.com/manaflow-ai/cmux/blob/7d5d308450eac2991e748c6387d8718704be891a/Sources/AppDelegate%2BNotificationOpen.swift).
 
 Remaining notification differences include transcript-derived completion
-summaries, agent background-work metadata, notification webhooks/mobile
-forwarding, full Kitty notification protocol support, and reliable offline
+summaries, notification webhooks/mobile forwarding, full Kitty notification
+protocol support, and reliable offline
 remote events. Terminal-scraped statuses still depend on each agent manifest.
 
 Other product gaps, in priority order:

--- a/diri/docs/notifications.md
+++ b/diri/docs/notifications.md
@@ -13,10 +13,23 @@ history remains available. Failed exits notify; clean exits and sessions
 closed through the app do not.
 
 For Claude, a parent work hook keeps the turn active until a completion hook
-arrives. Long tool calls, idle-looking input boxes and subagent completions do
-not produce “finished” alerts. If signals disappear, status can become unknown;
-elapsed time alone never completes a hook-owned turn. Sessions without work
-hooks retain terminal-based status detection.
+arrives with no reported running background tasks or scheduled session work.
+Repeated stops while that work remains pending, idle reminders and child-agent
+callbacks do not produce “finished” alerts. Permission and question alerts
+remain enabled. A drained parent stop completes once; older Claude versions
+that omit background-work metadata retain their normal stop behavior.
+
+Long tool calls and idle-looking input boxes cannot expire hook authority. If
+signals disappear, status can become unknown; elapsed time alone never finishes
+the turn. Sessions without work hooks use terminal detection, including Claude's
+braille/half-circle title spinners, live-turn footer and background-agent/MCP
+activity. Visible permission and question prompts outrank those working rules.
+
+The hook CLI retains only an optional aggregate `claudePendingWork` boolean in
+the version-1 activity seed. Task contents and scheduled prompts are never
+stored. Metadata-free reminders retain the fact for the same conversation;
+child callbacks cannot replace the parent's recovery signal. Old seeds without
+the additive field continue to load.
 
 A notification for the selected, visible session in the active app is recorded
 as read and makes no sound or desktop banner. A selected session behind


### PR DESCRIPTION
## Why

Claude's work hooks lost authority after seven seconds, letting an idle-looking input box complete an active turn. Separately, a parent `Stop` could send a completion alert while Claude still reported running background tasks or scheduled work. Newer Claude spinner characters were also classified as idle by the terminal fallback.

## What changed

- Keep a turn started by a parent work hook active until a completion signal; time alone cannot finish it.
- Suppress completion while `background_tasks` contains running work or `session_crons` is nonempty. Repeated stops and metadata-free reminders stay quiet; a drained stop completes once. Permission/question alerts remain available.
- Reject mismatched hook-event routing and keep child callbacks from replacing the parent's recovery signal.
- Preserve the aggregate pending-work boolean in the version-1 recovery seed, scoped to the conversation. Old seeds and Claude payloads without these fields remain compatible; task and cron contents are never persisted.
- Update the versioned Claude manifest for half-circle spinners, live-turn footers, and background-agent/MCP activity, below visible blockers in priority.

The behavior was compared with [cmux's background-work handling](https://github.com/manaflow-ai/cmux/blob/7d78b6e4cb0236c3b4eb354d851498b685801e00/CLI/cmux.swift#L31565) and [Herdr's Claude detection rules](https://github.com/herdrdev/herdr/blob/702aa1e45527509bec73dad9b8d443f449c0379b/src/detect/manifests/claude.toml).

## Verification

Regressions reproduced false completion during long tools, completion with pending background work, and idle classification of a working half-circle spinner before the fixes. Coverage also checks drained/older payloads, duplicate stops, child events, blockers, prompt-text exclusions, recovery and privacy.

Live validation with Claude Code 2.1.263 and the PR release Engine also passed: a 20-second foreground tool, a 40-second background shell, a background Agent, a manual permission request held for roughly 46 seconds, and the real 60-second idle reminder. No premature or duplicate completion timestamps; one completion after each finished turn. Native macOS banner presentation was not exercised. See `diri/docs/claude-notification-validation.md` for results and reproduction steps.

From `diri/`:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — 1,337 passed, 24 ignored, zero failures.
- `cargo build --workspace --release`

- [x] Ran the Rust checks from `scripts/check.sh` directly. Release publishing, license and optional browser checks are outside this change; no scripts or dependencies changed.
- [x] Session survival is covered by the workspace suite. Recovery adds an optional field; no Helper protocol or transport changes.
- [x] Security/privacy considered: only an aggregate work fact is retained, without task/cron payloads or new logging.
- [x] User-visible behavior documented in `diri/docs/notifications.md`.
- [x] Screenshot not applicable: status and notification logic with deterministic regressions; no layout changes or manual native-banner verification.
