### PR TITLE
Fix repeated Codex attention notifications during redraws

### DIFF
--- a/diri/crates/diri-engine/manifests/codex.json
+++ b/diri/crates/diri-engine/manifests/codex.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "id": "codex",
-  "version": "2026.08.15.1",
+  "version": "2026.09.10.1",
   "statusModel": "full",
   "agent": {
     "id": "codex",
@@ -66,7 +66,7 @@
     {
       "id": "action-required-title",
       "state": "blockedPermission",
-      "priority": 1100,
+      "priority": 925,
       "region": "osc_title",
       "when": {
         "contains": "action required"
@@ -75,8 +75,7 @@
         "visible_blocker"
       ],
       "capture": {
-        "region": "bottom_non_empty_lines",
-        "regionLines": 12,
+        "region": "osc_title",
         "maxChars": 400
       }
     },

--- a/diri/crates/diri-engine/src/detect/mod.rs
+++ b/diri/crates/diri-engine/src/detect/mod.rs
@@ -618,6 +618,86 @@ mod tests {
     }
 
     #[test]
+    fn codex_action_required_redraws_keep_the_same_notification_identity() {
+        use crate::status::{Authority, StatusReducer, StatusSignal};
+        use std::time::{Duration, SystemTime};
+
+        let engine = engine();
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(100);
+        let mut reducer = StatusReducer::new(Authority::ScreenPrimary, now);
+        let mut first = None;
+        for seconds in 0..20 {
+            // A queued async question keeps the title at Action Required even
+            // while Codex runs tools and repaints its elapsed-time footer.
+            let snapshot = ScreenSnapshot {
+                lines: vec![
+                    format!("• Ran tool {seconds}"),
+                    format!("• Working (27m {seconds:02}s • esc to interrupt)"),
+                    "• Queued follow-up inputs".into(),
+                    "  ? 1 question".into(),
+                    "    ⌥ + ↑ to answer".into(),
+                    "› Ask Codex to do anything".into(),
+                ],
+                osc_title: Some("Action Required | project".into()),
+                content_seq: seconds + 1,
+                ..ScreenSnapshot::default()
+            };
+            let observation = engine.evaluate(&snapshot, "codex").expect("title rule");
+            let outcome = reducer.reduce(
+                StatusSignal::Screen(observation),
+                now + Duration::from_secs(seconds),
+            );
+            assert!(
+                !outcome.turn_completed,
+                "a queued question is not completion"
+            );
+            let mut detail = outcome.needs_input.expect("pending question attention");
+            // Notification identity includes the summary and kind, excluding
+            // repaint timestamps. The rest of the detail must stay stable too.
+            detail.occurred_at = now.into();
+            if let Some(first) = &first {
+                assert_eq!(&detail, first, "redraw must not create a new alert");
+            } else {
+                first = Some(detail);
+            }
+        }
+    }
+
+    #[test]
+    fn codex_visible_prompts_outrank_the_generic_action_required_title() {
+        let engine = engine();
+        for (footer, expected, rule) in [
+            (
+                "Enter to submit answer",
+                ManifestState::BlockedQuestion,
+                "submit-answer",
+            ),
+            (
+                "Press enter to confirm or esc to cancel",
+                ManifestState::BlockedPermission,
+                "confirm-prompt",
+            ),
+        ] {
+            let snapshot = cursor_snapshot(
+                &[
+                    "╭────────────────────╮",
+                    "│ Which option?      │",
+                    "╰────────────────────╯",
+                    footer,
+                ],
+                Some("Action Required | project"),
+            );
+            let observation = engine.evaluate(&snapshot, "codex").expect("prompt rule");
+            assert_eq!(observation.state, expected);
+            assert_eq!(observation.matched_rule_id, rule);
+            assert_eq!(
+                observation.prompt_excerpt.as_deref().map(str::trim),
+                Some("Which option?")
+            );
+        }
+    }
+
+    #[test]
     fn cursor_osc_title_keeps_tool_turns_working_until_ready() {
         let engine = engine();
         let grep = cursor_snapshot(

--- a/diri/docs/notifications.md
+++ b/diri/docs/notifications.md
@@ -70,6 +70,11 @@ Kitty queries, icons, encoded payloads and callback actions are ignored.
 Inputs, multipart state and event queues are bounded; repeated identical
 terminal messages within five seconds are coalesced.
 
+Codex's generic `Action Required` title can remain visible while it continues
+working with a queued question. That title produces one stable attention alert;
+changing tool output and elapsed time are not new prompts. A visible question
+or permission prompt takes precedence and supplies its own prompt details.
+
 The same terminal sequences work over Diri's Remote PTY Holder transport while
 the local Engine is connected. The local Engine derives events from live raw
 output; the Holder does not run hooks or store product notifications. Replay


### PR DESCRIPTION
## Why

Codex can keep its terminal title at `Action Required` while continuing to work with a queued question. Diri captured the bottom 12 terminal lines for that title rule, so changing tool output or elapsed time changed the notification summary and generated repeated “Needs input” alerts for the same pending request. The generic title also overrode explicit question and permission prompts.

## What changed

- Capture the stable OSC title for the generic attention rule, preserving one notification identity across redraws.
- Give visible question and permission prompts precedence so they retain their specific kind and details.
- Bump the Codex manifest version, document the behavior, and add regression coverage through the real manifest evaluator and status reducer.

## Verification

- Both new regression tests failed before the fix and pass after it; they also pass on this isolated branch based on current `main`.
- `./scripts/check.sh` passed on this PR branch: shell/release guards, Rust formatting, workspace Clippy with warnings denied, full workspace tests, and dependency license policy.
- `cargo build --workspace --release` passed on this PR branch.
- Session transport, lifecycle, and wire formats are unchanged. No dependencies or operational logging were added.
- User-visible notification behavior is documented in `diri/docs/notifications.md`; there is no visual layout change requiring a screenshot.
