### PR TITLE
Fix false prompt delivery errors and replace the titlebar error strip

### DIFF
--- a/diri/crates/diri-app/src/launcher.rs
+++ b/diri/crates/diri-app/src/launcher.rs
@@ -1590,16 +1590,18 @@ impl LauncherOverlay {
                 self.close(cx);
             }
             Err(error) => {
-                let message = format!(
-                    "Prompt delivery was not confirmed: {error}. Your draft is saved in the composer. Check the session before trying again."
-                );
-                self.fallback_notice = Some(message.clone());
+                let message = if error.contains("initial_prompt_delivery_failed") {
+                    "Session opened. Check its terminal before sending again. Your draft is saved."
+                } else {
+                    "Couldn’t confirm delivery. Check the session before sending again. Your draft is saved."
+                };
+                self.fallback_notice = Some(message.into());
                 self.services
                     .store
                     .store
                     .write()
                     .expect("store lock")
-                    .report_prompt_delivery_failure(message);
+                    .report_prompt_delivery_failure(error);
                 self.services.store.publish_local_change();
                 cx.notify();
             }
@@ -4214,7 +4216,7 @@ mod tests {
                     .fallback_notice
                     .as_deref()
                     .unwrap()
-                    .contains("test delivery failed")
+                    .contains("Your draft is saved")
             );
             assert!(launcher.submit(cx));
             let retry = launcher.delivery.pending.unwrap();

--- a/diri/crates/diri-app/src/recovery.rs
+++ b/diri/crates/diri-app/src/recovery.rs
@@ -24,6 +24,7 @@ pub struct RecoveryNotice {
     pub kind: RecoveryKind,
     pub title: String,
     pub body: String,
+    pub detail: Option<String>,
     pub primary_action: Option<(RecoveryAction, &'static str)>,
     pub dismissible: bool,
 }
@@ -48,9 +49,13 @@ impl RecoveryNotice {
                 },
                 body: if failure.retrying {
                     "Waiting for the daemon to confirm the operation.".to_owned()
+                } else if failure.title == crate::store::PROMPT_DELIVERY_FAILURE_TITLE {
+                    "Check the session before sending again. Your draft is saved in the composer."
+                        .to_owned()
                 } else {
                     failure.detail.clone()
                 },
+                detail: Some(failure.detail.clone()),
                 primary_action: if failure.retrying { None } else { retry },
                 dismissible: !failure.retrying,
             });
@@ -62,6 +67,7 @@ impl RecoveryNotice {
                 kind: RecoveryKind::Connecting,
                 title: "Connecting to the Diri daemon".to_owned(),
                 body: "Sessions stay visible while the connection is established.".to_owned(),
+                detail: None,
                 primary_action: None,
                 dismissible: false,
             }),
@@ -69,6 +75,7 @@ impl RecoveryNotice {
                 kind: RecoveryKind::ManualAttention,
                 title: "The daemon needs attention".to_owned(),
                 body: "Retry the connection. If it still fails, relaunch Diri to replace the bundled daemon.".to_owned(),
+                detail: None,
                 primary_action: Some((RecoveryAction::RetryConnection, "Retry now")),
                 dismissible: false,
             }),
@@ -76,6 +83,7 @@ impl RecoveryNotice {
                 kind: RecoveryKind::Reconnecting,
                 title: "Daemon unavailable".to_owned(),
                 body: "Reconnecting automatically; existing sessions remain readable.".to_owned(),
+                detail: None,
                 primary_action: Some((RecoveryAction::RetryConnection, "Retry now")),
                 dismissible: false,
             }),
@@ -146,6 +154,23 @@ mod tests {
     fn unsafe_failed_actions_never_offer_retry() {
         let destructive = failure(false, false);
         let notice = RecoveryNotice::resolve(&DaemonState::Connected, Some(&destructive)).unwrap();
+        assert!(notice.primary_action.is_none());
+    }
+
+    #[test]
+    fn prompt_failure_keeps_diagnostics_out_of_the_visible_message() {
+        let failure = ActionFailure::fixture(
+            crate::store::PROMPT_DELIVERY_FAILURE_TITLE,
+            "initial_prompt_delivery_failed: session s_123 was created, but initial prompt delivery was not confirmed",
+            false,
+            false,
+        );
+        let notice = RecoveryNotice::resolve(&DaemonState::Connected, Some(&failure)).unwrap();
+        assert_eq!(notice.title, "Check prompt delivery");
+        assert!(notice.body.contains("Your draft is saved"));
+        assert!(!notice.body.contains("initial_prompt_delivery_failed"));
+        assert!(!notice.body.contains("s_123"));
+        assert!(notice.dismissible);
         assert!(notice.primary_action.is_none());
     }
 }

