### PR TITLE
Fix wrapped terminal links opening incomplete URLs

### DIFF
--- a/diri/crates/diri-term/src/element.rs
+++ b/diri/crates/diri-term/src/element.rs
@@ -652,7 +652,6 @@ impl TerminalElement {
     }
 
     /// The web URL whose text spans the given window cell, if any.
-    /// Wrapped multi-row URLs are out of scope: the scan is per logical row.
     #[must_use]
     pub fn link_at(&self, col: usize, window_row: usize) -> Option<String> {
         match self.reference_at(col, window_row) {
@@ -665,7 +664,8 @@ impl TerminalElement {
     ///
     /// The full whitespace-delimited row run is inspected, so clicking a line
     /// number or punctuation wrapper resolves the same reference as clicking
-    /// the path itself. Multi-row references are deliberately out of scope.
+    /// the path itself. URLs can continue across terminal rows or within an
+    /// indented/table column; file references remain confined to one row.
     #[must_use]
     pub fn reference_at(&self, col: usize, window_row: usize) -> Option<TerminalReference> {
         let viewport = mutex_lock(&self.shared.viewport);
@@ -676,7 +676,6 @@ impl TerminalElement {
             .iter()
             .map(|cell| crate::selection::cell_char(*cell))
             .collect();
-        drop(buffer);
         if col >= chars.len() {
             return None;
         }
@@ -684,6 +683,12 @@ impl TerminalElement {
         if !is_reference_char(chars[col]) {
             return None;
         }
+        if let Some(url) = wrapped_url_at(col, absolute_row, |row| {
+            viewport.row_at_absolute(&buffer, row)
+        }) {
+            return Some(TerminalReference::Url(url));
+        }
+        drop(buffer);
         let mut start = col;
         while start > 0 && is_reference_char(chars[start - 1]) {
             start -= 1;
@@ -1592,6 +1597,127 @@ fn url_from_run(run: &str) -> Option<String> {
     }
 }
 
+/// Grid cells do not carry soft-wrap or OSC 8 targets. Reconstruct visible URLs
+/// conservatively: bare links continue only at the terminal's right edge;
+/// prose/table links need an opening wrapper and its matching closing wrapper.
+/// Read through the viewport so cached history and held reading views agree
+/// with what the user actually clicked. Both lookbehind and URL size are bounded.
+fn wrapped_url_at(
+    col: usize,
+    clicked_row: i64,
+    row_at: impl Fn(i64) -> Vec<GridCell>,
+) -> Option<String> {
+    const MAX_ROWS: usize = 16;
+    const MAX_URL_BYTES: usize = 4096;
+    let read_row = |row| {
+        row_at(row)
+            .into_iter()
+            .map(crate::selection::cell_char)
+            .collect::<Vec<_>>()
+    };
+    for behind in 0..MAX_ROWS {
+        let start_row = clicked_row.checked_sub(behind as i64)?;
+        let chars = read_row(start_row);
+        let mut start = 0;
+        while start < chars.len() {
+            if chars[start].is_whitespace() {
+                start += 1;
+                continue;
+            }
+            let end = reference_run_end(&chars, start);
+            let mut candidate: String = chars[start..end].iter().collect();
+            let closer = match chars[start] {
+                '(' => Some(')'),
+                '[' => Some(']'),
+                '{' => Some('}'),
+                '<' => Some('>'),
+                '\'' => Some('\''),
+                '"' => Some('"'),
+                _ => None,
+            };
+            let already_closed = closer.is_some_and(|close| candidate[1..].contains(close));
+            if url_from_run(&candidate).is_some()
+                && !already_closed
+                && (closer.is_some() || end == chars.len())
+                && candidate.len() <= MAX_URL_BYTES
+            {
+                // A double-space gutter (or a drawn table border) separates
+                // columns. Single spaces belong to the label before the URL.
+                let mut lane_start = (0..start)
+                    .rev()
+                    .find(|&i| {
+                        matches!(chars[i], '|' | '│')
+                            || (chars[i].is_whitespace()
+                                && (i == 0 || chars[i - 1].is_whitespace()))
+                    })
+                    .map_or(0, |i| i + 1);
+                while lane_start < start && chars[lane_start].is_whitespace() {
+                    lane_start += 1;
+                }
+                let mut hit = behind == 0 && (start..end).contains(&col);
+                let mut at_edge = end == chars.len();
+                for ahead in 1..MAX_ROWS {
+                    let row_number = start_row.checked_add(ahead as i64)?;
+                    let next = read_row(row_number);
+                    let mut next_start = if at_edge { 0 } else { lane_start };
+                    if closer.is_some() {
+                        while next_start < next.len() && next[next_start].is_whitespace() {
+                            next_start += 1;
+                        }
+                    }
+                    if next_start >= next.len() || next[next_start].is_whitespace() {
+                        if closer.is_none() && ahead > 1 && hit {
+                            return url_from_run(&candidate);
+                        }
+                        break;
+                    }
+                    // Do not jump to another table column across an empty cell.
+                    if !at_edge && next_start != lane_start {
+                        break;
+                    }
+                    let next_end = reference_run_end(&next, next_start);
+                    let fragment: String = next[next_start..next_end].iter().collect();
+                    if url_from_run(&fragment).is_some() || fragment.contains(['|', '│', '─', '━'])
+                    {
+                        if closer.is_none() && ahead > 1 && hit {
+                            return url_from_run(&candidate);
+                        }
+                        break;
+                    }
+                    if candidate.len() + fragment.len() > MAX_URL_BYTES {
+                        break;
+                    }
+                    candidate.push_str(&fragment);
+                    hit |= row_number == clicked_row && (next_start..next_end).contains(&col);
+                    at_edge = next_end == next.len();
+                    let complete = closer.map_or(!at_edge, |close| fragment.contains(close));
+                    if complete {
+                        if hit {
+                            return url_from_run(&candidate);
+                        }
+                        break;
+                    }
+                    if !at_edge
+                        && (closer.is_none()
+                            || next.get(next_end + 1).is_some_and(|ch| !ch.is_whitespace()))
+                    {
+                        break;
+                    }
+                }
+            }
+            start = end;
+        }
+    }
+    None
+}
+
+fn reference_run_end(chars: &[char], start: usize) -> usize {
+    chars[start..]
+        .iter()
+        .position(|ch| ch.is_whitespace())
+        .map_or(chars.len(), |length| start + length)
+}
+
 fn trim_reference_run(run: &str) -> &str {
     run.trim()
         .trim_start_matches(['(', '[', '{', '<', '\'', '"'])
@@ -1715,6 +1841,164 @@ mod link_tests {
         TerminalImeState, TerminalInputHandler, TerminalReference, file_reference_from_run,
         mutex_lock, reference_from_run, url_from_run,
     };
+
+    fn terminal_with_rows(rows: &[&str]) -> super::TerminalElement {
+        let cols = rows.iter().map(|row| row.chars().count()).max().unwrap();
+        let mut buffer = crate::buffer::GridBuffer::new(cols as u16, rows.len() as u16);
+        for (row, text) in rows.iter().enumerate() {
+            for (col, ch) in text.chars().enumerate() {
+                buffer.cells[row * cols + col].scalar = u32::from(ch);
+            }
+        }
+        super::TerminalElement::new(Arc::new(std::sync::RwLock::new(buffer)))
+    }
+
+    #[test]
+    fn wrapped_url_in_table_opens_full_pr_from_either_row() {
+        let terminal = terminal_with_rows(&[
+            "  #6396 — Safari banner (https://github.com/anaralabs/anara/   Updates the existing PR",
+            "  pull/6396)                                                 routing.",
+        ]);
+        for (row, start, end) in [(0, 24, 56), (1, 2, 12)] {
+            for col in start..end {
+                assert_eq!(
+                    terminal.link_at(col, row).as_deref(),
+                    Some("https://github.com/anaralabs/anara/pull/6396"),
+                    "click at row {row}, col {col}"
+                );
+            }
+        }
+        assert_eq!(terminal.link_at(60, 0), None);
+        assert_eq!(terminal.link_at(60, 1), None);
+        assert_eq!(terminal.link_at(1, 1), None);
+    }
+
+    #[test]
+    fn wrapped_url_spans_three_indented_rows_and_keeps_query_and_fragment() {
+        let terminal = terminal_with_rows(&[
+            "  See (https://github.com/anaralabs/",
+            "  anara/pull/6396?diff=split&",
+            "  view=1#discussion).",
+            "                                        ",
+        ]);
+        for (col, row) in [(8, 0), (4, 1), (5, 2)] {
+            assert_eq!(
+                terminal.link_at(col, row).as_deref(),
+                Some("https://github.com/anaralabs/anara/pull/6396?diff=split&view=1#discussion")
+            );
+        }
+    }
+
+    #[test]
+    fn wrapped_url_at_terminal_edge_works_from_each_fragment() {
+        let terminal =
+            terminal_with_rows(&["https://github.com/anaralabs/", "anara/pull/6396 next"]);
+        for (col, row) in [(12, 0), (5, 1)] {
+            assert_eq!(
+                terminal.link_at(col, row).as_deref(),
+                Some("https://github.com/anaralabs/anara/pull/6396")
+            );
+        }
+        assert_eq!(terminal.link_at(16, 1), None);
+    }
+
+    #[test]
+    fn wrapped_url_can_end_exactly_at_terminal_edge() {
+        let terminal = terminal_with_rows(&["https://example.com/", "12345678901234567890"]);
+        for row in 0..2 {
+            assert_eq!(
+                terminal.link_at(5, row).as_deref(),
+                Some("https://example.com/12345678901234567890")
+            );
+        }
+    }
+
+    #[test]
+    fn wrapped_url_in_second_table_column_stays_in_its_column() {
+        let terminal = terminal_with_rows(&[
+            "  PR  See (https://github.com/anaralabs/   Details",
+            "  42  anara/pull/6396)                   More",
+        ]);
+        assert_eq!(
+            terminal.link_at(7, 1).as_deref(),
+            Some("https://github.com/anaralabs/anara/pull/6396")
+        );
+        assert_eq!(terminal.link_at(2, 1), None);
+        assert_eq!(terminal.link_at(42, 1), None);
+        let bordered = terminal_with_rows(&[
+            "│ (https://github.com/anaralabs/ │ Details │",
+            "│ anara/pull/6396)              │ More    │",
+        ]);
+        assert_eq!(
+            bordered.link_at(3, 1).as_deref(),
+            Some("https://github.com/anaralabs/anara/pull/6396")
+        );
+    }
+
+    #[test]
+    fn wrapped_url_does_not_join_unrelated_rows_or_table_cells() {
+        for rows in [
+            vec![
+                "  (https://example.com)",
+                "  unrelated/path)",
+                "                              ",
+            ],
+            vec![
+                "  (https://example.com/",
+                "  ────────────────────",
+                "  pull/6396)",
+            ],
+            vec![
+                "  (https://example.com/   Text",
+                "                         unrelated/path)",
+            ],
+            vec![
+                "  (https://example.com/",
+                "  unrelated prose)",
+                "                              ",
+            ],
+            vec![
+                "  https://example.com/",
+                "  unrelated/path)",
+                "                              ",
+            ],
+            vec!["https://example.com/", "https://example.org/"],
+        ] {
+            let terminal = terminal_with_rows(&rows);
+            assert_eq!(
+                terminal.link_at(3, 0).as_deref(),
+                Some(
+                    rows[0]
+                        .split_whitespace()
+                        .next()
+                        .unwrap()
+                        .trim_matches(['(', ')'])
+                ),
+                "{rows:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn wrapped_url_resolves_across_cached_history_and_live_grid() {
+        let terminal = terminal_with_rows(&[
+            "  pull/6396)",
+            "                                                                ",
+        ]);
+        let history = terminal_with_rows(&["  PR (https://github.com/anaralabs/anara/"]);
+        let cells = super::read_lock(&history.buffer).cells.clone();
+        {
+            let mut viewport = mutex_lock(&terminal.shared.viewport);
+            viewport.apply_rows(vec![cells], 0, 1, 3, 1, 2);
+            viewport.set_view_offset(1, 2);
+        }
+        for (col, row) in [(8, 0), (5, 1)] {
+            assert_eq!(
+                terminal.link_at(col, row).as_deref(),
+                Some("https://github.com/anaralabs/anara/pull/6396")
+            );
+        }
+    }
 
     #[test]
     fn terminal_renderer_never_creates_autonomous_frame_tasks() {


### PR DESCRIPTION
Clicking a terminal URL that continues onto another row currently opens only its first fragment. For example, a GitHub PR link split before `pull/6396` opens the repository instead of the PR.

Resolve wrapped URLs from either row, including indented table cells and cached scrollback. Keep reconstruction bounded and cover neighboring table text, separate links, and file references so unrelated content stays separate.

Validation: all 1,475 workspace tests passed (30 ignored), `cargo fmt --all -- --check`, workspace Clippy with warnings denied, and the workspace release build. Regression coverage reproduces the original truncated URL before the fix and checks clicks on both fragments afterward.
