### PR TITLE
Fix gaps in terminal block character rendering

### DIFF
--- a/diri/crates/diri-term/examples/block_elements.rs
+++ b/diri/crates/diri-term/examples/block_elements.rs
@@ -1,0 +1,105 @@
+//! Visual regression fixture for cell-sized Unicode block elements.
+//! Run with `cargo run -p diri-term --example block_elements`.
+//! Optional fixture controls: `DIRI_BLOCK_FONT_SIZE=13`, `DIRI_BLOCK_LIGHT=1`,
+//! or `DIRI_BLOCK_GRID=/path/to/encoded-grid-update` to replay captured cells.
+use diri_proto::grid::{ChangedRow, GridCell, GridUpdate, TermColor, TermStyle};
+use diri_term::{buffer::GridBuffer, element::TerminalElement, theme::TermTheme};
+use gpui::{
+    App, Bounds, Context, Render, Window, WindowBounds, WindowOptions, div, prelude::*, px, size,
+};
+use gpui_platform::application;
+
+struct Blocks {
+    terminal: TerminalElement,
+}
+impl Render for Blocks {
+    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+        div().size_full().child(self.terminal.clone())
+    }
+}
+fn main() {
+    application().run(|cx: &mut App| {
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(WindowBounds::Windowed(Bounds::centered(
+                    None,
+                    size(px(1100.0), px(700.0)),
+                    cx,
+                ))),
+                ..Default::default()
+            },
+            |window, cx| {
+                cx.new(|_| {
+                    let terminal = TerminalElement::with_buffer(GridBuffer::new(70, 23))
+                        .font(gpui::font(if cfg!(target_os = "macos") {
+                            "Menlo"
+                        } else {
+                            "monospace"
+                        }))
+                        .font_size(px(std::env::var("DIRI_BLOCK_FONT_SIZE")
+                            .ok()
+                            .and_then(|s| s.parse::<f32>().ok())
+                            .filter(|s| s.is_finite() && *s > 0.0)
+                            .unwrap_or(24.0)))
+                        .theme(if std::env::var_os("DIRI_BLOCK_LIGHT").is_some() {
+                            TermTheme::DIRIJOR_LIGHT
+                        } else {
+                            TermTheme::DIRIJOR_DARK
+                        })
+                        .focused(true);
+                    let lines = [
+                        "",
+                        "  Anara block rendering",
+                        "",
+                        "       ██            ██",
+                        "  ▄█▄  ██  ▄█▄  ▄█▄  ██  ▄█▄",
+                        "   ▀▀██████▀▀    ▀▀██████▀▀",
+                        "   ▄▄██████▄▄    ▄▄██████▄▄",
+                        "  ▀█▀  ██  ▀█▀  ▀█▀  ██  ▀█▀",
+                        "       ██            ██",
+                        "",
+                        "  Full / half blocks must touch across rows and columns.",
+                        "",
+                        "  ▀▁▂▃▄▅▆▇█▉▊▋▌▍▎▏▐ ▔▕ ▖▗▘▙▚▛▜▝▞▟",
+                        "",
+                        "  ██▀▀▄▄██   regular text stays on the same grid",
+                        "  ██▄▄▀▀██",
+                        "",
+                        "  Selectable Unicode cells; foreground follows the theme.",
+                    ];
+                    let changed_rows = (0..23)
+                        .map(|row| {
+                            let mut cells = vec![GridCell::BLANK; 70];
+                            for (col, ch) in lines.get(row).unwrap_or(&"").chars().enumerate() {
+                                cells[col] = GridCell::new(
+                                    ch as u32,
+                                    TermColor::Default,
+                                    TermColor::DefaultInverted,
+                                    TermStyle::empty(),
+                                );
+                            }
+                            ChangedRow::new(row as u16, cells)
+                        })
+                        .collect();
+                    let grid = GridUpdate {
+                        cols: 70,
+                        rows: 23,
+                        cursor_col: 4,
+                        cursor_row: 14,
+                        cursor_visible: true,
+                        is_full_snapshot: true,
+                        changed_rows,
+                    };
+                    let grid = std::env::var_os("DIRI_BLOCK_GRID").map_or(grid, |path| {
+                        GridUpdate::decode(&std::fs::read(path).expect("read captured grid"))
+                            .expect("decode captured grid")
+                    });
+                    terminal.apply(grid, window);
+                    Blocks { terminal }
+                })
+            },
+        )
+        .expect("open block fixture");
+        cx.activate(true);
+    });
+}