--- a/diri/crates/diri-app/src/root.rs
+++ b/diri/crates/diri-app/src/root.rs
@@ -3124,47 +3124,63 @@ impl RootView {
             .id("recovery-notice")
             .debug_selector(|| "RECOVERY_NOTICE".to_owned())
             .absolute()
-            .top_0()
-            .left_0()
-            .right_0()
-            .h(px(42.0))
-            .px(px(14.0))
+            .bottom(px(16.0))
+            .right(px(16.0))
+            .w(px(380.0))
+            .max_w(gpui::relative(0.9))
+            .p(px(14.0))
             .flex()
-            .items_center()
-            .gap(px(9.0))
-            .bg(colors.sidebar_surface())
-            .border_b_1()
-            .border_color(colors.primary.alpha(0.08))
+            .flex_col()
+            .gap(px(8.0))
+            .rounded(px(Radius::PANEL))
+            .bg(colors.floating_surface())
+            .border_1()
+            .border_color(colors.floating_stroke())
+            .shadow_lg()
+            .occlude()
+            .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
             .text_color(colors.primary)
-            .child(div().size(px(7.0)).flex_none().rounded_full().bg(accent))
             .child(
                 div()
-                    .min_w(px(0.0))
-                    .flex_1()
+                    .pr(px(24.0))
                     .flex()
-                    .items_baseline()
-                    .gap(px(7.0))
+                    .items_center()
+                    .gap(px(8.0))
+                    .child(sf_symbol(
+                        if matches!(
+                            notice.kind,
+                            RecoveryKind::ActionFailed | RecoveryKind::ManualAttention
+                        ) {
+                            "exclamationmark.triangle"
+                        } else {
+                            "arrow.triangle.2.circlepath"
+                        },
+                        13.0,
+                        accent,
+                    ))
                     .child(
                         div()
-                            .flex_none()
+                            .flex_1()
+                            .min_w(px(0.0))
                             .text_size(px(Typo::ROW_EMPHASIZED.size))
                             .font_weight(Typo::ROW_EMPHASIZED.weight)
                             .child(notice.title),
-                    )
-                    .child(
-                        div()
-                            .min_w(px(0.0))
-                            .text_ellipsis()
-                            .text_size(px(Typo::META.size))
-                            .text_color(colors.secondary)
-                            .child(bounded_notice_body(&notice.body)),
                     ),
+            )
+            .child(
+                div()
+                    .text_size(px(Typo::META.size))
+                    .line_height(px(18.0))
+                    .text_color(colors.secondary)
+                    .child(bounded_notice_body(&notice.body)),
             );
+        let mut actions = div().flex().items_center().gap(px(8.0));
         if let Some((action, label)) = notice.primary_action {
             let store = Arc::clone(&self.services.store.store);
-            bar = bar.child(
+            actions = actions.child(
                 div()
                     .id("recovery-primary-action")
+                    .self_start()
                     .h(px(27.0))
                     .px(px(9.0))
                     .flex_none()
@@ -3187,18 +3203,52 @@ impl RootView {
                     }),
             );
         }
+        let detail = notice.detail;
+        let has_actions = notice.primary_action.is_some() || detail.is_some();
+        if let Some(detail) = detail {
+            actions = actions.child(
+                div()
+                    .id("copy-recovery-details")
+                    .debug_selector(|| "copy-recovery-details".into())
+                    .h(px(28.0))
+                    .px(px(7.0))
+                    .flex()
+                    .items_center()
+                    .rounded(px(Radius::ROW))
+                    .cursor_pointer()
+                    .text_size(px(Typo::META.size))
+                    .text_color(colors.secondary)
+                    .hover(move |button| button.bg(colors.primary.alpha(0.06)))
+                    .child("Copy details")
+                    .on_click(move |_, _, cx| {
+                        cx.write_to_clipboard(gpui::ClipboardItem::new_string(detail.clone()));
+                        cx.stop_propagation();
+                    }),
+            );
+        }
+        if has_actions {
+            bar = bar.child(actions);
+        }
         if notice.dismissible {
             let store = Arc::clone(&self.services.store.store);
             bar = bar.child(
                 div()
                     .id("dismiss-recovery-notice")
-                    .size(px(24.0))
+                    .debug_selector(|| "dismiss-recovery-notice".into())
+                    .absolute()
+                    .top(px(9.0))
+                    .right(px(9.0))
+                    .size(px(28.0))
                     .flex_none()
                     .flex()
                     .items_center()
                     .justify_center()
                     .rounded(px(Radius::CHIP))
                     .cursor_pointer()
+                    .tooltip(move |_, cx| {
+                        cx.new(|_| crate::palette_chrome::PaletteTooltip("Dismiss".into(), colors))
+                            .into()
+                    })
                     .hover(move |button| button.bg(colors.primary.alpha(0.06)))
                     .child(sf_symbol_weighted(
                         "xmark",
@@ -3234,6 +3284,7 @@ impl Render for RootView {
             self.open_notification(session, event, window, cx);
         }
         let colors = self.colors();
+        let launcher_open = self.launcher.read(cx).is_open();
         let recovery_notice = if self.preview {
             None
         } else {
@@ -3243,9 +3294,15 @@ impl Render for RootView {
                 .store
                 .read()
                 .expect("session store lock poisoned");
-            RecoveryNotice::resolve(store.daemon_state(), store.action_failure())
+            // The composer owns its inline failure while open. Once closed,
+            // the same failure remains available here without duplicate copy.
+            RecoveryNotice::resolve(
+                store.daemon_state(),
+                store.action_failure().filter(|failure| {
+                    !launcher_open || failure.title != crate::store::PROMPT_DELIVERY_FAILURE_TITLE
+                }),
+            )
         };
-        let recovery_height = if recovery_notice.is_some() { 42.0 } else { 0.0 };
         #[cfg(target_os = "macos")]
         self.notifier.set_badge(
             self.services
@@ -3256,7 +3313,6 @@ impl Render for RootView {
                 .notifications()
                 .unread_count(),
         );
-        let launcher_open = self.launcher.read(cx).is_open();
         let notification_surface_visible = !launcher_open
             && !self.notification_panel_open
             && !self
@@ -3324,11 +3380,8 @@ impl Render for RootView {
         sidebar_surface.a += (1.0 - sidebar_surface.a) * self.sidebar_float;
         let peek_pointer_tracking = self.sidebar.read(cx).is_peeking().then(|| {
             let region = gpui::Bounds::new(
-                gpui::point(px(0.0), px(recovery_height)),
-                gpui::size(
-                    px(sidebar_width + inset),
-                    window.viewport_size().height - px(recovery_height),
-                ),
+                gpui::point(px(0.0), px(0.0)),
+                gpui::size(px(sidebar_width + inset), window.viewport_size().height),
             );
             // Capture moves even when a terminal or menu handles the bubble
             // phase. The gap and panel are one hover target, including the
@@ -3368,7 +3421,7 @@ impl Render for RootView {
             .id("sidebar-frame")
             .absolute()
             .left_0()
-            .top(px(recovery_height))
+            .top_0()
             .bottom_0()
             // Include the inset in the hover region so the edge and card
             // are one continuous target, including during docking.
@@ -3425,7 +3478,6 @@ impl Render for RootView {
             .key_context(key_context)
             .relative()
             .size_full()
-            .pt(px(recovery_height))
             // Real SF Pro (registered from SFNS.ttf at startup) for every UI
             // surface; the terminal grid sets its own mono font.
             .font_family(crate::fonts::ui_family())
@@ -3439,9 +3491,8 @@ impl Render for RootView {
                 MouseButton::Left,
                 cx.listener(move |this, event: &gpui::MouseDownEvent, _, _| {
                     let pointer_y = f32::from(event.position.y);
-                    this.titlebar_drag_armed = cfg!(target_os = "macos")
-                        && pointer_y >= recovery_height
-                        && pointer_y < recovery_height + Metrics::TITLE_BAR;
+                    this.titlebar_drag_armed =
+                        cfg!(target_os = "macos") && (0.0..Metrics::TITLE_BAR).contains(&pointer_y);
                 }),
             )
             .on_mouse_move(
@@ -3674,7 +3725,7 @@ impl Render for RootView {
                     .debug_selector(|| "sidebar-peek-edge".into())
                     .absolute()
                     .left_0()
-                    .top(px(recovery_height + 36.0))
+                    .top(px(36.0))
                     .bottom_0()
                     .w(px(SIDEBAR_PEEK_TRIGGER_WIDTH))
                     .on_hover(cx.listener(|this, hovered: &bool, window, cx| {
@@ -3738,11 +3789,7 @@ impl Render for RootView {
             root = root.child(self.recovery_notice(notice, colors));
         }
         if let Some(build) = &self.services.dev_build {
-            root = root.child(dev_build_marker(
-                build.marker_label(),
-                colors,
-                recovery_height + 10.0,
-            ));
+            root = root.child(dev_build_marker(build.marker_label(), colors, 10.0));
         }
         root
     }
@@ -4224,6 +4271,97 @@ mod tests {
             assert_eq!(root.sidebar_float, 0.0);
             assert_eq!(root.sidebar_seam, root.sidebar.read(cx).width());
         });
+    }
+
+    #[cfg(target_os = "macos")]
+    #[gpui::test]
+    fn recovery_notice_keeps_titlebar_clear_and_supports_copy_and_dismiss(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let services = test_services();
+        let store = services.store.clone();
+        let (root, cx) = cx.add_window_view(move |window, cx| {
+            let mut root = RootView::new(services, true, PreviewScenario::Typical, window, cx);
+            root.preview = false;
+            root.services
+                .store
+                .store
+                .write()
+                .unwrap()
+                .report_prompt_delivery_failure("diagnostic detail".into());
+            root
+        });
+        for width in [640.0, 1000.0] {
+            cx.simulate_resize(size(px(width), px(700.0)));
+            cx.run_until_parked();
+            let card = cx.debug_bounds("RECOVERY_NOTICE").unwrap();
+            assert!(card.top() > px(Metrics::TITLE_BAR));
+            assert!(card.right() <= px(width - 16.0));
+            assert!(card.bottom() <= px(684.0));
+            let button = cx.debug_bounds("copy-recovery-details").unwrap();
+            assert!(card.contains(&button.center()));
+            cx.simulate_click(button.center(), Modifiers::default());
+            assert_eq!(
+                cx.read_from_clipboard().unwrap().text().as_deref(),
+                Some("diagnostic detail")
+            );
+        }
+        let dismiss = cx.debug_bounds("dismiss-recovery-notice").unwrap().center();
+        cx.simulate_click(dismiss, Modifiers::default());
+        assert!(store.store.read().unwrap().action_failure().is_none());
+        root.update(cx, |_, cx| cx.notify());
+        cx.run_until_parked();
+        assert!(cx.debug_bounds("copy-recovery-details").is_none());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "writes a visual preview to DIRI_RECOVERY_SCREENSHOT"]
+    fn render_recovery_notice_screenshot() {
+        use gpui::{AppContext as _, HeadlessAppContext};
+        let output = std::env::var("DIRI_RECOVERY_SCREENSHOT").expect("output path");
+        let platform = gpui_platform::current_platform(true);
+        let mut cx = HeadlessAppContext::with_platform(
+            platform.text_system(),
+            Arc::new(diri_ui::IconAssets),
+            gpui_platform::current_headless_renderer,
+        );
+        cx.update(|cx| {
+            crate::fonts::init(cx);
+            cx.set_reduce_motion(true);
+        });
+        let services = test_services();
+        let width = if std::env::var_os("DIRI_RECOVERY_NARROW").is_some() {
+            640.0
+        } else {
+            1000.0
+        };
+        let window = cx.open_window(size(px(width), px(700.0)), |window, cx| {
+            cx.new(|cx| {
+                let mut root = RootView::new(services.clone(), true, PreviewScenario::Typical, window, cx);
+                root.preview = false;
+                let mut store = services.store.store.write().unwrap();
+                store.update_preferences(|prefs| {
+                    prefs.terminal_theme = if std::env::var_os("DIRI_RECOVERY_LIGHT").is_some() {
+                        "dirijor-light".into()
+                    } else {
+                        "dirijor-dark".into()
+                    };
+                }).unwrap();
+                store.report_prompt_delivery_failure("initial_prompt_delivery_failed: session s_123 was created, but initial prompt delivery was not confirmed: the agent never confirmed that it submitted".into());
+                drop(store);
+                services.store.publish_local_change();
+                root
+            })
+        }).expect("preview window");
+        cx.run_until_parked();
+        cx.capture_screenshot(window.into())
+            .expect("screenshot")
+            .save(output)
+            .expect("save");
+        cx.update_window(window.into(), |_, window, _| window.remove_window())
+            .unwrap();
+        cx.run_until_parked();
     }
 
     #[cfg(target_os = "macos")]

--- a/diri/crates/diri-app/src/store/mod.rs
+++ b/diri/crates/diri-app/src/store/mod.rs
@@ -178,6 +178,8 @@ impl RetryAction {
     }
 }
 
+pub(crate) const PROMPT_DELIVERY_FAILURE_TITLE: &str = "Check prompt delivery";
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct ActionFailure {
     pub title: String,
@@ -1016,7 +1018,7 @@ impl SessionStore {
         // Never offer a blind retry: the Agent may have accepted input before
         // the connection failed. The composer retains the reviewable draft.
         self.last_action_failure = Some(ActionFailure {
-            title: "Prompt delivery not confirmed".into(),
+            title: PROMPT_DELIVERY_FAILURE_TITLE.into(),
             detail,
             retrying: false,
             retry: None,

--- a/diri/crates/diri-engine/src/control.rs
+++ b/diri/crates/diri-engine/src/control.rs
@@ -3541,6 +3541,9 @@ fn submit_typed_prompt(
             )
         })
         .ok_or(InitialPromptFailure::SessionEnded)?;
+        let composer_had_prompt = probe.is_some_and(|probe| {
+            composer_text(&before).is_some_and(|composer| composer.contains(probe))
+        });
         with_session(registry, session_id, |session| session.submit_input())
             .ok_or(InitialPromptFailure::SessionEnded)?
             .map_err(|_| InitialPromptFailure::InputFailed)?;
@@ -3553,6 +3556,13 @@ fn submit_typed_prompt(
                 None => return Err(InitialPromptFailure::SessionEnded),
                 Some(now)
                     if probe.is_some_and(|probe| !now.contains(probe))
+                        // Codex keeps the submitted text in the transcript.
+                        // Require a composer that held our probe before Enter
+                        // and is still identifiable but no longer holds it.
+                        // An absent composer during a repaint proves nothing.
+                        || (composer_had_prompt && probe.is_some_and(|probe| {
+                            composer_text(&now).is_some_and(|composer| !composer.contains(probe))
+                        }))
                         // Plain CLI tools have no Agent status signals. A new
                         // response after Enter is their available confirmation;
                         // the pasted echo alone must never count as one.
@@ -3566,6 +3576,12 @@ fn submit_typed_prompt(
         }
     }
     Err(InitialPromptFailure::SubmissionUnconfirmed)
+}
+
+fn composer_text(screen: &str) -> Option<String> {
+    let lines: Vec<String> = screen.lines().map(str::to_owned).collect();
+    let body = crate::detect::prompt_box_body(&lines);
+    (!body.is_empty()).then(|| body.join("\n"))
 }
 
 /// Only fresh Agent evidence can acknowledge submission. A running process

--- a/diri/crates/diri-engine/src/detect/mod.rs
+++ b/diri/crates/diri-engine/src/detect/mod.rs
@@ -18,6 +18,7 @@ mod regions;
 
 pub use manifest::{Manifest, ManifestState, RegionKind, StatusModel};
 pub use redact::redact;
+pub(crate) use regions::prompt_box_body;
 
 use std::collections::HashMap;
 use std::path::Path;

--- a/diri/crates/diri-engine/tests/inject_prompt.rs
+++ b/diri/crates/diri-engine/tests/inject_prompt.rs
@@ -71,7 +71,11 @@ impl Control {
 }
 
 fn start_server(temp: &Path) -> Arc<ControlServer> {
-    let registry = Arc::new(Mutex::new(Registry::new(engine(), temp.join("state.json"))));
+    start_server_with_engine(temp, engine())
+}
+
+fn start_server_with_engine(temp: &Path, engine: Arc<ManifestEngine>) -> Arc<ControlServer> {
+    let registry = Arc::new(Mutex::new(Registry::new(engine, temp.join("state.json"))));
     let server = Arc::new(
         ControlServer::new(Arc::clone(&registry), temp.join("daemon.sock"))
             .with_logs_dir(temp.join("logs")),
@@ -89,6 +93,84 @@ fn start_server(temp: &Path) -> Arc<ControlServer> {
         });
     }
     server
+}
+
+/// Keep Codex's real screen rules, with a deterministic child instead of an
+/// installed Agent or account. The submitted prompt remains in the transcript.
+#[test]
+fn codex_prompt_retained_in_transcript_is_acknowledged_once() {
+    assert_codex_delivery(false);
+}
+
+#[test]
+fn codex_banner_repaint_does_not_acknowledge_a_swallowed_enter() {
+    assert_codex_delivery(true);
+}
+
+fn assert_codex_delivery(swallow_first_enter: bool) {
+    let temp = tempfile::tempdir().expect("temp");
+    let manifests = temp.path().join("manifests");
+    std::fs::create_dir(&manifests).unwrap();
+    let mut manifest: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(diri_engine::detect::bundled_manifest_dir().join("codex.json")).unwrap(),
+    )
+    .unwrap();
+    manifest["agent"].as_object_mut().unwrap().remove("binary");
+    std::fs::write(
+        manifests.join("codex.json"),
+        serde_json::to_vec(&manifest).unwrap(),
+    )
+    .unwrap();
+    let (engine, _) = ManifestEngine::load_dir(&manifests).unwrap();
+    let server = start_server_with_engine(temp.path(), Arc::new(engine));
+    let mut control = Control::connect(&server);
+    let prompt = "testing";
+    let framed_len = prompt.len() + 12;
+    let accepted = temp.path().join("accepted");
+    let extra_enter = temp.path().join("extra-enter");
+    let swallow = if swallow_first_enter {
+        // Unrelated banner output while the actual composer keeps the paste.
+        // A changed screen alone must not acknowledge this first Enter.
+        "printf '\\033[s\\033[1;40HUpdated banner\\033[u'; dd of=/dev/null bs=1 count=1 2>/dev/null"
+    } else {
+        ""
+    };
+    let script = format!(
+        r#"stty -echo -icanon min 1 time 0
+printf '\033[?2004h› '
+dd of=/dev/null bs=1 count={framed_len} 2>/dev/null
+printf '{prompt}'
+dd of=/dev/null bs=1 count=1 2>/dev/null
+{swallow}
+printf accepted > '{}'
+printf '\r\033[2K› {prompt}\r\nAnswer received.\r\n› '
+dd of=/dev/null bs=1 count=1 2>/dev/null
+printf duplicate > '{}'
+exec cat"#,
+        accepted.display(),
+        extra_enter.display()
+    );
+    let result = control.try_request(
+        "session.spawn",
+        json!({
+            "kind": { "codex": {} }, "cwd": "/tmp",
+            "argv": ["/bin/sh", "-c", script], "initialPrompt": prompt,
+        }),
+    );
+    let id = match &result {
+        Ok(value) => value["id"].as_str().unwrap().to_owned(),
+        Err(error) => error.message.split_whitespace().nth(1).unwrap().to_owned(),
+    };
+    control.request("session.kill", json!({ "sessionID": id }));
+    assert!(
+        accepted.exists(),
+        "fixture must receive the submitted prompt"
+    );
+    assert!(result.is_ok(), "sent prompt reported as failed: {result:?}");
+    assert!(
+        !extra_enter.exists(),
+        "accepted prompt received another Enter"
+    );
 }
 
 fn spawn(control: &mut Control, script: &str, shell: &str, prompt: &str) -> String {


### PR DESCRIPTION
Codex can keep a submitted prompt in its transcript after clearing the composer. Diri searched the entire screen for that text, reported `initial_prompt_delivery_failed`, and left the new-session composer open even though the message had sent. Submission now also recognizes a previously verified prompt leaving an identifiable composer, so the existing success path closes the launcher and selects the session. Unrelated banner changes still cannot acknowledge a swallowed Enter.

Replace the full-width titlebar error strip with a compact bottom-right recovery card. It wraps the message, preserves safe retry actions, provides dismiss and Copy details controls, and does not shift the terminal or sidebar. Prompt-delivery warnings appear only inline while the composer is open, with concise recovery copy and the original diagnostics retained for copying.

Validation:
- Reproduced the false failure with a deterministic Codex-manifest PTY fixture before fixing it; added coverage for retained transcript text, duplicate Enter prevention, and a swallowed Enter during a banner repaint.
- Full workspace tests: 1,436 passed; the final app suite, including card geometry/copy/dismiss and composer acknowledgement coverage: 608 passed.
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo build --workspace --release`.
- Native GPUI renders of the recovery card in dark appearance and light appearance at a narrow window width. The opt-in `render_recovery_notice_screenshot` fixture accepts `DIRI_RECOVERY_SCREENSHOT`, `DIRI_RECOVERY_LIGHT`, and `DIRI_RECOVERY_NARROW`.

Confirmation still relies on observable terminal/Agent evidence. Ambiguous outcomes keep the draft available; this change does not turn a PTY write into unconditional delivery success.
