### PR TITLE
Fix delayed local terminal redraws after mouse scrolling

### DIFF
--- a/diri/PERF.md
+++ b/diri/PERF.md
@@ -1,5 +1,22 @@
 # diri performance record
 
+## Local mouse-driven redraw publication (2026-09-10)
+
+The local Holder output follower waited for its ordinary 100 ms quiet tick
+after parsing a short redraw before notifying attached clients. Claude's
+mouse-driven transcript scrolling exposed this because every wheel response
+can end in silence. The wait now uses the remaining 8 ms output-batch budget
+while publication is pending; an idle follower keeps its existing blocking
+wait. No Holder/protocol changes or additional idle polling are introduced.
+
+`cargo test -p diri-engine --test held_scroll -- --nocapture` exercises an
+SGR wheel frame through the actual local Holder, PTY, Engine and binary
+attachment. A fullscreen fixture redraws once per wheel report, then waits.
+On macOS, the debug-build median of ten measured turns fell from 103.51 ms
+to 9.39 ms. The regression requires a median below 50 ms, leaving scheduler
+headroom while catching the former 100 ms wait. This measures arrival at the
+client socket, not display presentation or Claude's own scrolling speed.
+
 Historical measurements in this file are from the T16 release build on Apple
 Silicon, macOS 26.5.2, on 2026-07-23. They predate subsequent UI/font changes
 and are context, not proof that the current release passes. Release acceptance

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -2780,7 +2780,17 @@ fn pump_held(
         let from_log;
         let (start, chunk): (u64, &[u8]) = match live.as_mut().filter(|_| streaming) {
             Some(stream) => {
-                match stream.next_run_into(shared.quiet_tick(), LOG_READ_BUDGET, &mut live_run) {
+                // Once a redraw is pending, the next empty read is what
+                // publishes it. Waiting the ordinary idle tick here held an
+                // otherwise complete mouse-driven TUI frame for 100 ms. Keep
+                // draining within the batch deadline, then publish even if
+                // the child produces no more output. Truly idle sessions
+                // retain their existing blocking wait.
+                let timeout = publish_pending.map_or_else(
+                    || shared.quiet_tick(),
+                    |started| OUTPUT_BATCH_CEILING.saturating_sub(started.elapsed()),
+                );
+                match stream.next_run_into(timeout, LOG_READ_BUDGET, &mut live_run) {
                     // Contiguous by construction, and checked anyway: a run
                     // that does not start where the last one ended means
                     // something raced, and the log is the authority to fall

--- a/diri/crates/diri-engine/tests/held_scroll.rs
+++ b/diri/crates/diri-engine/tests/held_scroll.rs
@@ -1,0 +1,150 @@
+//! Mouse-driven TUI redraws must reach the actual attached client promptly.
+//! Reading Session::screen directly misses delays in grid publication.
+
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::os::unix::net::UnixStream;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use diri_engine::control::ControlServer;
+use diri_engine::session::HolderConfig;
+use diri_engine::{ManifestEngine, Registry};
+use diri_proto::ControlMessage;
+use diri_proto::frames::{Frame, FrameCodec, FrameType};
+use serde_json::json;
+
+struct SessionCleanup {
+    registry: Arc<Mutex<Registry>>,
+    id: String,
+}
+
+impl Drop for SessionCleanup {
+    fn drop(&mut self) {
+        let _ = self
+            .registry
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .terminate(&self.id, Duration::from_secs(2));
+    }
+}
+
+#[test]
+fn held_mouse_redraw_reaches_the_attached_grid_without_a_quiet_tick() {
+    let temp = tempfile::tempdir().unwrap();
+    let (engine, _) =
+        ManifestEngine::load_dir(&diri_engine::detect::bundled_manifest_dir()).unwrap();
+    let registry = Arc::new(Mutex::new(Registry::new(
+        Arc::new(engine),
+        temp.path().join("state.json"),
+    )));
+    let server = Arc::new(
+        ControlServer::new(Arc::clone(&registry), temp.path().join("daemon.sock"))
+            .with_logs_dir(temp.path().join("logs"))
+            .with_holder(HolderConfig {
+                holders_dir: temp.path().join("holders"),
+                executable: env!("CARGO_BIN_EXE_diri-holder").into(),
+            }),
+    );
+    let listener = server.bind().unwrap();
+    let serving = Arc::clone(&server);
+    std::thread::spawn(move || {
+        while let Ok((stream, _)) = listener.accept() {
+            let server = Arc::clone(&serving);
+            std::thread::spawn(move || {
+                let _ = server.serve(stream);
+            });
+        }
+    });
+    let mut control = UnixStream::connect(server.socket_path()).unwrap();
+    control
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .unwrap();
+    let mut replies = BufReader::new(control.try_clone().unwrap());
+    let mut request = |id, method: &str, params| {
+        let message = ControlMessage::Request {
+            id,
+            method: method.into(),
+            params: Some(params),
+        };
+        let mut bytes = serde_json::to_vec(&message).unwrap();
+        bytes.push(b'\n');
+        control.write_all(&bytes).unwrap();
+        let mut line = String::new();
+        replies.read_line(&mut line).unwrap();
+        match serde_json::from_str::<ControlMessage>(&line).unwrap() {
+            ControlMessage::Response {
+                result: Ok(value), ..
+            } => value,
+            other => panic!("request failed: {other:?}"),
+        }
+    };
+    // A tiny fullscreen TUI. One SGR wheel report causes one complete redraw,
+    // followed by silence, just like an idle Claude transcript being scrolled.
+    let spawned = request(
+        1,
+        "session.spawn",
+        json!({
+            "kind": { "shell": {} }, "cwd": "/tmp",
+            "argv": ["/bin/bash", "--noprofile", "--norc", "-c",
+                "stty -echo -icanon min 1 time 0; printf '\x1b[?1049h\x1b[?1000h\x1b[?1006hready'; n=0; while IFS= read -r -n 1 ch; do if [ \"$ch\" = M ]; then n=$((n+1)); printf '\x1b[Hscroll-%s\x1b[K\x1b[2;1Hfixed prompt' \"$n\"; fi; done"]
+        }),
+    );
+    let id = spawned["id"].as_str().unwrap().to_owned();
+    let _cleanup = SessionCleanup {
+        registry,
+        id: id.clone(),
+    };
+    let mut data = UnixStream::connect(server.socket_path()).unwrap();
+    data.set_read_timeout(Some(Duration::from_secs(10)))
+        .unwrap();
+    writeln!(data, "{}", json!({ "attach": id })).unwrap();
+    let mut codec = FrameCodec::new();
+    let mut chunk = [0; 64 << 10];
+    let mut input = data.try_clone().unwrap();
+    let mut wait_for = |needle: &str| {
+        loop {
+            let count = data
+                .read(&mut chunk)
+                .unwrap_or_else(|err| panic!("waiting for {needle}: {err}"));
+            assert!(count > 0, "attachment closed");
+            for frame in codec.feed(&chunk[..count]).unwrap() {
+                if frame.frame_type != FrameType::Grid {
+                    continue;
+                }
+                let update = frame.grid_payload().unwrap().unwrap();
+                if update.changed_rows.iter().any(|row| {
+                    let text: String = row
+                        .cells
+                        .iter()
+                        .map(|c| char::from_u32(c.scalar).unwrap_or(' '))
+                        .collect();
+                    text.contains(needle)
+                }) {
+                    return;
+                }
+            }
+        }
+    };
+    wait_for("ready");
+    let mut samples = Vec::new();
+    for turn in 1..=12 {
+        let started = Instant::now();
+        input
+            .write_all(&FrameCodec::encode(&Frame::scroll(0, 1, 0, 0)).unwrap())
+            .unwrap();
+        wait_for(&format!("scroll-{turn}"));
+        if turn > 2 {
+            samples.push(started.elapsed());
+        }
+    }
+    request(2, "session.kill", json!({ "sessionID": id }));
+    samples.sort();
+    let median = samples[samples.len() / 2];
+    eprintln!("held mouse-to-attached-grid median: {median:?}; samples: {samples:?}");
+    assert!(
+        median < Duration::from_millis(50),
+        "scroll redraws wait for the 100 ms idle tick: {median:?}"
+    );
+}


### PR DESCRIPTION
## Why

Local mouse-driven TUIs such as Claude Code could wait about 100 ms after finishing a scroll redraw before the attached app received it. The Holder output follower waited for the ordinary idle tick to determine that the output burst had ended.

## What changed

While grid publication is pending, wait only for the remaining 8 ms output-batch budget. Truly idle followers retain their existing blocking wait. No input, Holder protocol, session lifecycle, or remote transport changes.

Add an integration regression that sends SGR wheel input through a real local Holder/PTY and measures arrival at the binary client attachment. Its ten-turn median fell from 103.51 ms to 9.39 ms in the original workspace; the isolated PR checkout measured 9.75 ms. Document the measurement and its limits in `diri/PERF.md`.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --workspace --release`
- `cargo test -p diri-engine --test held_scroll -- --nocapture`

These Rust checks cover the changed scope; the broader historical `scripts/check.sh` wrapper was not used. The full suite includes Holder survival/adoption and reconnect coverage. This change adds no logging, credentials, dependencies, or protocol fields. There is no UI layout change. The confirmed redraw delay is fixed; visual evaluation of the original video's other jumps remains a manual check in the local preview.

Opened the release preview from this PR against the existing session store. Verified that the live Engine hash matches the PR build, session IDs are unchanged, and local Agent process IDs survive the handover.
