### PR TITLE
release: prepare diri 0.7.0

### DIFF
--- a/diri/Cargo.lock
+++ b/diri/Cargo.lock
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "diri-app"
-version = "0.6.5"
+version = "0.7.0"
 dependencies = [
  "base64 0.23.1",
  "block2 0.6.2",

--- a/diri/crates/diri-app/Cargo.toml
+++ b/diri/crates/diri-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diri-app"
-version = "0.6.5"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
- bump the desktop app and lockfile to 0.7.0
- prepare the release for Cursor billed usage, restored Cursor terminal behavior, faster mouse-driven redraws, and lower Holder/Engine overhead

## Verification
- cargo check -p diri-app