### PR TITLE
release: prepare diri 0.6.3

### DIFF
--- a/diri/Cargo.lock
+++ b/diri/Cargo.lock
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "diri-app"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "block2 0.6.2",
  "diri-client",

--- a/diri/crates/diri-app/Cargo.toml
+++ b/diri/crates/diri-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diri-app"
-version = "0.6.2"
+version = "0.6.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
- bump the desktop app and lockfile to 0.6.3
- prepare the release for the diri.sh launch, release-synced website downloads, correct Claude completion notifications, and reliable archived-session revival

## Verification
- `cargo check -p diri-app`
- `https://diri.sh/` returns HTTP 200