### PR TITLE
fix: track shell jobs and keep visible activity moving

### DIFF
--- a/diri/REMOTE_PORT.md
+++ b/diri/REMOTE_PORT.md
@@ -559,9 +559,13 @@ batched executable discovery, persistence probing, and atomic activation as
 required capabilities. Protocol 1.4 additively preserves granular mouse
 tracking/encoding bits and the raw mouse-input frame while retaining the old
 any-mouse compatibility bit. Protocol 1.5 additively reports the PTY foreground
-process group (`HelloAck.foregroundPid` and `ForegroundProcess`) so a shell can
-show work only while a foreground job is running. Older Helpers omit the
-field; older Engines ignore the extra JSON and never see the new frame.
+process group (`HelloAck.foregroundPid` and `ForegroundProcess`) so the Engine
+can distinguish an idle shell from a foreground job. Plain-shell sidebar
+indicators remain hidden; foreground Agent indicators follow normal attention
+rules. Older Helpers omit the field; older Engines ignore the extra JSON and
+never see the new frame. Foreground probes are armed only for an attached
+compatible controller and are cleared when it disconnects, so a detached
+Holder sleeps between PTY, lifecycle, and attach events.
 
 The protocol includes:
 

--- a/diri/REMOTE_PORT.md
+++ b/diri/REMOTE_PORT.md
@@ -558,7 +558,10 @@ declares terminal, session management, environment capture, directory listing,
 batched executable discovery, persistence probing, and atomic activation as
 required capabilities. Protocol 1.4 additively preserves granular mouse
 tracking/encoding bits and the raw mouse-input frame while retaining the old
-any-mouse compatibility bit.
+any-mouse compatibility bit. Protocol 1.5 additively reports the PTY foreground
+process group (`HelloAck.foregroundPid` and `ForegroundProcess`) so a shell can
+show work only while a foreground job is running. Older Helpers omit the
+field; older Engines ignore the extra JSON and never see the new frame.
 
 The protocol includes:
 
@@ -577,6 +580,7 @@ Resize
 Ping
 Pong
 ProcessExit
