### PR TITLE
release: prepare diri 0.6.5

### DIFF
--- a/diri/Cargo.lock
+++ b/diri/Cargo.lock
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "diri-app"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "block2 0.6.2",
  "diri-client",

--- a/diri/crates/diri-app/Cargo.toml
+++ b/diri/crates/diri-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diri-app"
-version = "0.6.4"
+version = "0.6.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
- bump the desktop app and lockfile to 0.6.5
- prepare the release for correct Codex prompt acknowledgement, compact recovery notices, reliable sidebar preview dismissal, and clearer activity feedback

## Verification
- `cargo check -p diri-app`