### PR TITLE
Reduce holder memory and repeated engine CPU work

### DIFF
--- a/diri/PERF.md
+++ b/diri/PERF.md
@@ -1,5 +1,88 @@
 # diri performance record
 
+## Live-session CPU and local Holder memory (2026-09-09)
+
+The reported Activity Monitor usage was reproduced on the installed 0.6.5
+app: app CPU commonly 8–15% (one 28% interval), Engine 3–6%, local Holder
+1–2.5%; physical footprints approximately 419–424, 186–191 and 126 MB.
+The workload included 20 local and 56 remote sessions and mouse interaction;
+these are not idle acceptance measurements. App stack samples primarily showed
+rendering, and about 266 MB of its memory map was graphics-related. This pass
+does not claim to resolve or reduce that graphics allocation.
+
+Three Engine/local Holder changes address directly observed waste:
+
+- A local Holder that predates output streaming is negotiated once per adopted
+  session. Previously each quiet tick/log wake reconnected and elicited the
+  same rejection. The socket/Session regression first failed with 12
+  negotiations across ten real log updates, then passed with one. A second
+  test drops the first connection and verifies transport failures still retry.
+  No protocol, input-delivery, or session-survival behavior changes.
+- The local Holder opens its append-only log with no in-memory raw-output ring.
+  No Holder operation reads that ring; the Engine reads the durable file and
+  the independent bounded live queue serves output subscribers. A regression
+  verifies zero retained ring bytes and exact tail replay after file rotation.
+  Terminal scrollback and Engine/Remote Helper output budgets are unchanged.
+- Codex title refreshes batch sessions by their exact account-profile directory.
+  Each pass opens each candidate database, inspects its schema, and reads the
+  bounded title index once for the group. Statements are reused within the pass
+  and all resources then drop. There is no persistent title cache or change to
+  the one-second cadence. Tests preserve explicit/index/generated title priority,
+  immediate observation of renames, missing fields, and account isolation.
+
+Measurements use Apple Silicon/macOS 26.5.2 and the repository's current pinned
+Rust 1.97.1 release toolchain. The new `holderbench` launches a private manager
+with 20 real PTYs, drains 5 MiB per session, waits two seconds, then measures the
+manager's physical footprint and five seconds of idle CPU. It excludes the
+Engine, desktop and synthetic producer processes. The same benchmark executable
+was run against the saved pre-change Holder and the changed Holder.
+
+| Measurement | Before / individual reads | After / batched reads |
+| --- | ---: | ---: |
+| Holder physical footprint, median of three runs | 150.1 MiB | 7.3 MiB |
+| Holder footprint range | 146.0–155.1 MiB | 7.1–8.1 MiB |
+| Twenty Codex titles, median of 21 passes | 1.77 ms | 0.19 ms |
+
+The Holder memory reduction is approximately 95%. Idle Holder CPU was noisy
+(0.30–0.37% before and 0.17–0.38% after), so no idle-CPU percentage improvement
+is claimed. The title comparison measures twenty individual calls versus one
+shared pass in the same release build, not total Engine CPU. Launch-plus-drain
+timings also varied; they are not a terminal-throughput comparison.
+
+A separate `fleetbench` comparison releases 20 sessions together to drain
+16 MiB of generated colored log lines each, using the same Engine executable
+and changing only `DIRI_HOLDER_BIN`. All 120 sessions across three paired runs
+finished. Median aggregate throughput was 116.5 MiB/s before and 118.8 MiB/s
+after (ranges 111.5–118.7 and 114.7–124.3 MiB/s). This supports comparable
+throughput while removing the retained ring, not a broad throughput-speedup
+claim. There was no desktop attached during either fixture.
+
+Reproduce from `diri/`:
+
+```sh
+cargo build --release -p diri-engine --bin diri-holder --example holderbench
+DIRI_HOLDER_BIN="$PWD/target/release/diri-holder" target/release/examples/holderbench 20
+cargo test --release -p diri-engine --lib codex_title_batch_timing -- --ignored --nocapture
+cargo test -p diri-engine --test holder_output_compat -- --nocapture
+```
+
+All fixtures use temporary state and terminate only their own sessions. Existing
+production processes were not replaced or stopped. The Engine improvements need
+an Engine update; the memory saving requires an updated Holder process. The
+long-lived local manager cannot pick up new code until its sessions end and it
+restarts, including sessions subsequently launched through that old manager.
+
+Validation in the original development workspace: formatting, Clippy with
+`-D warnings`, all workspace tests
+(1,349 passed, 26 intentionally ignored), release build, and terminal performance
+gate passed. The release gate measured local input-to-grid median 113 µs and
+persistent input p95 16 µs. No UI/rendering behavior or production dependency
+was changed by this pass. That workspace also contained separate terminal/parser
+optimizations; those edits are not included in this CPU/memory PR. The numbers
+above describe that measured workspace, not a newly measured desktop release.
+
+## Historical baseline
+
 Historical measurements in this file are from the T16 release build on Apple
 Silicon, macOS 26.5.2, on 2026-07-23. They predate subsequent UI/font changes
 and are context, not proof that the current release passes. Release acceptance

