### PR TITLE
Keep scrolled reading text stable during streaming redraws

### DIFF
--- a/diri/PERF.md
+++ b/diri/PERF.md
@@ -1,5 +1,21 @@
 # diri performance record
 
+## Stable reading during streaming redraws (2026-09-10)
+
+An absolute scroll anchor did not protect text still backed by the live grid.
+The desktop now captures one grid when scrolling away from live, and retains
+already fetched history rows within the existing 512-row cache until returning
+to live. Live damage still updates the authoritative mirror. No new lock,
+worker, parser, or Holder allocation is involved; the extra screen copy exists
+only for a scrolled terminal.
+
+Run `cargo bench -p diri-term --bench reading_view -- --sample-size 10
+--measurement-time 1 --warm-up-time 1` from this workspace. On macOS arm64 in
+release mode, the 160×50 case measured capture/release at 1.41–1.42 µs,
+live full-screen damage at 5.97–6.09 µs, and damage while reading at
+6.01–6.14 µs. Damage timings include cloning each input frame. These are local
+mirror/capture microbenchmarks, not display-presentation or PTY latency gates.
+
 ## Local mouse-driven redraw publication (2026-09-10)
 
 The local Holder output follower waited for its ordinary 100 ms quiet tick

--- a/diri/REMOTE_PORT.md
+++ b/diri/REMOTE_PORT.md
@@ -644,6 +644,14 @@ behind pass/fail status.
 
 ## Desktop integration
 
+While the desktop terminal is scrolled back, its renderer retains one local
+screen snapshot and preserves already fetched rows in its bounded 512-row
+history cache. This keeps Agent redraws and overlapping history replies from
+replacing text under the reader. The live grid continues receiving every
+update. Returning to live or entering the alternate screen releases the reading
+view; the next scroll fetches fresh history. This is client presentation state,
+not another terminal parser, Holder snapshot, or protocol change.
+
 The desktop app initializes a newly added SSH host immediately and displays the
 bootstrap state. The Engine returns only sanitized facts such as Build ID,
 protocol version, cwd, shell, and persistence level. It does not expose the full

--- a/diri/crates/diri-term/Cargo.toml
+++ b/diri/crates/diri-term/Cargo.toml
@@ -17,3 +17,7 @@ gpui_platform = { workspace = true, features = ["test-support"] }
 [[bench]]
 name = "terminal_renderer"
 harness = false
+
+[[bench]]
+name = "reading_view"
+harness = false

