### PR TITLE
feat: add Cursor dashboard usage to account totals

### DIFF
--- a/diri/Cargo.lock
+++ b/diri/Cargo.lock
@@ -1368,6 +1368,7 @@ dependencies = [
 name = "diri-app"
 version = "0.5.0"
 dependencies = [
+ "base64 0.23.1",
  "block2 0.6.2",
  "diri-client",
  "diri-proto",
@@ -1384,6 +1385,7 @@ dependencies = [
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
  "objc2-user-notifications",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/diri/crates/diri-app/Cargo.toml
+++ b/diri/crates/diri-app/Cargo.toml
@@ -29,6 +29,7 @@ entitlements = "../../assets/diri.entitlements"
 background-app = false
 
 [dependencies]
+base64.workspace = true
 diri-client.workspace = true
 diri-proto.workspace = true
 diri-term.workspace = true
@@ -40,6 +41,7 @@ gpui_platform.workspace = true
 image.workspace = true
 nucleo-matcher.workspace = true
 notify.workspace = true
+rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/diri/crates/diri-app/src/main.rs
+++ b/diri/crates/diri-app/src/main.rs
@@ -59,7 +59,8 @@ use tokio::runtime::{Builder as RuntimeBuilder, Runtime};
 use crate::store::{StoreRuntime, WindowMode, WindowPlacement};
 use crate::updates::UpdateHandle;
 use crate::usage::{
-    TranscriptInvalidation, TranscriptWatcher, UsageSnapshot, UsageStore, merge_fleet_usage,
+    TranscriptInvalidation, TranscriptWatcher, UsageSnapshot, UsageStore, merge_cursor_usage,
+    merge_fleet_usage,
 };
 
 pub mod store;
@@ -353,7 +354,7 @@ async fn publish_usage_refresh(
     invalidated: Option<Vec<PathBuf>>,
     home: &std::path::Path,
 ) -> Option<UsageStore> {
-    let (store, snapshot) = tokio::task::spawn_blocking(move || {
+    let (mut store, snapshot) = tokio::task::spawn_blocking(move || {
         let snapshot = match invalidated {
             Some(paths) => store.refresh_paths(&paths),
             None => store.refresh(),
@@ -363,6 +364,7 @@ async fn publish_usage_refresh(
     .await
     .ok()?;
     let snapshot = merge_fleet_usage(snapshot, home).await;
+    let snapshot = merge_cursor_usage(&mut store, snapshot, home).await;
     usage_tx.send_replace(snapshot);
     Some(store)
 }

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -2495,7 +2495,10 @@ impl Sidebar {
             usage = usage
                 .child(usage_row("Session", "resets in 2h 14m", "$2.31", colors))
                 .child(usage_row("Today", "1.8M tokens", "$4.82", colors))
-                .child(usage_row("This month", "", "$86.40", colors));
+                .child(usage_row("This month", "", "$86.40", colors))
+                .child(usage_row("Claude Code", "", "$40.10", colors))
+                .child(usage_row("Codex", "", "$22.00", colors))
+                .child(usage_row("Cursor", "", "$24.30", colors));
         } else if let Some(snapshot) = self.usage {
             usage = usage
                 .child(usage_row(
@@ -2526,6 +2529,30 @@ impl Sidebar {
                     &UsageFormat::money(snapshot.month().cost),
                     colors,
                 ));
+            if snapshot.claude.month.cost > 0.0 {
+                usage = usage.child(usage_row(
+                    "Claude Code",
+                    "",
+                    &UsageFormat::money(snapshot.claude.month.cost),
+                    colors,
+                ));
+            }
+            if snapshot.codex.month.cost > 0.0 {
+                usage = usage.child(usage_row(
+                    "Codex",
+                    "",
+                    &UsageFormat::money(snapshot.codex.month.cost),
+                    colors,
+                ));
+            }
+            if snapshot.cursor.month.cost > 0.0 {
+                usage = usage.child(usage_row(
+                    "Cursor",
+                    "",
+                    &UsageFormat::money(snapshot.cursor.month.cost),
+                    colors,
+                ));
+            }
         } else {
             usage = usage.child(
                 div()

--- a/diri/crates/diri-app/src/usage/cache.rs
+++ b/diri/crates/diri-app/src/usage/cache.rs
@@ -42,6 +42,18 @@ pub(crate) struct UsageCacheFile {
     pub version: u32,
     pub files: BTreeMap<String, UsageFileEntry>,
     pub seen: BTreeMap<i64, Vec<u64>>,
+    #[serde(default)]
+    pub cursor: CursorLedger,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub(crate) struct CursorLedger {
+    #[serde(default)]
+    pub last_event_ms: i64,
+    #[serde(default)]
+    pub hours: BTreeMap<i64, UsageHourAgg>,
+    #[serde(default)]
+    pub seen: BTreeMap<i64, Vec<u64>>,
 }
 
 impl Default for UsageCacheFile {
@@ -50,6 +62,7 @@ impl Default for UsageCacheFile {
             version: CACHE_VERSION,
             files: BTreeMap::new(),
             seen: BTreeMap::new(),
+            cursor: CursorLedger::default(),
         }
     }
 }

--- a/diri/crates/diri-app/src/usage/cursor.rs
+++ b/diri/crates/diri-app/src/usage/cursor.rs
@@ -1,0 +1,579 @@
+//! Cursor dashboard usage events. Token counts and billed cents come from
+//! Cursor's personal usage API, not local transcripts (those have no usage).
+//!
+//! Auth is read from the signed-in Cursor IDE store or macOS keychain. Tokens
+//! travel through curl's stdin config and are never logged.
+
+use std::{
+    path::{Path, PathBuf},
+    process::Stdio,
+    time::Duration,
+};
+
+use serde_json::Value;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+
+use super::{
+    UsageSnapshot,
+    model::UsageHourAgg,
+    parser::fnv1a,
+    store::{Clock, UsageStore},
+};
+
+const DASHBOARD_URL: &str = "https://cursor.com/api/dashboard/get-filtered-usage-events";
+const OAUTH_TOKEN_URL: &str = "https://api2.cursor.sh/oauth/token";
+/// Cursor's public native OAuth client id (same value TokenLeader uses).
+const OAUTH_CLIENT_ID: &str = "KbZUR41cY7W6zRSdpSUJ7I7mLYBKOCmB";
+const PAGE_SIZE: u32 = 100;
+const MAX_PAGES: u32 = 10;
+const OVERLAP_MS: i64 = 5 * 60 * 1000;
+const FETCH_TIMEOUT_SECS: u64 = 25;
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct CursorUsageEvent {
+    pub id: String,
+    pub timestamp_ms: i64,
+    pub model: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub cache_write_tokens: i64,
+    pub cost: f64,
+}
+
+pub(crate) fn event_hour(event: &CursorUsageEvent) -> i64 {
+    event.timestamp_ms.div_euclid(3_600_000)
+}
+
+pub(crate) fn event_aggregate(event: &CursorUsageEvent) -> UsageHourAgg {
+    UsageHourAgg {
+        i: event.input_tokens,
+        o: event.output_tokens,
+        cr: event.cache_read_tokens,
+        cw: event.cache_write_tokens,
+        c: event.cost,
+    }
+}
+
+pub(crate) fn map_dashboard_event(value: &Value) -> Option<CursorUsageEvent> {
+    let timestamp_ms = parse_timestamp_ms(value.get("timestamp"))?;
+    let usage = value.get("tokenUsage");
+    let input_tokens = integer(value.get("inputTokens")).or_else(|| {
+        usage
+            .and_then(|usage| usage.get("inputTokens"))
+            .map(integer_value)
+    });
+    let output_tokens = integer(value.get("outputTokens")).or_else(|| {
+        usage
+            .and_then(|usage| usage.get("outputTokens"))
+            .map(integer_value)
+    });
+    let cache_write = usage
+        .and_then(|usage| usage.get("cacheWriteTokens"))
+        .map(integer_value)
+        .unwrap_or(0);
+    let cache_read = usage
+        .and_then(|usage| usage.get("cacheReadTokens"))
+        .map(integer_value)
+        .unwrap_or(0);
+    let cents = float(value.get("totalCents")).or_else(|| {
+        usage
+            .and_then(|usage| usage.get("totalCents"))
+            .map(float_value)
+    });
+    let model = value
+        .get("modelName")
+        .and_then(Value::as_str)
+        .or_else(|| value.get("model").and_then(Value::as_str))
+        .unwrap_or("cursor")
+        .trim();
+    let model = if model.is_empty() {
+        "cursor".to_owned()
+    } else {
+        model.to_owned()
+    };
+    let id = value
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty())
+        .map(str::to_owned)
+        .unwrap_or_else(|| {
+            format!(
+                "{timestamp_ms}:{model}:{}:{}:{cache_write}:{cache_read}",
+                input_tokens.unwrap_or(0),
+                output_tokens.unwrap_or(0)
+            )
+        });
+    Some(CursorUsageEvent {
+        id,
+        timestamp_ms,
+        model,
+        input_tokens: input_tokens.unwrap_or(0).max(0),
+        output_tokens: output_tokens.unwrap_or(0).max(0),
+        cache_read_tokens: cache_read.max(0),
+        cache_write_tokens: cache_write.max(0),
+        cost: cents.unwrap_or(0.0).max(0.0) / 100.0,
+    })
+}
+
+pub(crate) fn events_from_dashboard_body(body: &Value) -> Vec<CursorUsageEvent> {
+    body.get("usageEvents")
+        .or_else(|| body.get("usageEventsDisplay"))
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(map_dashboard_event)
+        .collect()
+}
+
+pub(crate) fn workos_session_token(access_token: &str) -> Option<String> {
+    let access_token = access_token.trim();
+    if access_token.is_empty() {
+        return None;
+    }
+    if access_token.contains("::") {
+        return Some(access_token.to_owned());
+    }
+    let user_id = user_id_from_jwt(access_token)?;
+    Some(format!("{user_id}::{access_token}"))
+}
+
+fn user_id_from_jwt(access_token: &str) -> Option<String> {
+    let payload = access_token.split('.').nth(1)?;
+    let decoded = decode_b64url(payload)?;
+    let value: Value = serde_json::from_slice(&decoded).ok()?;
+    let sub = value.get("sub")?.as_str()?.trim();
+    if sub.is_empty() {
+        return None;
+    }
+    Some(
+        sub.rsplit_once('|')
+            .map(|(_, id)| id)
+            .unwrap_or(sub)
+            .to_owned(),
+    )
+}
+
+fn decode_b64url(input: &str) -> Option<Vec<u8>> {
+    use base64::Engine as _;
+    use base64::engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD};
+
+    URL_SAFE_NO_PAD.decode(input).ok().or_else(|| {
+        let mut padded = input.to_owned();
+        while !padded.len().is_multiple_of(4) {
+            padded.push('=');
+        }
+        URL_SAFE.decode(padded).ok()
+    })
+}
+
+struct CursorAuth {
+    session_token: String,
+    refresh_token: Option<String>,
+    machine_id: Option<String>,
+}
+
+pub async fn merge_cursor_usage<C: Clock>(
+    store: &mut UsageStore<C>,
+    mut snapshot: UsageSnapshot,
+    home: &Path,
+) -> UsageSnapshot {
+    let Some(mut auth) = load_cursor_auth(home) else {
+        return snapshot;
+    };
+    let start_ms = store.cursor_fetch_start_ms();
+    match fetch_cursor_events(&mut auth, start_ms).await {
+        Ok(events) if !events.is_empty() => {
+            snapshot.cursor = store.ingest_cursor_events(&events);
+        }
+        Ok(_) => {}
+        Err(_) => {}
+    }
+    snapshot
+}
+
+fn load_cursor_auth(home: &Path) -> Option<CursorAuth> {
+    let from_ide = read_ide_auth(home);
+    let access = from_ide
+        .as_ref()
+        .and_then(|auth| auth.access_token.clone())
+        .or_else(keychain_access_token)?;
+    let session_token = workos_session_token(&access)?;
+    if session_token.chars().any(char::is_control) {
+        return None;
+    }
+    let refresh = from_ide
+        .as_ref()
+        .and_then(|auth| auth.refresh_token.clone())
+        .or_else(keychain_refresh_token)
+        .filter(|token| !token.is_empty() && !token.chars().any(char::is_control));
+    let machine_id = from_ide
+        .and_then(|auth| auth.machine_id)
+        .filter(|id| !id.is_empty() && !id.chars().any(char::is_control));
+    Some(CursorAuth {
+        session_token,
+        refresh_token: refresh,
+        machine_id,
+    })
+}
+
+struct IdeAuth {
+    access_token: Option<String>,
+    refresh_token: Option<String>,
+    machine_id: Option<String>,
+}
+
+fn read_ide_auth(home: &Path) -> Option<IdeAuth> {
+    let path = cursor_state_db(home);
+    if !path.is_file() {
+        return None;
+    }
+    let connection = rusqlite::Connection::open_with_flags(
+        &path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .ok()?;
+    let _ = connection.busy_timeout(Duration::from_millis(40));
+    Some(IdeAuth {
+        access_token: query_item(&connection, "cursorAuth/accessToken"),
+        refresh_token: query_item(&connection, "cursorAuth/refreshToken"),
+        machine_id: query_item(&connection, "storage.serviceMachineId")
+            .or_else(|| query_item(&connection, "telemetry.machineId")),
+    })
+}
+
+fn cursor_state_db(home: &Path) -> PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        home.join("Library/Application Support/Cursor/User/globalStorage/state.vscdb")
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        home.join(".config/Cursor/User/globalStorage/state.vscdb")
+    }
+}
+
+fn query_item(connection: &rusqlite::Connection, key: &str) -> Option<String> {
+    let value: String = connection
+        .query_row(
+            "SELECT value FROM ItemTable WHERE key = ?1 LIMIT 1",
+            [key],
+            |row| row.get(0),
+        )
+        .ok()?;
+    let value = value.trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_owned())
+    }
+}
+
+fn keychain_access_token() -> Option<String> {
+    keychain_password("cursor-access-token")
+}
+
+fn keychain_refresh_token() -> Option<String> {
+    keychain_password("cursor-refresh-token")
+}
+
+fn keychain_password(service: &str) -> Option<String> {
+    #[cfg(target_os = "macos")]
+    {
+        let output = std::process::Command::new("/usr/bin/security")
+            .args([
+                "find-generic-password",
+                "-s",
+                service,
+                "-a",
+                "cursor-user",
+                "-w",
+            ])
+            .stdin(Stdio::null())
+            .stderr(Stdio::null())
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let value = String::from_utf8(output.stdout).ok()?;
+        let value = value.trim();
+        if value.is_empty() {
+            None
+        } else {
+            Some(value.to_owned())
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = service;
+        None
+    }
+}
+
+async fn fetch_cursor_events(
+    auth: &mut CursorAuth,
+    start_ms: i64,
+) -> Result<Vec<CursorUsageEvent>, ()> {
+    let mut events = Vec::new();
+    for page in 1..=MAX_PAGES {
+        let body = serde_json::json!({
+            "page": page,
+            "pageSize": PAGE_SIZE,
+            "startDate": start_ms.max(0),
+        });
+        let (status, payload) = dashboard_post(auth, &body).await?;
+        if status == 401 || status == 403 {
+            refresh_session(auth).await?;
+            let (status, payload) = dashboard_post(auth, &body).await?;
+            if status != 200 {
+                return Err(());
+            }
+            let has_next = payload
+                .pointer("/pagination/hasNextPage")
+                .and_then(Value::as_bool);
+            let page_events = events_from_dashboard_body(&payload);
+            let count = page_events.len();
+            events.extend(page_events);
+            if has_next == Some(false) || (has_next != Some(true) && count < PAGE_SIZE as usize) {
+                break;
+            }
+            continue;
+        }
+        if status != 200 {
+            return Err(());
+        }
+        let has_next = payload
+            .pointer("/pagination/hasNextPage")
+            .and_then(Value::as_bool);
+        let page_events = events_from_dashboard_body(&payload);
+        let count = page_events.len();
+        events.extend(page_events);
+        if has_next == Some(false) || (has_next != Some(true) && count < PAGE_SIZE as usize) {
+            break;
+        }
+    }
+    Ok(events)
+}
+
+async fn dashboard_post(auth: &CursorAuth, body: &Value) -> Result<(u16, Value), ()> {
+    let mut headers = vec![
+        ("Content-Type".into(), "application/json".into()),
+        (
+            "Cookie".into(),
+            format!("WorkosCursorSessionToken={}", auth.session_token),
+        ),
+        ("Origin".into(), "https://cursor.com".into()),
+    ];
+    if let Some(machine_id) = &auth.machine_id {
+        headers.push(("x-cursor-client-id".into(), machine_id.clone()));
+    }
+    http_json("POST", DASHBOARD_URL, &headers, Some(body)).await
+}
+
+async fn refresh_session(auth: &mut CursorAuth) -> Result<(), ()> {
+    let refresh = auth.refresh_token.as_deref().ok_or(())?;
+    let body = serde_json::json!({
+        "grant_type": "refresh_token",
+        "client_id": OAUTH_CLIENT_ID,
+        "refresh_token": refresh,
+    });
+    let (status, payload) = http_json("POST", OAUTH_TOKEN_URL, &[], Some(&body)).await?;
+    if status != 200 || payload.get("shouldLogout").and_then(Value::as_bool) == Some(true) {
+        return Err(());
+    }
+    let access = payload
+        .get("access_token")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+        .ok_or(())?;
+    auth.session_token = workos_session_token(access).ok_or(())?;
+    Ok(())
+}
+
+async fn http_json(
+    method: &str,
+    url: &str,
+    headers: &[(String, String)],
+    body: Option<&Value>,
+) -> Result<(u16, Value), ()> {
+    let mut config = String::from("silent\nproto = \"=https\"\n");
+    config.push_str(&format!("max-time = \"{FETCH_TIMEOUT_SECS}\"\n"));
+    config.push_str("max-filesize = \"2097152\"\n");
+    config.push_str("write-out = \"\\n%{http_code}\"\n");
+    config.push_str("request = \"");
+    config.push_str(method);
+    config.push_str("\"\nurl = \"");
+    config.push_str(&curl_escape(url));
+    config.push_str("\"\n");
+    for (name, value) in headers {
+        if name.chars().any(char::is_control) || value.chars().any(char::is_control) {
+            return Err(());
+        }
+        config.push_str("header = \"");
+        config.push_str(&curl_escape(&format!("{name}: {value}")));
+        config.push_str("\"\n");
+    }
+    if let Some(body) = body {
+        config.push_str("data = \"");
+        config.push_str(&curl_escape(&body.to_string()));
+        config.push_str("\"\n");
+    }
+    let mut child = Command::new("/usr/bin/curl")
+        .args(["-q", "--config", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|_| ())?;
+    let mut stdin = child.stdin.take().ok_or(())?;
+    stdin.write_all(config.as_bytes()).await.map_err(|_| ())?;
+    drop(stdin);
+    let output = tokio::time::timeout(
+        Duration::from_secs(FETCH_TIMEOUT_SECS + 4),
+        child.wait_with_output(),
+    )
+    .await
+    .map_err(|_| ())?
+    .map_err(|_| ())?;
+    if !output.status.success() {
+        return Err(());
+    }
+    let raw = std::str::from_utf8(&output.stdout).map_err(|_| ())?;
+    let (body, status) = raw.rsplit_once('\n').ok_or(())?;
+    let status: u16 = status.trim().parse().map_err(|_| ())?;
+    if body.is_empty() {
+        return Ok((status, Value::Null));
+    }
+    let payload = serde_json::from_str(body).unwrap_or(Value::Null);
+    Ok((status, payload))
+}
+
+fn curl_escape(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn parse_timestamp_ms(value: Option<&Value>) -> Option<i64> {
+    let value = value?;
+    let ms = if let Some(number) = value.as_i64() {
+        number
+    } else if let Some(number) = value.as_f64() {
+        number as i64
+    } else {
+        value.as_str()?.parse::<i64>().ok()?
+    };
+    (ms > 0).then_some(ms)
+}
+
+fn integer(value: Option<&Value>) -> Option<i64> {
+    value.map(integer_value)
+}
+
+fn integer_value(value: &Value) -> i64 {
+    value
+        .as_i64()
+        .or_else(|| value.as_f64().map(|number| number as i64))
+        .unwrap_or(0)
+}
+
+fn float(value: Option<&Value>) -> Option<f64> {
+    value.map(float_value)
+}
+
+fn float_value(value: &Value) -> f64 {
+    value
+        .as_f64()
+        .or_else(|| value.as_i64().map(|number| number as f64))
+        .unwrap_or(0.0)
+}
+
+pub(crate) fn cursor_overlap_ms() -> i64 {
+    OVERLAP_MS
+}
+
+pub(crate) fn event_dedup_hash(id: &str) -> u64 {
+    fnv1a(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn maps_model_name_and_billed_cents() {
+        let event = map_dashboard_event(&json!({
+            "id": "evt-123",
+            "timestamp": "1704067200000",
+            "modelName": "claude-4.5-sonnet",
+            "inputTokens": 100,
+            "outputTokens": 50,
+            "totalCents": 1.23,
+        }))
+        .unwrap();
+        assert_eq!(event.id, "evt-123");
+        assert_eq!(event.model, "claude-4.5-sonnet");
+        assert_eq!(event.input_tokens, 100);
+        assert_eq!(event.output_tokens, 50);
+        assert!((event.cost - 0.0123).abs() < 1e-9);
+        assert_eq!(event_hour(&event), 1704067200000 / 3_600_000);
+    }
+
+    #[test]
+    fn reads_nested_token_usage() {
+        let event = map_dashboard_event(&json!({
+            "id": "evt-456",
+            "timestamp": 1_700_000_000_000_i64,
+            "model": "gpt-4.1",
+            "tokenUsage": {
+                "inputTokens": 10,
+                "outputTokens": 5,
+                "cacheWriteTokens": 2,
+                "cacheReadTokens": 3,
+                "totalCents": 0.5,
+            },
+        }))
+        .unwrap();
+        assert_eq!(event.input_tokens, 10);
+        assert_eq!(event.cache_write_tokens, 2);
+        assert_eq!(event.cache_read_tokens, 3);
+        assert!((event.cost - 0.005).abs() < 1e-9);
+    }
+
+    #[test]
+    fn workos_cookie_uses_jwt_subject_tail() {
+        let payload = base64::Engine::encode(
+            &base64::engine::general_purpose::URL_SAFE_NO_PAD,
+            br#"{"sub":"auth0|user-99"}"#,
+        );
+        let jwt = format!("header.{payload}.sig");
+        assert_eq!(
+            workos_session_token(&jwt).as_deref(),
+            Some(format!("user-99::{jwt}").as_str())
+        );
+        assert_eq!(
+            workos_session_token("abc::already").as_deref(),
+            Some("abc::already")
+        );
+    }
+
+    #[test]
+    fn dashboard_body_prefers_usage_events() {
+        let events = events_from_dashboard_body(&json!({
+            "usageEvents": [{
+                "id": "a",
+                "timestamp": 1_700_000_000_000_i64,
+                "model": "composer-1",
+                "inputTokens": 1,
+                "outputTokens": 2,
+                "totalCents": 10
+            }],
+            "usageEventsDisplay": [],
+        }));
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].model, "composer-1");
+    }
+}

--- a/diri/crates/diri-app/src/usage/mod.rs
+++ b/diri/crates/diri-app/src/usage/mod.rs
@@ -1,9 +1,10 @@
-//! Incremental, daemon-free usage accounting for Claude Code and Codex transcripts.
+//! Incremental usage accounting for Claude Code, Codex, and Cursor.
 //!
-//! Costs are computed locally from the transcripts on disk; nothing is sent
-//! anywhere and no provider API is queried.
+//! Claude and Codex costs come from local transcripts. Cursor usage is fetched
+//! from Cursor's dashboard API using the signed-in IDE/CLI session.
 
 mod cache;
+mod cursor;
 mod fleet;
 mod model;
 mod parser;
@@ -12,6 +13,7 @@ mod store;
 mod timestamp;
 mod watcher;
 
+pub(crate) use cursor::merge_cursor_usage;
 pub(crate) use fleet::merge_fleet_usage;
 pub use model::{ProviderUsage, UsageHourAgg, UsageSnapshot, UsageTotals};
 pub use pricing::PRICING_ENTRY_COUNT;

--- a/diri/crates/diri-app/src/usage/model.rs
+++ b/diri/crates/diri-app/src/usage/model.rs
@@ -54,6 +54,7 @@ pub struct ProviderUsage {
 pub struct UsageSnapshot {
     pub claude: ProviderUsage,
     pub codex: ProviderUsage,
+    pub cursor: ProviderUsage,
     pub session_cost: Option<f64>,
     pub session_started_at: Option<i64>,
     pub session_ends_at: Option<i64>,
@@ -66,6 +67,7 @@ impl UsageSnapshot {
     pub fn today(self) -> UsageTotals {
         let mut totals = self.claude.today;
         totals += self.codex.today;
+        totals += self.cursor.today;
         totals
     }
 
@@ -73,6 +75,7 @@ impl UsageSnapshot {
     pub fn month(self) -> UsageTotals {
         let mut totals = self.claude.month;
         totals += self.codex.month;
+        totals += self.cursor.month;
         totals
     }
 }

--- a/diri/crates/diri-app/src/usage/store.rs
+++ b/diri/crates/diri-app/src/usage/store.rs
@@ -7,7 +7,8 @@ use std::{
 
 use super::{
     cache::{self, UsageCacheFile, UsageFileEntry},
-    model::{UsageHourAgg, UsageSnapshot, UsageTotals},
+    cursor::{CursorUsageEvent, event_aggregate, event_dedup_hash, event_hour},
+    model::{ProviderUsage, UsageHourAgg, UsageSnapshot, UsageTotals},
     parser::{parse_claude, parse_codex, tail_hash},
     timestamp::days_from_civil,
 };
@@ -156,6 +157,30 @@ impl<C: Clock> UsageStore<C> {
             .iter()
             .map(|(root, _)| root.clone())
             .collect()
+    }
+
+    pub(crate) fn cursor_fetch_start_ms(&self) -> i64 {
+        let now_ms = self.clock.read().unix_seconds.saturating_mul(1_000);
+        let last = self.ledger.cache.cursor.last_event_ms;
+        if last > 0 {
+            last.saturating_sub(super::cursor::cursor_overlap_ms())
+                .max(0)
+        } else {
+            now_ms
+                .saturating_sub(RETENTION_DAYS.saturating_mul(86_400).saturating_mul(1_000))
+                .max(0)
+        }
+    }
+
+    pub(crate) fn ingest_cursor_events(&mut self, events: &[CursorUsageEvent]) -> ProviderUsage {
+        let reading = self.clock.read();
+        let cutoff_hour = reading.unix_seconds / 3_600 - RETENTION_DAYS * 24;
+        let changed = ingest_cursor(&mut self.ledger.cache, events, cutoff_hour);
+        self.ledger.dirty |= changed;
+        if self.ledger.dirty && cache::save(&self.paths.cache_file, &self.ledger.cache).is_ok() {
+            self.ledger.dirty = false;
+        }
+        provider_from_hours(&self.ledger.cache.cursor.hours, reading)
     }
 }
 
@@ -393,6 +418,13 @@ fn scan(
     cache.seen.retain(|hour, _| *hour >= cutoff_hour);
     changed |= seen_before_retain != cache.seen.len();
 
+    let cursor_hours_before = cache.cursor.hours.len();
+    let cursor_seen_before = cache.cursor.seen.len();
+    cache.cursor.hours.retain(|hour, _| *hour >= cutoff_hour);
+    cache.cursor.seen.retain(|hour, _| *hour >= cutoff_hour);
+    changed |= cursor_hours_before != cache.cursor.hours.len()
+        || cursor_seen_before != cache.cursor.seen.len();
+
     let mut claude_hours = BTreeMap::new();
     let mut codex_hours = BTreeMap::new();
     for (path, entry) in &cache.files {
@@ -412,7 +444,7 @@ fn scan(
     }
 
     (
-        snapshot(&claude_hours, &codex_hours, reading),
+        snapshot(&claude_hours, &codex_hours, &cache.cursor.hours, reading),
         stats,
         changed,
     )
@@ -538,6 +570,7 @@ fn walk(root: &Path, provider: UsageProvider, files: &mut Vec<(PathBuf, UsagePro
 fn snapshot(
     claude_hours: &BTreeMap<i64, UsageHourAgg>,
     codex_hours: &BTreeMap<i64, UsageHourAgg>,
+    cursor_hours: &BTreeMap<i64, UsageHourAgg>,
     reading: ClockReading,
 ) -> UsageSnapshot {
     let mut result = UsageSnapshot {
@@ -563,6 +596,7 @@ fn snapshot(
             result.codex.month += aggregate;
         }
     }
+    result.cursor = provider_from_hours(cursor_hours, reading);
 
     let mut block_start = None;
     let mut block_totals = UsageTotals::default();
@@ -586,6 +620,60 @@ fn snapshot(
         }
     }
     result
+}
+
+fn provider_from_hours(
+    hours: &BTreeMap<i64, UsageHourAgg>,
+    reading: ClockReading,
+) -> ProviderUsage {
+    let mut result = ProviderUsage::default();
+    let today_start_hour = reading.today_started_at / 3_600;
+    let month_start_hour = reading.month_started_at / 3_600;
+    for (&hour, &aggregate) in hours {
+        if hour >= today_start_hour {
+            result.today += aggregate;
+        }
+        if hour >= month_start_hour {
+            result.month += aggregate;
+        }
+    }
+    result
+}
+
+fn ingest_cursor(
+    cache: &mut UsageCacheFile,
+    events: &[CursorUsageEvent],
+    cutoff_hour: i64,
+) -> bool {
+    let hours_before = cache.cursor.hours.len();
+    let seen_before = cache.cursor.seen.len();
+    cache.cursor.hours.retain(|hour, _| *hour >= cutoff_hour);
+    cache.cursor.seen.retain(|hour, _| *hour >= cutoff_hour);
+    let mut changed =
+        hours_before != cache.cursor.hours.len() || seen_before != cache.cursor.seen.len();
+    for event in events {
+        let hour = event_hour(event);
+        if hour < cutoff_hour {
+            continue;
+        }
+        let hash = event_dedup_hash(&event.id);
+        let seen = cache.cursor.seen.entry(hour).or_default();
+        if seen.contains(&hash) {
+            continue;
+        }
+        seen.push(hash);
+        cache
+            .cursor
+            .hours
+            .entry(hour)
+            .or_default()
+            .merge(event_aggregate(event));
+        if event.timestamp_ms > cache.cursor.last_event_ms {
+            cache.cursor.last_event_ms = event.timestamp_ms;
+        }
+        changed = true;
+    }
+    changed
 }
 
 #[cfg(all(unix, target_pointer_width = "64"))]

--- a/diri/crates/diri-app/src/usage/tests.rs
+++ b/diri/crates/diri-app/src/usage/tests.rs
@@ -5,6 +5,7 @@ use tempfile::TempDir;
 
 use super::{
     Clock, ClockReading, ScanPaths, UsageProvider, UsageStore,
+    cursor::CursorUsageEvent,
     parser::fnv1a,
     pricing::{match_claude, match_openai},
     timestamp::parse_timestamp,
@@ -116,6 +117,7 @@ fn aggregates_costs_dedupes_claude_and_preserves_provider_totals() {
     assert_eq!(snapshot.codex.month, snapshot.codex.today);
     assert_eq!(snapshot.codex.session.total_tokens(), 0);
 
+    assert_eq!(snapshot.cursor.today.total_tokens(), 0);
     assert_eq!(snapshot.today().total_tokens(), 3_000);
     assert_close(snapshot.today().cost, 0.011_027_5);
     assert_close(snapshot.session_cost.unwrap(), 0.007_927_5);
@@ -439,6 +441,56 @@ fn ordered_pricing_table_and_fnv_hash_match_the_swift_constants() {
         assert_eq!((pricing.input, pricing.output), (input, output));
     }
     assert_eq!(fnv1a("hello"), 0xa430_d846_80aa_bd0b);
+}
+
+#[test]
+fn ingest_cursor_events_dedupes_and_survives_refresh() {
+    let fixture = Fixture::new();
+    let mut store = fixture.store(
+        "2026-07-22T12:00:00Z",
+        "2026-07-22T00:00:00Z",
+        "2026-07-01T00:00:00Z",
+    );
+    let event = CursorUsageEvent {
+        id: "evt-1".into(),
+        timestamp_ms: timestamp("2026-07-22T10:12:00.000Z") * 1_000,
+        model: "composer-1".into(),
+        input_tokens: 100,
+        output_tokens: 20,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        cost: 1.5,
+    };
+    let usage = store.ingest_cursor_events(&[event.clone(), event.clone()]);
+    assert_eq!(usage.today.input_tokens, 100);
+    assert_eq!(usage.today.output_tokens, 20);
+    assert_close(usage.today.cost, 1.5);
+    assert_eq!(usage.month, usage.today);
+
+    let snapshot = store.refresh();
+    assert_eq!(snapshot.cursor.today.input_tokens, 100);
+    assert_close(snapshot.cursor.today.cost, 1.5);
+    assert_eq!(snapshot.today().total_tokens(), 120);
+    assert_close(snapshot.today().cost, 1.5);
+    assert_eq!(
+        store.cursor_fetch_start_ms(),
+        event.timestamp_ms - 5 * 60 * 1_000
+    );
+
+    let cache: Value = serde_json::from_slice(&fs::read(&fixture.cache).unwrap()).unwrap();
+    assert_eq!(cache["cursor"]["last_event_ms"], event.timestamp_ms);
+    assert_eq!(
+        cache["cursor"]["seen"]
+            .as_object()
+            .unwrap()
+            .values()
+            .next()
+            .unwrap()
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Why

Diri already totals Claude Code and Codex from local transcripts, but Cursor transcripts have no usage fields. Signed-in Cursor spend never showed up in the account menu.

## What changed

- Fetch billed Cursor usage from the dashboard API using the signed-in IDE/CLI session (same cookie/OAuth path TokenLeader uses).
- Fold Cursor into existing Session / Today / This month totals, with a Cursor (and other harness) month split in the account popover when cost is above zero.
- Keep Claude/Codex transcript accounting unchanged. Cache version stays 2 so existing ledgers are not wiped.

## Verification

- [x] `cargo fmt --all -- --check`, `cargo clippy -p diri-app --all-targets -- -D warnings`, and `cargo test -p diri-app --bin diri usage` pass. Full `./scripts/check.sh` was not run.
- [x] Existing sessions still survive app and daemon restarts, or the migration is documented.
- [x] I considered security and privacy impact (processes, IPC, logs, updates, remote hosts).
- [x] User-visible behavior or setup changes are documented.
- [ ] UI changes include a screenshot or short recording.

- Tokens travel through curl stdin config and are never logged.
- Auth is read-only from Cursor `ItemTable` / macOS keychain. Tokens are not written back.
- No live Cursor network calls in tests; mapping, JWT cookie, ingest dedup, and refresh persistence are unit-tested.