--- a/diri/REMOTE_PORT.md
+++ b/diri/REMOTE_PORT.md
@@ -517,6 +517,19 @@ faster socket acknowledgement for slower end-to-grid delivery. The local
 daemon's held-output follower is raised only while the session is recently
 attached or receiving input, then returns to default QoS.
 
+Local output-stream negotiation also respects surviving Holder versions. A
+completed rejection is remembered for the attached session lifetime, and the
+Engine keeps following its durable log without probing on every wakeup.
+Transport failures and interrupted supported streams remain retryable. This
+changes no local or remote wire format and never replaces a live Holder.
+
+The local Holder's `OutputLog` writer retains no raw-output ring: no Holder
+operation reads it. Durable file output, offsets, rotation and exit markers
+remain unchanged; the separate bounded live-output queue still serves attached
+Engines. The Engine and remote Helper retain their existing history/output
+budgets. Existing Holder processes keep their original allocations until their
+sessions end naturally.
+
 ## Controller lease
 
 The completed baseline permits exactly one live attach/controller. A new attach

--- a/diri/crates/diri-engine/examples/holderbench.rs
+++ b/diri/crates/diri-engine/examples/holderbench.rs
@@ -1,0 +1,119 @@
+//! Retained memory/idle CPU after real local Holders each drain 5 MiB.
+//! Run: DIRI_HOLDER_BIN=/absolute/diri-holder cargo run --release -p diri-engine --example holderbench -- 20
+//! Only private fixture sessions are launched and terminated.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use diri_engine::holder::{
+    HolderClient, HolderLaunchSpec, HolderLauncher, HolderManagerClient, HolderManagerPaths,
+    HolderPaths,
+};
+
+const BYTES: usize = 5 << 20;
+
+struct Fleet {
+    clients: Vec<HolderClient>,
+    manager: HolderManagerClient,
+}
+
+impl Drop for Fleet {
+    fn drop(&mut self) {
+        for client in &self.clients {
+            let _ = client.kill_tree();
+        }
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while self.manager.shutdown_if_idle().is_err() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+}
+
+fn main() {
+    let mode = std::env::args().nth(1).unwrap_or_else(|| "20".into());
+    if mode == "--produce" {
+        let buffer = [b'x'; 64 << 10];
+        let mut out = std::io::stdout().lock();
+        for _ in 0..BYTES / buffer.len() {
+            out.write_all(&buffer).unwrap();
+        }
+        out.flush().unwrap();
+        std::thread::sleep(Duration::from_secs(120));
+        return;
+    }
+    let count: usize = mode.parse().expect("session count");
+    assert!((1..=64).contains(&count));
+    let binary = PathBuf::from(std::env::var_os("DIRI_HOLDER_BIN").expect("DIRI_HOLDER_BIN"));
+    let root = tempfile::Builder::new()
+        .prefix("diri-hbench-")
+        .tempdir_in("/tmp")
+        .unwrap();
+    let directory = root.path().join("holders");
+    let manager_paths = HolderManagerPaths::new(&directory);
+    let mut fleet = Fleet {
+        clients: Vec::new(),
+        manager: HolderManagerClient::new(manager_paths.socket()),
+    };
+    let producer = std::env::current_exe().unwrap();
+    let started = Instant::now();
+    for index in 0..count {
+        let id = format!("s_bench_{index}");
+        let paths = HolderPaths::new(&directory, &id);
+        // Register cleanup before launch, including ambiguous launch failures.
+        fleet.clients.push(HolderClient::new(paths.socket()));
+        HolderLauncher::launch(
+            &binary,
+            &paths,
+            &HolderLaunchSpec {
+                session_id: id.clone(),
+                socket_path: paths.socket().to_string_lossy().into_owned(),
+                pid_file_path: paths.pid_file().to_string_lossy().into_owned(),
+                log_file_path: root
+                    .path()
+                    .join("logs")
+                    .join(format!("{id}.bin"))
+                    .to_string_lossy()
+                    .into_owned(),
+                argv: vec![producer.to_string_lossy().into_owned(), "--produce".into()],
+                cwd: root.path().to_string_lossy().into_owned(),
+                environment: Default::default(),
+                cols: 80,
+                rows: 24,
+                disk_capacity: 32 << 20,
+            },
+        )
+        .unwrap();
+    }
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while !fleet
+        .clients
+        .iter()
+        .all(|c| c.stat().is_ok_and(|s| s.log_offset >= BYTES as u64))
+    {
+        assert!(
+            Instant::now() < deadline,
+            "Holders did not drain all output"
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    let drain_ms = started.elapsed().as_millis();
+    std::thread::sleep(Duration::from_secs(2));
+    let pid = fleet.manager.ping().unwrap();
+    let footprint = diri_engine::governor::footprint_of(&[pid]);
+    let before = diri_engine::governor::cpu_time_of(&[pid]);
+    let started = Instant::now();
+    std::thread::sleep(Duration::from_secs(5));
+    let after = diri_engine::governor::cpu_time_of(&[pid]);
+    let cpu =
+        after.checked_sub(before).unwrap() as f64 / 1e9 / started.elapsed().as_secs_f64() * 100.0;
+    assert!(footprint > 0, "memory probe unavailable");
+    println!(
+        "{}",
+        serde_json::json!({
+            "holder_binary":binary,"sessions":count,"bytes_per_session":BYTES,
+            "drain_ms":drain_ms,"holder_footprint_mib":footprint as f64 / 1048576.0,
+            "holder_idle_cpu_percent":cpu
+        })
+    );
+}

--- a/diri/crates/diri-engine/src/history.rs
+++ b/diri/crates/diri-engine/src/history.rs
@@ -809,24 +809,61 @@ pub(crate) fn profile_codex_title(
     home: &Path,
     thread_id: &str,
 ) -> Option<String> {
-    if !safe_agent_id(thread_id) {
-        return None;
-    }
-    let codex_home = profile.map_or_else(|| home.join(".codex"), |p| PathBuf::from(&p.config_home));
-    let database = codex_database_titles(&codex_home, thread_id).unwrap_or_default();
-    database
-        .explicit
-        .or_else(|| codex_indexed_title(&codex_home, thread_id))
-        .or(database.fallback)
+    profile_codex_titles(profile, home, &[thread_id]).remove(thread_id)
 }
 
-fn codex_database_titles(codex_home: &Path, thread_id: &str) -> Option<CodexTitleCandidates> {
-    for path in newest_codex_state_files(codex_home) {
-        if let Some(titles) = codex_database_title(&path, thread_id) {
-            return Some(titles);
+/// One refresh pass over one profile. Connections, schema discovery and the
+/// bounded index read are shared by the requested sessions, then dropped. No
+/// persistent database connection or title cache can hide a provider rename.
+pub(crate) fn profile_codex_titles(
+    profile: Option<&diri_proto::AgentAccountProfile>,
+    home: &Path,
+    thread_ids: &[&str],
+) -> HashMap<String, String> {
+    let thread_ids: HashSet<_> = thread_ids
+        .iter()
+        .copied()
+        .filter(|id| safe_agent_id(id))
+        .collect();
+    if thread_ids.is_empty() {
+        return HashMap::new();
+    }
+    let codex_home = profile.map_or_else(|| home.join(".codex"), |p| PathBuf::from(&p.config_home));
+    let mut database = HashMap::new();
+    for path in newest_codex_state_files(&codex_home) {
+        let missing: Vec<_> = thread_ids
+            .iter()
+            .copied()
+            .filter(|id| !database.contains_key(*id))
+            .collect();
+        if missing.is_empty() {
+            break;
+        }
+        if let Some(titles) = codex_database_titles(&path, &missing) {
+            database.extend(titles);
         }
     }
-    None
+    let indexed_ids = thread_ids
+        .iter()
+        .copied()
+        .filter(|id| {
+            database
+                .get(*id)
+                .is_none_or(|title| title.explicit.is_none())
+        })
+        .collect();
+    let mut indexed = codex_indexed_titles(&codex_home, &indexed_ids);
+    thread_ids
+        .into_iter()
+        .filter_map(|id| {
+            let candidate = database.remove(id).unwrap_or_default();
+            candidate
+                .explicit
+                .or_else(|| indexed.remove(id))
+                .or(candidate.fallback)
+                .map(|title| (id.to_owned(), title))
+        })
+        .collect()
 }
 
 fn newest_codex_state_files(codex_home: &Path) -> Vec<PathBuf> {
@@ -855,7 +892,10 @@ fn newest_codex_state_files(codex_home: &Path) -> Vec<PathBuf> {
     paths
 }
 
-fn codex_database_title(path: &Path, thread_id: &str) -> Option<CodexTitleCandidates> {
+fn codex_database_titles(
+    path: &Path,
+    thread_ids: &[&str],
+) -> Option<HashMap<String, CodexTitleCandidates>> {
     let connection = Connection::open_with_flags(
         path,
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
@@ -886,23 +926,40 @@ fn codex_database_title(path: &Path, thread_id: &str) -> Option<CodexTitleCandid
         field("title"),
         field("first_user_message"),
     );
-    connection
-        .query_row(&query, params![thread_id], |row| {
-            let explicit = row.get::<_, Option<String>>(0)?;
-            let generated = row.get::<_, Option<String>>(1)?;
-            let first_prompt = row.get::<_, Option<String>>(2)?;
-            Ok(CodexTitleCandidates {
-                explicit: explicit.and_then(clean_provider_title),
-                fallback: generated
-                    .and_then(clean_provider_title)
-                    .or_else(|| first_prompt.and_then(clean_provider_title)),
+    let mut statement = connection.prepare(&query).ok()?;
+    let mut titles = HashMap::new();
+    for thread_id in thread_ids {
+        if let Ok(Some(candidate)) = statement
+            .query_row(params![thread_id], |row| {
+                let explicit = row.get::<_, Option<String>>(0)?;
+                let generated = row.get::<_, Option<String>>(1)?;
+                let first_prompt = row.get::<_, Option<String>>(2)?;
+                Ok(CodexTitleCandidates {
+                    explicit: explicit.and_then(clean_provider_title),
+                    fallback: generated
+                        .and_then(clean_provider_title)
+                        .or_else(|| first_prompt.and_then(clean_provider_title)),
+                })
             })
-        })
-        .optional()
-        .ok()?
+            .optional()
+        {
+            titles.insert((*thread_id).to_owned(), candidate);
+        }
+    }
+    Some(titles)
 }
 
-fn codex_indexed_title(codex_home: &Path, thread_id: &str) -> Option<String> {
+fn codex_indexed_titles(codex_home: &Path, thread_ids: &HashSet<&str>) -> HashMap<String, String> {
+    if thread_ids.is_empty() {
+        return HashMap::new();
+    }
+    read_codex_indexed_titles(codex_home, thread_ids).unwrap_or_default()
+}
+
+fn read_codex_indexed_titles(
+    codex_home: &Path,
+    thread_ids: &HashSet<&str>,
+) -> Option<HashMap<String, String>> {
     let mut handle = open_regular_readonly(&codex_home.join("session_index.jsonl"))?;
     let end = handle.seek(SeekFrom::End(0)).ok()?;
     let start = end.saturating_sub(CODEX_INDEX_BYTES as u64);
@@ -917,25 +974,26 @@ fn codex_indexed_title(codex_home: &Path, thread_id: &str) -> Option<String> {
     if start > 0 {
         lines.next();
     }
-    let mut newest = None;
+    let mut newest = HashMap::new();
     for line in lines {
-        if !line.contains(thread_id) {
+        if !thread_ids.iter().any(|id| line.contains(id)) {
             continue;
         }
         let Ok(object) = serde_json::from_str::<Value>(line) else {
             continue;
         };
-        if object.get("id").and_then(Value::as_str) == Some(thread_id)
+        if let Some(id) = object.get("id").and_then(Value::as_str)
+            && thread_ids.contains(id)
             && let Some(title) = object
                 .get("thread_name")
                 .and_then(Value::as_str)
                 .map(str::to_owned)
                 .and_then(clean_provider_title)
         {
-            newest = Some(title);
+            newest.insert(id.to_owned(), title);
         }
     }
-    newest
+    Some(newest)
 }
 
 fn clean_provider_title(title: String) -> Option<String> {
@@ -1307,6 +1365,76 @@ mod tests {
         assert_eq!(
             codex_title(home.path(), "thread-9").as_deref(),
             Some("Generated database title")
+        );
+    }
+
+    #[test]
+    fn codex_title_batch_preserves_priority_and_observes_renames() {
+        let home = tempfile::tempdir().unwrap();
+        let config = home.path().join(".codex");
+        std::fs::create_dir_all(&config).unwrap();
+        let db = Connection::open(config.join("state_1.sqlite")).unwrap();
+        db.execute_batch("CREATE TABLE threads (id TEXT PRIMARY KEY, name TEXT, title TEXT, first_user_message TEXT);
+            INSERT INTO threads VALUES ('explicit', 'My rename', 'Generated', NULL),
+            ('indexed', NULL, 'Generated', NULL), ('fallback', NULL, NULL, 'First prompt');").unwrap();
+        write(
+            &config.join("session_index.jsonl"),
+            "{\"id\":\"explicit\",\"thread_name\":\"Index loses\"}\n{\"id\":\"indexed\",\"thread_name\":\"Old index\"}\n{\"id\":\"indexed\",\"thread_name\":\"Latest index\"}\n",
+        );
+        let ids = ["explicit", "indexed", "fallback", "absent", "../invalid"];
+        let result = profile_codex_titles(None, home.path(), &ids);
+        assert_eq!(result.len(), 3);
+        assert_eq!(result["explicit"], "My rename");
+        assert_eq!(result["indexed"], "Latest index");
+        assert_eq!(result["fallback"], "First prompt");
+        db.execute(
+            "UPDATE threads SET name = 'New rename' WHERE id = 'explicit'",
+            [],
+        )
+        .unwrap();
+        assert_eq!(
+            profile_codex_titles(None, home.path(), &ids)["explicit"],
+            "New rename"
+        );
+    }
+
+    #[test]
+    #[ignore = "timing comparison; run with --release --ignored --nocapture"]
+    fn codex_title_batch_timing() {
+        let home = tempfile::tempdir().unwrap();
+        let config = home.path().join(".codex");
+        std::fs::create_dir_all(&config).unwrap();
+        let db = Connection::open(config.join("state_1.sqlite")).unwrap();
+        db.execute_batch("CREATE TABLE threads (id TEXT PRIMARY KEY, name TEXT, title TEXT, first_user_message TEXT);").unwrap();
+        let ids: Vec<_> = (0..20).map(|n| format!("thread-{n}")).collect();
+        for id in &ids {
+            db.execute(
+                "INSERT INTO threads VALUES (?1, 'Fixture title', NULL, NULL)",
+                params![id],
+            )
+            .unwrap();
+        }
+        let borrowed: Vec<_> = ids.iter().map(String::as_str).collect();
+        let mut single = Vec::new();
+        let mut batch = Vec::new();
+        for _ in 0..21 {
+            let start = std::time::Instant::now();
+            for id in &ids {
+                assert!(profile_codex_title(None, home.path(), id).is_some());
+            }
+            single.push(start.elapsed());
+            let start = std::time::Instant::now();
+            assert_eq!(
+                profile_codex_titles(None, home.path(), &borrowed).len(),
+                ids.len()
+            );
+            batch.push(start.elapsed());
+        }
+        single.sort_unstable();
+        batch.sort_unstable();
+        eprintln!(
+            "20 Codex titles: individual median {:?}, batch median {:?}",
+            single[10], batch[10]
         );
     }
 

--- a/diri/crates/diri-engine/src/holder/server.rs
+++ b/diri/crates/diri-engine/src/holder/server.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use base64::Engine as _;
 
-use crate::log::{DEFAULT_RING_CAPACITY, OutputLog};
+use crate::log::OutputLog;
 use crate::pty::{Pty, PtySpec};
 
 use super::client::HolderClient;
@@ -283,7 +283,10 @@ fn open_log(spec: &HolderLaunchSpec) -> HolderResult<OutputLog> {
     } else {
         super::protocol::DEFAULT_DISK_CAPACITY as usize
     };
-    OutputLog::open(directory, session, DEFAULT_RING_CAPACITY, capacity, false)
+    // The Holder only appends and reports offsets. Its consumers either read
+    // the durable file themselves or receive the separate bounded live queue;
+    // retaining a second raw-output ring here has no reader.
+    OutputLog::open(directory, session, 0, capacity, false)
         .map_err(|error| HolderError::io("open output log", error))
 }
 
@@ -797,5 +800,43 @@ fn set_nonblocking(fd: i32) {
         if flags >= 0 {
             libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn holder_log_retains_no_duplicate_output_and_replays_from_disk() {
+        let root = tempfile::tempdir().unwrap();
+        let spec = HolderLaunchSpec {
+            session_id: "s_log".into(),
+            socket_path: String::new(),
+            pid_file_path: String::new(),
+            log_file_path: root.path().join("s_log.bin").to_string_lossy().into_owned(),
+            argv: Vec::new(),
+            cwd: String::new(),
+            environment: Default::default(),
+            cols: 80,
+            rows: 24,
+            disk_capacity: 4096,
+        };
+        let mut writer = open_log(&spec).unwrap();
+        let bytes = b"\x1b[2Joutput retained in the durable log\r\n";
+        for _ in 0..200 {
+            writer.append(bytes).unwrap();
+        }
+        writer.flush().unwrap();
+        let tail = writer.tail_offset();
+        assert_eq!(
+            writer.ring_start_offset(),
+            tail,
+            "the Holder never reads its ring"
+        );
+        let mut reader = OutputLog::reader(root.path(), "s_log").unwrap();
+        let (start, replay) = reader.read(tail - bytes.len() as u64, bytes.len());
+        assert_eq!(start, tail - bytes.len() as u64);
+        assert_eq!(replay, bytes, "log rotation must preserve the final output");
     }
 }

--- a/diri/crates/diri-engine/src/registry.rs
+++ b/diri/crates/diri-engine/src/registry.rs
@@ -1415,6 +1415,34 @@ pub(crate) fn scan_native_title_refreshes(
     let Some(home) = user_home() else {
         return Vec::new();
     };
+    // Group by the exact bound provider directory for this pass. Opening the
+    // same SQLite database and scanning its index once per session made the
+    // one-second title refresh scale with repeated filesystem/schema work.
+    let mut codex_groups: HashMap<Option<&str>, Vec<&NativeTitleRefreshRequest>> = HashMap::new();
+    for request in &requests {
+        if request.kind.id() == AgentKind::CODEX_ID {
+            codex_groups
+                .entry(
+                    request
+                        .account_profile
+                        .as_ref()
+                        .map(|p| p.config_home.as_str()),
+                )
+                .or_default()
+                .push(request);
+        }
+    }
+    let mut codex_titles = HashMap::new();
+    for group in codex_groups.values() {
+        let ids: Vec<_> = group.iter().map(|r| r.agent_session_id.as_str()).collect();
+        let titles =
+            crate::history::profile_codex_titles(group[0].account_profile.as_ref(), &home, &ids);
+        for request in group {
+            if let Some(title) = titles.get(&request.agent_session_id) {
+                codex_titles.insert(request.id.clone(), title.clone());
+            }
+        }
+    }
     requests
         .into_iter()
         .map(|request| {
@@ -1433,11 +1461,7 @@ pub(crate) fn scan_native_title_refreshes(
                         )
                     })
                     .and_then(|mut transcript| transcript.latest_claude_title()),
-                AgentKind::CODEX_ID => crate::history::profile_codex_title(
-                    request.account_profile.as_ref(),
-                    &home,
-                    &request.agent_session_id,
-                ),
+                AgentKind::CODEX_ID => codex_titles.remove(&request.id),
                 _ => None,
             };
             NativeTitleRefreshResult { request, title }
@@ -1754,6 +1778,54 @@ pub(crate) fn session_project_id(root: &str, host: Option<&str>) -> diri_proto::
 mod tests {
     use super::*;
     use diri_proto::{AgentKind, DateMillis, ProjectId, Resumability, SessionId, TitleSource};
+
+    #[test]
+    fn title_refresh_batch_keeps_profiles_with_the_same_thread_id_separate() {
+        let root = tempfile::tempdir().unwrap();
+        let mut requests = Vec::new();
+        for label in ["Personal", "Work"] {
+            let config = root.path().join(label);
+            std::fs::create_dir_all(&config).unwrap();
+            let db = rusqlite::Connection::open(config.join("state_1.sqlite")).unwrap();
+            db.execute_batch("CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT);")
+                .unwrap();
+            db.execute("INSERT INTO threads VALUES ('same-thread', ?1)", [label])
+                .unwrap();
+            for index in 0..2 {
+                requests.push(NativeTitleRefreshRequest {
+                    account_profile: Some(diri_proto::AgentAccountProfile {
+                        id: label.into(),
+                        label: label.into(),
+                        agent: "codex".into(),
+                        host: None,
+                        config_home: config.to_string_lossy().into_owned(),
+                        is_default: false,
+                    }),
+                    id: format!("{label}-{index}"),
+                    kind: AgentKind::CODEX,
+                    cwd: "/tmp".into(),
+                    agent_session_id: "same-thread".into(),
+                    transcript_path: None,
+                });
+            }
+        }
+        let refreshed = scan_native_title_refreshes(requests);
+        assert_eq!(refreshed.len(), 4);
+        for result in refreshed {
+            assert_eq!(
+                result.title.as_deref(),
+                Some(
+                    result
+                        .request
+                        .account_profile
+                        .as_ref()
+                        .unwrap()
+                        .label
+                        .as_str()
+                )
+            );
+        }
+    }
 
     fn record(id: &str) -> SessionRecord {
         SessionRecord {

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -2739,6 +2739,11 @@ fn pump_held(
     // and the loop just goes back to reading the file from the offset it had
     // reached.
     let mut live: Option<crate::holder::HolderOutputStream> = None;
+    // An adopted Holder keeps the same executable for this session's life.
+    // Remember a completed negative negotiation; otherwise every log wakeup
+    // reconnects just to receive the same unsupported-operation response.
+    // Transport errors remain retryable, as do interrupted supported streams.
+    let mut output_stream_supported = true;
     // Reused across passes: a fresh allocation per pass would charge every
     // byte of output an allocation it does not need.
     let mut live_run: Vec<u8> = Vec::new();
@@ -2758,20 +2763,24 @@ fn pump_held(
         // holder begins filling a queue this loop is not yet reading, and once
         // that queue is full the pump waits on it for every chunk. Waiting for
         // a drained log keeps the handover to a few frames.
-        if live.is_none() && drained {
-            if let Ok(Some(stream)) = client.open_output_stream() {
-                // A drained log does not mean the holder is where the log
-                // ends: writes are queued, so it can be megabytes further on.
-                // Subscribing across that distance is the worst case — the
-                // holder fills a queue this loop cannot read until the file
-                // catches up, then drops it for being full, and both ends
-                // repeat. Take the subscription only when the gap is small
-                // enough to close immediately, and otherwise keep tailing and
-                // try again the next time the log runs dry.
-                live_from = stream.start_offset();
-                if live_from.saturating_sub(offset) <= LIVE_HANDOVER_GAP {
-                    live = Some(stream);
+        if output_stream_supported && live.is_none() && drained {
+            match client.open_output_stream() {
+                Ok(Some(stream)) => {
+                    // A drained log does not mean the holder is where the log
+                    // ends: writes are queued, so it can be megabytes further on.
+                    // Subscribing across that distance is the worst case — the
+                    // holder fills a queue this loop cannot read until the file
+                    // catches up, then drops it for being full, and both ends
+                    // repeat. Take the subscription only when the gap is small
+                    // enough to close immediately, and otherwise keep tailing and
+                    // try again the next time the log runs dry.
+                    live_from = stream.start_offset();
+                    if live_from.saturating_sub(offset) <= LIVE_HANDOVER_GAP {
+                        live = Some(stream);
+                    }
                 }
+                Ok(None) => output_stream_supported = false,
+                Err(_) => {}
             }
             drained = false;
         }

--- a/diri/crates/diri-engine/tests/holder_output_compat.rs
+++ b/diri/crates/diri-engine/tests/holder_output_compat.rs
@@ -1,0 +1,149 @@
+//! An old live Holder must not be renegotiated on every log wakeup.
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixListener;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use diri_engine::holder::{HolderPaths, protocol::HolderStat};
+use diri_engine::session::{HolderConfig, Session, SessionSpec};
+use diri_engine::{Authority, ManifestEngine, OutputLog, PtySpec};
+
+struct OldHolder {
+    stop: Arc<AtomicBool>,
+    attempts: Arc<AtomicUsize>,
+    worker: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Drop for OldHolder {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        self.worker.take().unwrap().join().unwrap();
+    }
+}
+
+fn wait_for(mut condition: impl FnMut() -> bool) {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while !condition() {
+        assert!(Instant::now() < deadline, "condition timed out");
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
+#[test]
+fn old_holder_is_negotiated_once_while_log_output_keeps_arriving() {
+    exercise_old_holder(false);
+}
+
+#[test]
+fn failed_transport_is_retried_before_pinning_old_holder_capabilities() {
+    exercise_old_holder(true);
+}
+
+fn exercise_old_holder(fail_first: bool) {
+    let root = tempfile::tempdir_in("/tmp").unwrap();
+    let config = HolderConfig {
+        holders_dir: root.path().join("holders"),
+        executable: "/unused".into(),
+    };
+    let paths = HolderPaths::new(&config.holders_dir, "s_compat");
+    std::fs::create_dir_all(&paths.directory).unwrap();
+    let listener = UnixListener::bind(paths.socket()).unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let stat = HolderStat {
+        child_pid: std::process::id() as i32,
+        alive: true,
+        log_offset: 0,
+        foreground_pid: None,
+        cols: Some(80),
+        rows: Some(24),
+        epoch_offset: Some(0),
+    };
+    let stop = Arc::new(AtomicBool::new(false));
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let worker = {
+        let stop = stop.clone();
+        let attempts = attempts.clone();
+        let stat = stat.clone();
+        std::thread::spawn(move || {
+            while !stop.load(Ordering::Relaxed) {
+                let (mut stream, _) = match listener.accept() {
+                    Ok(pair) => pair,
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(1));
+                        continue;
+                    }
+                    Err(e) => panic!("accept: {e}"),
+                };
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(1)))
+                    .unwrap();
+                let mut line = String::new();
+                BufReader::new(&mut stream).read_line(&mut line).unwrap();
+                let request: serde_json::Value = serde_json::from_str(&line).unwrap();
+                let response = match request["op"].as_str().unwrap() {
+                    "stat" => serde_json::json!({"ok":true,"stat":stat}),
+                    "output-stream" => {
+                        let attempt = attempts.fetch_add(1, Ordering::Relaxed);
+                        if fail_first && attempt == 0 {
+                            // No completed negotiation: a transport failure
+                            // must not disable a potentially supported stream.
+                            continue;
+                        }
+                        serde_json::json!({"ok":false,"error":"unknown variant `output-stream`"})
+                    }
+                    op => panic!("unexpected operation {op}"),
+                };
+                serde_json::to_writer(&mut stream, &response).unwrap();
+                stream.write_all(b"\n").unwrap();
+            }
+        })
+    };
+    let holder = OldHolder {
+        stop,
+        attempts,
+        worker: Some(worker),
+    };
+    let logs = root.path().join("logs");
+    let mut log = OutputLog::writer(&logs, "s_compat").unwrap();
+    let (engine, _) =
+        ManifestEngine::load_dir(&diri_engine::detect::bundled_manifest_dir()).unwrap();
+    let session = Session::adopt(
+        SessionSpec {
+            id: "s_compat".into(),
+            pty: PtySpec::new(vec!["/bin/cat".into()], "/tmp").size(80, 24),
+            manifest_id: "shell".into(),
+            authority: Authority::ProcessOnly,
+            logs_dir: logs,
+            holder: Some(config.clone()),
+            remote: None,
+            defer_launch: false,
+        },
+        &config,
+        &stat,
+        Arc::new(engine),
+    )
+    .unwrap();
+    wait_for(|| holder.attempts.load(Ordering::Relaxed) > 0);
+    for index in 0..10 {
+        let marker = format!("compat-output-{index}");
+        log.append(format!("{marker}\r\n").as_bytes()).unwrap();
+        wait_for(|| {
+            session
+                .screen_lines()
+                .iter()
+                .any(|line| line.contains(&marker))
+        });
+    }
+    std::thread::sleep(Duration::from_millis(150));
+    drop(session);
+    let attempts = holder.attempts.load(Ordering::Relaxed);
+    eprintln!("old-holder output negotiations across ten log updates: {attempts}");
+    assert_eq!(
+        attempts,
+        if fail_first { 2 } else { 1 },
+        "unsupported output streaming must stay on log transport"
+    );
+}

--- a/diri/crates/diri-engine/tests/holder_output_compat.rs
+++ b/diri/crates/diri-engine/tests/holder_output_compat.rs
@@ -20,7 +20,10 @@ struct OldHolder {
 impl Drop for OldHolder {
     fn drop(&mut self) {
         self.stop.store(true, Ordering::Relaxed);
-        self.worker.take().unwrap().join().unwrap();
+        let result = self.worker.take().unwrap().join();
+        if !std::thread::panicking() {
+            result.unwrap();
+        }
     }
 }
 
@@ -77,12 +80,7 @@ fn exercise_old_holder(fail_first: bool) {
                     }
                     Err(e) => panic!("accept: {e}"),
                 };
-                stream
-                    .set_read_timeout(Some(Duration::from_secs(1)))
-                    .unwrap();
-                let mut line = String::new();
-                BufReader::new(&mut stream).read_line(&mut line).unwrap();
-                let request: serde_json::Value = serde_json::from_str(&line).unwrap();
+                let request = read_request(&mut stream);
                 let response = match request["op"].as_str().unwrap() {
                     "stat" => serde_json::json!({"ok":true,"stat":stat}),
                     "output-stream" => {
@@ -146,4 +144,32 @@ fn exercise_old_holder(fail_first: bool) {
         if fail_first { 2 } else { 1 },
         "unsupported output streaming must stay on log transport"
     );
+}
+
+fn read_request(stream: &mut std::os::unix::net::UnixStream) -> serde_json::Value {
+    // Keep accept nonblocking for shutdown, but wait for the client's request
+    // on the accepted socket. macOS inherits the listener's nonblocking flag.
+    stream.set_nonblocking(false).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(1)))
+        .unwrap();
+    let mut line = String::new();
+    BufReader::new(stream).read_line(&mut line).unwrap();
+    serde_json::from_str(&line).unwrap()
+}
+
+#[test]
+fn fake_holder_waits_for_request_after_nonblocking_accept() {
+    use std::os::unix::net::UnixStream;
+    let (mut server, mut client) = UnixStream::pair().unwrap();
+    // macOS can inherit this flag from the nonblocking listener. The client
+    // need not have written its request when accept returns.
+    server.set_nonblocking(true).unwrap();
+    let writer = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(30));
+        let _ = client.write_all(b"{\"op\":\"stat\"}\n");
+    });
+    let request = read_request(&mut server);
+    writer.join().unwrap();
+    assert_eq!(request["op"], "stat");
 }

--- a/diri/scripts/terminal-perf-gate.sh
+++ b/diri/scripts/terminal-perf-gate.sh
@@ -15,3 +15,4 @@ cargo bench --locked -p diri-term --bench terminal_renderer -- \
 cargo test --locked --release -p diri-engine --test holder \
     holder_input_latency_is_reported -- --ignored --exact --nocapture
 cargo test --locked --release -p diri-engine --test attach -- --nocapture
+cargo test --locked --release -p diri-engine --test holder_output_compat -- --nocapture


### PR DESCRIPTION
## Why

Long-lived local Holders that predate output streaming reject the same negotiation on every log wakeup. The Engine repeatedly reconnects instead of remembering the rejection. Local Holders also retain a raw-output ring that no Holder operation reads, and Codex title refreshes repeat database/schema/index work for every session.

## What changed

- Remember a completed negative output-stream negotiation for the adopted session; transient transport failures and interrupted supported streams remain retryable.
- Remove the unread local Holder output ring while preserving durable logs, offsets, rotation, exit markers and the bounded live-output queue.
- Batch Codex title reads per account-profile directory without a persistent cache or slower refresh cadence.
- Add regressions, a reproducible Holder memory benchmark, and measured results in `diri/PERF.md`.

The development-workspace fixture measured median Holder footprint of **150.1 → 7.3 MiB** across 20 PTYs after 5 MiB of output each. Twenty title reads measured **1.77 → 0.19 ms** for individual calls versus one batched pass. Throughput remained comparable. These are scoped fixture measurements, not a claim that desktop graphics memory or total idle CPU has been fixed.

Existing production processes were not replaced. Holder memory savings require the updated manager process after its existing sessions finish. No protocol, production dependency, or UI change is included. Unrelated working-tree edits are excluded.

## Verification

Original development workspace: formatting, workspace Clippy, 1,349 passing tests, release build, and terminal performance gate passed. That workspace included separately documented parser/renderer changes. The isolated PR branch is based on current `main`; `./scripts/check.sh` passed, including formatting, workspace Clippy, 1,445 passing tests (30 intentionally ignored), shell/release guards, and the dependency license policy.

- [x] `./scripts/check.sh` passes on the isolated PR branch.
- [x] Existing sessions survive app/daemon restarts: adoption, checkpoint, holder-session and attach regressions passed in the development workspace.
- [x] Security/privacy considered: existing local transport only; no credentials or protocol payload logging; account profiles stay isolated.
- [x] Rollout behavior and measurement limits documented in `diri/PERF.md` and `diri/REMOTE_PORT.md`.
- [x] UI screenshots not applicable: no UI changes.