--- a/diri/crates/diri-term/src/blocks.rs
+++ b/diri/crates/diri-term/src/blocks.rs
@@ -1,0 +1,130 @@
+//! Solid Unicode block elements are terminal geometry, not font glyphs.
+//!
+//! Rectangles use eighths of a cell and shared edges so font bearings, fallback
+//! metrics and line spacing cannot introduce seams into adjoining blocks.
+
+use gpui::{Bounds, Pixels, Point, point, size};
+
+use crate::metrics::CellMetrics;
+
+#[derive(Clone, Copy)]
+pub(crate) struct BlockGlyph(&'static [[u8; 4]]);
+
+impl BlockGlyph {
+    pub(crate) fn from_scalar(scalar: u32) -> Option<Self> {
+        Some(Self(match scalar {
+            0x2580 => &[[0, 0, 8, 4]], // upper half
+            0x2581 => &[[0, 7, 8, 8]],
+            0x2582 => &[[0, 6, 8, 8]],
+            0x2583 => &[[0, 5, 8, 8]],
+            0x2584 => &[[0, 4, 8, 8]], // lower half
+            0x2585 => &[[0, 3, 8, 8]],
+            0x2586 => &[[0, 2, 8, 8]],
+            0x2587 => &[[0, 1, 8, 8]],
+            0x2588 => &[[0, 0, 8, 8]], // full block
+            0x2589 => &[[0, 0, 7, 8]],
+            0x258a => &[[0, 0, 6, 8]],
+            0x258b => &[[0, 0, 5, 8]],
+            0x258c => &[[0, 0, 4, 8]], // left half
+            0x258d => &[[0, 0, 3, 8]],
+            0x258e => &[[0, 0, 2, 8]],
+            0x258f => &[[0, 0, 1, 8]],
+            0x2590 => &[[4, 0, 8, 8]], // right half
+            // Shaded blocks (2591–2593) retain their font's stipple pattern.
+            0x2594 => &[[0, 0, 8, 1]],
+            0x2595 => &[[7, 0, 8, 8]],
+            0x2596 => &[[0, 4, 4, 8]],
+            0x2597 => &[[4, 4, 8, 8]],
+            0x2598 => &[[0, 0, 4, 4]],
+            0x2599 => &[[0, 0, 4, 4], [0, 4, 8, 8]],
+            0x259a => &[[0, 0, 4, 4], [4, 4, 8, 8]],
+            0x259b => &[[0, 0, 8, 4], [0, 4, 4, 8]],
+            0x259c => &[[0, 0, 8, 4], [4, 4, 8, 8]],
+            0x259d => &[[4, 0, 8, 4]],
+            0x259e => &[[4, 0, 8, 4], [0, 4, 4, 8]],
+            0x259f => &[[4, 0, 8, 4], [0, 4, 8, 8]],
+            _ => return None,
+        }))
+    }
+
+    pub(crate) fn rectangles(
+        self,
+        origin: Point<Pixels>,
+        metrics: CellMetrics,
+        col: usize,
+        row: u16,
+    ) -> impl Iterator<Item = Bounds<Pixels>> {
+        self.0.iter().map(move |&[left, top, right, bottom]| {
+            let x = |edge: u8| origin.x + metrics.cell_width * (col as f32 + f32::from(edge) / 8.0);
+            let y = |edge: u8| {
+                origin.y + metrics.line_height * (f32::from(row) + f32::from(edge) / 8.0)
+            };
+            Bounds::new(
+                point(x(left), y(top)),
+                size(x(right) - x(left), y(bottom) - y(top)),
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{FontId, px};
+
+    #[test]
+    fn adjoining_blocks_share_edges_at_fractional_cell_sizes() {
+        for width in [7.25, 8.5, 14.449219] {
+            let metrics =
+                CellMetrics::from_measurements(px(width), px(12.0), px(5.0), px(0.0), FontId(0));
+            let origin = point(px(2.25), px(3.5));
+            let rect = |ch, col, row| {
+                BlockGlyph::from_scalar(ch as u32)
+                    .unwrap()
+                    .rectangles(origin, metrics, col, row)
+                    .next()
+                    .unwrap()
+            };
+            for col in [0, 1, 19, 159] {
+                assert_eq!(rect('█', col, 1).right(), rect('█', col + 1, 1).left());
+                assert_eq!(rect('█', col, 1).bottom(), rect('█', col, 2).top());
+                assert_eq!(rect('▀', col, 1).bottom(), rect('▄', col, 1).top());
+                assert_eq!(rect('▌', col, 1).right(), rect('▐', col, 1).left());
+            }
+        }
+    }
+
+    #[test]
+    fn fractional_and_quadrant_blocks_have_exact_nonoverlapping_coverage() {
+        let areas = [
+            32, 8, 16, 24, 32, 40, 48, 56, 64, 56, 48, 40, 32, 24, 16, 8, 32, 0, 0, 0, 8, 8, 16,
+            16, 16, 48, 32, 48, 48, 16, 32, 48,
+        ];
+        for (offset, expected_area) in areas.into_iter().enumerate() {
+            let block = BlockGlyph::from_scalar(0x2580 + offset as u32);
+            if expected_area == 0 {
+                assert!(block.is_none(), "shaded blocks keep their font pattern");
+                continue;
+            }
+            let mut covered = [[false; 8]; 8];
+            for &[left, top, right, bottom] in block.unwrap().0 {
+                for row in &mut covered[usize::from(top)..usize::from(bottom)] {
+                    for pixel in &mut row[usize::from(left)..usize::from(right)] {
+                        assert!(!*pixel, "overlap would darken dim/translucent blocks");
+                        *pixel = true;
+                    }
+                }
+            }
+            assert_eq!(
+                covered
+                    .into_iter()
+                    .flatten()
+                    .filter(|covered| *covered)
+                    .count(),
+                expected_area
+            );
+        }
+        assert!(BlockGlyph::from_scalar('A' as u32).is_none());
+        assert!(BlockGlyph::from_scalar('─' as u32).is_none());
+    }
+}

--- a/diri/crates/diri-term/src/element.rs
+++ b/diri/crates/diri-term/src/element.rs
@@ -12,6 +12,7 @@ use gpui::{
     point, px, relative, size,
 };
 
+use crate::blocks::BlockGlyph;
 use crate::buffer::{ApplySummary, ChangedRenderRow, GridBuffer};
 use crate::find::{
     FindSnapshot, FindSpan, NavigationTarget, SearchJob, SearchRequest, SearchResult,
@@ -350,6 +351,7 @@ struct CursorPaint {
     col: u16,
     quad: PaintQuad,
     glyph: Option<ShapedLine>,
+    block: Option<BlockGlyph>,
 }
 
 impl TerminalElement {
@@ -1176,6 +1178,12 @@ impl Element for TerminalElement {
                     self.theme.cursor,
                 ),
                 glyph: self.shape_cursor_glyph(cell, metrics, window),
+                block: self
+                    .theme
+                    .resolve_cell(cell)
+                    .visible
+                    .then(|| BlockGlyph::from_scalar(cell.scalar))
+                    .flatten(),
             })
         } else {
             None
@@ -1330,6 +1338,16 @@ impl Element for TerminalElement {
 
             if let Some(cursor) = prepaint.cursor.take() {
                 window.paint_quad(cursor.quad);
+                if let Some(block) = cursor.block {
+                    for rect in block.rectangles(
+                        bounds.origin,
+                        metrics,
+                        usize::from(cursor.col),
+                        cursor.row,
+                    ) {
+                        window.paint_quad(fill(rect, self.theme.cursor_text));
+                    }
+                }
                 if let Some(glyph) = cursor.glyph {
                     let origin = point(
                         bounds.left() + metrics.x_for_col(cursor.col),
@@ -1425,11 +1443,26 @@ fn append_row_quads(
             && !cell
                 .style
                 .contains(diri_proto::grid::TermStyle::CROSSED_OUT)
+            && BlockGlyph::from_scalar(cell.scalar).is_none()
     });
     if is_plain {
         return;
     }
     append_background_quads(row, row_index, origin, metrics, theme, background_quads);
+    // Keep blocks in the foreground layer, above selection/search backgrounds
+    // and below the cursor. The same path serves cached live rows and history.
+    for (col, cell) in row.iter().enumerate() {
+        if let Some(block) = BlockGlyph::from_scalar(cell.scalar) {
+            let style = theme.resolve_cell(*cell);
+            if style.visible {
+                decoration_quads.extend(
+                    block
+                        .rectangles(origin, metrics, col, row_index)
+                        .map(|bounds| fill(bounds, style.foreground)),
+                );
+            }
+        }
+    }
     append_decoration_quads(row, row_index, origin, metrics, theme, decoration_quads);
 }
 
@@ -1571,7 +1604,7 @@ fn styled_font(base: &Font, style: ResolvedCellStyle) -> Font {
 }
 
 fn render_char(cell: GridCell, visible: bool) -> char {
-    if !visible || cell.scalar == 0 {
+    if !visible || cell.scalar == 0 || BlockGlyph::from_scalar(cell.scalar).is_some() {
         return ' ';
     }
     char::from_u32(cell.scalar)
@@ -1703,6 +1736,101 @@ fn read_lock<T>(lock: &RwLock<T>) -> RwLockReadGuard<'_, T> {
 fn write_lock<T>(lock: &RwLock<T>) -> RwLockWriteGuard<'_, T> {
     lock.write()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+#[cfg(test)]
+mod block_tests {
+    use super::*;
+    use diri_proto::grid::{TermColor, TermStyle};
+
+    #[test]
+    fn anara_blocks_fill_their_cell_and_keep_adjacent_text_in_place() {
+        let metrics =
+            CellMetrics::from_measurements(px(8.5), px(12.0), px(5.0), px(0.0), FontId(0));
+        for (ch, top, height) in [('█', 0.0, 17.0), ('▀', 0.0, 8.5), ('▄', 8.5, 8.5)] {
+            let cell = GridCell::new(
+                ch as u32,
+                TermColor::Default,
+                TermColor::DefaultInverted,
+                TermStyle::empty(),
+            );
+            let mut backgrounds = Vec::new();
+            let mut foregrounds = Vec::new();
+            append_row_quads(
+                &[cell],
+                1,
+                point(px(2.0), px(3.0)),
+                metrics,
+                TermTheme::default(),
+                &mut backgrounds,
+                &mut foregrounds,
+            );
+            assert_eq!(
+                foregrounds.len(),
+                1,
+                "{ch} must use cell geometry, not font ink bounds"
+            );
+            assert_eq!(
+                foregrounds[0].bounds,
+                Bounds::new(point(px(2.0), px(20.0 + top)), size(px(8.5), px(height)))
+            );
+            let terminal = TerminalElement::with_buffer(GridBuffer::default());
+            let (text, _) = terminal.row_text_and_runs(&[
+                cell,
+                GridCell::new('A' as u32, cell.fg, cell.bg, cell.style),
+            ]);
+            assert_eq!(
+                text, " A",
+                "the block must reserve one text column without painting a second glyph"
+            );
+        }
+    }
+
+    #[test]
+    fn blocks_preserve_terminal_colors_styles_and_source_text() {
+        let metrics =
+            CellMetrics::from_measurements(px(8.0), px(12.0), px(4.0), px(0.0), FontId(0));
+        for theme in [TermTheme::DIRIJOR_DARK, TermTheme::DIRIJOR_LIGHT] {
+            for style in [
+                TermStyle::empty(),
+                TermStyle::DIM,
+                TermStyle::INVERSE,
+                TermStyle::BOLD | TermStyle::ITALIC,
+                TermStyle::INVISIBLE,
+            ] {
+                let cell = GridCell::new(
+                    '█' as u32,
+                    TermColor::Rgb(120, 150, 180),
+                    TermColor::Rgb(20, 30, 40),
+                    style,
+                );
+                let mut backgrounds = Vec::new();
+                let mut foregrounds = Vec::new();
+                append_row_quads(
+                    &[cell],
+                    0,
+                    Point::default(),
+                    metrics,
+                    theme,
+                    &mut backgrounds,
+                    &mut foregrounds,
+                );
+                assert_eq!(backgrounds.len(), 1);
+                if style.contains(TermStyle::INVISIBLE) {
+                    assert!(foregrounds.is_empty());
+                } else {
+                    assert_eq!(foregrounds.len(), 1);
+                    assert_eq!(
+                        foregrounds[0].background,
+                        fill(foregrounds[0].bounds, theme.resolve_cell(cell).foreground).background
+                    );
+                }
+                let mut buffer = GridBuffer::new(1, 1);
+                buffer.cells[0] = cell;
+                assert_eq!(buffer.row_text_with_columns(0).unwrap().0, "█");
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/diri/crates/diri-term/src/lib.rs
+++ b/diri/crates/diri-term/src/lib.rs
@@ -1,5 +1,6 @@
 //! GPUI grid rendering, terminal input encoding, selection, scrollback viewport, and find highlighting.
 
+mod blocks;
 pub mod buffer;
 pub mod element;
 pub mod find;


### PR DESCRIPTION
## Change

Anara's block-character logo appeared as disconnected horizontal strips in Diri. The renderer shaped `█`, `▀`, and `▄` as ordinary font glyphs, whose ink bounds do not fill the terminal cell. Draw solid Unicode block elements from exact cell-relative rectangles instead, so adjoining blocks meet regardless of font bearings and line spacing.

The same foreground geometry serves live rows, scrollback and the cursor. Color, dim/inverse/invisible styles and the original Unicode grid contents are preserved. Fractional and quadrant blocks use the same path; shaded blocks retain their font pattern. No dependencies, terminal parsing, protocol or session-lifecycle changes.

Adds a standalone `cargo run -p diri-term --example block_elements` visual fixture, including optional font-size, light-theme and encoded-grid replay controls.

## Verification

- Regression test failed on the base renderer and passes with the fix; 89 terminal tests pass, including shared edges at fractional widths, exact block coverage, colors/styles and preserved source text.
- Captured output from the Anara preview and replayed it through the Rust terminal parser; confirmed the logo's characters and grid positions are intact.
- Manually compared the base and fixed native visual fixtures at 24 px on macOS: the base reproduces the horizontal gaps; the fixed logo is continuous and adjacent text remains aligned. The additional small-font captured-grid visual check was inconclusive because the UI tool lost the test window. Light/dark color handling is covered by automated tests; Linux visual verification remains untested.
- `cargo fmt --all -- --check` — passed.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `cargo test --workspace` — 1,470 passed, zero failures (rerun with local socket access after the sandbox blocked fixture binds).
- `cargo build --workspace --release` — passed.
- Release terminal renderer benchmark — passed existing cache/frame gates; frame p90 0.788 ms, max 2.187 ms, zero frame-budget overruns (with macOS graphics-service access).