+ForegroundProcess
 Signal
 AcquireControl
 ControlGranted

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -5344,11 +5344,14 @@ impl Sidebar {
     /// One bounded 8 Hz wake for the whole sidebar, only while working marks
     /// are shown. A one-shot is rearmed by painting, so an unmounted sidebar
     /// cannot keep a background loop alive.
+    ///
+    /// Visibility/occlusion is GPUI's job (display-link stops when the
+    /// window is truly hidden). `is_window_active` is only OS focus, so
+    /// gating on it freezes a still-visible window on another monitor.
     fn schedule_activity_tick(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let animate = self.working_row_rendered
             && (self.ui.visible || self.peek_open)
             && self.settings_nav.is_none()
-            && window.is_window_active()
             && !cx.reduce_motion();
         if !animate {
             self.activity_tick = None;
@@ -5357,11 +5360,10 @@ impl Sidebar {
                 cx.background_executor()
                     .timer(Duration::from_millis(125))
                     .await;
-                let _ = this.update_in(cx, |this, window, cx| {
+                let _ = this.update_in(cx, |this, _window, cx| {
                     this.activity_tick = None;
                     if (this.ui.visible || this.peek_open)
                         && this.settings_nav.is_none()
-                        && window.is_window_active()
                         && !cx.reduce_motion()
                     {
                         this.activity_frame = (this.activity_frame + 1) % 8;
@@ -7923,6 +7925,24 @@ mod tests {
             paints.get() > 0,
             "working animation froze without pointer input"
         );
+    }
+
+    #[gpui::test]
+    fn working_sidebar_keeps_animating_when_the_window_is_unfocused(cx: &mut TestAppContext) {
+        let (sidebar, _, cx) = drag_harness(cx);
+        cx.update(|window, _| window.activate_window());
+        cx.run_until_parked();
+        cx.deactivate_window();
+        cx.run_until_parked();
+        for _ in 0..3 {
+            let frame = sidebar.read_with(cx, |sidebar, _| sidebar.activity_frame);
+            cx.executor().advance_clock(Duration::from_millis(125));
+            cx.run_until_parked();
+            assert_eq!(
+                sidebar.read_with(cx, |sidebar, _| sidebar.activity_frame),
+                (frame + 1) % 8,
+            );
+        }
     }
 
     #[gpui::test]

--- a/diri/crates/diri-engine/src/holder/server.rs
+++ b/diri/crates/diri-engine/src/holder/server.rs
@@ -767,15 +767,14 @@ fn current_stat(shared: &Shared) -> HolderStat {
     let pty = shared.pty.lock().expect("pty");
     // SAFETY: kill with signal 0 only checks existence.
     let child_alive = unsafe { libc::kill(shared.child_pid, 0) } == 0;
-    let master_fd = pty.writer().map(|stream| stream.as_raw_fd()).unwrap_or(-1);
-    // SAFETY: tcgetpgrp on the master; -1 fd yields an error, mapped to None.
-    let foreground = unsafe { libc::tcgetpgrp(master_fd) };
     let size = pty.size().ok();
     HolderStat {
         child_pid: shared.child_pid,
         alive: !finished && child_alive,
         log_offset: shared.log.lock().expect("log").tail_offset(),
-        foreground_pid: (foreground > 0).then_some(foreground),
+        // Sample the live owner. A cloned writer dropped before `tcgetpgrp`
+        // leaves a closed fd, so every job looks like the idle shell.
+        foreground_pid: pty.foreground_pgid(),
         cols: size.map(|(cols, _)| cols),
         rows: size.map(|(_, rows)| rows),
         epoch_offset: Some(shared.epoch_offset),

--- a/diri/crates/diri-engine/src/session.rs
+++ b/diri/crates/diri-engine/src/session.rs
@@ -1553,7 +1553,27 @@ impl Session {
             Transport::Remote(client) => client.write(bytes)?,
         }
         self.feed_signal(StatusSignal::UserKeystroke);
+        self.sample_shell_foreground();
         Ok(())
+    }
+
+    fn sample_shell_foreground(&self) {
+        if self.manifest_id != "shell" {
+            return;
+        }
+        match &self.transport {
+            Transport::Direct(pty) => {
+                let (child_pid, pgid) = {
+                    let pty = pty.lock().expect("pty");
+                    (pty.pid() as i32, pty.foreground_pgid())
+                };
+                apply_foreground_sample(&self.shared, &self.manifest_id, child_pid, pgid);
+            }
+            Transport::Held(client) => {
+                sample_held_foreground(&self.shared, client, &self.manifest_id);
+            }
+            Transport::Remote(_) => {}
+        }
     }
 
     fn observe_prompt_input(&self, bytes: &[u8]) {
@@ -1884,6 +1904,37 @@ fn apply(shared: &Shared, outcome: &ReducerOutcome) {
     }
 }
 
+fn apply_foreground_sample(
+    shared: &Shared,
+    manifest_id: &str,
+    child_pid: i32,
+    foreground_pgid: Option<i32>,
+) {
+    if manifest_id != "shell" {
+        return;
+    }
+    let Some(running) = crate::status::foreground_job_running(child_pid, foreground_pgid) else {
+        return;
+    };
+    let outcome = shared
+        .reducer
+        .lock()
+        .expect("reducer")
+        .reduce(StatusSignal::ForegroundJob { running }, SystemTime::now());
+    apply(shared, &outcome);
+}
+
+fn sample_held_foreground(shared: &Shared, client: &HolderClient, manifest_id: &str) {
+    if manifest_id != "shell" {
+        return;
+    }
+    let Ok(stat) = client.stat() else {
+        return;
+    };
+    shared.child_pid.store(stat.child_pid, Ordering::SeqCst);
+    apply_foreground_sample(shared, manifest_id, stat.child_pid, stat.foreground_pid);
+}
+
 /// Rescans the visible screen for artifact URLs every ~2s, only when the
 /// content actually changed and only when it plausibly contains a URL —
 /// most screens never pay more than a substring check.
@@ -2114,6 +2165,15 @@ fn handle_remote_message(
                 record_remote_exit(shared, ProcessExit { code, signal });
                 return RemoteConnectionDisposition::Exited;
             }
+            if let RemoteProcessState::Running { pid } = acknowledgement.process_state {
+                shared.child_pid.store(pid as i32, Ordering::SeqCst);
+                apply_foreground_sample(
+                    shared,
+                    manifest_id,
+                    pid as i32,
+                    acknowledgement.foreground_pid,
+                );
+            }
             *hello_accepted = true;
             RemoteConnectionDisposition::Continue
         }
@@ -2191,6 +2251,15 @@ fn handle_remote_message(
         }
         RemoteMessage::Error(error) if error.fatal => RemoteConnectionDisposition::Fatal,
         RemoteMessage::Error(_) => RemoteConnectionDisposition::Continue,
+        RemoteMessage::ForegroundProcess(foreground) => {
+            apply_foreground_sample(
+                shared,
+                manifest_id,
+                shared.child_pid.load(Ordering::SeqCst),
+                foreground.pid,
+            );
+            RemoteConnectionDisposition::Continue
+        }
         _ => RemoteConnectionDisposition::Fatal,
     }
 }
@@ -2485,6 +2554,17 @@ fn pump(
                 .expect("reducer")
                 .reduce(StatusSignal::Tick, last_tick);
             apply(&shared, &outcome);
+            // Sample from the PTY owner, not `reader`: `tcgetpgrp` on the
+            // live read fd can swallow canonical-mode input.
+            if manifest_id == "shell" {
+                let pgid = pty.lock().ok().and_then(|pty| pty.foreground_pgid());
+                apply_foreground_sample(
+                    &shared,
+                    &manifest_id,
+                    shared.child_pid.load(Ordering::SeqCst),
+                    pgid,
+                );
+            }
         }
     }
 
@@ -2926,6 +3006,7 @@ fn pump_held(
                 .expect("reducer")
                 .reduce(StatusSignal::Tick, SystemTime::now());
             apply(&shared, &outcome);
+            sample_held_foreground(&shared, &client, &manifest_id);
 
             if last_liveness.elapsed() >= LIVENESS_INTERVAL {
                 last_liveness = Instant::now();
@@ -3055,8 +3136,11 @@ fn pump_held(
             }
             if let Some(observation) = observation {
                 let outcome = reducer.reduce(StatusSignal::Screen(observation), now);
-                drop(reducer);
                 apply(&shared, &outcome);
+            }
+            drop(reducer);
+            if !replaying {
+                sample_held_foreground(&shared, &client, &manifest_id);
             }
         }
     }
@@ -3496,6 +3580,6 @@ mod notification_tests {
         assert!(shared.state_version.load(Ordering::SeqCst) > 0);
         apply_remote_output(&shared, &engine, "shell", &mut seq, end, bytes, false).unwrap();
         assert!(!shared.screen.lock().unwrap().has_notifications());
-        assert_eq!(*shared.status.lock().unwrap(), SessionStatus::Working);
+        assert_eq!(*shared.status.lock().unwrap(), SessionStatus::Idle);
     }
 }

--- a/diri/crates/diri-engine/src/status/mod.rs
+++ b/diri/crates/diri-engine/src/status/mod.rs
@@ -34,6 +34,8 @@ pub enum Authority {
     /// Codex: the screen drives state, notify confirms done.
     ScreenPrimary,
     /// Everything else: starting → working → exited, nothing more.
+    /// Shell is the exception: working follows the PTY foreground group, not
+    /// process liveness, so an idle login prompt is idle.
     ProcessOnly,
 }
 
@@ -100,6 +102,11 @@ pub enum StatusSignal {
     Screen(ScreenObservation),
     PtyOutputActivity,
     UserKeystroke,
+    /// The PTY foreground process group is, or is not, the session child.
+    /// Shell sessions use this to show work only while a foreground job runs.
+    ForegroundJob {
+        running: bool,
+    },
     ProcessExit {
         code: Option<i32>,
         signal: Option<i32>,
@@ -297,22 +304,11 @@ impl StatusReducer {
             return outcome;
         }
 
-        // processOnly: starting → working on first output, then only exit moves it.
+        // processOnly: starting → working on first output, then only exit
+        // moves it. A shell is still process-only, but an idle login prompt
+        // is not work: Working follows the foreground process group.
         if self.authority == Authority::ProcessOnly {
-            if matches!(signal, StatusSignal::PtyOutputActivity) {
-                if self.status == SessionStatus::Starting {
-                    self.state.turn_in_flight = true;
-                    self.set_status(SessionStatus::Working, &mut outcome);
-                }
-                self.state.last_signal_at = now;
-                self.publish_evidence(
-                    StatusEvidenceSource::ProcessLiveness,
-                    None,
-                    Some(StatusFallbackReason::ProcessOnly),
-                    now,
-                    &mut outcome,
-                );
-            }
+            self.reduce_process_only(signal, now, &mut outcome);
             return outcome;
         }
 
@@ -330,11 +326,13 @@ impl StatusReducer {
             StatusSignal::Tick => None,
             StatusSignal::PtyOutputActivity
             | StatusSignal::UserKeystroke
+            | StatusSignal::ForegroundJob { .. }
             | StatusSignal::ProcessExit { .. } => None,
         };
 
         match signal {
             StatusSignal::ProcessExit { .. } => {} // handled above
+            StatusSignal::ForegroundJob { .. } => {}
             StatusSignal::PtyOutputActivity => {
                 // Bytes alone do not establish work: late terminal repaints,
                 // title updates and status lines continue after a turn ends.
@@ -487,6 +485,64 @@ impl StatusReducer {
             self.evidence = Some(candidate.clone());
             outcome.status_evidence = Some(candidate);
         }
+    }
+
+    fn reduce_process_only(
+        &mut self,
+        signal: StatusSignal,
+        now: SystemTime,
+        outcome: &mut ReducerOutcome,
+    ) {
+        match signal {
+            StatusSignal::ForegroundJob { running } if self.tracks_shell_jobs() => {
+                self.state.last_signal_at = now;
+                self.apply_shell_job(running, now, outcome);
+            }
+            StatusSignal::PtyOutputActivity => {
+                self.state.last_signal_at = now;
+                if self.tracks_shell_jobs() {
+                    // Prompt output is not a job. Drop Starting so an older
+                    // Helper that never sends ForegroundJob cannot sit on
+                    // Loading forever; a later job sample still wins.
+                    if self.status == SessionStatus::Starting {
+                        self.set_status(SessionStatus::Idle, outcome);
+                    }
+                } else if self.status == SessionStatus::Starting {
+                    self.state.turn_in_flight = true;
+                    self.set_status(SessionStatus::Working, outcome);
+                }
+                self.publish_evidence(
+                    StatusEvidenceSource::ProcessLiveness,
+                    None,
+                    Some(StatusFallbackReason::ProcessOnly),
+                    now,
+                    outcome,
+                );
+            }
+            _ => {}
+        }
+    }
+
+    fn tracks_shell_jobs(&self) -> bool {
+        self.manifest_id.as_deref() == Some("shell")
+    }
+
+    fn apply_shell_job(&mut self, running: bool, now: SystemTime, outcome: &mut ReducerOutcome) {
+        let next = if running {
+            self.state.turn_in_flight = true;
+            SessionStatus::Working
+        } else {
+            self.state.turn_in_flight = false;
+            SessionStatus::Idle
+        };
+        self.set_status(next, outcome);
+        self.publish_evidence(
+            StatusEvidenceSource::ProcessLiveness,
+            None,
+            Some(StatusFallbackReason::ProcessOnly),
+            now,
+            outcome,
+        );
     }
 
     fn set_status(&mut self, new: SessionStatus, outcome: &mut ReducerOutcome) {
@@ -923,6 +979,17 @@ impl StatusReducer {
             self.commit_idle(now, outcome);
         }
     }
+}
+
+/// Whether the PTY foreground group is a job other than the session child.
+/// `None` until both pids are known.
+#[must_use]
+pub fn foreground_job_running(child_pid: i32, foreground_pgid: Option<i32>) -> Option<bool> {
+    if child_pid <= 1 {
+        return None;
+    }
+    let pgid = foreground_pgid.filter(|pgid| *pgid > 0)?;
+    Some(pgid != child_pid)
 }
 
 fn needs_input_kind(state: ManifestState) -> Option<NeedsInputKind> {

--- a/diri/crates/diri-engine/src/status/tests.rs
+++ b/diri/crates/diri-engine/src/status/tests.rs
@@ -555,6 +555,43 @@ fn a_process_only_agent_goes_working_on_first_output_then_exits() {
 }
 
 #[test]
+fn a_shell_is_idle_at_a_prompt_and_working_only_for_a_foreground_job() {
+    let mut reducer =
+        StatusReducer::new(Authority::ProcessOnly, t0()).with_manifest("shell", Some("1"));
+    let now = t0() + Duration::from_secs(1);
+
+    let outcome = reducer.reduce(StatusSignal::PtyOutputActivity, now);
+    assert_eq!(outcome.status_change, Some(SessionStatus::Idle));
+    assert!(!outcome.turn_completed);
+
+    let outcome = reducer.reduce(StatusSignal::ForegroundJob { running: true }, now);
+    assert_eq!(outcome.status_change, Some(SessionStatus::Working));
+    assert!(!outcome.turn_completed);
+
+    // Output from `sleep` is not required; the job itself is the signal.
+    let outcome = reducer.reduce(
+        StatusSignal::ForegroundJob { running: true },
+        now + Duration::from_secs(1),
+    );
+    assert_eq!(outcome.status_change, None);
+
+    let outcome = reducer.reduce(
+        StatusSignal::ForegroundJob { running: false },
+        now + Duration::from_secs(2),
+    );
+    assert_eq!(outcome.status_change, Some(SessionStatus::Idle));
+    assert!(!outcome.turn_completed);
+}
+
+#[test]
+fn foreground_job_running_is_the_child_process_group_test() {
+    assert_eq!(super::foreground_job_running(0, Some(12)), None);
+    assert_eq!(super::foreground_job_running(42, None), None);
+    assert_eq!(super::foreground_job_running(42, Some(42)), Some(false));
+    assert_eq!(super::foreground_job_running(42, Some(99)), Some(true));
+}
+
+#[test]
 fn a_signalled_exit_is_reported_as_signalled() {
     let mut reducer = StatusReducer::new(Authority::HooksPrimary, t0());
     let outcome = reducer.reduce(

--- a/diri/crates/diri-engine/tests/holder.rs
+++ b/diri/crates/diri-engine/tests/holder.rs
@@ -38,6 +38,7 @@ fn spec(paths: &HolderPaths, logs: &Path, argv: &[&str]) -> HolderLaunchSpec {
             ),
             ("TERM".to_string(), "xterm-256color".to_string()),
             ("HOME".to_string(), "/tmp".to_string()),
+            ("PS1".to_string(), "$ ".to_string()),
         ]),
         cols: 80,
         rows: 24,
@@ -253,12 +254,18 @@ fn stat_reports_a_foreground_job_other_than_the_shell() {
     let root = holders_dir("fgjob");
     let logs = root.join("logs");
     let paths = HolderPaths::new(&root, "s_fgjob");
-    let launch = spec(&paths, &logs, &["/bin/zsh", "-f", "-i"]);
+    let launch = spec(&paths, &logs, &["/bin/bash", "--norc", "--noprofile", "-i"]);
     let server = std::thread::spawn(move || HolderServer::run(launch));
     let client = HolderClient::new(paths.socket());
     wait_until("holder ready", Duration::from_secs(5), || client.is_alive());
 
     let child = client.stat().expect("stat").child_pid;
+    wait_until("shell claimed tty", Duration::from_secs(2), || {
+        client
+            .stat()
+            .ok()
+            .is_some_and(|stat| stat.foreground_pid == Some(child))
+    });
     client.write(b"sleep 8\n").expect("write sleep");
     wait_until("foreground job", Duration::from_secs(3), || {
         client.stat().ok().is_some_and(|stat| {

--- a/diri/crates/diri-engine/tests/holder.rs
+++ b/diri/crates/diri-engine/tests/holder.rs
@@ -37,6 +37,7 @@ fn spec(paths: &HolderPaths, logs: &Path, argv: &[&str]) -> HolderLaunchSpec {
                 std::env::var("PATH").unwrap_or_default(),
             ),
             ("TERM".to_string(), "xterm-256color".to_string()),
+            ("HOME".to_string(), "/tmp".to_string()),
         ]),
         cols: 80,
         rows: 24,
@@ -245,6 +246,29 @@ fn a_second_holder_for_the_same_session_refuses_to_double_run() {
 
     client.kill_tree().expect("kill");
     first.join().expect("join").expect("first run ends cleanly");
+}
+
+#[test]
+fn stat_reports_a_foreground_job_other_than_the_shell() {
+    let root = holders_dir("fgjob");
+    let logs = root.join("logs");
+    let paths = HolderPaths::new(&root, "s_fgjob");
+    let launch = spec(&paths, &logs, &["/bin/zsh", "-f", "-i"]);
+    let server = std::thread::spawn(move || HolderServer::run(launch));
+    let client = HolderClient::new(paths.socket());
+    wait_until("holder ready", Duration::from_secs(5), || client.is_alive());
+
+    let child = client.stat().expect("stat").child_pid;
+    client.write(b"sleep 8\n").expect("write sleep");
+    wait_until("foreground job", Duration::from_secs(3), || {
+        client.stat().ok().is_some_and(|stat| {
+            stat.foreground_pid
+                .is_some_and(|pgid| pgid > 0 && pgid != child)
+        })
+    });
+
+    client.kill_tree().expect("kill");
+    server.join().expect("join").expect("clean end");
 }
 
 #[test]

--- a/diri/crates/diri-engine/tests/holder_session.rs
+++ b/diri/crates/diri-engine/tests/holder_session.rs
@@ -417,3 +417,38 @@ fn failed_holder_stop_keeps_the_live_session_tracked_until_retry() {
     assert!(registry.get("s_stop_retry").is_none());
     let _ = std::fs::remove_dir_all(root);
 }
+
+#[test]
+fn a_held_shell_is_working_while_a_foreground_job_runs() {
+    let root = holders_dir("fgwork");
+    let logs = root.join("logs");
+    let holder = holder_config(&root);
+    let spec = SessionSpec {
+        id: "s_fgwork".into(),
+        pty: PtySpec::new(vec!["/bin/zsh".into(), "-f".into(), "-i".into()], "/tmp")
+            .env("PATH", "/usr/bin:/bin")
+            .env("TERM", "xterm-256color")
+            .env("HOME", "/tmp")
+            .env("PS1", "> "),
+        manifest_id: "shell".into(),
+        authority: Authority::ProcessOnly,
+        logs_dir: logs.to_path_buf(),
+        holder: Some(holder),
+        remote: None,
+        defer_launch: false,
+    };
+    let mut session = Session::spawn(spec, engine()).expect("spawn");
+    wait_until("idle shell prompt", Duration::from_secs(5), || {
+        matches!(session.status(), SessionStatus::Idle)
+    });
+
+    session.write_input(b"sleep 30\n").expect("write sleep");
+    wait_until("working foreground job", Duration::from_secs(3), || {
+        matches!(session.status(), SessionStatus::Working)
+    });
+
+    session
+        .terminate(Duration::from_secs(2))
+        .expect("terminate");
+    let _ = std::fs::remove_dir_all(root);
+}

--- a/diri/crates/diri-engine/tests/holder_session.rs
+++ b/diri/crates/diri-engine/tests/holder_session.rs
@@ -425,11 +425,19 @@ fn a_held_shell_is_working_while_a_foreground_job_runs() {
     let holder = holder_config(&root);
     let spec = SessionSpec {
         id: "s_fgwork".into(),
-        pty: PtySpec::new(vec!["/bin/zsh".into(), "-f".into(), "-i".into()], "/tmp")
-            .env("PATH", "/usr/bin:/bin")
-            .env("TERM", "xterm-256color")
-            .env("HOME", "/tmp")
-            .env("PS1", "> "),
+        pty: PtySpec::new(
+            vec![
+                "/bin/bash".into(),
+                "--norc".into(),
+                "--noprofile".into(),
+                "-i".into(),
+            ],
+            "/tmp",
+        )
+        .env("PATH", "/usr/bin:/bin")
+        .env("TERM", "xterm-256color")
+        .env("HOME", "/tmp")
+        .env("PS1", "$ "),
         manifest_id: "shell".into(),
         authority: Authority::ProcessOnly,
         logs_dir: logs.to_path_buf(),

--- a/diri/crates/diri-proto/src/remote_pty.rs
+++ b/diri/crates/diri-proto/src/remote_pty.rs
@@ -18,8 +18,9 @@ use crate::grid::{GridCodecError, GridUpdate};
 use crate::terminal::MouseModes;
 
 pub const PROTOCOL_MAJOR: u16 = 1;
-pub const PROTOCOL_MINOR: u16 = 4;
+pub const PROTOCOL_MINOR: u16 = 5;
 pub const MOUSE_INPUT_PROTOCOL_MINOR: u16 = 4;
+pub const FOREGROUND_PROCESS_PROTOCOL_MINOR: u16 = 5;
 pub const MAX_CONTROL_FRAME_BYTES: usize = 64 * 1024;
 pub const MAX_ARGUMENTS: usize = 512;
 pub const MAX_ENVIRONMENT_VARIABLES: usize = 4096;
@@ -48,6 +49,7 @@ const KIND_ERROR: u8 = 41;
 const KIND_GRID_DELTA: u8 = 42;
 const KIND_SCROLLBACK_REQUEST: u8 = 43;
 const KIND_SCROLLBACK_RESPONSE: u8 = 44;
+const KIND_FOREGROUND_PROCESS: u8 = 45;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -252,6 +254,9 @@ pub struct HelloAck {
     pub process_state: RemoteProcessState,
     pub output_offset: u64,
     pub snapshot_sequence: u64,
+    /// PTY foreground process group. Absent from protocol 1.4 HelloAck.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub foreground_pid: Option<i32>,
 }
 
 impl HelloAck {
@@ -663,6 +668,13 @@ pub struct ProcessExit {
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ForegroundProcess {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pid: Option<i32>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Signal {
     pub controller_epoch: u64,
     pub signal: i32,
@@ -745,6 +757,7 @@ pub enum RemoteMessage {
     ScrollbackRequest(ScrollbackRequest),
     ScrollbackResponse(ScrollbackResponse),
     Error(RemoteError),
+    ForegroundProcess(ForegroundProcess),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -930,6 +943,9 @@ impl RemoteCodec {
                 append_json(KIND_SCROLLBACK_RESPONSE, value, output, start)
             }
             RemoteMessage::Error(value) => append_json(KIND_ERROR, value, output, start),
+            RemoteMessage::ForegroundProcess(value) => {
+                append_json(KIND_FOREGROUND_PROCESS, value, output, start)
+            }
         })();
 
         if let Err(error) = result {
@@ -1129,13 +1145,16 @@ fn decode_message(kind: u8, payload: &[u8]) -> Result<RemoteMessage, RemoteCodec
             kind, payload,
         )?)),
         KIND_ERROR => Ok(RemoteMessage::Error(decode_json(kind, payload)?)),
+        KIND_FOREGROUND_PROCESS => Ok(RemoteMessage::ForegroundProcess(decode_json(
+            kind, payload,
+        )?)),
         _ => Err(RemoteCodecError::UnknownMessageType(kind)),
     }
 }
 
 fn validate_kind(kind: u8) -> Result<(), RemoteCodecError> {
     if (1..=FrameType::Mouse as u8).contains(&kind)
-        || (KIND_HELLO..=KIND_SCROLLBACK_RESPONSE).contains(&kind)
+        || (KIND_HELLO..=KIND_FOREGROUND_PROCESS).contains(&kind)
     {
         Ok(())
     } else {
@@ -1378,6 +1397,24 @@ mod tests {
             RemoteCodec::new().feed(&encoded).expect("decode"),
             vec![message]
         );
+    }
+
+    #[test]
+    fn foreground_process_round_trips_and_older_hello_ack_omits_the_pid() {
+        let message = RemoteMessage::ForegroundProcess(ForegroundProcess { pid: Some(456) });
+        let encoded = RemoteCodec::encode(&message).expect("encode");
+        assert_eq!(encoded[0], KIND_FOREGROUND_PROCESS);
+        assert_eq!(
+            RemoteCodec::new().feed(&encoded).expect("decode"),
+            vec![message]
+        );
+
+        let ack: HelloAck = serde_json::from_str(
+            r#"{"protocol":{"major":1,"minor":4},"holderBuildId":"b","sessionIncarnation":"i","capabilities":[],"controllerEpoch":1,"processState":{"state":"running","pid":12},"outputOffset":0,"snapshotSequence":1}"#,
+        )
+        .expect("legacy hello ack");
+        assert_eq!(ack.foreground_pid, None);
+        assert_eq!(ack.process_state, RemoteProcessState::Running { pid: 12 });
     }
 
     #[test]

--- a/diri/crates/diri-pty/src/unix.rs
+++ b/diri/crates/diri-pty/src/unix.rs
@@ -105,11 +105,11 @@ impl Pty {
                 if libc::ioctl(slave_fd, libc::TIOCSCTTY as _, 0) < 0 {
                     return Err(io::Error::last_os_error());
                 }
-
-                let maximum = libc::getdtablesize();
-                for fd in 3..maximum {
-                    libc::close(fd);
-                }
+                // stdin is already the slave; pin this session as the
+                // foreground group so a parent `TIOCGPGRP` is defined
+                // before exec. Ignore failure: TIOCSCTTY already set pgrp.
+                let _ = libc::tcsetpgrp(0, libc::getpid());
+                close_extra_fds();
                 Ok(())
             });
         }
@@ -132,7 +132,7 @@ impl Pty {
     /// before the call yields EBADF and looks like no job.
     #[must_use]
     pub fn foreground_pgid(&self) -> Option<i32> {
-        foreground_pgid(self.master.as_raw_fd())
+        foreground_pgid(self.master.as_raw_fd()).or_else(|| proc_tpgid(self.child.id()))
     }
 
     pub fn resize(&self, cols: u16, rows: u16) -> io::Result<()> {
@@ -224,10 +224,52 @@ fn exit_from(status: std::process::ExitStatus) -> Exit {
         .map_or_else(|| Exit::Code(status.code().unwrap_or(-1)), Exit::Signal)
 }
 
+fn close_extra_fds() {
+    // GitHub runners set NOFILE to ~1M. Closing that range one fd at a
+    // time delays exec by seconds and the foreground-job tests time out.
+    #[cfg(target_os = "linux")]
+    // SAFETY: called after fork in the child; fds 0-2 stay the slave.
+    unsafe {
+        libc::close_range(3, libc::c_uint::MAX, 0);
+    }
+    #[cfg(not(target_os = "linux"))]
+    unsafe {
+        // SAFETY: same child-side ownership; macOS NOFILE is small enough
+        // that walking the table is cheap.
+        let maximum = libc::getdtablesize();
+        for fd in 3..maximum {
+            libc::close(fd);
+        }
+    }
+}
+
 fn foreground_pgid(fd: RawFd) -> Option<i32> {
     // SAFETY: `tcgetpgrp` on an owned PTY master; a bad fd returns -1.
     let pgid = unsafe { libc::tcgetpgrp(fd) };
     (pgid > 0).then_some(pgid)
+}
+
+/// Linux parents often see `tcgetpgrp(master) == 0` even after the child
+/// claimed the slave. `/proc/<pid>/stat` tpgid is the child's view of the
+/// same tty and does not require the caller to own it.
+fn proc_tpgid(pid: u32) -> Option<i32> {
+    #[cfg(target_os = "linux")]
+    {
+        let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+        return tpgid_from_stat(&stat);
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = pid;
+        None
+    }
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn tpgid_from_stat(stat: &str) -> Option<i32> {
+    let after = stat.get(stat.rfind(')')? + 2..)?;
+    let tpgid: i32 = after.split_whitespace().nth(5)?.parse().ok()?;
+    (tpgid > 0).then_some(tpgid)
 }
 
 /// Independently clonable handle on the PTY master.
@@ -392,36 +434,60 @@ mod tests {
     }
 
     #[test]
+    fn tpgid_is_the_eighth_stat_field_after_a_spaced_comm() {
+        let stat = "42 (sleep 8) R 1 10 10 34816 99 0";
+        assert_eq!(tpgid_from_stat(stat), Some(99));
+        assert_eq!(tpgid_from_stat("42 (sleep 8) R 1"), None);
+        assert_eq!(tpgid_from_stat("no-paren 1 2 3 4 5 6"), None);
+    }
+
+    #[test]
     fn foreground_pgid_tracks_a_job_other_than_the_shell() {
         use std::time::{Duration, Instant};
 
-        let spec = PtySpec::new(vec!["/bin/zsh".into(), "-f".into(), "-i".into()], "/tmp")
-            .env("PATH", "/usr/bin:/bin")
-            .env("TERM", "xterm-256color")
-            .env("HOME", "/tmp")
-            .env("PS1", "> ");
+        // bash is on every CI image; zsh is not. Interactive + job control
+        // puts `sleep` in a process group other than the shell.
+        let spec = PtySpec::new(
+            vec![
+                "/bin/bash".into(),
+                "--norc".into(),
+                "--noprofile".into(),
+                "-i".into(),
+            ],
+            "/tmp",
+        )
+        .env("PATH", "/usr/bin:/bin")
+        .env("TERM", "xterm-256color")
+        .env("HOME", "/tmp")
+        .env("PS1", "$ ");
         let pty = Pty::spawn(&spec).expect("spawn shell");
         let child = pty.pid() as i32;
         let mut reader = pty.reader().expect("reader");
         reader.set_nonblocking(true).ok();
         let mut writer = pty.writer().expect("writer");
         let mut drain = [0u8; 4096];
-        let start = Instant::now();
-        while start.elapsed() < Duration::from_millis(400) {
+        let claimed = Instant::now() + Duration::from_secs(2);
+        let mut last = None;
+        while Instant::now() < claimed {
             let _ = reader.read(&mut drain);
+            last = pty.foreground_pgid();
+            if last == Some(child) {
+                break;
+            }
             std::thread::sleep(Duration::from_millis(20));
         }
+        assert_eq!(last, Some(child), "shell never claimed the tty");
         writer.write_all(b"sleep 8\n").expect("write sleep");
         writer.flush().expect("flush");
         let deadline = Instant::now() + Duration::from_secs(3);
         loop {
             let _ = reader.read(&mut drain);
-            let pgid = pty.foreground_pgid();
-            if pgid.is_some_and(|pgid| pgid > 0 && pgid != child) {
+            last = pty.foreground_pgid();
+            if last.is_some_and(|pgid| pgid > 0 && pgid != child) {
                 break;
             }
             if Instant::now() >= deadline {
-                panic!("sleep never became the foreground group; last={pgid:?} child={child}");
+                panic!("sleep never became the foreground group; last={last:?} child={child}");
             }
             std::thread::sleep(Duration::from_millis(20));
         }

--- a/diri/crates/diri-pty/src/unix.rs
+++ b/diri/crates/diri-pty/src/unix.rs
@@ -124,6 +124,17 @@ impl Pty {
         self.child.id()
     }
 
+    /// The process group currently in the foreground on this PTY, if any.
+    ///
+    /// Call this on the owner, not on the live read stream: `tcgetpgrp` on
+    /// the same fd the pump is reading can lose canonical-mode input. Do not
+    /// extract a raw fd from a temporary clone either; closing that clone
+    /// before the call yields EBADF and looks like no job.
+    #[must_use]
+    pub fn foreground_pgid(&self) -> Option<i32> {
+        foreground_pgid(self.master.as_raw_fd())
+    }
+
     pub fn resize(&self, cols: u16, rows: u16) -> io::Result<()> {
         if cols == 0 || rows == 0 {
             return Err(io::Error::new(
@@ -211,6 +222,12 @@ fn exit_from(status: std::process::ExitStatus) -> Exit {
     status
         .signal()
         .map_or_else(|| Exit::Code(status.code().unwrap_or(-1)), Exit::Signal)
+}
+
+fn foreground_pgid(fd: RawFd) -> Option<i32> {
+    // SAFETY: `tcgetpgrp` on an owned PTY master; a bad fd returns -1.
+    let pgid = unsafe { libc::tcgetpgrp(fd) };
+    (pgid > 0).then_some(pgid)
 }
 
 /// Independently clonable handle on the PTY master.
@@ -372,6 +389,42 @@ mod tests {
         reader.read_to_end(&mut output).expect("read output");
         assert_eq!(pty.wait().expect("wait"), Exit::Code(0));
         assert!(String::from_utf8_lossy(&output).contains("exact value:1"));
+    }
+
+    #[test]
+    fn foreground_pgid_tracks_a_job_other_than_the_shell() {
+        use std::time::{Duration, Instant};
+
+        let spec = PtySpec::new(vec!["/bin/zsh".into(), "-f".into(), "-i".into()], "/tmp")
+            .env("PATH", "/usr/bin:/bin")
+            .env("TERM", "xterm-256color")
+            .env("HOME", "/tmp")
+            .env("PS1", "> ");
+        let pty = Pty::spawn(&spec).expect("spawn shell");
+        let child = pty.pid() as i32;
+        let mut reader = pty.reader().expect("reader");
+        reader.set_nonblocking(true).ok();
+        let mut writer = pty.writer().expect("writer");
+        let mut drain = [0u8; 4096];
+        let start = Instant::now();
+        while start.elapsed() < Duration::from_millis(400) {
+            let _ = reader.read(&mut drain);
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        writer.write_all(b"sleep 8\n").expect("write sleep");
+        writer.flush().expect("flush");
+        let deadline = Instant::now() + Duration::from_secs(3);
+        loop {
+            let _ = reader.read(&mut drain);
+            let pgid = pty.foreground_pgid();
+            if pgid.is_some_and(|pgid| pgid > 0 && pgid != child) {
+                break;
+            }
+            if Instant::now() >= deadline {
+                panic!("sleep never became the foreground group; last={pgid:?} child={child}");
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
     }
 
     #[test]

--- a/diri/crates/diri-pty/src/unix.rs
+++ b/diri/crates/diri-pty/src/unix.rs
@@ -231,12 +231,14 @@ fn close_extra_fds() {
     unsafe {
         // SAFETY: after fork in the child; fds 0-2 stay the slave. musl has
         // no close_range wrapper, so the syscall is used on gnu and musl.
-        libc::syscall(libc::SYS_close_range, 3, libc::c_uint::MAX, 0);
+        if libc::syscall(libc::SYS_close_range, 3, libc::c_uint::MAX, 0) == 0 {
+            return;
+        }
     }
-    #[cfg(not(target_os = "linux"))]
     unsafe {
-        // SAFETY: same child-side ownership; macOS NOFILE is small enough
-        // that walking the table is cheap.
+        // SAFETY: same child-side ownership. Linux before close_range (or a
+        // seccomp policy denying it) still needs every inherited fd closed.
+        // macOS uses this path directly.
         let maximum = libc::getdtablesize();
         for fd in 3..maximum {
             libc::close(fd);
@@ -410,6 +412,112 @@ fn platform_exit_watcher(pid: u32) -> io::Result<OwnedFd> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pty_child_does_not_inherit_extra_descriptors() {
+        #[cfg(target_os = "linux")]
+        if let Ok(error) = std::env::var("DIRI_TEST_CLOSE_RANGE_ERRNO") {
+            block_close_range(error.parse().expect("errno"));
+        }
+
+        let file = File::open("/dev/null").expect("open sentinel");
+        // Deliberately inherit an fd without CLOEXEC, well above the stdio
+        // and shell startup descriptors, without replacing an existing fd.
+        // SAFETY: file is live; F_DUPFD returns a fresh descriptor on success.
+        let fd = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_DUPFD, 200) };
+        assert!(fd >= 200);
+        // SAFETY: fcntl returned a new descriptor owned by this test.
+        let sentinel = unsafe { OwnedFd::from_raw_fd(fd) };
+        let spec = PtySpec::new(
+            vec![
+                "/bin/sh".into(),
+                "-c".into(),
+                "if [ -e \"/dev/fd/$1\" ]; then exit 42; fi; printf clean".into(),
+                "fd-test".into(),
+                sentinel.as_raw_fd().to_string(),
+            ],
+            "/",
+        );
+        let mut pty = Pty::spawn(&spec).expect("spawn");
+        let mut output = Vec::new();
+        pty.reader()
+            .expect("reader")
+            .read_to_end(&mut output)
+            .expect("output");
+        assert_eq!(
+            pty.wait().expect("wait"),
+            Exit::Code(0),
+            "inherited sentinel fd"
+        );
+        assert_eq!(output, b"clean");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn pty_closes_descriptors_when_close_range_is_unavailable_or_denied() {
+        for error in [libc::ENOSYS, libc::EPERM] {
+            let output = Command::new(std::env::current_exe().expect("test binary"))
+                .args([
+                    "--exact",
+                    "unix::tests::pty_child_does_not_inherit_extra_descriptors",
+                    "--nocapture",
+                ])
+                .env("DIRI_TEST_CLOSE_RANGE_ERRNO", error.to_string())
+                .output()
+                .expect("run isolated seccomp test");
+            assert!(
+                output.status.success(),
+                "close_range errno {error}: {}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn block_close_range(error: u32) {
+        // Only this disposable test process and its children receive the
+        // filter. No privileges or host configuration are required.
+        let mut instructions = [
+            libc::sock_filter {
+                code: (libc::BPF_LD | libc::BPF_W | libc::BPF_ABS) as u16,
+                jt: 0,
+                jf: 0,
+                k: 0,
+            },
+            libc::sock_filter {
+                code: (libc::BPF_JMP | libc::BPF_JEQ | libc::BPF_K) as u16,
+                jt: 0,
+                jf: 1,
+                k: libc::SYS_close_range as u32,
+            },
+            libc::sock_filter {
+                code: (libc::BPF_RET | libc::BPF_K) as u16,
+                jt: 0,
+                jf: 0,
+                k: libc::SECCOMP_RET_ERRNO | error,
+            },
+            libc::sock_filter {
+                code: (libc::BPF_RET | libc::BPF_K) as u16,
+                jt: 0,
+                jf: 0,
+                k: libc::SECCOMP_RET_ALLOW,
+            },
+        ];
+        let filter = libc::sock_fprog {
+            len: instructions.len() as u16,
+            filter: instructions.as_mut_ptr(),
+        };
+        // SAFETY: no_new_privs only restricts this process; the filter points
+        // to initialized BPF instructions for the duration of prctl.
+        unsafe {
+            assert_eq!(libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0), 0);
+            assert_eq!(
+                libc::prctl(libc::PR_SET_SECCOMP, libc::SECCOMP_MODE_FILTER, &filter),
+                0
+            );
+        }
+    }
 
     #[test]
     fn structured_argv_environment_and_size_reach_the_child() {

--- a/diri/crates/diri-pty/src/unix.rs
+++ b/diri/crates/diri-pty/src/unix.rs
@@ -228,9 +228,10 @@ fn close_extra_fds() {
     // GitHub runners set NOFILE to ~1M. Closing that range one fd at a
     // time delays exec by seconds and the foreground-job tests time out.
     #[cfg(target_os = "linux")]
-    // SAFETY: called after fork in the child; fds 0-2 stay the slave.
     unsafe {
-        libc::close_range(3, libc::c_uint::MAX, 0);
+        // SAFETY: after fork in the child; fds 0-2 stay the slave. musl has
+        // no close_range wrapper, so the syscall is used on gnu and musl.
+        libc::syscall(libc::SYS_close_range, 3, libc::c_uint::MAX, 0);
     }
     #[cfg(not(target_os = "linux"))]
     unsafe {
@@ -256,7 +257,7 @@ fn proc_tpgid(pid: u32) -> Option<i32> {
     #[cfg(target_os = "linux")]
     {
         let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
-        return tpgid_from_stat(&stat);
+        tpgid_from_stat(&stat)
     }
     #[cfg(not(target_os = "linux"))]
     {

--- a/diri/crates/diri-remote/src/holder.rs
+++ b/diri/crates/diri-remote/src/holder.rs
@@ -11,9 +11,10 @@ use std::time::{Duration, Instant};
 
 use diri_proto::frames::{Frame, FrameType, MAX_FRAME_BYTES};
 use diri_proto::remote_pty::{
-    ControlGranted, ControlRevoked, FullSnapshot, GridDelta, Hello, HelloAck, LaunchRequest,
-    LaunchResult, PHASE_ONE_HOLDER_CAPABILITIES, ProcessExit, RemoteCodec, RemoteError,
-    RemoteMessage, RemoteProcessState, ScrollbackResponse, validate_terminal_dimensions,
+    ControlGranted, ControlRevoked, FOREGROUND_PROCESS_PROTOCOL_MINOR, ForegroundProcess,
+    FullSnapshot, GridDelta, Hello, HelloAck, LaunchRequest, LaunchResult,
+    PHASE_ONE_HOLDER_CAPABILITIES, ProcessExit, RemoteCodec, RemoteError, RemoteMessage,
+    RemoteProcessState, ScrollbackResponse, validate_terminal_dimensions,
 };
 use diri_pty::{Exit, ExitWatcher, Pty, PtySpec, PtyStream};
 use diri_terminal_state::HeadlessScreen;
@@ -38,6 +39,8 @@ const MAX_PENDING_INPUT_BYTES: usize = 1 << 20;
 const OUTPUT_FRAME_BYTES: usize = 64 << 10;
 const REPLAY_BUDGET_BYTES: usize = 4 << 20;
 const PERSIST_OFFSET_INTERVAL: u64 = 1 << 20;
+const FOREGROUND_PROBE_AFTER_INPUT: Duration = Duration::from_millis(100);
+const FOREGROUND_PROBE_WHILE_JOB: Duration = Duration::from_secs(1);
 
 pub const PHASE_ONE_CAPABILITIES: &[diri_proto::remote_pty::RemoteCapability] =
     PHASE_ONE_HOLDER_CAPABILITIES;
@@ -415,6 +418,9 @@ struct Holder {
     pending_output_offset: u64,
     interactive_grid_budget: u8,
     last_persisted_offset: u64,
+    controller_protocol_minor: u16,
+    last_foreground_pid: Option<Option<i32>>,
+    foreground_probe_deadline: Option<Instant>,
 }
 
 impl Holder {
@@ -490,6 +496,9 @@ impl Holder {
             pending_output_offset: 0,
             interactive_grid_budget: 0,
             last_persisted_offset: 0,
+            controller_protocol_minor: 0,
+            last_foreground_pid: None,
+            foreground_probe_deadline: None,
         })
     }
 
@@ -556,9 +565,7 @@ impl Holder {
                 });
                 index
             });
-            let timeout = self
-                .dirty_since
-                .map_or(-1, |since| poll_timeout(since + DIFF_COALESCE));
+            let timeout = self.poll_timeout_ms();
             // SAFETY: `descriptors` owns initialized pollfd entries for the
             // duration of the call. A negative timeout sleeps indefinitely.
             let ready = unsafe {
@@ -624,6 +631,7 @@ impl Holder {
                 self.flush_output()?;
                 self.emit_grid_delta()?;
             }
+            self.emit_foreground_process()?;
         }
     }
 
@@ -947,6 +955,9 @@ impl Holder {
         self.state.controller_epoch = self.state.controller_epoch.saturating_add(1);
         let epoch = self.state.controller_epoch;
         connection.epoch = Some(epoch);
+        self.controller_protocol_minor = hello.protocol.minor;
+        let foreground_pid = self.pty.foreground_pgid();
+        self.last_foreground_pid = Some(foreground_pid);
         connection.queue(RemoteMessage::HelloAck(HelloAck {
             protocol: diri_proto::remote_pty::ProtocolVersion::CURRENT,
             holder_build_id: BUILD_ID.to_string(),
@@ -956,6 +967,7 @@ impl Holder {
             process_state: self.state.process_state.clone(),
             output_offset: self.state.output_offset,
             snapshot_sequence: self.state.snapshot_sequence,
+            foreground_pid,
         }))?;
         self.queue_replay(connection, hello.last_acknowledged_output_offset)?;
         self.state.snapshot_sequence = self.state.snapshot_sequence.saturating_add(1);
@@ -1005,6 +1017,7 @@ impl Holder {
         // next the actual echo/TUI response. Keep the fast path bounded to
         // those two frames so a keystroke cannot unthrottle a bulk stream.
         self.interactive_grid_budget = INTERACTIVE_GRID_BUDGET;
+        self.foreground_probe_deadline = Some(Instant::now() + FOREGROUND_PROBE_AFTER_INPUT);
         self.flush_input()
     }
 
@@ -1043,6 +1056,55 @@ impl Holder {
             }
             Err(error) => Err(error),
         }
+    }
+
+    fn poll_timeout_ms(&self) -> libc::c_int {
+        let grid = self
+            .dirty_since
+            .map(|since| poll_timeout(since + DIFF_COALESCE));
+        let probe = self.foreground_probe_deadline.map(poll_timeout);
+        match (grid, probe) {
+            (Some(a), Some(b)) => a.min(b),
+            (Some(a), None) => a,
+            (None, Some(b)) => b,
+            (None, None) => -1,
+        }
+    }
+
+    fn emit_foreground_process(&mut self) -> io::Result<()> {
+        if self.controller_protocol_minor < FOREGROUND_PROCESS_PROTOCOL_MINOR {
+            self.foreground_probe_deadline = None;
+            return Ok(());
+        }
+        if self
+            .connection
+            .as_ref()
+            .is_none_or(|connection| connection.epoch.is_none())
+        {
+            return Ok(());
+        }
+        let pid = self.pty.foreground_pgid();
+        if self.last_foreground_pid != Some(pid) {
+            self.last_foreground_pid = Some(pid);
+            self.queue(RemoteMessage::ForegroundProcess(ForegroundProcess { pid }))?;
+        }
+        let child_pid = match self.state.process_state {
+            RemoteProcessState::Running { pid } => pid as i32,
+            RemoteProcessState::Exited { .. } => {
+                self.foreground_probe_deadline = None;
+                return Ok(());
+            }
+        };
+        let running = pid.is_some_and(|pgid| pgid != child_pid);
+        if running {
+            self.foreground_probe_deadline = Some(Instant::now() + FOREGROUND_PROBE_WHILE_JOB);
+        } else if self
+            .foreground_probe_deadline
+            .is_some_and(|deadline| deadline <= Instant::now())
+        {
+            self.foreground_probe_deadline = None;
+        }
+        Ok(())
     }
 
     fn emit_grid_delta(&mut self) -> io::Result<()> {

--- a/diri/crates/diri-remote/src/holder.rs
+++ b/diri/crates/diri-remote/src/holder.rs
@@ -1081,6 +1081,9 @@ impl Holder {
             .as_ref()
             .is_none_or(|connection| connection.epoch.is_none())
         {
+            // No controller consumes these samples. An expired deadline must
+            // not keep poll(0) spinning after EOF, release, or a failed write.
+            self.foreground_probe_deadline = None;
             return Ok(());
         }
         let pid = self.pty.foreground_pgid();

--- a/diri/crates/diri-remote/tests/holder_e2e.rs
+++ b/diri/crates/diri-remote/tests/holder_e2e.rs
@@ -207,6 +207,7 @@ fn message_kinds(messages: &[RemoteMessage]) -> String {
             RemoteMessage::ScrollbackRequest(_) => "ScrollbackRequest",
             RemoteMessage::ScrollbackResponse(_) => "ScrollbackResponse",
             RemoteMessage::Error(_) => "Error",
+            RemoteMessage::ForegroundProcess(_) => "ForegroundProcess",
         })
         .collect::<Vec<_>>()
         .join(",")

--- a/diri/crates/diri-remote/tests/holder_e2e.rs
+++ b/diri/crates/diri-remote/tests/holder_e2e.rs
@@ -380,6 +380,78 @@ fn detach_reconnect_preserves_pid_snapshot_and_input() {
 }
 
 #[test]
+fn detached_foreground_job_does_not_spin_the_holder() {
+    let temporary = tempfile::tempdir().expect("temp");
+    let state_dir = temporary.path().join("state");
+    let request = LaunchRequest {
+        session_id: "foreground-detach".into(),
+        session_token: token(),
+        argv: vec![
+            "/bin/bash".into(),
+            "--norc".into(),
+            "--noprofile".into(),
+            "-i".into(),
+        ],
+        cwd: "/".into(),
+        environment: vec![diri_proto::remote_pty::EnvironmentVariable {
+            name: "PATH".into(),
+            value: "/usr/bin:/bin".into(),
+        }],
+        cols: 80,
+        rows: 24,
+        persistence: PersistenceCapability::NonPersistent,
+    };
+    let launch: LaunchResult = run_json("launch", &state_dir, Some(&request));
+    struct Cleanup<'a>(&'a std::path::Path, SessionSelector);
+    impl Drop for Cleanup<'_> {
+        fn drop(&mut self) {
+            let _: SessionInspection = run_json("kill", self.0, Some(&self.1));
+        }
+    }
+    let _cleanup = Cleanup(
+        &state_dir,
+        SessionSelector {
+            session_id: launch.session_id.clone(),
+            session_token: token(),
+            expected_incarnation: Some(launch.session_incarnation.clone()),
+        },
+    );
+    let mut attach = Attach::open(&state_dir, hello(&launch, None, "foreground-client"));
+    attach.receive_until(Duration::from_secs(2), |message| {
+        matches!(message, RemoteMessage::FullSnapshot(_))
+    });
+    attach.send(RemoteMessage::Terminal(Frame::input(
+        b"sleep 30\n".to_vec(),
+    )));
+    attach.receive_until(Duration::from_secs(3), |message| {
+        matches!(message, RemoteMessage::ForegroundProcess(foreground)
+            if foreground.pid.is_some_and(|pid| pid > 0 && pid != launch.process_pid as i32))
+    });
+    drop(attach);
+
+    // Let the one-second job probe expire after the Bridge has disconnected.
+    // A stale deadline makes poll(0) spin even though sleep produces no output.
+    std::thread::sleep(Duration::from_millis(1200));
+    let before = diri_engine::governor::cpu_time_of(&[launch.holder_pid as i32]);
+    std::thread::sleep(Duration::from_secs(1));
+    let cpu =
+        diri_engine::governor::cpu_time_of(&[launch.holder_pid as i32]).saturating_sub(before);
+    let mut reattached = Attach::open(&state_dir, hello(&launch, None, "foreground-reconnect"));
+    let messages = reattached.receive_until(Duration::from_secs(2), |message| {
+        matches!(message, RemoteMessage::FullSnapshot(_))
+    });
+    assert!(messages.iter().any(|message| matches!(message,
+        RemoteMessage::HelloAck(ack)
+            if ack.process_state == (RemoteProcessState::Running { pid: launch.process_pid })
+                && ack.foreground_pid.is_some_and(|pid| pid != launch.process_pid as i32)
+    )));
+    assert!(
+        cpu < 100_000_000,
+        "detached Holder used {cpu} ns CPU in one second"
+    );
+}
+
+#[test]
 fn holder_agent_has_a_real_editable_resizable_terminal() {
     let temporary = tempfile::tempdir().expect("temp");
     let state_dir = temporary.path().join("state");

--- a/diri/scripts/dev.sh
+++ b/diri/scripts/dev.sh
@@ -93,18 +93,19 @@ fi
 build_label="${branch}@${short_sha}${dirty}"
 bundle_id="com.dirijor.diri.dev.${short_sha}"
 display_name="diri dev ${short_sha}"
+dev_app_support="${target_dir}/diri-dev-${short_sha}-support"
 
-mkdir -p "${target_dir}"
+mkdir -p "${target_dir}" "${dev_app_support}"
+chmod 700 "${dev_app_support}"
 
 cd "${workspace_dir}"
 echo "==> Building ${display_name} (${profile})"
-# diri-app does not pull dirijord-rs into target/<profile>/; build both so a
-# clean checkout launches against this tree's Engine instead of a missing or
-# stale binary (installed app / leftover debug build).
+# diri-app does not pull the Engine or Holder into target/<profile>/; build all
+# three so a clean checkout cannot launch against stale session processes.
 if (( ${#cargo_args[@]} > 0 )); then
-    cargo build --package diri-app --bin diri --package diri-engine --bin dirijord-rs "${cargo_args[@]}"
+    cargo build --package diri-app --bin diri --package diri-engine --bin dirijord-rs --bin diri-holder "${cargo_args[@]}"
 else
-    cargo build --package diri-app --bin diri --package diri-engine --bin dirijord-rs
+    cargo build --package diri-app --bin diri --package diri-engine --bin dirijord-rs --bin diri-holder
 fi
 
 binary="${target_dir}/${profile}/diri"
@@ -116,6 +117,12 @@ fi
 engine_bin="${target_dir}/${profile}/dirijord-rs"
 if [[ ! -x "${engine_bin}" ]]; then
     echo "error: cargo did not produce ${engine_bin}" >&2
+    exit 1
+fi
+
+holder_bin="${target_dir}/${profile}/diri-holder"
+if [[ ! -x "${holder_bin}" ]]; then
+    echo "error: cargo did not produce ${holder_bin}" >&2
     exit 1
 fi
 
@@ -160,7 +167,11 @@ codesign --force --sign - \
     "${app_path}"
 codesign --verify --deep --strict "${app_path}"
 
-launch_environment=("DIRI_DEV=1" "DIRI_DEV_BUILD=${build_label}")
+launch_environment=(
+    "DIRI_DEV=1"
+    "DIRI_DEV_BUILD=${build_label}"
+    "DIRIJOR_APP_SUPPORT=${dev_app_support}"
+)
 if [[ -n "${settings_preview}" ]]; then
     launch_environment+=("DIRI_SETTINGS_PREVIEW=${settings_preview}")
 fi


### PR DESCRIPTION
Shell sessions now report Idle at the prompt and Working while a foreground job runs. Protocol 1.5 additively reports the PTY foreground process group; older Helpers remain compatible. Sidebar activity continues animating when Diri is visible but unfocused.

This branch includes current main and preserves #246: plain-shell sidebar indicators stay hidden, while detected foreground Agents use the normal attention rules.

The remote Holder clears its foreground probe when the controller disconnects, preventing an expired timer from spinning while detached. Linux PTY startup retains the fast `close_range` path and falls back to individual closes when the syscall is unavailable or denied.

Verification:
- Added a detach/CPU/reconnect regression: the Holder stays quiet and reconnects to the same shell and foreground job.
- Added inherited-FD coverage and Linux subprocess tests forcing `close_range` to return ENOSYS and EPERM.
- Re-ran the original local detach repro: CPU time remained unchanged over the two-second disconnected measurement.
- `cargo fmt --all -- --check` passed.
- `cargo clippy --workspace --all-targets -- -D warnings` passed.
- `cargo test --workspace` passed: 1,492 tests, 30 ignored.
- `cargo build --workspace --release` passed on macOS arm64.
- Linux x86_64 musl Clippy passed for all `diri-pty` targets, including the forced syscall-failure tests; native execution is covered by CI.