--- a/diri/crates/diri-term/benches/reading_view.rs
+++ b/diri/crates/diri-term/benches/reading_view.rs
@@ -1,0 +1,48 @@
+//! Cost of capturing a reading view and continuing to consume live damage.
+use criterion::{Criterion, criterion_group, criterion_main};
+use diri_proto::grid::{ChangedRow, GridCell, GridUpdate};
+use diri_term::{buffer::GridBuffer, element::TerminalElement};
+use std::hint::black_box;
+
+fn reading_view(c: &mut Criterion) {
+    const COLS: u16 = 160;
+    const ROWS: u16 = 50;
+    let element = TerminalElement::with_buffer(GridBuffer::new(COLS, ROWS));
+    let mut group = c.benchmark_group("reading_view_160x50");
+    group.bench_function("capture_and_release", |b| {
+        b.iter(|| {
+            black_box(element.set_view_offset(1, usize::from(ROWS)));
+            black_box(element.scroll_to_live(usize::from(ROWS)));
+        });
+    });
+
+    let frames = ['a', 'b'].map(|ch| GridUpdate {
+        cols: COLS,
+        rows: ROWS,
+        cursor_col: 0,
+        cursor_row: ROWS - 1,
+        cursor_visible: true,
+        is_full_snapshot: false,
+        changed_rows: (0..ROWS)
+            .map(|y| {
+                let mut cell = GridCell::BLANK;
+                cell.scalar = u32::from(ch);
+                ChangedRow::new(y, vec![cell; usize::from(COLS)])
+            })
+            .collect(),
+    });
+    for held in [false, true] {
+        element.set_view_offset(i64::from(held), usize::from(ROWS));
+        let mut next = 0;
+        group.bench_function(if held { "held_damage" } else { "live_damage" }, |b| {
+            b.iter(|| {
+                black_box(element.apply_damage(frames[next].clone()));
+                next ^= 1;
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, reading_view);
+criterion_main!(benches);

--- a/diri/crates/diri-term/src/element.rs
+++ b/diri/crates/diri-term/src/element.rs
@@ -476,8 +476,12 @@ impl TerminalElement {
         // Absolute rows keep a selection attached while the viewport moves,
         // but not when the daemon replaces cells at those rows. Damage is
         // row-granular, so unrelated live output and history remain selected.
-        let live_start_row = mutex_lock(&self.shared.viewport).live_start_row();
+        let mut viewport = mutex_lock(&self.shared.viewport);
+        let live_start_row = viewport.live_start_row();
         let mut buffer = write_lock(&self.buffer);
+        viewport.hold_reading_view(&buffer);
+        let reading_held = viewport.view_offset() > 0;
+        drop(viewport);
         let replaces_grid =
             update.is_full_snapshot || buffer.cols != update.cols || buffer.rows != update.rows;
         let damaged_cols = usize::from(if replaces_grid {
@@ -486,7 +490,7 @@ impl TerminalElement {
             update.cols
         });
         let mut selection = mutex_lock(&self.shared.selection);
-        let selection_overlaps_damage = if selection.range().is_none() {
+        let selection_overlaps_damage = if reading_held || selection.range().is_none() {
             false
         } else if replaces_grid {
             (0..buffer.rows.max(update.rows)).any(|row| {
@@ -534,15 +538,27 @@ impl TerminalElement {
     }
 
     pub fn set_view_offset(&self, offset: i64, visible_rows: usize) -> bool {
-        mutex_lock(&self.shared.viewport).set_view_offset(offset, visible_rows)
+        let mut viewport = mutex_lock(&self.shared.viewport);
+        let changed = viewport.set_view_offset(offset, visible_rows);
+        viewport.hold_reading_view(&read_lock(&self.buffer));
+        if changed && viewport.view_offset() == 0 {
+            mutex_lock(&self.shared.selection).clear();
+        }
+        changed
     }
 
     pub fn scroll_to_live(&self, visible_rows: usize) -> bool {
-        mutex_lock(&self.shared.viewport).scroll_to_live(visible_rows)
+        self.set_view_offset(0, visible_rows)
     }
 
     pub fn scroll_to_absolute(&self, absolute_row: i64, anchor: f32, visible_rows: usize) -> bool {
-        mutex_lock(&self.shared.viewport).scroll_to_absolute(absolute_row, anchor, visible_rows)
+        let mut viewport = mutex_lock(&self.shared.viewport);
+        let changed = viewport.scroll_to_absolute(absolute_row, anchor, visible_rows);
+        viewport.hold_reading_view(&read_lock(&self.buffer));
+        if changed && viewport.view_offset() == 0 {
+            mutex_lock(&self.shared.selection).clear();
+        }
+        changed
     }
 
     /// Updates daemon-owned terminal modes and reports whether entering the
@@ -573,7 +589,12 @@ impl TerminalElement {
         let route = mutex_lock(&self.shared.scroll_router).route(modes, event)?;
         match route {
             WheelRoute::Local { lines } => {
-                mutex_lock(&self.shared.viewport).scroll_by(lines, usize::from(event.visible_rows));
+                let mut viewport = mutex_lock(&self.shared.viewport);
+                let changed = viewport.scroll_by(lines, usize::from(event.visible_rows));
+                viewport.hold_reading_view(&read_lock(&self.buffer));
+                if changed && viewport.view_offset() == 0 {
+                    mutex_lock(&self.shared.selection).clear();
+                }
             }
             // This route leaves the viewport still while the foreground
             // program may repaint beneath the selection's coordinates.
@@ -1960,6 +1981,41 @@ mod selection_repaint_tests {
         element
     }
 
+    #[test]
+    fn streaming_redraw_preserves_scrolled_reading_window() {
+        let element = populated_element();
+        mutex_lock(&element.shared.viewport).apply_rows(
+            vec![row("history")],
+            7,
+            8,
+            11,
+            1,
+            usize::from(ROWS),
+        );
+        element.set_view_offset(1, usize::from(ROWS));
+        let reading = element
+            .viewport()
+            .compose(&super::read_lock(&element.buffer), usize::from(ROWS));
+
+        // An agent redraws its live screen while the reader is one row up.
+        element.apply_damage(update(true, &[(0, "new"), (1, "output"), (2, "below")]));
+
+        assert_eq!(
+            element
+                .viewport()
+                .compose(&super::read_lock(&element.buffer), usize::from(ROWS)),
+            reading,
+            "streaming must not replace text already visible to a scrolled reader",
+        );
+        element.scroll_to_live(usize::from(ROWS));
+        assert_eq!(
+            element
+                .viewport()
+                .window_row(&super::read_lock(&element.buffer), 0),
+            row("new")
+        );
+    }
+
     fn wheel(delta: f32) -> WheelEvent {
         WheelEvent {
             delta: WheelDelta::Lines(delta),
@@ -1968,6 +2024,100 @@ mod selection_repaint_tests {
             visible_rows: ROWS,
             line_height: 16.0,
         }
+    }
+
+    fn history_reply(
+        first: i64,
+        live: i64,
+        seq: u64,
+        texts: &[&str],
+    ) -> diri_proto::methods::ReadScrollbackCellsResult {
+        diri_proto::methods::ReadScrollbackCellsResult {
+            payload: diri_proto::grid::GridRowCodec::encode_rows(
+                &texts.iter().map(|text| row(text)).collect::<Vec<_>>(),
+            )
+            .unwrap(),
+            first_row: first,
+            row_count: texts.len() as i64,
+            live_start_row: live,
+            total_rows: live + i64::from(ROWS),
+            cols: i64::from(COLS),
+            content_seq: seq,
+        }
+    }
+
+    #[test]
+    fn scrolling_before_first_fetch_holds_live_text_and_selection() {
+        let element = populated_element();
+        element.route_wheel(wheel(1.0));
+        element.apply_damage(update(false, &[(0, "new")]));
+        element
+            .complete_scrollback_fetch(history_reply(7, 8, 2, &["history"]), usize::from(ROWS))
+            .unwrap();
+        assert_eq!(
+            element
+                .viewport()
+                .compose(&super::read_lock(&element.buffer), 3),
+            vec![row("history"), row("zero"), row("one")]
+        );
+        element.begin_selection(0, 1);
+        element.drag_selection(4, 1);
+        element.apply_damage(update(false, &[(0, "again")]));
+        assert_eq!(element.selected_text(), "zero");
+        element.scroll_to_live(3);
+        assert_eq!(element.selected_text(), "");
+        element.route_wheel(wheel(1.0));
+        element
+            .complete_scrollback_fetch(history_reply(17, 18, 3, &["fresh"]), 3)
+            .unwrap();
+        assert_eq!(
+            element.view_offset(),
+            1,
+            "a new scroll starts at the current live edge"
+        );
+        assert_eq!(
+            element
+                .viewport()
+                .compose(&super::read_lock(&element.buffer), 3),
+            vec![row("fresh"), row("again"), row("one")]
+        );
+    }
+
+    #[test]
+    fn overlapping_history_replies_and_live_growth_preserve_reading_text() {
+        let element = populated_element();
+        element
+            .complete_scrollback_fetch(history_reply(6, 8, 1, &["hist six", "hist sev"]), 3)
+            .unwrap();
+        element.set_view_offset(2, 3);
+        let reading = element
+            .viewport()
+            .compose(&super::read_lock(&element.buffer), 3);
+        for seq in 2..10 {
+            element.apply_damage(update(true, &[(0, "new"), (1, "output"), (2, "below")]));
+            element
+                .complete_scrollback_fetch(
+                    history_reply(7, 8 + seq as i64, seq, &["changed", "changed"]),
+                    3,
+                )
+                .unwrap();
+            assert_eq!(
+                element
+                    .viewport()
+                    .compose(&super::read_lock(&element.buffer), 3),
+                reading
+            );
+            assert_eq!(element.viewport().absolute_row(0), 6);
+        }
+        element.set_modes(true, MouseModes::OFF);
+        assert_eq!(element.view_offset(), 0);
+        assert!(element.viewport().cached_row(6).is_none());
+        assert_eq!(
+            element
+                .viewport()
+                .window_row(&super::read_lock(&element.buffer), 0),
+            row("new")
+        );
     }
 
     fn visible_selection_count(element: &TerminalElement) -> usize {

--- a/diri/crates/diri-term/src/scrollback.rs
+++ b/diri/crates/diri-term/src/scrollback.rs
@@ -150,6 +150,10 @@ pub struct ScrollbackViewport {
     geometry_known: bool,
     cache_seq: Option<u64>,
     cache: BTreeMap<i64, Vec<GridCell>>,
+    /// One screen captured when leaving live. Agents can rewrite these rows
+    /// in place; an absolute scroll anchor alone cannot preserve their text.
+    held_live: Option<GridBuffer>,
+    held_live_start: Option<i64>,
     in_flight: Option<Range<i64>>,
     queued: Option<Range<i64>>,
 }
@@ -215,6 +219,9 @@ impl ScrollbackViewport {
             return false;
         }
         self.view_offset = clamped;
+        if clamped == 0 {
+            self.release_reading_view();
+        }
         self.sync_anchor();
         self.queue_missing_window(visible_rows);
         true
@@ -274,6 +281,15 @@ impl ScrollbackViewport {
     #[must_use]
     pub fn row_at_absolute(&self, buffer: &GridBuffer, absolute_row: i64) -> Vec<GridCell> {
         let cols = usize::from(buffer.cols);
+        if self.view_offset > 0
+            && let Some(held) = &self.held_live
+            && let Ok(row) = usize::try_from(
+                absolute_row.saturating_sub(self.held_live_start.unwrap_or(self.live_start_row)),
+            )
+            && let Some(cells) = held.row(row)
+        {
+            return normalized_row(cells, cols);
+        }
         let source = if absolute_row >= self.live_start_row {
             usize::try_from(absolute_row - self.live_start_row)
                 .ok()
@@ -302,6 +318,28 @@ impl ScrollbackViewport {
             .collect()
     }
 
+    /// Called at local navigation and before applying live damage. The live
+    /// mirror keeps receiving every update; only the reading view is held.
+    pub(crate) fn hold_reading_view(&mut self, buffer: &GridBuffer) {
+        if self.view_offset > 0 && self.held_live.is_none() {
+            self.held_live = Some(buffer.clone());
+            self.held_live_start = self.geometry_known.then_some(self.live_start_row);
+        }
+    }
+
+    fn release_reading_view(&mut self) {
+        self.held_live = None;
+        self.held_live_start = None;
+        // A later scroll starts a fresh reading view, including history that
+        // may have been rewritten or evicted while this view was held.
+        self.cache.clear();
+        self.cache_seq = None;
+        self.queued = None;
+        // Live grid updates carry no history geometry. After following live,
+        // the next reply must establish a fresh origin for the captured screen.
+        self.geometry_known = false;
+    }
+
     /// Returns the next coalesced request and marks it in flight. Until it is
     /// completed, further viewport movement is merged into one queued range.
     pub fn begin_fetch(&mut self, visible_rows: usize) -> Option<ScrollbackRequest> {
@@ -320,8 +358,8 @@ impl ScrollbackViewport {
         })
     }
 
-    /// Completes the active request and ingests decoded rows. A content-sequence
-    /// change invalidates all old cached absolute rows before inserting data.
+    /// Completes the active request and ingests decoded rows. While reading,
+    /// already fetched rows survive sequence changes and overlapping replies.
     pub fn complete_fetch(
         &mut self,
         result: ReadScrollbackCellsResult,
@@ -365,12 +403,21 @@ impl ScrollbackViewport {
     ) {
         let old_sequence = self.cache_seq;
         if old_sequence != Some(content_seq) {
-            self.cache.clear();
+            if self.view_offset == 0 {
+                self.cache.clear();
+            }
             self.cache_seq = Some(content_seq);
         }
         for (index, row) in rows.into_iter().enumerate() {
             let absolute = first_row.saturating_add(i64::try_from(index).unwrap_or(i64::MAX));
-            self.cache.insert(absolute, row);
+            if self.view_offset > 0 {
+                self.cache.entry(absolute).or_insert(row);
+            } else {
+                self.cache.insert(absolute, row);
+            }
+        }
+        if self.held_live.is_some() && self.held_live_start.is_none() {
+            self.held_live_start = Some(live_start_row);
         }
         self.live_start_row = live_start_row;
         self.total_rows = total_rows.max(0);
@@ -383,6 +430,9 @@ impl ScrollbackViewport {
             self.view_offset = self.live_start_row.saturating_sub(anchor);
         }
         self.view_offset = self.view_offset.clamp(0, self.max_offset(visible_rows));
+        if self.view_offset == 0 && self.held_live.is_some() {
+            self.release_reading_view();
+        }
         self.sync_anchor();
         self.cap_cache_near_viewport();
         // Recompute rather than replaying a range queued against old geometry
@@ -417,6 +467,7 @@ impl ScrollbackViewport {
             return false;
         }
         self.view_offset = 0;
+        self.release_reading_view();
         self.anchor = None;
         self.queued = None;
         true


### PR DESCRIPTION
## Change

Streaming Agent redraws could replace text underneath a scrolled reader: the scroll anchor held row positions, but part of the reading window still came from the changing live grid. History replies could also invalidate or overwrite cached reading rows.

Capture one screen when leaving live and preserve fetched rows within the existing bounded history cache while reading. Continue applying every update to the live mirror. Returning to live immediately displays the latest output, releases the reading view, and refreshes history coordinates for the next scroll. Selection and copy retain the displayed text during redraws; entering the alternate screen releases the reading view.

This changes desktop presentation only, with no Holder or protocol changes. Architecture notes and a reproducible capture/damage benchmark are included.

## Verification

- Reproduced the failure with `streaming_redraw_preserves_scrolled_reading_window` before the fix; it now passes.
- Regression coverage includes repeated redraws, overlapping history replies, live-edge growth, scrolling before the first history response, selection/copy, returning to live, a subsequent scroll, and alternate-screen entry.
- Passed `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, and `cargo build --workspace --release`. Workspace tests required access to local socket/PTY fixtures outside the sandbox. Also passed package Clippy after adding the benchmark.
- Release benchmark at 160×50: capture/release 1.41–1.42 µs; live damage 5.97–6.09 µs; damage while reading 6.01–6.14 µs.
- Verification used automated terminal tests; no manual desktop visual check or real SSH soak was performed.
