### PR TITLE
feat: add Cursor billed usage to account totals and Settings

### DIFF
--- a/diri/Cargo.lock
+++ b/diri/Cargo.lock
@@ -1539,6 +1539,7 @@ dependencies = [
 name = "diri-app"
 version = "0.6.5"
 dependencies = [
+ "base64 0.23.1",
  "block2 0.6.2",
  "diri-client",
  "diri-proto",

--- a/diri/crates/diri-app/Cargo.toml
+++ b/diri/crates/diri-app/Cargo.toml
@@ -29,6 +29,7 @@ entitlements = "../../assets/diri.entitlements"
 background-app = false
 
 [dependencies]
+base64.workspace = true
 diri-web = { path = "../diri-web" }
 qrcode = { version = "0.14", default-features = false }
 raw-window-handle.workspace = true

--- a/diri/crates/diri-app/src/main.rs
+++ b/diri/crates/diri-app/src/main.rs
@@ -85,7 +85,8 @@ use crate::commands::{
 use crate::store::{StoreRuntime, WindowMode, WindowPlacement};
 use crate::updates::UpdateHandle;
 use crate::usage::{
-    TranscriptInvalidation, TranscriptWatcher, UsageSnapshot, UsageStore, merge_fleet_usage,
+    TranscriptInvalidation, TranscriptWatcher, UsageSnapshot, UsageStore, merge_cursor_usage,
+    merge_fleet_usage,
 };
 
 pub mod store;
@@ -492,7 +493,7 @@ async fn publish_usage_refresh(
     invalidated: Option<Vec<PathBuf>>,
     home: &std::path::Path,
 ) -> Option<UsageStore> {
-    let (store, snapshot) = tokio::task::spawn_blocking(move || {
+    let (mut store, snapshot) = tokio::task::spawn_blocking(move || {
         let snapshot = match invalidated {
             Some(paths) => store.refresh_paths(&paths),
             None => store.refresh(),
@@ -502,6 +503,7 @@ async fn publish_usage_refresh(
     .await
     .ok()?;
     let snapshot = merge_fleet_usage(snapshot, home).await;
+    let snapshot = merge_cursor_usage(&mut store, snapshot, home).await;
     usage_tx.send_modify(|current| {
         let limits = std::mem::take(&mut current.limits);
         *current = snapshot;

--- a/diri/crates/diri-app/src/main.rs
+++ b/diri/crates/diri-app/src/main.rs
@@ -85,8 +85,8 @@ use crate::commands::{
 use crate::store::{StoreRuntime, WindowMode, WindowPlacement};
 use crate::updates::UpdateHandle;
 use crate::usage::{
-    TranscriptInvalidation, TranscriptWatcher, UsageSnapshot, UsageStore, merge_cursor_usage,
-    merge_fleet_usage,
+    CursorBatch, CursorRefresh, TranscriptInvalidation, TranscriptWatcher, UsageSnapshot,
+    UsageStore, merge_fleet_usage,
 };
 
 pub mod store;
@@ -264,73 +264,13 @@ fn main() {
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from("/nonexistent"));
         tokio.spawn(async move {
-            let mut store = UsageStore::new();
-            let roots = store.watch_roots();
-            let Some(returned_store) =
-                publish_usage_refresh(store, &usage_tx, None, &usage_home).await
-            else {
-                return;
-            };
-            store = returned_store;
-            let mut watcher = TranscriptWatcher::new(&roots).ok();
-            let mut invalidated = HashSet::<PathBuf>::new();
-            let mut reconcile = false;
-            let mut refresh_due: Option<tokio::time::Instant> = None;
-            let mut reconciliation = tokio::time::interval(USAGE_RECONCILE_INTERVAL);
-            reconciliation.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-            reconciliation.tick().await; // initial full refresh already completed above
-            loop {
-                tokio::select! {
-                    event = async {
-                        match watcher.as_mut() {
-                            Some(watcher) => watcher.recv().await,
-                            None => std::future::pending().await,
-                        }
-                    } => {
-                        match event {
-                            Some(TranscriptInvalidation::Paths(paths)) => {
-                                invalidated.extend(paths);
-                            }
-                            Some(TranscriptInvalidation::Reconcile) | None => {
-                                reconcile = true;
-                            }
-                        }
-                        refresh_due = Some(tokio::time::Instant::now() + USAGE_REFRESH_DEBOUNCE);
-                    }
-                    _ = async {
-                        if let Some(deadline) = refresh_due {
-                            tokio::time::sleep_until(deadline).await;
-                        } else {
-                            std::future::pending().await
-                        }
-                    } => {
-                        refresh_due = None;
-                        let paths = (!reconcile).then(|| invalidated.drain().collect::<Vec<_>>());
-                        invalidated.clear();
-                        reconcile = false;
-                        let Some(returned_store) =
-                            publish_usage_refresh(store, &usage_tx, paths, &usage_home).await
-                        else {
-                            return;
-                        };
-                        store = returned_store;
-                    }
-                    _ = reconciliation.tick() => {
-                        // FSEvents can coalesce/drop events. A rare reconciliation
-                        // preserves correctness without tying a recursive walk to
-                        // every session status/resource update.
-                        let Some(returned_store) =
-                            publish_usage_refresh(store, &usage_tx, None, &usage_home).await
-                        else {
-                            return;
-                        };
-                        store = returned_store;
-                        invalidated.clear();
-                        reconcile = false;
-                        refresh_due = None;
-                    }
-                }
-            }
+            run_usage_updates(
+                UsageStore::new(),
+                usage_tx,
+                usage_home,
+                CursorRefresh::default(),
+            )
+            .await;
         });
     }
     let (usage_limits_refresh, mut limits_requests) = tokio::sync::mpsc::channel(1);
@@ -487,13 +427,121 @@ fn main() {
     });
 }
 
+async fn run_usage_updates(
+    mut store: UsageStore,
+    usage_tx: tokio::sync::watch::Sender<UsageSnapshot>,
+    usage_home: PathBuf,
+    mut cursor: CursorRefresh,
+) {
+    cursor.start(&usage_home, store.cursor_fetch_window());
+    let mut cursor_interval = tokio::time::interval(Duration::from_secs(60));
+    cursor_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    cursor_interval.tick().await;
+    let mut reconciliation = tokio::time::interval(USAGE_RECONCILE_INTERVAL);
+    reconciliation.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    reconciliation.tick().await; // initial full refresh follows below
+    let roots = store.watch_roots();
+    let Some(returned_store) = publish_usage_refresh(store, &usage_tx, None, &usage_home).await
+    else {
+        return;
+    };
+    store = returned_store;
+    let mut watcher = TranscriptWatcher::new(&roots).ok();
+    let mut invalidated = HashSet::<PathBuf>::new();
+    let mut reconcile = false;
+    let mut refresh_due: Option<tokio::time::Instant> = None;
+    loop {
+        tokio::select! {
+            _ = cursor_interval.tick() => {
+                cursor.start(&usage_home, store.cursor_fetch_window());
+            }
+            result = cursor.next() => {
+                if let Ok(batch) = result {
+                    let Some(returned_store) = publish_cursor_batch(store, batch, &usage_tx).await else {
+                        return;
+                    };
+                    store = returned_store;
+                }
+            }
+            event = async {
+                match watcher.as_mut() {
+                    Some(watcher) => watcher.recv().await,
+                    None => std::future::pending().await,
+                }
+            } => {
+                match event {
+                    Some(TranscriptInvalidation::Paths(paths)) => {
+                        invalidated.extend(paths);
+                    }
+                    Some(TranscriptInvalidation::Reconcile) | None => {
+                        reconcile = true;
+                    }
+                }
+                refresh_due = Some(tokio::time::Instant::now() + USAGE_REFRESH_DEBOUNCE);
+            }
+            _ = async {
+                if let Some(deadline) = refresh_due {
+                    tokio::time::sleep_until(deadline).await;
+                } else {
+                    std::future::pending().await
+                }
+            } => {
+                refresh_due = None;
+                let paths = (!reconcile).then(|| invalidated.drain().collect::<Vec<_>>());
+                invalidated.clear();
+                reconcile = false;
+                let Some(returned_store) =
+                    publish_usage_refresh(store, &usage_tx, paths, &usage_home).await
+                else {
+                    return;
+                };
+                store = returned_store;
+            }
+            _ = reconciliation.tick() => {
+                // FSEvents can coalesce/drop events. A rare reconciliation
+                // preserves correctness without tying a recursive walk to
+                // every session status/resource update.
+                let Some(returned_store) =
+                    publish_usage_refresh(store, &usage_tx, None, &usage_home).await
+                else {
+                    return;
+                };
+                store = returned_store;
+                invalidated.clear();
+                reconcile = false;
+                refresh_due = None;
+            }
+        }
+    }
+}
+
+async fn publish_cursor_batch(
+    mut store: UsageStore,
+    batch: CursorBatch,
+    usage_tx: &tokio::sync::watch::Sender<UsageSnapshot>,
+) -> Option<UsageStore> {
+    let (store, cursor, history) = tokio::task::spawn_blocking(move || {
+        let cursor = store.ingest_cursor_batch(batch);
+        let history = store.cursor_history();
+        (store, cursor, history)
+    })
+    .await
+    .ok()?;
+    usage_tx.send_modify(|snapshot| {
+        snapshot.cursor = cursor;
+        snapshot.updated_at = usage::Clock::read(&usage::SystemClock).unix_seconds;
+        Arc::make_mut(&mut snapshot.history).cursor = history;
+    });
+    Some(store)
+}
+
 async fn publish_usage_refresh(
     mut store: UsageStore,
     usage_tx: &tokio::sync::watch::Sender<UsageSnapshot>,
     invalidated: Option<Vec<PathBuf>>,
     home: &std::path::Path,
 ) -> Option<UsageStore> {
-    let (mut store, snapshot) = tokio::task::spawn_blocking(move || {
+    let (store, snapshot) = tokio::task::spawn_blocking(move || {
         let snapshot = match invalidated {
             Some(paths) => store.refresh_paths(&paths),
             None => store.refresh(),
@@ -503,7 +551,6 @@ async fn publish_usage_refresh(
     .await
     .ok()?;
     let snapshot = merge_fleet_usage(snapshot, home).await;
-    let snapshot = merge_cursor_usage(&mut store, snapshot, home).await;
     usage_tx.send_modify(|current| {
         let limits = std::mem::take(&mut current.limits);
         *current = snapshot;
@@ -658,4 +705,43 @@ fn load_system_fonts(cx: &mut App) {
 #[cfg(not(target_os = "macos"))]
 fn load_system_fonts(cx: &mut App) {
     fonts::init(cx);
+}
+
+#[cfg(test)]
+mod usage_refresh_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn cursor_regression_slow_fetch_does_not_block_local_updates() {
+        let home = tempfile::tempdir().unwrap();
+        let paths = usage::ScanPaths::for_home(home.path());
+        std::fs::create_dir_all(&paths.roots[0].0).unwrap();
+        // An empty local store still has a published timestamp and must finish
+        // startup even while Cursor is waiting indefinitely on a response.
+        let store = UsageStore::with_paths_and_clock(paths, usage::SystemClock);
+        let (usage_tx, mut usage_rx) = tokio::sync::watch::channel(UsageSnapshot::default());
+        let cursor = CursorRefresh::with_task(tokio::spawn(std::future::pending()));
+        let worker = tokio::spawn(run_usage_updates(
+            store,
+            usage_tx,
+            home.path().to_owned(),
+            cursor,
+        ));
+        tokio::time::timeout(Duration::from_secs(5), usage_rx.changed())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_ne!(usage_rx.borrow_and_update().updated_at, 0);
+        // Advance the real reconciliation loop deterministically; this must
+        // publish again while the same Cursor fetch remains pending.
+        tokio::time::pause();
+        tokio::time::advance(USAGE_RECONCILE_INTERVAL).await;
+        tokio::time::resume();
+        tokio::time::timeout(Duration::from_secs(5), usage_rx.changed())
+            .await
+            .unwrap()
+            .unwrap();
+        worker.abort();
+        let _ = worker.await;
+    }
 }

--- a/diri/crates/diri-app/src/usage/cache.rs
+++ b/diri/crates/diri-app/src/usage/cache.rs
@@ -50,10 +50,21 @@ pub(crate) struct UsageCacheFile {
     pub cursor: CursorLedger,
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub(crate) struct CursorFetchWindow {
+    pub start_ms: i64,
+    pub end_ms: i64,
+    pub next_page: u32,
+    pub newest_event_ms: i64,
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub(crate) struct CursorLedger {
     #[serde(default)]
     pub last_event_ms: i64,
+    /// An unfinished newest-first walk. Its time bounds stay fixed across retries.
+    #[serde(default)]
+    pub pending: Option<CursorFetchWindow>,
     #[serde(default)]
     pub hours: BTreeMap<i64, UsageHourAgg>,
     #[serde(default)]

--- a/diri/crates/diri-app/src/usage/cache.rs
+++ b/diri/crates/diri-app/src/usage/cache.rs
@@ -46,6 +46,20 @@ pub(crate) struct UsageCacheFile {
     pub version: u32,
     pub files: BTreeMap<String, UsageFileEntry>,
     pub seen: BTreeMap<i64, Vec<u64>>,
+    #[serde(default)]
+    pub cursor: CursorLedger,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub(crate) struct CursorLedger {
+    #[serde(default)]
+    pub last_event_ms: i64,
+    #[serde(default)]
+    pub hours: BTreeMap<i64, UsageHourAgg>,
+    #[serde(default)]
+    pub seen: BTreeMap<i64, Vec<u64>>,
+    #[serde(default)]
+    pub details: super::dashboard::ModelHours,
 }
 
 impl Default for UsageCacheFile {
@@ -54,6 +68,7 @@ impl Default for UsageCacheFile {
             version: CACHE_VERSION,
             files: BTreeMap::new(),
             seen: BTreeMap::new(),
+            cursor: CursorLedger::default(),
         }
     }
 }

--- a/diri/crates/diri-app/src/usage/cursor.rs
+++ b/diri/crates/diri-app/src/usage/cursor.rs
@@ -1,0 +1,583 @@
+//! Cursor dashboard usage events. Token counts and billed cents come from
+//! Cursor's personal usage API, not local transcripts (those have no usage).
+//!
+//! Auth is read from the signed-in Cursor IDE store or macOS keychain. Tokens
+//! travel through curl's stdin config and are never logged.
+
+use std::{
+    path::{Path, PathBuf},
+    process::Stdio,
+    sync::Arc,
+    time::Duration,
+};
+
+use serde_json::Value;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+
+use super::{
+    UsageSnapshot,
+    model::UsageHourAgg,
+    parser::fnv1a,
+    store::{Clock, UsageStore},
+};
+
+const DASHBOARD_URL: &str = "https://cursor.com/api/dashboard/get-filtered-usage-events";
+const OAUTH_TOKEN_URL: &str = "https://api2.cursor.sh/oauth/token";
+/// Cursor's public native OAuth client id (same value TokenLeader uses).
+const OAUTH_CLIENT_ID: &str = "KbZUR41cY7W6zRSdpSUJ7I7mLYBKOCmB";
+const PAGE_SIZE: u32 = 100;
+const MAX_PAGES: u32 = 10;
+const OVERLAP_MS: i64 = 5 * 60 * 1000;
+const FETCH_TIMEOUT_SECS: u64 = 25;
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct CursorUsageEvent {
+    pub id: String,
+    pub timestamp_ms: i64,
+    pub model: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub cache_write_tokens: i64,
+    pub cost: f64,
+}
+
+pub(crate) fn event_hour(event: &CursorUsageEvent) -> i64 {
+    event.timestamp_ms.div_euclid(3_600_000)
+}
+
+pub(crate) fn event_aggregate(event: &CursorUsageEvent) -> UsageHourAgg {
+    UsageHourAgg {
+        i: event.input_tokens,
+        o: event.output_tokens,
+        cr: event.cache_read_tokens,
+        cw: event.cache_write_tokens,
+        c: event.cost,
+    }
+}
+
+pub(crate) fn map_dashboard_event(value: &Value) -> Option<CursorUsageEvent> {
+    let timestamp_ms = parse_timestamp_ms(value.get("timestamp"))?;
+    let usage = value.get("tokenUsage");
+    let input_tokens = integer(value.get("inputTokens")).or_else(|| {
+        usage
+            .and_then(|usage| usage.get("inputTokens"))
+            .map(integer_value)
+    });
+    let output_tokens = integer(value.get("outputTokens")).or_else(|| {
+        usage
+            .and_then(|usage| usage.get("outputTokens"))
+            .map(integer_value)
+    });
+    let cache_write = usage
+        .and_then(|usage| usage.get("cacheWriteTokens"))
+        .map(integer_value)
+        .unwrap_or(0);
+    let cache_read = usage
+        .and_then(|usage| usage.get("cacheReadTokens"))
+        .map(integer_value)
+        .unwrap_or(0);
+    let cents = float(value.get("totalCents")).or_else(|| {
+        usage
+            .and_then(|usage| usage.get("totalCents"))
+            .map(float_value)
+    });
+    let model = value
+        .get("modelName")
+        .and_then(Value::as_str)
+        .or_else(|| value.get("model").and_then(Value::as_str))
+        .unwrap_or("cursor")
+        .trim();
+    let model = if model.is_empty() {
+        "cursor".to_owned()
+    } else {
+        model.to_owned()
+    };
+    let id = value
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty())
+        .map(str::to_owned)
+        .unwrap_or_else(|| {
+            format!(
+                "{timestamp_ms}:{model}:{}:{}:{cache_write}:{cache_read}",
+                input_tokens.unwrap_or(0),
+                output_tokens.unwrap_or(0)
+            )
+        });
+    Some(CursorUsageEvent {
+        id,
+        timestamp_ms,
+        model,
+        input_tokens: input_tokens.unwrap_or(0).max(0),
+        output_tokens: output_tokens.unwrap_or(0).max(0),
+        cache_read_tokens: cache_read.max(0),
+        cache_write_tokens: cache_write.max(0),
+        cost: cents.unwrap_or(0.0).max(0.0) / 100.0,
+    })
+}
+
+pub(crate) fn events_from_dashboard_body(body: &Value) -> Vec<CursorUsageEvent> {
+    body.get("usageEvents")
+        .or_else(|| body.get("usageEventsDisplay"))
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(map_dashboard_event)
+        .collect()
+}
+
+pub(crate) fn workos_session_token(access_token: &str) -> Option<String> {
+    let access_token = access_token.trim();
+    if access_token.is_empty() {
+        return None;
+    }
+    if access_token.contains("::") {
+        return Some(access_token.to_owned());
+    }
+    let user_id = user_id_from_jwt(access_token)?;
+    Some(format!("{user_id}::{access_token}"))
+}
+
+fn user_id_from_jwt(access_token: &str) -> Option<String> {
+    let payload = access_token.split('.').nth(1)?;
+    let decoded = decode_b64url(payload)?;
+    let value: Value = serde_json::from_slice(&decoded).ok()?;
+    let sub = value.get("sub")?.as_str()?.trim();
+    if sub.is_empty() {
+        return None;
+    }
+    Some(
+        sub.rsplit_once('|')
+            .map(|(_, id)| id)
+            .unwrap_or(sub)
+            .to_owned(),
+    )
+}
+
+fn decode_b64url(input: &str) -> Option<Vec<u8>> {
+    use base64::Engine as _;
+    use base64::engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD};
+
+    URL_SAFE_NO_PAD.decode(input).ok().or_else(|| {
+        let mut padded = input.to_owned();
+        while !padded.len().is_multiple_of(4) {
+            padded.push('=');
+        }
+        URL_SAFE.decode(padded).ok()
+    })
+}
+
+struct CursorAuth {
+    session_token: String,
+    refresh_token: Option<String>,
+    machine_id: Option<String>,
+}
+
+pub async fn merge_cursor_usage<C: Clock>(
+    store: &mut UsageStore<C>,
+    mut snapshot: UsageSnapshot,
+    home: &Path,
+) -> UsageSnapshot {
+    let Some(mut auth) = load_cursor_auth(home) else {
+        return snapshot;
+    };
+    let start_ms = store.cursor_fetch_start_ms();
+    match fetch_cursor_events(&mut auth, start_ms).await {
+        Ok(events) if !events.is_empty() => {
+            snapshot.cursor = store.ingest_cursor_events(&events);
+            let mut history = snapshot.history.as_ref().clone();
+            history.cursor = store.cursor_history();
+            snapshot.history = Arc::new(history);
+        }
+        Ok(_) => {}
+        Err(_) => {}
+    }
+    snapshot
+}
+
+fn load_cursor_auth(home: &Path) -> Option<CursorAuth> {
+    let from_ide = read_ide_auth(home);
+    let access = from_ide
+        .as_ref()
+        .and_then(|auth| auth.access_token.clone())
+        .or_else(keychain_access_token)?;
+    let session_token = workos_session_token(&access)?;
+    if session_token.chars().any(char::is_control) {
+        return None;
+    }
+    let refresh = from_ide
+        .as_ref()
+        .and_then(|auth| auth.refresh_token.clone())
+        .or_else(keychain_refresh_token)
+        .filter(|token| !token.is_empty() && !token.chars().any(char::is_control));
+    let machine_id = from_ide
+        .and_then(|auth| auth.machine_id)
+        .filter(|id| !id.is_empty() && !id.chars().any(char::is_control));
+    Some(CursorAuth {
+        session_token,
+        refresh_token: refresh,
+        machine_id,
+    })
+}
+
+struct IdeAuth {
+    access_token: Option<String>,
+    refresh_token: Option<String>,
+    machine_id: Option<String>,
+}
+
+fn read_ide_auth(home: &Path) -> Option<IdeAuth> {
+    let path = cursor_state_db(home);
+    if !path.is_file() {
+        return None;
+    }
+    let connection = rusqlite::Connection::open_with_flags(
+        &path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .ok()?;
+    let _ = connection.busy_timeout(Duration::from_millis(40));
+    Some(IdeAuth {
+        access_token: query_item(&connection, "cursorAuth/accessToken"),
+        refresh_token: query_item(&connection, "cursorAuth/refreshToken"),
+        machine_id: query_item(&connection, "storage.serviceMachineId")
+            .or_else(|| query_item(&connection, "telemetry.machineId")),
+    })
+}
+
+fn cursor_state_db(home: &Path) -> PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        home.join("Library/Application Support/Cursor/User/globalStorage/state.vscdb")
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        home.join(".config/Cursor/User/globalStorage/state.vscdb")
+    }
+}
+
+fn query_item(connection: &rusqlite::Connection, key: &str) -> Option<String> {
+    let value: String = connection
+        .query_row(
+            "SELECT value FROM ItemTable WHERE key = ?1 LIMIT 1",
+            [key],
+            |row| row.get(0),
+        )
+        .ok()?;
+    let value = value.trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_owned())
+    }
+}
+
+fn keychain_access_token() -> Option<String> {
+    keychain_password("cursor-access-token")
+}
+
+fn keychain_refresh_token() -> Option<String> {
+    keychain_password("cursor-refresh-token")
+}
+
+fn keychain_password(service: &str) -> Option<String> {
+    #[cfg(target_os = "macos")]
+    {
+        let output = std::process::Command::new("/usr/bin/security")
+            .args([
+                "find-generic-password",
+                "-s",
+                service,
+                "-a",
+                "cursor-user",
+                "-w",
+            ])
+            .stdin(Stdio::null())
+            .stderr(Stdio::null())
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let value = String::from_utf8(output.stdout).ok()?;
+        let value = value.trim();
+        if value.is_empty() {
+            None
+        } else {
+            Some(value.to_owned())
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = service;
+        None
+    }
+}
+
+async fn fetch_cursor_events(
+    auth: &mut CursorAuth,
+    start_ms: i64,
+) -> Result<Vec<CursorUsageEvent>, ()> {
+    let mut events = Vec::new();
+    for page in 1..=MAX_PAGES {
+        let body = serde_json::json!({
+            "page": page,
+            "pageSize": PAGE_SIZE,
+            "startDate": start_ms.max(0),
+        });
+        let (status, payload) = dashboard_post(auth, &body).await?;
+        if status == 401 || status == 403 {
+            refresh_session(auth).await?;
+            let (status, payload) = dashboard_post(auth, &body).await?;
+            if status != 200 {
+                return Err(());
+            }
+            let has_next = payload
+                .pointer("/pagination/hasNextPage")
+                .and_then(Value::as_bool);
+            let page_events = events_from_dashboard_body(&payload);
+            let count = page_events.len();
+            events.extend(page_events);
+            if has_next == Some(false) || (has_next != Some(true) && count < PAGE_SIZE as usize) {
+                break;
+            }
+            continue;
+        }
+        if status != 200 {
+            return Err(());
+        }
+        let has_next = payload
+            .pointer("/pagination/hasNextPage")
+            .and_then(Value::as_bool);
+        let page_events = events_from_dashboard_body(&payload);
+        let count = page_events.len();
+        events.extend(page_events);
+        if has_next == Some(false) || (has_next != Some(true) && count < PAGE_SIZE as usize) {
+            break;
+        }
+    }
+    Ok(events)
+}
+
+async fn dashboard_post(auth: &CursorAuth, body: &Value) -> Result<(u16, Value), ()> {
+    let mut headers = vec![
+        ("Content-Type".into(), "application/json".into()),
+        (
+            "Cookie".into(),
+            format!("WorkosCursorSessionToken={}", auth.session_token),
+        ),
+        ("Origin".into(), "https://cursor.com".into()),
+    ];
+    if let Some(machine_id) = &auth.machine_id {
+        headers.push(("x-cursor-client-id".into(), machine_id.clone()));
+    }
+    http_json("POST", DASHBOARD_URL, &headers, Some(body)).await
+}
+
+async fn refresh_session(auth: &mut CursorAuth) -> Result<(), ()> {
+    let refresh = auth.refresh_token.as_deref().ok_or(())?;
+    let body = serde_json::json!({
+        "grant_type": "refresh_token",
+        "client_id": OAUTH_CLIENT_ID,
+        "refresh_token": refresh,
+    });
+    let (status, payload) = http_json("POST", OAUTH_TOKEN_URL, &[], Some(&body)).await?;
+    if status != 200 || payload.get("shouldLogout").and_then(Value::as_bool) == Some(true) {
+        return Err(());
+    }
+    let access = payload
+        .get("access_token")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+        .ok_or(())?;
+    auth.session_token = workos_session_token(access).ok_or(())?;
+    Ok(())
+}
+
+async fn http_json(
+    method: &str,
+    url: &str,
+    headers: &[(String, String)],
+    body: Option<&Value>,
+) -> Result<(u16, Value), ()> {
+    let mut config = String::from("silent\nproto = \"=https\"\n");
+    config.push_str(&format!("max-time = \"{FETCH_TIMEOUT_SECS}\"\n"));
+    config.push_str("max-filesize = \"2097152\"\n");
+    config.push_str("write-out = \"\\n%{http_code}\"\n");
+    config.push_str("request = \"");
+    config.push_str(method);
+    config.push_str("\"\nurl = \"");
+    config.push_str(&curl_escape(url));
+    config.push_str("\"\n");
+    for (name, value) in headers {
+        if name.chars().any(char::is_control) || value.chars().any(char::is_control) {
+            return Err(());
+        }
+        config.push_str("header = \"");
+        config.push_str(&curl_escape(&format!("{name}: {value}")));
+        config.push_str("\"\n");
+    }
+    if let Some(body) = body {
+        config.push_str("data = \"");
+        config.push_str(&curl_escape(&body.to_string()));
+        config.push_str("\"\n");
+    }
+    let mut child = Command::new("/usr/bin/curl")
+        .args(["-q", "--config", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|_| ())?;
+    let mut stdin = child.stdin.take().ok_or(())?;
+    stdin.write_all(config.as_bytes()).await.map_err(|_| ())?;
+    drop(stdin);
+    let output = tokio::time::timeout(
+        Duration::from_secs(FETCH_TIMEOUT_SECS + 4),
+        child.wait_with_output(),
+    )
+    .await
+    .map_err(|_| ())?
+    .map_err(|_| ())?;
+    if !output.status.success() {
+        return Err(());
+    }
+    let raw = std::str::from_utf8(&output.stdout).map_err(|_| ())?;
+    let (body, status) = raw.rsplit_once('\n').ok_or(())?;
+    let status: u16 = status.trim().parse().map_err(|_| ())?;
+    if body.is_empty() {
+        return Ok((status, Value::Null));
+    }
+    let payload = serde_json::from_str(body).unwrap_or(Value::Null);
+    Ok((status, payload))
+}
+
+fn curl_escape(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn parse_timestamp_ms(value: Option<&Value>) -> Option<i64> {
+    let value = value?;
+    let ms = if let Some(number) = value.as_i64() {
+        number
+    } else if let Some(number) = value.as_f64() {
+        number as i64
+    } else {
+        value.as_str()?.parse::<i64>().ok()?
+    };
+    (ms > 0).then_some(ms)
+}
+
+fn integer(value: Option<&Value>) -> Option<i64> {
+    value.map(integer_value)
+}
+
+fn integer_value(value: &Value) -> i64 {
+    value
+        .as_i64()
+        .or_else(|| value.as_f64().map(|number| number as i64))
+        .unwrap_or(0)
+}
+
+fn float(value: Option<&Value>) -> Option<f64> {
+    value.map(float_value)
+}
+
+fn float_value(value: &Value) -> f64 {
+    value
+        .as_f64()
+        .or_else(|| value.as_i64().map(|number| number as f64))
+        .unwrap_or(0.0)
+}
+
+pub(crate) fn cursor_overlap_ms() -> i64 {
+    OVERLAP_MS
+}
+
+pub(crate) fn event_dedup_hash(id: &str) -> u64 {
+    fnv1a(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn maps_model_name_and_billed_cents() {
+        let event = map_dashboard_event(&json!({
+            "id": "evt-123",
+            "timestamp": "1704067200000",
+            "modelName": "claude-4.5-sonnet",
+            "inputTokens": 100,
+            "outputTokens": 50,
+            "totalCents": 1.23,
+        }))
+        .unwrap();
+        assert_eq!(event.id, "evt-123");
+        assert_eq!(event.model, "claude-4.5-sonnet");
+        assert_eq!(event.input_tokens, 100);
+        assert_eq!(event.output_tokens, 50);
+        assert!((event.cost - 0.0123).abs() < 1e-9);
+        assert_eq!(event_hour(&event), 1704067200000 / 3_600_000);
+    }
+
+    #[test]
+    fn reads_nested_token_usage() {
+        let event = map_dashboard_event(&json!({
+            "id": "evt-456",
+            "timestamp": 1_700_000_000_000_i64,
+            "model": "gpt-4.1",
+            "tokenUsage": {
+                "inputTokens": 10,
+                "outputTokens": 5,
+                "cacheWriteTokens": 2,
+                "cacheReadTokens": 3,
+                "totalCents": 0.5,
+            },
+        }))
+        .unwrap();
+        assert_eq!(event.input_tokens, 10);
+        assert_eq!(event.cache_write_tokens, 2);
+        assert_eq!(event.cache_read_tokens, 3);
+        assert!((event.cost - 0.005).abs() < 1e-9);
+    }
+
+    #[test]
+    fn workos_cookie_uses_jwt_subject_tail() {
+        let payload = base64::Engine::encode(
+            &base64::engine::general_purpose::URL_SAFE_NO_PAD,
+            br#"{"sub":"auth0|user-99"}"#,
+        );
+        let jwt = format!("header.{payload}.sig");
+        assert_eq!(
+            workos_session_token(&jwt).as_deref(),
+            Some(format!("user-99::{jwt}").as_str())
+        );
+        assert_eq!(
+            workos_session_token("abc::already").as_deref(),
+            Some("abc::already")
+        );
+    }
+
+    #[test]
+    fn dashboard_body_prefers_usage_events() {
+        let events = events_from_dashboard_body(&json!({
+            "usageEvents": [{
+                "id": "a",
+                "timestamp": 1_700_000_000_000_i64,
+                "model": "composer-1",
+                "inputTokens": 1,
+                "outputTokens": 2,
+                "totalCents": 10
+            }],
+            "usageEventsDisplay": [],
+        }));
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].model, "composer-1");
+    }
+}

--- a/diri/crates/diri-app/src/usage/cursor.rs
+++ b/diri/crates/diri-app/src/usage/cursor.rs
@@ -7,7 +7,6 @@
 use std::{
     path::{Path, PathBuf},
     process::Stdio,
-    sync::Arc,
     time::Duration,
 };
 
@@ -15,12 +14,7 @@ use serde_json::Value;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 
-use super::{
-    UsageSnapshot,
-    model::UsageHourAgg,
-    parser::fnv1a,
-    store::{Clock, UsageStore},
-};
+use super::{cache::CursorFetchWindow, model::UsageHourAgg, parser::fnv1a};
 
 const DASHBOARD_URL: &str = "https://cursor.com/api/dashboard/get-filtered-usage-events";
 const OAUTH_TOKEN_URL: &str = "https://api2.cursor.sh/oauth/token";
@@ -175,26 +169,56 @@ struct CursorAuth {
     machine_id: Option<String>,
 }
 
-pub async fn merge_cursor_usage<C: Clock>(
-    store: &mut UsageStore<C>,
-    mut snapshot: UsageSnapshot,
-    home: &Path,
-) -> UsageSnapshot {
-    let Some(mut auth) = load_cursor_auth(home) else {
-        return snapshot;
-    };
-    let start_ms = store.cursor_fetch_start_ms();
-    match fetch_cursor_events(&mut auth, start_ms).await {
-        Ok(events) if !events.is_empty() => {
-            snapshot.cursor = store.ingest_cursor_events(&events);
-            let mut history = snapshot.history.as_ref().clone();
-            history.cursor = store.cursor_history();
-            snapshot.history = Arc::new(history);
+/// A bounded page batch; only a complete walk may advance the committed watermark.
+pub(crate) struct CursorBatch {
+    pub events: Vec<CursorUsageEvent>,
+    pub window: CursorFetchWindow,
+    pub complete: bool,
+}
+
+/// One independent fetch at a time. Transcript updates never wait on this task.
+#[derive(Default)]
+pub(crate) struct CursorRefresh {
+    task: Option<tokio::task::JoinHandle<Result<CursorBatch, ()>>>,
+}
+
+impl CursorRefresh {
+    pub(crate) fn start(&mut self, home: &Path, window: CursorFetchWindow) {
+        if self.task.is_some() {
+            return;
         }
-        Ok(_) => {}
-        Err(_) => {}
+        let home = home.to_owned();
+        self.task = Some(tokio::spawn(async move {
+            // SQLite and Keychain access must not block a Tokio worker.
+            let mut auth = tokio::task::spawn_blocking(move || load_cursor_auth(&home))
+                .await
+                .map_err(|_| ())?
+                .ok_or(())?;
+            fetch_cursor_events(&CurlHttp, &mut auth, window).await
+        }));
     }
-    snapshot
+
+    pub(crate) async fn next(&mut self) -> Result<CursorBatch, ()> {
+        let Some(task) = self.task.as_mut() else {
+            return std::future::pending().await;
+        };
+        let result = task.await.map_err(|_| ()).and_then(|result| result);
+        self.task = None;
+        result
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_task(task: tokio::task::JoinHandle<Result<CursorBatch, ()>>) -> Self {
+        Self { task: Some(task) }
+    }
+}
+
+impl Drop for CursorRefresh {
+    fn drop(&mut self) {
+        if let Some(task) = &self.task {
+            task.abort();
+        }
+    }
 }
 
 fn load_cursor_auth(home: &Path) -> Option<CursorAuth> {
@@ -317,51 +341,66 @@ fn keychain_password(service: &str) -> Option<String> {
 }
 
 async fn fetch_cursor_events(
+    http: &impl CursorHttp,
     auth: &mut CursorAuth,
-    start_ms: i64,
-) -> Result<Vec<CursorUsageEvent>, ()> {
+    mut window: CursorFetchWindow,
+) -> Result<CursorBatch, ()> {
     let mut events = Vec::new();
-    for page in 1..=MAX_PAGES {
+    let mut complete = false;
+    for _ in 0..MAX_PAGES {
         let body = serde_json::json!({
-            "page": page,
+            "page": window.next_page,
             "pageSize": PAGE_SIZE,
-            "startDate": start_ms.max(0),
+            "startDate": window.start_ms.max(0),
+            "endDate": window.end_ms,
         });
-        let (status, payload) = dashboard_post(auth, &body).await?;
+        let (mut status, mut payload) = dashboard_post(http, auth, &body).await?;
         if status == 401 || status == 403 {
-            refresh_session(auth).await?;
-            let (status, payload) = dashboard_post(auth, &body).await?;
-            if status != 200 {
-                return Err(());
-            }
-            let has_next = payload
-                .pointer("/pagination/hasNextPage")
-                .and_then(Value::as_bool);
-            let page_events = events_from_dashboard_body(&payload);
-            let count = page_events.len();
-            events.extend(page_events);
-            if has_next == Some(false) || (has_next != Some(true) && count < PAGE_SIZE as usize) {
-                break;
-            }
-            continue;
+            refresh_session(http, auth).await?;
+            (status, payload) = dashboard_post(http, auth, &body).await?;
         }
         if status != 200 {
             return Err(());
         }
+        // Invalid responses must not masquerade as the end of a successful walk.
+        let raw_events = payload
+            .get("usageEvents")
+            .or_else(|| payload.get("usageEventsDisplay"))
+            .and_then(Value::as_array)
+            .ok_or(())?;
+        let count = raw_events.len();
+        let page_events = events_from_dashboard_body(&payload);
+        if page_events.len() != count {
+            return Err(());
+        }
+        for event in &page_events {
+            window.newest_event_ms = window.newest_event_ms.max(event.timestamp_ms);
+        }
+        events.extend(page_events);
         let has_next = payload
             .pointer("/pagination/hasNextPage")
             .and_then(Value::as_bool);
-        let page_events = events_from_dashboard_body(&payload);
-        let count = page_events.len();
-        events.extend(page_events);
+        window.next_page = window.next_page.checked_add(1).ok_or(())?;
         if has_next == Some(false) || (has_next != Some(true) && count < PAGE_SIZE as usize) {
+            complete = true;
             break;
         }
+        if count == 0 {
+            return Err(());
+        }
     }
-    Ok(events)
+    Ok(CursorBatch {
+        events,
+        window,
+        complete,
+    })
 }
 
-async fn dashboard_post(auth: &CursorAuth, body: &Value) -> Result<(u16, Value), ()> {
+async fn dashboard_post(
+    http: &impl CursorHttp,
+    auth: &CursorAuth,
+    body: &Value,
+) -> Result<(u16, Value), ()> {
     let mut headers = vec![
         ("Content-Type".into(), "application/json".into()),
         (
@@ -373,17 +412,23 @@ async fn dashboard_post(auth: &CursorAuth, body: &Value) -> Result<(u16, Value),
     if let Some(machine_id) = &auth.machine_id {
         headers.push(("x-cursor-client-id".into(), machine_id.clone()));
     }
-    http_json("POST", DASHBOARD_URL, &headers, Some(body)).await
+    http.post(DASHBOARD_URL, &headers, body).await
 }
 
-async fn refresh_session(auth: &mut CursorAuth) -> Result<(), ()> {
+async fn refresh_session(http: &impl CursorHttp, auth: &mut CursorAuth) -> Result<(), ()> {
     let refresh = auth.refresh_token.as_deref().ok_or(())?;
     let body = serde_json::json!({
         "grant_type": "refresh_token",
         "client_id": OAUTH_CLIENT_ID,
         "refresh_token": refresh,
     });
-    let (status, payload) = http_json("POST", OAUTH_TOKEN_URL, &[], Some(&body)).await?;
+    let (status, payload) = http
+        .post(
+            OAUTH_TOKEN_URL,
+            &[("Content-Type".into(), "application/json".into())],
+            &body,
+        )
+        .await?;
     if status != 200 || payload.get("shouldLogout").and_then(Value::as_bool) == Some(true) {
         return Err(());
     }
@@ -395,6 +440,28 @@ async fn refresh_session(auth: &mut CursorAuth) -> Result<(), ()> {
         .ok_or(())?;
     auth.session_token = workos_session_token(access).ok_or(())?;
     Ok(())
+}
+
+trait CursorHttp {
+    async fn post(
+        &self,
+        url: &str,
+        headers: &[(String, String)],
+        body: &Value,
+    ) -> Result<(u16, Value), ()>;
+}
+
+struct CurlHttp;
+
+impl CursorHttp for CurlHttp {
+    async fn post(
+        &self,
+        url: &str,
+        headers: &[(String, String)],
+        body: &Value,
+    ) -> Result<(u16, Value), ()> {
+        http_json("POST", url, headers, Some(body)).await
+    }
 }
 
 async fn http_json(
@@ -579,5 +646,187 @@ mod tests {
         }));
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].model, "composer-1");
+    }
+    struct RefreshHttp;
+
+    impl CursorHttp for RefreshHttp {
+        async fn post(
+            &self,
+            url: &str,
+            headers: &[(String, String)],
+            body: &Value,
+        ) -> Result<(u16, Value), ()> {
+            assert_eq!(url, OAUTH_TOKEN_URL);
+            assert!(
+                headers
+                    .iter()
+                    .any(|(name, value)| name == "Content-Type" && value == "application/json"),
+                "JSON refresh requests must declare their content type"
+            );
+            assert_eq!(body["grant_type"], "refresh_token");
+            Ok((200, json!({"access_token": "user::refreshed"})))
+        }
+    }
+
+    #[tokio::test]
+    async fn cursor_regression_refresh_declares_json() {
+        let mut auth = CursorAuth {
+            session_token: "user::expired".into(),
+            refresh_token: Some("fixture-refresh".into()),
+            machine_id: None,
+        };
+        refresh_session(&RefreshHttp, &mut auth).await.unwrap();
+        assert_eq!(auth.session_token, "user::refreshed");
+    }
+
+    struct PagesHttp;
+
+    impl CursorHttp for PagesHttp {
+        async fn post(
+            &self,
+            url: &str,
+            _: &[(String, String)],
+            body: &Value,
+        ) -> Result<(u16, Value), ()> {
+            assert_eq!(url, DASHBOARD_URL);
+            let page = body["page"].as_u64().unwrap();
+            let events: Vec<_> = ((page - 1) * 100..(page * 100).min(1001))
+                .map(|index| {
+                    json!({
+                        "id": format!("event-{index}"),
+                        "timestamp": 1_784_717_999_000_i64 - index as i64 * 60_000,
+                        "totalCents": 100,
+                    })
+                })
+                .collect();
+            Ok((
+                200,
+                json!({
+                    "usageEvents": events,
+                    "pagination": {"hasNextPage": page < 11},
+                }),
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn cursor_regression_fetch_keeps_older_pages() {
+        let mut auth = CursorAuth {
+            session_token: "user::fixture".into(),
+            refresh_token: None,
+            machine_id: None,
+        };
+        let window = CursorFetchWindow {
+            start_ms: 0,
+            end_ms: 1_784_718_000_000,
+            next_page: 1,
+            newest_event_ms: 0,
+        };
+        let first = fetch_cursor_events(&PagesHttp, &mut auth, window)
+            .await
+            .unwrap();
+        assert!(!first.complete);
+        assert_eq!(first.window.next_page, 11);
+        assert_eq!(first.window.start_ms, window.start_ms);
+        assert_eq!(first.window.end_ms, window.end_ms);
+        let second = fetch_cursor_events(&PagesHttp, &mut auth, first.window)
+            .await
+            .unwrap();
+        assert!(second.complete);
+        assert_eq!(
+            first.events.len() + second.events.len(),
+            1001,
+            "older usage must remain reachable after the page cap"
+        );
+    }
+    struct ScriptHttp {
+        responses: std::cell::RefCell<std::collections::VecDeque<Result<(u16, Value), ()>>>,
+        requests: std::cell::RefCell<Vec<(String, Value)>>,
+    }
+
+    impl CursorHttp for ScriptHttp {
+        async fn post(
+            &self,
+            url: &str,
+            headers: &[(String, String)],
+            body: &Value,
+        ) -> Result<(u16, Value), ()> {
+            assert!(
+                headers
+                    .iter()
+                    .any(|(name, value)| name == "Content-Type" && value == "application/json")
+            );
+            self.requests.borrow_mut().push((url.into(), body.clone()));
+            self.responses
+                .borrow_mut()
+                .pop_front()
+                .expect("unexpected extra request")
+        }
+    }
+
+    #[tokio::test]
+    async fn cursor_regression_expired_auth_retries_the_same_page() {
+        let http = ScriptHttp {
+            responses: std::cell::RefCell::new(
+                [
+                    Ok((401, Value::Null)),
+                    Ok((200, json!({"access_token": "user::refreshed"}))),
+                    Ok((
+                        200,
+                        json!({"usageEvents": [], "pagination": {"hasNextPage": false}}),
+                    )),
+                ]
+                .into(),
+            ),
+            requests: Default::default(),
+        };
+        let mut auth = CursorAuth {
+            session_token: "user::expired".into(),
+            refresh_token: Some("fixture".into()),
+            machine_id: None,
+        };
+        let window = CursorFetchWindow {
+            start_ms: 1000,
+            end_ms: 2000,
+            next_page: 11,
+            newest_event_ms: 1500,
+        };
+        let batch = fetch_cursor_events(&http, &mut auth, window).await.unwrap();
+        assert!(batch.complete);
+        let requests = http.requests.borrow();
+        assert_eq!(requests[0], requests[2]);
+        assert_eq!(requests[1].0, OAUTH_TOKEN_URL);
+        assert_eq!(auth.session_token, "user::refreshed");
+    }
+
+    #[tokio::test]
+    async fn cursor_regression_failed_pages_do_not_complete_a_walk() {
+        for response in [
+            Err(()),
+            Ok((500, Value::Null)),
+            Ok((200, Value::Null)),
+            Ok((200, json!({"usageEvents": [{"timestamp": "invalid"}]}))),
+        ] {
+            let http = ScriptHttp {
+                responses: std::cell::RefCell::new([
+                    Ok((200, json!({"usageEvents": [{"timestamp": 1500}], "pagination": {"hasNextPage": true}}))),
+                    response,
+                ].into()),
+                requests: Default::default(),
+            };
+            let mut auth = CursorAuth {
+                session_token: "user::fixture".into(),
+                refresh_token: None,
+                machine_id: None,
+            };
+            let window = CursorFetchWindow {
+                start_ms: 1000,
+                end_ms: 2000,
+                next_page: 11,
+                newest_event_ms: 1500,
+            };
+            assert!(fetch_cursor_events(&http, &mut auth, window).await.is_err());
+            assert_eq!(http.requests.borrow().len(), 2);
+        }
     }
 }

--- a/diri/crates/diri-app/src/usage/dashboard.rs
+++ b/diri/crates/diri-app/src/usage/dashboard.rs
@@ -32,6 +32,27 @@ impl UsageDetail {
     }
 }
 
+pub(crate) fn record_billed(hours: &mut ModelHours, model: &str, hour: i64, tokens: UsageHourAgg) {
+    hours
+        .entry(
+            if model.is_empty() {
+                "Unknown model"
+            } else {
+                model
+            }
+            .to_owned(),
+        )
+        .or_default()
+        .entry(hour)
+        .or_default()
+        .merge(UsageDetail {
+            tokens,
+            reasoning: 0,
+            priced_tokens: tokens.i + tokens.o + tokens.cr + tokens.cw,
+            read_savings: 0.0,
+        });
+}
+
 pub(crate) fn record(
     hours: &mut ModelHours,
     model: &str,
@@ -67,6 +88,7 @@ pub(crate) fn record(
 pub struct UsageHistory {
     pub(crate) claude: ModelHours,
     pub(crate) codex: ModelHours,
+    pub(crate) cursor: ModelHours,
 }
 
 #[derive(Clone, Debug)]
@@ -79,13 +101,14 @@ pub struct ModelRow {
 #[derive(Clone, Debug, Default)]
 pub struct DayRow {
     pub day: i64,
-    pub providers: [UsageDetail; 2],
+    pub providers: [UsageDetail; 3],
 }
 
 impl DayRow {
     pub fn total(&self) -> UsageDetail {
         let mut detail = self.providers[0];
         detail.merge(self.providers[1]);
+        detail.merge(self.providers[2]);
         detail
     }
 }
@@ -93,7 +116,7 @@ impl DayRow {
 #[derive(Clone, Debug, Default)]
 pub struct UsageReport {
     pub total: UsageDetail,
-    pub providers: [UsageDetail; 2],
+    pub providers: [UsageDetail; 3],
     pub days: Vec<DayRow>,
     pub models: Vec<ModelRow>,
     pub active_days: usize,
@@ -130,7 +153,10 @@ impl UsageHistory {
                 .collect(),
             ..UsageReport::default()
         };
-        for (provider, models) in [&self.claude, &self.codex].into_iter().enumerate() {
+        for (provider, models) in [&self.claude, &self.codex, &self.cursor]
+            .into_iter()
+            .enumerate()
+        {
             for (model, hours) in models {
                 let mut detail = UsageDetail::default();
                 for (&hour, &value) in hours.range(start * 24..=now.div_euclid(3_600)) {

--- a/diri/crates/diri-app/src/usage/mod.rs
+++ b/diri/crates/diri-app/src/usage/mod.rs
@@ -17,7 +17,7 @@ mod store;
 mod timestamp;
 mod watcher;
 
-pub(crate) use cursor::merge_cursor_usage;
+pub(crate) use cursor::{CursorBatch, CursorRefresh};
 pub(crate) use fleet::merge_fleet_usage;
 pub use model::{ProviderUsage, UsageHourAgg, UsageSnapshot, UsageTotals};
 pub use pricing::PRICING_ENTRY_COUNT;

--- a/diri/crates/diri-app/src/usage/mod.rs
+++ b/diri/crates/diri-app/src/usage/mod.rs
@@ -1,10 +1,12 @@
-//! Incremental, daemon-free usage accounting for Claude Code and Codex transcripts.
+//! Incremental usage accounting for Claude Code, Codex, and Cursor.
 //!
-//! Costs are computed locally from the transcripts on disk; nothing is sent
-//! anywhere. The separate limits reader queries provider-reported subscription
-//! windows without deriving quota percentages from these estimates.
+//! Claude and Codex costs come from local transcripts. Cursor usage is fetched
+//! from Cursor's dashboard API using the signed-in IDE/CLI session. The
+//! separate limits reader queries provider-reported subscription windows
+//! without deriving quota percentages from these estimates.
 
 mod cache;
+mod cursor;
 pub mod dashboard;
 mod fleet;
 pub(crate) mod limits;
@@ -15,6 +17,7 @@ mod store;
 mod timestamp;
 mod watcher;
 
+pub(crate) use cursor::merge_cursor_usage;
 pub(crate) use fleet::merge_fleet_usage;
 pub use model::{ProviderUsage, UsageHourAgg, UsageSnapshot, UsageTotals};
 pub use pricing::PRICING_ENTRY_COUNT;

--- a/diri/crates/diri-app/src/usage/model.rs
+++ b/diri/crates/diri-app/src/usage/model.rs
@@ -54,6 +54,7 @@ pub struct ProviderUsage {
 pub struct UsageSnapshot {
     pub claude: ProviderUsage,
     pub codex: ProviderUsage,
+    pub cursor: ProviderUsage,
     pub session_cost: Option<f64>,
     pub session_started_at: Option<i64>,
     pub session_ends_at: Option<i64>,
@@ -70,6 +71,7 @@ impl UsageSnapshot {
     pub fn today(&self) -> UsageTotals {
         let mut totals = self.claude.today;
         totals += self.codex.today;
+        totals += self.cursor.today;
         totals
     }
 
@@ -77,6 +79,7 @@ impl UsageSnapshot {
     pub fn month(&self) -> UsageTotals {
         let mut totals = self.claude.month;
         totals += self.codex.month;
+        totals += self.cursor.month;
         totals
     }
 }

--- a/diri/crates/diri-app/src/usage/store.rs
+++ b/diri/crates/diri-app/src/usage/store.rs
@@ -9,7 +9,9 @@ use diri_proto::paths::DirijorPaths;
 
 use super::{
     cache::{self, UsageCacheFile, UsageFileEntry},
-    model::{UsageHourAgg, UsageSnapshot, UsageTotals},
+    cursor::{CursorUsageEvent, event_aggregate, event_dedup_hash, event_hour},
+    dashboard,
+    model::{ProviderUsage, UsageHourAgg, UsageSnapshot, UsageTotals},
     parser::{parse_claude, parse_codex, tail_hash},
     timestamp::days_from_civil,
 };
@@ -158,6 +160,34 @@ impl<C: Clock> UsageStore<C> {
             .iter()
             .map(|(root, _)| root.clone())
             .collect()
+    }
+
+    pub(crate) fn cursor_fetch_start_ms(&self) -> i64 {
+        let now_ms = self.clock.read().unix_seconds.saturating_mul(1_000);
+        let last = self.ledger.cache.cursor.last_event_ms;
+        if last > 0 {
+            last.saturating_sub(super::cursor::cursor_overlap_ms())
+                .max(0)
+        } else {
+            now_ms
+                .saturating_sub(RETENTION_DAYS.saturating_mul(86_400).saturating_mul(1_000))
+                .max(0)
+        }
+    }
+
+    pub(crate) fn ingest_cursor_events(&mut self, events: &[CursorUsageEvent]) -> ProviderUsage {
+        let reading = self.clock.read();
+        let cutoff_hour = reading.unix_seconds / 3_600 - RETENTION_DAYS * 24;
+        let changed = ingest_cursor(&mut self.ledger.cache, events, cutoff_hour);
+        self.ledger.dirty |= changed;
+        if self.ledger.dirty && cache::save(&self.paths.cache_file, &self.ledger.cache).is_ok() {
+            self.ledger.dirty = false;
+        }
+        provider_from_hours(&self.ledger.cache.cursor.hours, reading)
+    }
+
+    pub(crate) fn cursor_history(&self) -> dashboard::ModelHours {
+        self.ledger.cache.cursor.details.clone()
     }
 }
 
@@ -402,6 +432,17 @@ fn scan(
     cache.seen.retain(|hour, _| *hour >= cutoff_hour);
     changed |= seen_before_retain != cache.seen.len();
 
+    let cursor_hours_before = cache.cursor.hours.len();
+    let cursor_seen_before = cache.cursor.seen.len();
+    cache.cursor.hours.retain(|hour, _| *hour >= cutoff_hour);
+    cache.cursor.seen.retain(|hour, _| *hour >= cutoff_hour);
+    cache.cursor.details.retain(|_, hours| {
+        hours.retain(|hour, _| *hour >= cutoff_hour);
+        !hours.is_empty()
+    });
+    changed |= cursor_hours_before != cache.cursor.hours.len()
+        || cursor_seen_before != cache.cursor.seen.len();
+
     let mut claude_hours = BTreeMap::new();
     let mut codex_hours = BTreeMap::new();
     for (path, entry) in &cache.files {
@@ -420,13 +461,14 @@ fn scan(
         }
     }
 
-    let mut result = snapshot(&claude_hours, &codex_hours, reading);
+    let mut result = snapshot(&claude_hours, &codex_hours, &cache.cursor.hours, reading);
     let mut history = super::dashboard::UsageHistory::default();
     for (path, entry) in &cache.files {
         if let Some(provider) = provider_for_path(Path::new(path), &paths.roots) {
             history.merge(provider, &entry.details);
         }
     }
+    history.cursor = cache.cursor.details.clone();
     result.history = std::sync::Arc::new(history);
     (result, stats, changed)
 }
@@ -551,6 +593,7 @@ fn walk(root: &Path, provider: UsageProvider, files: &mut Vec<(PathBuf, UsagePro
 fn snapshot(
     claude_hours: &BTreeMap<i64, UsageHourAgg>,
     codex_hours: &BTreeMap<i64, UsageHourAgg>,
+    cursor_hours: &BTreeMap<i64, UsageHourAgg>,
     reading: ClockReading,
 ) -> UsageSnapshot {
     let mut result = UsageSnapshot {
@@ -576,6 +619,7 @@ fn snapshot(
             result.codex.month += aggregate;
         }
     }
+    result.cursor = provider_from_hours(cursor_hours, reading);
 
     let mut block_start = None;
     let mut block_totals = UsageTotals::default();
@@ -599,6 +643,61 @@ fn snapshot(
         }
     }
     result
+}
+
+fn provider_from_hours(
+    hours: &BTreeMap<i64, UsageHourAgg>,
+    reading: ClockReading,
+) -> ProviderUsage {
+    let mut result = ProviderUsage::default();
+    let today_start_hour = reading.today_started_at / 3_600;
+    let month_start_hour = reading.month_started_at / 3_600;
+    for (&hour, &aggregate) in hours {
+        if hour >= today_start_hour {
+            result.today += aggregate;
+        }
+        if hour >= month_start_hour {
+            result.month += aggregate;
+        }
+    }
+    result
+}
+
+fn ingest_cursor(
+    cache: &mut UsageCacheFile,
+    events: &[CursorUsageEvent],
+    cutoff_hour: i64,
+) -> bool {
+    let hours_before = cache.cursor.hours.len();
+    let seen_before = cache.cursor.seen.len();
+    cache.cursor.hours.retain(|hour, _| *hour >= cutoff_hour);
+    cache.cursor.seen.retain(|hour, _| *hour >= cutoff_hour);
+    cache.cursor.details.retain(|_, hours| {
+        hours.retain(|hour, _| *hour >= cutoff_hour);
+        !hours.is_empty()
+    });
+    let mut changed =
+        hours_before != cache.cursor.hours.len() || seen_before != cache.cursor.seen.len();
+    for event in events {
+        let hour = event_hour(event);
+        if hour < cutoff_hour {
+            continue;
+        }
+        let hash = event_dedup_hash(&event.id);
+        let seen = cache.cursor.seen.entry(hour).or_default();
+        if seen.contains(&hash) {
+            continue;
+        }
+        seen.push(hash);
+        let tokens = event_aggregate(event);
+        cache.cursor.hours.entry(hour).or_default().merge(tokens);
+        dashboard::record_billed(&mut cache.cursor.details, &event.model, hour, tokens);
+        if event.timestamp_ms > cache.cursor.last_event_ms {
+            cache.cursor.last_event_ms = event.timestamp_ms;
+        }
+        changed = true;
+    }
+    changed
 }
 
 #[cfg(all(unix, target_pointer_width = "64"))]

--- a/diri/crates/diri-app/src/usage/store.rs
+++ b/diri/crates/diri-app/src/usage/store.rs
@@ -8,8 +8,8 @@ use std::{
 use diri_proto::paths::DirijorPaths;
 
 use super::{
-    cache::{self, UsageCacheFile, UsageFileEntry},
-    cursor::{CursorUsageEvent, event_aggregate, event_dedup_hash, event_hour},
+    cache::{self, CursorFetchWindow, UsageCacheFile, UsageFileEntry},
+    cursor::{CursorBatch, CursorUsageEvent, event_aggregate, event_dedup_hash, event_hour},
     dashboard,
     model::{ProviderUsage, UsageHourAgg, UsageSnapshot, UsageTotals},
     parser::{parse_claude, parse_codex, tail_hash},
@@ -162,24 +162,43 @@ impl<C: Clock> UsageStore<C> {
             .collect()
     }
 
-    pub(crate) fn cursor_fetch_start_ms(&self) -> i64 {
+    pub(crate) fn cursor_fetch_window(&self) -> CursorFetchWindow {
+        if let Some(pending) = self.ledger.cache.cursor.pending {
+            return pending;
+        }
         let now_ms = self.clock.read().unix_seconds.saturating_mul(1_000);
         let last = self.ledger.cache.cursor.last_event_ms;
-        if last > 0 {
+        let start_ms = if last > 0 {
             last.saturating_sub(super::cursor::cursor_overlap_ms())
                 .max(0)
         } else {
-            now_ms
-                .saturating_sub(RETENTION_DAYS.saturating_mul(86_400).saturating_mul(1_000))
-                .max(0)
+            now_ms.saturating_sub(RETENTION_DAYS * 86_400_000).max(0)
+        };
+        CursorFetchWindow {
+            start_ms,
+            end_ms: now_ms,
+            next_page: 1,
+            newest_event_ms: last,
         }
     }
 
-    pub(crate) fn ingest_cursor_events(&mut self, events: &[CursorUsageEvent]) -> ProviderUsage {
+    pub(crate) fn ingest_cursor_batch(&mut self, batch: CursorBatch) -> ProviderUsage {
         let reading = self.clock.read();
         let cutoff_hour = reading.unix_seconds / 3_600 - RETENTION_DAYS * 24;
-        let changed = ingest_cursor(&mut self.ledger.cache, events, cutoff_hour);
-        self.ledger.dirty |= changed;
+        let changed = ingest_cursor(&mut self.ledger.cache, &batch.events, cutoff_hour);
+        let cursor = &mut self.ledger.cache.cursor;
+        let pending = (!batch.complete).then_some(batch.window);
+        let last_event_ms = if batch.complete {
+            batch.window.newest_event_ms
+        } else {
+            cursor.last_event_ms
+        };
+        self.ledger.dirty |=
+            changed || cursor.pending != pending || cursor.last_event_ms != last_event_ms;
+        cursor.pending = pending;
+        cursor.last_event_ms = last_event_ms;
+        // Save aggregates and progress together. A failed write is retried by the
+        // normal ledger refresh; replay after a crash is deduplicated.
         if self.ledger.dirty && cache::save(&self.paths.cache_file, &self.ledger.cache).is_ok() {
             self.ledger.dirty = false;
         }
@@ -692,9 +711,6 @@ fn ingest_cursor(
         let tokens = event_aggregate(event);
         cache.cursor.hours.entry(hour).or_default().merge(tokens);
         dashboard::record_billed(&mut cache.cursor.details, &event.model, hour, tokens);
-        if event.timestamp_ms > cache.cursor.last_event_ms {
-            cache.cursor.last_event_ms = event.timestamp_ms;
-        }
         changed = true;
     }
     changed

--- a/diri/crates/diri-app/src/usage/tests.rs
+++ b/diri/crates/diri-app/src/usage/tests.rs
@@ -5,6 +5,7 @@ use tempfile::TempDir;
 
 use super::{
     Clock, ClockReading, ScanPaths, UsageProvider, UsageStore,
+    cursor::CursorUsageEvent,
     parser::fnv1a,
     pricing::{match_claude, match_openai},
     timestamp::parse_timestamp,
@@ -116,6 +117,7 @@ fn aggregates_costs_dedupes_claude_and_preserves_provider_totals() {
     assert_eq!(snapshot.codex.month, snapshot.codex.today);
     assert_eq!(snapshot.codex.session.total_tokens(), 0);
 
+    assert_eq!(snapshot.cursor.today.total_tokens(), 0);
     assert_eq!(snapshot.today().total_tokens(), 3_000);
     assert_close(snapshot.today().cost, 0.011_027_5);
     assert_close(snapshot.session_cost.unwrap(), 0.007_927_5);
@@ -439,6 +441,61 @@ fn ordered_pricing_table_and_fnv_hash_match_the_swift_constants() {
         assert_eq!((pricing.input, pricing.output), (input, output));
     }
     assert_eq!(fnv1a("hello"), 0xa430_d846_80aa_bd0b);
+}
+
+#[test]
+fn ingest_cursor_events_dedupes_and_survives_refresh() {
+    let fixture = Fixture::new();
+    let mut store = fixture.store(
+        "2026-07-22T12:00:00Z",
+        "2026-07-22T00:00:00Z",
+        "2026-07-01T00:00:00Z",
+    );
+    let event = CursorUsageEvent {
+        id: "evt-1".into(),
+        timestamp_ms: timestamp("2026-07-22T10:12:00.000Z") * 1_000,
+        model: "composer-1".into(),
+        input_tokens: 100,
+        output_tokens: 20,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        cost: 1.5,
+    };
+    let usage = store.ingest_cursor_events(&[event.clone(), event.clone()]);
+    assert_eq!(usage.today.input_tokens, 100);
+    assert_eq!(usage.today.output_tokens, 20);
+    assert_close(usage.today.cost, 1.5);
+    assert_eq!(usage.month, usage.today);
+
+    let snapshot = store.refresh();
+    assert_eq!(snapshot.cursor.today.input_tokens, 100);
+    assert_close(snapshot.cursor.today.cost, 1.5);
+    assert_eq!(snapshot.today().total_tokens(), 120);
+    assert_close(snapshot.today().cost, 1.5);
+    assert_eq!(
+        store.cursor_fetch_start_ms(),
+        event.timestamp_ms - 5 * 60 * 1_000
+    );
+    let report = snapshot.history.report(snapshot.updated_at, 30);
+    assert_eq!(report.models.len(), 1);
+    assert_eq!(report.models[0].model, "composer-1");
+    assert_eq!(report.models[0].provider, 2);
+    assert_close(report.providers[2].tokens.c, 1.5);
+
+    let cache: Value = serde_json::from_slice(&fs::read(&fixture.cache).unwrap()).unwrap();
+    assert_eq!(cache["cursor"]["last_event_ms"], event.timestamp_ms);
+    assert_eq!(
+        cache["cursor"]["seen"]
+            .as_object()
+            .unwrap()
+            .values()
+            .next()
+            .unwrap()
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
 }
 
 #[test]

--- a/diri/crates/diri-app/src/usage/tests.rs
+++ b/diri/crates/diri-app/src/usage/tests.rs
@@ -5,7 +5,7 @@ use tempfile::TempDir;
 
 use super::{
     Clock, ClockReading, ScanPaths, UsageProvider, UsageStore,
-    cursor::CursorUsageEvent,
+    cursor::{CursorBatch, CursorUsageEvent},
     parser::fnv1a,
     pricing::{match_claude, match_openai},
     timestamp::parse_timestamp,
@@ -461,7 +461,13 @@ fn ingest_cursor_events_dedupes_and_survives_refresh() {
         cache_write_tokens: 0,
         cost: 1.5,
     };
-    let usage = store.ingest_cursor_events(&[event.clone(), event.clone()]);
+    let mut window = store.cursor_fetch_window();
+    window.newest_event_ms = event.timestamp_ms;
+    let usage = store.ingest_cursor_batch(CursorBatch {
+        events: vec![event.clone(), event.clone()],
+        window,
+        complete: true,
+    });
     assert_eq!(usage.today.input_tokens, 100);
     assert_eq!(usage.today.output_tokens, 20);
     assert_close(usage.today.cost, 1.5);
@@ -473,7 +479,7 @@ fn ingest_cursor_events_dedupes_and_survives_refresh() {
     assert_eq!(snapshot.today().total_tokens(), 120);
     assert_close(snapshot.today().cost, 1.5);
     assert_eq!(
-        store.cursor_fetch_start_ms(),
+        store.cursor_fetch_window().start_ms,
         event.timestamp_ms - 5 * 60 * 1_000
     );
     let report = snapshot.history.report(snapshot.updated_at, 30);
@@ -759,4 +765,59 @@ fn codex_repeated_usage_is_not_billed_again_after_cache_reload() {
         220,
         "equal-sized real requests must both count when cumulative usage advances"
     );
+}
+
+#[test]
+fn cursor_regression_checkpoint_survives_restart_and_replay() {
+    let fixture = Fixture::new();
+    let make_store = || {
+        fixture.store(
+            "2026-07-22T12:00:00Z",
+            "2026-07-22T00:00:00Z",
+            "2026-07-01T00:00:00Z",
+        )
+    };
+    let mut store = make_store();
+    let original = store.cursor_fetch_window();
+    let newest = CursorUsageEvent {
+        id: "newest".into(),
+        timestamp_ms: timestamp("2026-07-22T11:00:00Z") * 1000,
+        model: "composer".into(),
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        cost: 1.0,
+    };
+    let mut pending = original;
+    pending.next_page = 11;
+    pending.newest_event_ms = newest.timestamp_ms;
+    store.ingest_cursor_batch(CursorBatch {
+        events: vec![newest.clone()],
+        window: pending,
+        complete: false,
+    });
+    // Transcript refresh and process restart must retain the unfinished window,
+    // even though newer events have already been included in the totals.
+    let _ = store.refresh();
+    let mut store = make_store();
+    assert_eq!(store.cursor_fetch_window(), pending);
+    let cache: Value = serde_json::from_slice(&fs::read(&fixture.cache).unwrap()).unwrap();
+    assert_eq!(cache["cursor"]["last_event_ms"], 0);
+    let mut oldest = newest.clone();
+    oldest.id = "oldest".into();
+    oldest.timestamp_ms -= 86_400_000;
+    for _ in 0..2 {
+        store.ingest_cursor_batch(CursorBatch {
+            events: vec![newest.clone(), oldest.clone()],
+            window: pending,
+            complete: true,
+        });
+    }
+    let snapshot = make_store().refresh();
+    assert_close(snapshot.cursor.month.cost, 2.0);
+    assert_eq!(snapshot.cursor.month.input_tokens, 20);
+    let next = store.cursor_fetch_window();
+    assert_eq!(next.next_page, 1);
+    assert_eq!(next.start_ms, newest.timestamp_ms - 300_000);
 }

--- a/diri/crates/diri-app/src/usage_page.rs
+++ b/diri/crates/diri-app/src/usage_page.rs
@@ -4,12 +4,12 @@ use crate::usage::dashboard::{UsageReport, date_label};
 use crate::usage::{UsageFormat, UsageSnapshot};
 use gpui::relative;
 
-const PROVIDERS: [&str; 2] = ["Claude Code", "Codex"];
+const PROVIDERS: [&str; 3] = ["Claude Code", "Codex", "Cursor"];
 fn provider_color(provider: usize, colors: SemanticColors) -> Rgba {
-    if provider == 0 {
-        rgba(0xcf876dff)
-    } else {
-        colors.secondary
+    match provider {
+        0 => rgba(0xcf876dff),
+        2 => rgba(0x6d8fcfff),
+        _ => colors.secondary,
     }
 }
 
@@ -26,7 +26,7 @@ impl UtilitySurfaces {
         if self.usage.updated_at == 0 {
             return settings_page("Usage", div().flex().flex_col().gap(px(8.0)).py(px(24.0))
                 .child(label("Reading local usage…", 14.0, colors.primary))
-                .child(label("Preparing costs and token history from your Claude Code and Codex transcripts.", 12.0, colors.secondary)), colors).into_any_element();
+                .child(label("Preparing costs and token history from local Claude Code and Codex transcripts, plus billed Cursor usage when signed in.", 12.0, colors.secondary)), colors).into_any_element();
         }
         let report = self
             .usage
@@ -129,7 +129,7 @@ impl UtilitySurfaces {
                                 .font_weight(FontWeight::MEDIUM),
                             )
                             .child(label(
-                                "At model rates, not your subscription bill",
+                                "Claude and Codex at model rates. Cursor is billed usage.",
                                 11.0,
                                 colors.tertiary,
                             )),
@@ -200,15 +200,15 @@ impl UtilitySurfaces {
         if loaded && total.total_tokens() == 0 {
             content = content.child(div().p(px(20.0)).rounded(px(8.0)).bg(colors.primary.alpha(0.035)).flex().flex_col().gap(px(6.0))
                 .child(label("Your usage starts with a conversation", 14.0, colors.primary))
-                .child(label("Use Claude Code or Codex on this Mac. Available transcript history appears here automatically.", 12.0, colors.secondary))
+                .child(label("Use Claude Code, Codex, or Cursor on this Mac. Transcript history and signed-in Cursor usage appear here automatically.", 12.0, colors.secondary))
                 .child(label("Try a longer date range to see earlier activity.", 12.0, colors.secondary)));
         }
         content = content.child(hero).child(metrics).child(self.usage_breakdown(&report, colors, cx))
             .child(div().flex().flex_col().gap(px(7.0))
                 .child(label("About these estimates", 12.0, colors.primary).font_weight(FontWeight::MEDIUM))
-                .child(label(format!("{:.1}% of tokens model priced · {} unpriced tokens · No provider billing data", ratio(report.total.priced_tokens as f64, total.total_tokens() as f64) * 100.0, UsageFormat::tokens(total.total_tokens() - report.total.priced_tokens)), 11.0, colors.secondary))
-                .child(label("Uses Diri’s bundled model rates. Unpriced usage is excluded from cost. Cache read savings compare cached reads with uncached input rates; cache write premiums are excluded.", 11.0, colors.tertiary))
-                .child(label("Updates automatically from available local Claude Code and Codex transcripts, including sessions outside Diri. Remote usage is not included in this detailed view.", 11.0, colors.tertiary)));
+                .child(label(format!("{:.1}% of tokens priced · {} unpriced tokens", ratio(report.total.priced_tokens as f64, total.total_tokens() as f64) * 100.0, UsageFormat::tokens(total.total_tokens() - report.total.priced_tokens)), 11.0, colors.secondary))
+                .child(label("Uses Diri’s bundled model rates for Claude and Codex. Cursor costs come from billed dashboard events. Unpriced Claude/Codex usage is excluded from cost. Cache read savings compare cached reads with uncached input rates; cache write premiums are excluded.", 11.0, colors.tertiary))
+                .child(label("Updates automatically from local Claude Code and Codex transcripts, including sessions outside Diri, plus billed Cursor usage when signed in. Remote Claude/Codex usage is not included in this detailed view.", 11.0, colors.tertiary)));
         settings_page("Usage", content, colors).into_any_element()
     }
 
@@ -258,7 +258,7 @@ impl UtilitySurfaces {
             );
             bar =
                 bar.tooltip(move |_, cx| cx.new(|_| UsageTooltip(tooltip.clone(), colors)).into());
-            for provider in (0..2).rev() {
+            for provider in (0..3).rev() {
                 bar = bar.child(
                     div()
                         .w_full()
@@ -354,7 +354,8 @@ impl UtilitySurfaces {
                     .justify_end()
                     .gap(px(12.0))
                     .child(provider_label(0, colors))
-                    .child(provider_label(1, colors)),
+                    .child(provider_label(1, colors))
+                    .child(provider_label(2, colors)),
             )
     }
 


### PR DESCRIPTION
## Why

Diri already totals Claude Code and Codex from local transcripts, but Cursor transcripts have no usage fields. Signed-in Cursor spend never showed up in the account menu or Settings → Usage.

## What changed

- Fetch billed Cursor usage from the dashboard API using the signed-in IDE/CLI session (same cookie/OAuth path TokenLeader uses).
- Fold Cursor into Session / Today / This month totals, and into the Settings usage dashboard as a third provider with per-model rows.
- Keep Claude/Codex transcript accounting unchanged. Cache version stays 4 so existing ledgers are not wiped.

## Verification

- [x] `cargo fmt --all`, `cargo clippy -p diri-app --all-targets -- -D warnings`, and `cargo test -p diri-app --bin diri usage` pass. Full `./scripts/check.sh` was not run.
- [x] Existing sessions still survive app and daemon restarts, or the migration is documented.
- [x] I considered security and privacy impact (processes, IPC, logs, updates, remote hosts).
- [x] User-visible behavior or setup changes are documented.
- [x] UI changes include a screenshot or short recording.

- Tokens travel through curl stdin config and are never logged.
- Auth is read-only from Cursor `ItemTable` / macOS keychain. Tokens are not written back.
- No live Cursor network calls in tests; mapping, JWT cookie, ingest dedup, refresh persistence, and history rows are unit-tested.

Replaces #234, which was accidentally based on a stale fork main.