### PR TITLE
Fix loading and working indicators for plain terminals

### DIFF
--- a/diri/crates/diri-app/src/session_presentation.rs
+++ b/diri/crates/diri-app/src/session_presentation.rs
@@ -92,6 +92,13 @@ pub(crate) fn status_state(session: &SessionRecord, migrating: bool) -> StatusSt
     }
 }
 
+pub(crate) fn is_loading(session: &SessionRecord, migrating: bool) -> bool {
+    !migrating
+        && session.hibernation.is_none()
+        && session.effective_kind() != &ProtoAgentKind::SHELL
+        && matches!(session.status, diri_proto::SessionStatus::Starting)
+}
+
 pub(crate) fn ui_agent_kind(kind: &ProtoAgentKind) -> AgentKind {
     // Brand vocabulary, not a protocol type: a manifest agent the client has
     // no hand-drawn mark for falls back to the generic terminal treatment.
@@ -108,6 +115,34 @@ pub(crate) fn ui_agent_kind(kind: &ProtoAgentKind) -> AgentKind {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn plain_terminal_has_no_loading_or_working_indicator() {
+        use crate::sidebar::{PreviewScenario, SidebarPreviewFixture};
+        use diri_proto::SessionStatus;
+
+        let mut session = SidebarPreviewFixture::make(PreviewScenario::Typical)
+            .list
+            .sessions
+            .into_iter()
+            .find(|session| session.kind == ProtoAgentKind::SHELL)
+            .expect("shell fixture");
+        for status in [
+            SessionStatus::Starting,
+            SessionStatus::Working,
+            SessionStatus::Idle,
+        ] {
+            session.status = status;
+            assert!(!is_loading(&session, false));
+            assert_eq!(status_state(&session, false), StatusState::None);
+        }
+
+        session.foreground_agent = Some(ProtoAgentKind::CLAUDE_CODE);
+        session.status = SessionStatus::Starting;
+        assert!(is_loading(&session, false));
+        assert_eq!(status_state(&session, false), StatusState::Working);
+        assert!(!is_loading(&session, true));
+    }
 
     #[test]
     fn every_activity_frame_is_embedded_in_the_app() {

--- a/diri/crates/diri-app/src/sidebar/view.rs
+++ b/diri/crates/diri-app/src/sidebar/view.rs
@@ -39,7 +39,7 @@ use crate::switcher::display_title;
 use crate::updates::{UpdateCommand, UpdatePhase, UpdateState};
 use crate::usage::{UsageFormat, UsageSnapshot};
 
-use crate::session_presentation::{activity_mark, status_state, ui_agent_kind};
+use crate::session_presentation::{activity_mark, is_loading, status_state, ui_agent_kind};
 
 use super::{
     CursorMove, DragItem, DropZone, Popover, PreviewScenario, SidebarPreviewFixture,
@@ -2556,9 +2556,7 @@ impl Sidebar {
             && self.ui.focus_cursor.as_ref() == Some(&id);
         let archived = session.is_archived();
         let hibernated = session.hibernation.is_some();
-        let loading = !migrating
-            && !hibernated
-            && matches!(session.status, diri_proto::SessionStatus::Starting);
+        let loading = is_loading(session, migrating);
         let session_is_remote = session.host.is_some();
         let ended = matches!(session.status, diri_proto::SessionStatus::Exited(_)) && !archived;
         let host_label = session.host.as_ref().map(|host| {
@@ -8022,6 +8020,35 @@ mod tests {
             sidebar_activity_state(StatusState::NeedsInput { destructive: true }, true),
             StatusState::NeedsInput { destructive: true },
         );
+    }
+
+    #[gpui::test]
+    fn plain_terminal_sidebar_does_not_schedule_activity_frames(cx: &mut TestAppContext) {
+        let (sidebar, _, cx) = drag_harness(cx);
+        cx.update(|window, _| window.activate_window());
+        cx.run_until_parked();
+        for status in [
+            diri_proto::SessionStatus::Starting,
+            diri_proto::SessionStatus::Working,
+        ] {
+            sidebar.update(cx, |sidebar, cx| {
+                let mut store = sidebar.store.write().unwrap();
+                let sessions: Vec<_> = store.sessions().values().cloned().collect();
+                for session in sessions {
+                    let mut session = (*session).clone();
+                    session.kind = ProtoAgentKind::SHELL;
+                    session.foreground_agent = None;
+                    session.status = status.clone();
+                    store.upsert_session(session);
+                }
+                cx.notify();
+            });
+            cx.run_until_parked();
+            sidebar.read_with(cx, |sidebar, _| {
+                assert!(!sidebar.working_row_rendered);
+                assert!(sidebar.activity_tick.is_none());
+            });
+        }
     }
 
     #[test]

--- a/diri/crates/diri-engine/src/registry.rs
+++ b/diri/crates/diri-engine/src/registry.rs
@@ -2777,6 +2777,7 @@ mod tests {
     #[test]
     fn completed_turn_time_folds_into_attention_state() {
         let mut session = record("completed");
+        session.kind = AgentKind::CLAUDE_CODE;
         session.status = SessionStatus::Working;
         let view = SessionView {
             id: "completed".to_owned(),

--- a/diri/crates/diri-proto/src/model.rs
+++ b/diri/crates/diri-proto/src/model.rs
@@ -825,6 +825,17 @@ impl SessionRecord {
     }
 
     pub fn attention(&self) -> AttentionLevel {
+        // A shell's Starting/Working status describes process liveness, not
+        // an Agent turn. It has no completion event to clear an activity mark.
+        // A detected foreground Agent still uses the normal attention rules.
+        if self.effective_kind() == &AgentKind::SHELL
+            && matches!(
+                self.status,
+                SessionStatus::Starting | SessionStatus::Working | SessionStatus::Idle
+            )
+        {
+            return AttentionLevel::None;
+        }
         match self.status {
             SessionStatus::NeedsInput(_) => AttentionLevel::NeedsInput,
             SessionStatus::Working | SessionStatus::Starting => AttentionLevel::Working,

--- a/diri/crates/diri-proto/tests/control_roundtrip.rs
+++ b/diri/crates/diri-proto/tests/control_roundtrip.rs
@@ -401,6 +401,28 @@ fn session_record_host_field_is_wire_compatible() {
     typed_round_trip(&record);
 }
 
+#[test]
+fn plain_terminal_liveness_does_not_report_agent_activity() {
+    let sessions: SessionListResult = fixture_ok(FIXTURES[1]);
+    let mut record = sessions.sessions[0].clone();
+    record.kind = diri_proto::AgentKind::SHELL;
+    record.foreground_agent = None;
+    for host in [None, Some("forge".to_owned())] {
+        record.host = host;
+        for status in [
+            SessionStatus::Starting,
+            SessionStatus::Working,
+            SessionStatus::Idle,
+        ] {
+            record.status = status;
+            assert_eq!(record.attention(), diri_proto::AttentionLevel::None);
+        }
+    }
+    record.foreground_agent = Some(diri_proto::AgentKind::CLAUDE_CODE);
+    record.status = SessionStatus::Working;
+    assert_eq!(record.attention(), diri_proto::AttentionLevel::Working);
+}
+
 /// The subscribe filter is a wire contract with a Swift daemon, and the exact
 /// key names are what makes it take effect. A daemon that predates the filter
 /// ignores unknown keys and streams everything, so a mis-spelled key fails


### PR DESCRIPTION
## Change

Opening a plain terminal showed a loading or working indicator because the sidebar treated shell process liveness as Agent activity. Shells have no Agent completion event to clear that state.

Keep plain terminals quiet in the shared attention model and omit their sidebar Loading chip. Detected foreground Agents retain their activity indicators. Terminal-only rows also stop scheduling animation frames.

## Verification

- Reproduced both incorrect attention and Loading states with failing regression tests, then verified they pass.
- Added a rendered-sidebar regression covering Starting and Working shell updates with no animation timer.
- Passed `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, and `cargo build --workspace --release` (using cached dependencies with `--offline`).
- Workspace tests ran outside the sandbox to allow fixture sockets and PTYs. No manual desktop check or screenshot was captured.

No transport, wire-format, or stored-format changes.
