### PR TITLE
Match terminal toolbar to terminal background

### DIFF
--- a/diri/crates/diri-app/src/terminal_pane.rs
+++ b/diri/crates/diri-app/src/terminal_pane.rs
@@ -2408,7 +2408,7 @@ impl TerminalPane {
             .flex()
             .items_center()
             .justify_between()
-            .bg(colors.sidebar_surface())
+            .bg(colors.background)
             .child(
                 div()
                     .min_w(px(0.0))
@@ -3026,7 +3026,7 @@ impl Render for TerminalPane {
                 .overflow_hidden()
                 .border_l_1()
                 .border_color(sidebar_colors.primary.alpha(0.08))
-                .bg(sidebar_colors.sidebar_surface())
+                .bg(theme.background)
                 .child(self.render_header(&session, sidebar_colors, cx));
             let terminal_surface = div()
                 .relative()
@@ -3068,7 +3068,7 @@ impl Render for TerminalPane {
                             .px(px(Metrics::TOOLBAR_EDGE_INSET))
                             .flex()
                             .items_center()
-                            .bg(sidebar_colors.sidebar_surface())
+                            .bg(theme.background)
                             .child(control),
                     )
                 })


### PR DESCRIPTION
The terminal toolbar used the sidebar's tinted surface, leaving a visible color band above the terminal. Use the selected terminal theme's background for the toolbar, its surrounding pane, and the empty-pane toolbar so the surfaces blend seamlessly across light and dark themes.

Validation:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --offline -- -D warnings`
- `cargo test --workspace --offline` (passed with local socket access; the sandboxed attempt could not bind fixture sockets)
- `cargo build --workspace --release --offline`
- Built app UI smoke preview (`DIRI_UI_SMOKE_TEST=1`)
